### PR TITLE
RES-209/214: stability policy doc + contributing guide overhaul

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,52 @@
+---
+name: Good first issue
+about: A well-scoped task suitable for a first-time contributor.
+title: "RES-NNN: <one-line summary>"
+labels: ["good first issue", "ticket"]
+assignees: ""
+---
+
+<!--
+Thanks for filing a good-first-issue! These should be:
+  - Well-scoped (a few hours of focused work at most)
+  - Self-contained (no deep dependency on other in-flight work)
+  - Clearly described (someone unfamiliar with the codebase can pick it up)
+
+Before filing, skim `.board/tickets/OPEN/` to confirm this isn't already tracked.
+-->
+
+## Context
+
+_What is this ticket about, in one or two sentences? Link to any related
+tickets, code, or docs._
+
+## Goal
+
+_What should the state of the codebase be when this ticket is closed?_
+
+## Acceptance criteria
+
+- [ ] _Criterion 1 — something observable, e.g. "`foo.rs` example runs and
+      matches its `.expected.txt`"_
+- [ ] _Criterion 2_
+- [ ] _Criterion 3_
+
+## Hints for the contributor
+
+- **Where to start**: _file / module / function the contributor should open
+  first._
+- **Where to add tests**: _e.g. `resilient/src/main.rs` under `#[cfg(test)]
+  mod tests`, or a new `resilient/examples/foo.rs` with a
+  `foo.expected.txt` sidecar._
+- **Relevant docs**: _links to SYNTAX.md / STABILITY.md / `.board/ROADMAP.md`
+  sections that explain surrounding context._
+
+## Out of scope
+
+_Anything explicitly NOT part of this ticket — helps keep the PR focused._
+
+---
+
+New to the project? Read
+[CONTRIBUTING.md](../CONTRIBUTING.md) first — it covers dev setup, how to
+claim a ticket, and the PR checklist.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,61 @@
+<!--
+Thanks for contributing to Resilient!
+
+Before you hit "Create pull request":
+  - Read CONTRIBUTING.md (dev setup, ticket workflow, commit format)
+  - Keep this PR focused on a single ticket where possible
+  - Match the commit subject `RES-NNN: short description`
+-->
+
+## Description
+
+_What does this PR change? Describe the *why* more than the *what* —
+reviewers can read the diff for the what._
+
+## Linked issue
+
+Closes #<issue-number>
+
+<!-- If there is no GitHub issue but there is a .board ticket, reference it:
+Ticket: `.board/tickets/IN_PROGRESS/RES-NNN-*.md`
+-->
+
+## Acceptance criteria
+
+<!-- Copy the acceptance criteria from the linked issue and tick them off as
+they land in this PR. -->
+
+- [ ] _Criterion 1_
+- [ ] _Criterion 2_
+- [ ] _Criterion 3_
+
+## Test evidence
+
+<!-- Paste the commands you ran and summarise the result. Screenshots /
+logs welcome for user-visible behaviour. -->
+
+```
+$ cargo test --manifest-path resilient/Cargo.toml
+... all tests passed ...
+```
+
+- [ ] New tests added (unit and/or `.expected.txt` golden)
+- [ ] `cargo fmt --all` clean
+- [ ] `cargo clippy --all-targets -- -D warnings` clean
+- [ ] `cargo build --manifest-path resilient/Cargo.toml` succeeds with any
+      feature flags this PR touches
+
+## Stability impact
+
+<!-- If this PR changes the language surface, note which STABILITY.md
+category is affected and whether a CHANGELOG entry was added.
+Delete this section if it is purely internal / not surface-visible. -->
+
+- [ ] STABILITY.md CHANGELOG updated (if user-visible syntax or builtin
+      changed)
+- [ ] `.board/` ticket moved from `IN_PROGRESS/` to `DONE/` (with closing
+      commit hash recorded)
+
+## Notes for reviewers
+
+_Anything tricky, surprising, or explicitly out-of-scope?_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,73 +4,119 @@ Welcome — and thank you for your interest in Resilient! Contributions from
 humans, AI agents, and automated tooling are all equally welcome. Every
 improvement, no matter how small, helps push the language forward.
 
+New here? Skip to [Good first issues](#good-first-issues) for a handful of
+tickets sized for a first PR.
+
+---
+
+## Quick Start
+
+```bash
+# 1. Clone
+git clone https://github.com/EricSpencer00/Resilient.git
+cd Resilient
+
+# 2. Build the compiler (default features — no z3, no lsp, no jit)
+cargo build --manifest-path resilient/Cargo.toml
+
+# 3. Run the compiler test suite
+cargo test --manifest-path resilient/Cargo.toml
+
+# 4. Build the embedded runtime
+cargo build --manifest-path resilient-runtime/Cargo.toml
+cargo test  --manifest-path resilient-runtime/Cargo.toml
+
+# 5. Run an example
+cargo run --manifest-path resilient/Cargo.toml -- resilient/examples/hello.rs
+```
+
+If all four commands succeed, you have a working dev environment.
+
 ---
 
 ## Setting Up the Development Environment
 
 ### Prerequisites
 
-- **Rust** (stable toolchain) — install via [rustup.rs](https://rustup.rs/)
-- **z3** (optional, for SMT-backed verification)
+- **Rust** (stable toolchain) — install via [rustup.rs](https://rustup.rs/).
+  Edition 2024 is required; any recent stable rustc will do.
+- **z3** (optional, only if you work on verifier code with `--features z3`)
   - macOS: `brew install z3`
   - Linux: `sudo apt-get install libz3-dev z3`
+- **Cross-compile targets** (optional, for `resilient-runtime` cross builds):
+
+  ```bash
+  rustup target add thumbv7em-none-eabihf   # Cortex-M4F
+  rustup target add thumbv6m-none-eabi      # Cortex-M0/M0+
+  rustup target add riscv32imac-unknown-none-elf
+  ```
+
+### Feature flags
+
+The `resilient` crate has several opt-in features; pick only what you need.
+
+| Feature | Flag                     | What it enables                                                    |
+|---------|--------------------------|--------------------------------------------------------------------|
+| `z3`    | `cargo build --features z3`  | Z3-backed SMT verification (requires libz3).                   |
+| `lsp`   | `cargo build --features lsp` | Language server over stdio (`resilient --lsp`).                |
+| `jit`   | `cargo build --features jit` | Cranelift JIT backend (heavy deps; off by default).            |
+| `ffi`   | `cargo build --features ffi` | Dynamic FFI via `extern "lib" { ... }` in the tree walker.     |
+
+The `resilient-runtime` crate has its own feature set — notably
+`--features alloc` (heap types) and `--features ffi-static` (static FFI
+registry). See its `Cargo.toml` for the full list.
 
 ### Building
 
 ```bash
-# Clone the repo
-git clone https://github.com/EricSpencer00/Resilient.git
-cd Resilient
+# Compiler / CLI driver
+cargo build --manifest-path resilient/Cargo.toml
 
-# Build the compiler
-cd resilient
-cargo build
+# With Z3 support
+cargo build --manifest-path resilient/Cargo.toml --features z3
 
-# Build the embedded runtime
-cd ../resilient-runtime
-cargo build
+# With the LSP server
+cargo build --manifest-path resilient/Cargo.toml --features lsp
 
-# Build with the alloc feature
-cargo build --features alloc
+# Embedded runtime
+cargo build --manifest-path resilient-runtime/Cargo.toml
+cargo build --manifest-path resilient-runtime/Cargo.toml --features alloc
+cargo build --manifest-path resilient-runtime/Cargo.toml --features ffi-static
 
-# Build with z3 support (requires z3 installed)
-cd ../resilient
-cargo build --features z3
+# Cross-compile check
+cargo build --manifest-path resilient-runtime/Cargo.toml --target thumbv7em-none-eabihf
 ```
 
-### Running Tests
+### Running tests
 
 ```bash
-# Compiler + interpreter tests
-cd resilient
-cargo test
+# Compiler + interpreter tests (default)
+cargo test --manifest-path resilient/Cargo.toml
 
 # With Z3 integration tests
-cargo test --features z3
+cargo test --manifest-path resilient/Cargo.toml --features z3
 
-# Embedded runtime — default (alloc-free, 11 tests)
-cd resilient-runtime
-cargo test
+# With FFI tests (tree walker)
+cargo test --manifest-path resilient/Cargo.toml --features ffi
 
-# With alloc feature (14 tests)
-cargo test --features alloc
+# Embedded runtime — default (no_std, alloc-free)
+cargo test --manifest-path resilient-runtime/Cargo.toml
 
-# With static-only feature (13 tests)
-cargo test --features static-only
+# With alloc feature
+cargo test --manifest-path resilient-runtime/Cargo.toml --features alloc
+
+# Static FFI registry
+cargo test --manifest-path resilient-runtime/Cargo.toml --features ffi-static
 ```
 
-### Cross-compile targets (optional)
+### Formatting and lints
 
 ```bash
-rustup target add thumbv7em-none-eabihf   # Cortex-M4F
-rustup target add thumbv6m-none-eabi      # Cortex-M0/M0+
-rustup target add riscv32imac-unknown-none-elf
-
-cd resilient-runtime
-cargo build --target thumbv7em-none-eabihf
-cargo build --target thumbv6m-none-eabi
-cargo build --target riscv32imac-unknown-none-elf
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
 ```
+
+Both must pass before a PR can merge; CI enforces them.
 
 ---
 
@@ -82,12 +128,13 @@ Resilient/
 │   ├── src/                        # Lexer, parser, type checker, VM, JIT, builtins
 │   └── examples/                   # Example programs (each with .expected.txt sidecar)
 ├── resilient-runtime/              # no_std-compatible embedded runtime crate
-│   └── src/                        # Value types, ops, sink abstraction
-├── resilient-runtime-cortex-m-demo/# Cortex-M4F cross-compile demo (build check)
+│   └── src/                        # Value types, ops, sink abstraction, FFI registry
+├── resilient-runtime-cortex-m-demo/# Cortex-M4F cross-compile demo (size-gated in CI)
 ├── docs/                           # Static site source (published to GitHub Pages)
 ├── benchmarks/                     # Benchmark scripts and RESULTS.md
 ├── self-host/                      # Self-hosting bootstrap experiments
 ├── scripts/                        # Helper shell scripts (CI, size gate, etc.)
+├── STABILITY.md                    # Pre-1.0 stability policy (read before upgrading)
 ├── .board/                         # Project management board
 │   ├── ROADMAP.md                  # Goalpost ladder (G1–G20+)
 │   └── tickets/                    # Ticket files (OPEN / IN_PROGRESS / DONE)
@@ -96,7 +143,7 @@ Resilient/
 
 ---
 
-## Ticket and Issue Workflow
+## The `.board/` Workflow
 
 Resilient uses a lightweight file-based ticket system under `.board/tickets/`.
 GitHub Issues mirror the OPEN tickets so external contributors can see and
@@ -105,23 +152,46 @@ claim work without needing special repo access.
 ### Ticket lifecycle
 
 ```
-OPEN  →  IN_PROGRESS  →  DONE
+.board/tickets/OPEN/  →  .board/tickets/IN_PROGRESS/  →  .board/tickets/DONE/
 ```
 
-- **OPEN** — `/.board/tickets/OPEN/RES-NNN-short-title.md`
-  Filed when work is defined but not yet started.
-- **IN_PROGRESS** — `/.board/tickets/IN_PROGRESS/RES-NNN-short-title.md`
-  Move the file when you start work. Add your name / agent ID to the ticket.
-- **DONE** — `/.board/tickets/DONE/RES-NNN-short-title.md`
-  Move the file when the work lands on `main`. Record the closing commit hash.
+- **OPEN** — `.board/tickets/OPEN/RES-NNN-short-title.md`
+  Filed when work is defined but not yet started. These mirror the GitHub
+  Issues tagged with `ticket`.
+- **IN_PROGRESS** — `.board/tickets/IN_PROGRESS/RES-NNN-short-title.md`
+  Move the file when you start work. Add your name / agent ID to the ticket
+  header as `Claimed-by:`.
+- **DONE** — `.board/tickets/DONE/RES-NNN-short-title.md`
+  Move the file when the work lands on `main`. Record the closing commit
+  hash in the ticket footer.
 
-### Claiming a ticket
+### Picking up a ticket
 
-1. Pick an OPEN ticket (or open a GitHub Issue for new work).
-2. Move the ticket file from `OPEN/` to `IN_PROGRESS/`.
-3. Add a `Claimed-by:` line to the ticket header.
-4. Open a draft PR referencing the ticket number early so others know work is
-   in progress.
+1. Skim `.board/tickets/OPEN/` (or the GitHub Issues list) and pick one. New
+   contributors — look for issues tagged `good first issue`.
+2. **Claim it** by moving the file:
+
+   ```bash
+   git mv .board/tickets/OPEN/RES-NNN-*.md .board/tickets/IN_PROGRESS/
+   ```
+
+   Add a `Claimed-by: <your-github-handle>` line to the ticket header and
+   commit that move as its own commit, or include it in your first PR.
+3. Open a **draft PR** early — this signals to others that the ticket is
+   taken.
+4. When the PR merges, move the ticket to `DONE/` and record the commit hash
+   in the ticket footer.
+5. Close the corresponding GitHub Issue (`Closes #N` in the PR body does this
+   automatically).
+
+### Good first issues
+
+New contributors: the `good first issue` label on GitHub marks tickets that
+are well-scoped for a first PR. They come with clear acceptance criteria and
+generally don't require deep knowledge of the compiler internals.
+
+Browse them at:
+<https://github.com/EricSpencer00/Resilient/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>
 
 ---
 
@@ -129,10 +199,18 @@ OPEN  →  IN_PROGRESS  →  DONE
 
 - **Ticket work**: `RES-NNN: short description`
   Example: `RES-207: add struct literal syntax to parser`
+- **Multi-ticket change**: join the ticket IDs with `/`.
+  Example: `RES-209/214: stability policy doc + contributing guide overhaul`
 - **Other fixes / chores**: free-form, but keep the first line under 72 chars.
   Example: `Fix typo in CONTRIBUTING.md`
 - **Multi-line bodies** are welcome for complex changes — explain *why*, not
   just *what*.
+- AI-agent-authored commits should include a `Co-Authored-By:` trailer so
+  authorship is transparent. Example:
+
+  ```
+  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+  ```
 
 ---
 
@@ -140,8 +218,9 @@ OPEN  →  IN_PROGRESS  →  DONE
 
 ### General
 
-- Follow existing code style. Run `cargo fmt` before committing.
-- Run `cargo clippy -- -D warnings` and address all warnings.
+- Run `cargo fmt --all` before committing.
+- Run `cargo clippy --all-targets -- -D warnings` and fix every warning —
+  CI rejects clippy warnings.
 - Every new language feature must have tests. Every new example program must
   have a `.expected.txt` golden-output sidecar in `resilient/examples/`.
 
@@ -171,23 +250,37 @@ OPEN  →  IN_PROGRESS  →  DONE
 - Tests that require z3 must be gated with `#[cfg(feature = "z3")]` or placed
   under `cargo test --features z3`.
 
+### Stability-sensitive changes
+
+Before changing anything listed as **stable** in [STABILITY.md](STABILITY.md),
+read that file's "How Breaking Changes Land" section. Breaking changes to
+stable surface require a deprecation plan in the ticket.
+
 ---
 
-## Pull Request Guidelines
+## Pull Request Checklist
 
-- **Keep PRs small and focused.** One ticket = one PR is ideal.
-- **Link the GitHub Issue** in the PR description:
-  `Closes #<issue-number>` or `Fixes #<issue-number>`.
-- **CI must be green** before requesting review. The workflows gate on:
-  - `cargo test` (host)
-  - `cargo test --features z3`
-  - `cargo test --features alloc` in `resilient-runtime`
-  - Cross-compile for `thumbv7em-none-eabihf`, `thumbv6m-none-eabi`,
-    and `riscv32imac-unknown-none-elf`
-  - Size gate (`.text` ≤ 64 KiB for the Cortex-M4F demo)
-  - Performance gate (`cargo bench` regression check)
-- Include a brief description of *what* changed and *why*.
-- Update `CHANGELOG` or the relevant ticket file if appropriate.
+Before marking a PR ready for review:
+
+- [ ] Linked GitHub issue in the PR body (`Closes #N` / `Fixes #N`).
+- [ ] Commit subject follows `RES-NNN: short description`.
+- [ ] `cargo fmt --all` clean.
+- [ ] `cargo clippy --all-targets -- -D warnings` clean.
+- [ ] `cargo test` passes on the crates you touched (with relevant features).
+- [ ] New behaviour has tests (unit or `.expected.txt` golden).
+- [ ] Documentation updated if user-visible behaviour changed (README,
+      SYNTAX.md, docs/, STABILITY.md CHANGELOG).
+- [ ] Ticket moved from `IN_PROGRESS/` to `DONE/` in the same PR when the
+      work is complete.
+
+CI gates PRs on all of the above plus:
+
+- Cross-compile for `thumbv7em-none-eabihf`, `thumbv6m-none-eabi`, and
+  `riscv32imac-unknown-none-elf`.
+- Size gate (`.text` ≤ 64 KiB for the Cortex-M4F demo).
+- Performance gate (`cargo bench` regression check).
+
+Keep PRs small and focused — one ticket per PR is ideal.
 
 ---
 
@@ -196,19 +289,12 @@ OPEN  →  IN_PROGRESS  →  DONE
 AI agents are first-class contributors. The same rules apply as for humans:
 
 - Follow the commit format (`RES-NNN: short description` for ticket work).
-- Open PRs against `main`; do not force-push.
+- Open PRs against `main`; never force-push.
 - Keep PRs focused — one ticket, one concern.
 - All CI checks must pass before requesting a merge.
-- If an agent opens a PR on behalf of a human, include a `Co-Authored-By:`
-  trailer in the commit message so authorship is transparent.
-- Agents may claim tickets by moving them from `OPEN/` to `IN_PROGRESS/` and
-  adding `Claimed-by: <agent-id>` to the ticket header.
-
-Example commit trailer for agent-assisted work:
-
-```
-Co-Authored-By: Claude Sonnet <noreply@anthropic.com>
-```
+- Include a `Co-Authored-By:` trailer on any agent-assisted commit.
+- Claim tickets by moving them from `OPEN/` to `IN_PROGRESS/` and adding
+  `Claimed-by: <agent-id>` to the ticket header.
 
 ---
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,172 @@
+# Resilient Stability Policy
+
+Resilient is **pre-1.0**. This document describes the stability guarantees the
+project offers today and the guarantees it will offer once the language hits
+1.0.
+
+If you are depending on Resilient in production, read this file end-to-end
+before upgrading compiler versions.
+
+---
+
+## TL;DR
+
+- Current status: **pre-1.0** — breaking changes can land at any time, with no
+  deprecation cycle. They are always recorded in the [CHANGELOG](#changelog)
+  below.
+- `resilient --version` prints a one-line reminder of this status.
+- Some features are **experimental** and will almost certainly change; others
+  are **stable** and already follow a best-effort deprecation path. The lists
+  are in [Feature stability](#feature-stability).
+- Experimental surface is marked with a `# @experimental` comment convention.
+
+---
+
+## Versioning Intent (post-1.0)
+
+Once Resilient reaches 1.0 the project will follow
+[Semantic Versioning 2.0](https://semver.org/):
+
+- **MAJOR** (`X.y.z`) — incremented for backwards-incompatible changes to the
+  stable surface area (see below). Requires at least one MINOR release that
+  ships the replacement alongside a deprecation warning. Removed items stay in
+  the CHANGELOG indefinitely.
+- **MINOR** (`x.Y.z`) — backwards-compatible additions: new syntax that does
+  not conflict with existing programs, new builtins, new stdlib functions,
+  new compiler flags, additional diagnostics. May also promote an experimental
+  feature to stable. Never removes anything.
+- **PATCH** (`x.y.Z`) — backwards-compatible bug fixes, performance
+  improvements, and documentation. No surface-visible changes.
+
+Compiler-internal APIs (the `resilient` crate's Rust types, the VM bytecode
+format, the JIT ABI, the `resilient-runtime` crate's non-public items) are
+**never** covered by SemVer and may change in any release.
+
+---
+
+## Pre-1.0 Rules
+
+Until the first `1.0.0` tag:
+
+- **Any release can break any program.** The surface area is still being
+  designed — expect syntax, keyword spellings, builtin signatures, and
+  standard-library shapes to move.
+- **Every breaking change is logged** in the [CHANGELOG](#changelog) section at
+  the bottom of this file, with a one-line migration hint where practical.
+- **No deprecation cycle is required** pre-1.0, but where it's cheap the
+  compiler will still emit a warning for one release before removing a
+  construct.
+- Tagged releases (`v0.x.y`) are reproducible snapshots — pin to one if you
+  want a stable target.
+- `main` is always green in CI but is not considered stable at any point.
+
+---
+
+## Feature Stability
+
+### Stable (deprecation cycle required before removal)
+
+These features are considered the core of the language and will go through a
+deprecation cycle before any breaking change, even pre-1.0:
+
+- **Core syntax**: `let`, `fn`, `if` / `else`, `while`, `match`, `return`
+- **Primitive types**: `Int` (i64), `Float` (f64), `Bool`, `String`, `Bytes`
+- **Basic control flow**: expression-level `if`, `while` loops, `match`
+  expressions on primitives
+- **Integer and float arithmetic operators**: `+`, `-`, `*`, `/`, `%`, `==`,
+  `!=`, `<`, `<=`, `>`, `>=`
+- **Function call syntax** and the `fn name(type arg, ...)` declaration form
+- **String/byte literal escape syntax** (`\n`, `\t`, `\\`, `\"`, `\xNN`,
+  `\u{NNNN}`)
+
+Where a change is unavoidable, the compiler will emit a deprecation warning
+for at least one release before the construct stops compiling.
+
+### Experimental (may change without notice)
+
+These features are useful today but still evolving. Expect breaking changes
+with no warning cycle:
+
+- **`live` blocks** — retry / backoff / timeout semantics, escalation rules,
+  and telemetry counter names. See tickets RES-138..RES-142.
+- **Effect system** — effect annotations, effect polymorphism for higher-order
+  functions (RES-193), and the exact spelling of effect names.
+- **FFI (`extern` blocks)** — both the tree-walker dynamic-load path and the
+  `resilient-runtime` static registry behind `--features ffi-static`. Types
+  that can cross the boundary, struct-by-pointer support (RES-215), and
+  callback support (RES-216) are all actively changing.
+- **Z3 verification** — verifier directives, certificate format, and the
+  SMT encoding (especially the overflow-aware encoding tracked by RES-134).
+  Runs only with `--features z3`; API shape is expected to change as the
+  verifier evolves.
+- **Package manager (`resilient pkg`)** — subcommand names, manifest format
+  (RES-212), and resolution rules.
+- **Language server (`--lsp`)** — request/response shapes beyond stock LSP
+  are subject to change; new features land as RES-183/184/190 progress.
+
+If you build on any of the above, expect to rev your code on most releases.
+
+---
+
+## The `@experimental` Convention
+
+There is no attribute syntax yet; experimental surface is flagged with a
+comment above the declaration:
+
+```resilient
+# @experimental: live-block API may change — see STABILITY.md
+fn retry_with_backoff(int attempts) {
+    live backoff(base_ms=10, factor=2, max_ms=1000) {
+        # ...
+    }
+}
+```
+
+The convention is:
+
+- The comment appears on its own line directly above the declaration.
+- It starts with `# @experimental` followed by a colon and a short reason.
+- Tooling does not currently enforce this — it's a promise to future readers,
+  not a compiler-checked attribute. A proper attribute syntax is tracked for a
+  future ticket.
+
+Files in `resilient/examples/` that exercise experimental surface should carry
+the marker near the top of the file.
+
+---
+
+## How Breaking Changes Land
+
+1. The change is proposed as a ticket (`RES-NNN`) under `.board/tickets/`.
+2. If the affected surface is listed as **stable** above, the ticket must
+   include a deprecation plan: which version prints a warning, which version
+   removes the construct.
+3. The change ships behind a PR that updates this file's CHANGELOG with:
+   - The date (YYYY-MM).
+   - The version that first contains the change.
+   - A one-line description.
+   - A pointer to the migration (ticket link or short snippet).
+4. `resilient --version` keeps pointing contributors at this document so
+   nobody upgrades blind.
+
+---
+
+## CHANGELOG
+
+Chronological log of breaking and stability-relevant changes. Newest first.
+
+| Date    | Version | Area        | Change                                                                                           |
+|---------|---------|-------------|--------------------------------------------------------------------------------------------------|
+| 2026-04 | 0.1.x   | FFI         | Static-registry FFI landed behind `--features ffi-static` in `resilient-runtime`. Experimental — signatures, type mapping, and registration macros may change (RES-FFI phase 1). |
+| 2026-04 | 0.1.x   | FFI         | `extern "lib" { fn name(...) -> T = "symbol"; }` syntax added for dynamically loaded libm-style libraries in the tree walker. Experimental; struct-by-pointer and callbacks tracked as RES-215 / RES-216. |
+| 2026-04 | 0.1.x   | live blocks | `live backoff(base_ms=, factor=, max_ms=)` and `live within Nms` clauses formalised (RES-138 / RES-139 / RES-142). Keyword and parameter names experimental. |
+| 2026-04 | 0.1.x   | live blocks | Nested `live` escalation rules and telemetry counter names finalised for the tree walker (RES-140 / RES-141). Counter names experimental. |
+| 2026-04 | 0.1.x   | CLI         | `resilient --version` / `-V` added; prints the pre-1.0 stability notice pointing here (RES-209). |
+
+New entries go at the top of the table.
+
+---
+
+## Questions?
+
+Open an issue or email [ericspencer1450@gmail.com](mailto:ericspencer1450@gmail.com).

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -9458,6 +9458,17 @@ fn main() {
     // Get command line arguments
     let args: Vec<String> = env::args().collect();
 
+    // RES-209: `--version` / `-V` prints the compiler version plus a
+    // pre-1.0 stability notice and exits. See STABILITY.md at the
+    // repo root for the policy this notice points to.
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        println!(
+            "resilient {}: pre-1.0 — breaking changes possible (see STABILITY.md)",
+            env!("CARGO_PKG_VERSION")
+        );
+        std::process::exit(0);
+    }
+
     // RES-211: `--help` / `-h` prints a short usage summary listing
     // the most-used flags. Kept hand-rolled (no clap dep) to match
     // the rest of the driver's arg-parsing style.


### PR DESCRIPTION
## Summary

- **RES-209** — new `STABILITY.md` at the repo root documenting the pre-1.0 stability policy: breaking changes can land at any time but are always logged in the CHANGELOG, post-1.0 will follow SemVer, and language surface is split into `stable` (deprecation cycle required) and `experimental` (may change without notice) buckets. Includes a `# @experimental` comment convention for marking unstable declarations.
- **RES-209** — `resilient --version` / `-V` now prints the compiler version plus `pre-1.0 — breaking changes possible (see STABILITY.md)` so nobody upgrades blind.
- **RES-214** — CONTRIBUTING.md rewritten: quick-start section, feature-flag matrix (`z3`/`lsp`/`jit`/`ffi`), test recipes for both `resilient/` and `resilient-runtime/`, expanded `.board/` workflow (OPEN → IN_PROGRESS → DONE), claim/commit/PR checklist. Good-first-issue pointer included.
- **RES-214** — new `.github/ISSUE_TEMPLATE/good_first_issue.md` and `.github/PULL_REQUEST_TEMPLATE.md` with description / linked-issue / acceptance-criteria / test-evidence sections.

## Linked issues

Closes #18
Closes #23

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml` succeeds (no new warnings)
- [x] `./resilient/target/debug/resilient --version` prints `resilient 0.1.0: pre-1.0 — breaking changes possible (see STABILITY.md)`
- [x] `./resilient/target/debug/resilient -V` produces the same notice
- [ ] Reviewer spot-check of STABILITY.md CHANGELOG entries for FFI / live blocks
- [ ] Reviewer skim of CONTRIBUTING.md for any command that doesn't match the current workspace

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>