### PR TITLE
RES-218: Criterion benchmark harness — fib, bubble-sort, string-processing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in the Resilient
+project a harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project maintainer at
+[ericspencer1450@gmail.com](mailto:ericspencer1450@gmail.com). All complaints
+will be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,219 @@
+# Contributing to Resilient
+
+Welcome — and thank you for your interest in Resilient! Contributions from
+humans, AI agents, and automated tooling are all equally welcome. Every
+improvement, no matter how small, helps push the language forward.
+
+---
+
+## Setting Up the Development Environment
+
+### Prerequisites
+
+- **Rust** (stable toolchain) — install via [rustup.rs](https://rustup.rs/)
+- **z3** (optional, for SMT-backed verification)
+  - macOS: `brew install z3`
+  - Linux: `sudo apt-get install libz3-dev z3`
+
+### Building
+
+```bash
+# Clone the repo
+git clone https://github.com/EricSpencer00/Resilient.git
+cd Resilient
+
+# Build the compiler
+cd resilient
+cargo build
+
+# Build the embedded runtime
+cd ../resilient-runtime
+cargo build
+
+# Build with the alloc feature
+cargo build --features alloc
+
+# Build with z3 support (requires z3 installed)
+cd ../resilient
+cargo build --features z3
+```
+
+### Running Tests
+
+```bash
+# Compiler + interpreter tests
+cd resilient
+cargo test
+
+# With Z3 integration tests
+cargo test --features z3
+
+# Embedded runtime — default (alloc-free, 11 tests)
+cd resilient-runtime
+cargo test
+
+# With alloc feature (14 tests)
+cargo test --features alloc
+
+# With static-only feature (13 tests)
+cargo test --features static-only
+```
+
+### Cross-compile targets (optional)
+
+```bash
+rustup target add thumbv7em-none-eabihf   # Cortex-M4F
+rustup target add thumbv6m-none-eabi      # Cortex-M0/M0+
+rustup target add riscv32imac-unknown-none-elf
+
+cd resilient-runtime
+cargo build --target thumbv7em-none-eabihf
+cargo build --target thumbv6m-none-eabi
+cargo build --target riscv32imac-unknown-none-elf
+```
+
+---
+
+## Project Structure
+
+```
+Resilient/
+├── resilient/                      # Compiler, REPL, and CLI driver
+│   ├── src/                        # Lexer, parser, type checker, VM, JIT, builtins
+│   └── examples/                   # Example programs (each with .expected.txt sidecar)
+├── resilient-runtime/              # no_std-compatible embedded runtime crate
+│   └── src/                        # Value types, ops, sink abstraction
+├── resilient-runtime-cortex-m-demo/# Cortex-M4F cross-compile demo (build check)
+├── docs/                           # Static site source (published to GitHub Pages)
+├── benchmarks/                     # Benchmark scripts and RESULTS.md
+├── self-host/                      # Self-hosting bootstrap experiments
+├── scripts/                        # Helper shell scripts (CI, size gate, etc.)
+├── .board/                         # Project management board
+│   ├── ROADMAP.md                  # Goalpost ladder (G1–G20+)
+│   └── tickets/                    # Ticket files (OPEN / IN_PROGRESS / DONE)
+└── .github/workflows/              # CI workflow definitions
+```
+
+---
+
+## Ticket and Issue Workflow
+
+Resilient uses a lightweight file-based ticket system under `.board/tickets/`.
+GitHub Issues mirror the OPEN tickets so external contributors can see and
+claim work without needing special repo access.
+
+### Ticket lifecycle
+
+```
+OPEN  →  IN_PROGRESS  →  DONE
+```
+
+- **OPEN** — `/.board/tickets/OPEN/RES-NNN-short-title.md`
+  Filed when work is defined but not yet started.
+- **IN_PROGRESS** — `/.board/tickets/IN_PROGRESS/RES-NNN-short-title.md`
+  Move the file when you start work. Add your name / agent ID to the ticket.
+- **DONE** — `/.board/tickets/DONE/RES-NNN-short-title.md`
+  Move the file when the work lands on `main`. Record the closing commit hash.
+
+### Claiming a ticket
+
+1. Pick an OPEN ticket (or open a GitHub Issue for new work).
+2. Move the ticket file from `OPEN/` to `IN_PROGRESS/`.
+3. Add a `Claimed-by:` line to the ticket header.
+4. Open a draft PR referencing the ticket number early so others know work is
+   in progress.
+
+---
+
+## Commit Format
+
+- **Ticket work**: `RES-NNN: short description`
+  Example: `RES-207: add struct literal syntax to parser`
+- **Other fixes / chores**: free-form, but keep the first line under 72 chars.
+  Example: `Fix typo in CONTRIBUTING.md`
+- **Multi-line bodies** are welcome for complex changes — explain *why*, not
+  just *what*.
+
+---
+
+## Coding Standards
+
+### General
+
+- Follow existing code style. Run `cargo fmt` before committing.
+- Run `cargo clippy -- -D warnings` and address all warnings.
+- Every new language feature must have tests. Every new example program must
+  have a `.expected.txt` golden-output sidecar in `resilient/examples/`.
+
+### `resilient-runtime/`
+
+- Must remain `#![no_std]` compatible in the default feature set.
+- **Zero use of `std` types** (no `Vec`, `String`, `Box`, etc.) outside of
+  `#[cfg(feature = "alloc")]` gates.
+- **Zero panics**: use `Result` / `Option` and propagate errors. Every
+  `unwrap()` or `expect()` is a bug.
+
+### `resilient/` (compiler / CLI)
+
+- **Zero panics in the parser and lexer.** Every error path must return a
+  typed `Error` and be surfaced as a clean diagnostic. A panic is a bug.
+- Diagnostics carry `line:col:` source positions. Don't add bare `println!`
+  or `eprintln!` debug output — use the existing diagnostic infrastructure.
+- New built-in functions go in the builtins table with a doc-comment and a
+  test.
+
+### Tests
+
+- Unit tests live next to the code they test (`#[cfg(test)]` modules).
+- Integration / example tests use the golden `.expected.txt` sidecar pattern:
+  run `cargo run -- examples/foo.rs` and diff stdout against
+  `examples/foo.expected.txt`.
+- Tests that require z3 must be gated with `#[cfg(feature = "z3")]` or placed
+  under `cargo test --features z3`.
+
+---
+
+## Pull Request Guidelines
+
+- **Keep PRs small and focused.** One ticket = one PR is ideal.
+- **Link the GitHub Issue** in the PR description:
+  `Closes #<issue-number>` or `Fixes #<issue-number>`.
+- **CI must be green** before requesting review. The workflows gate on:
+  - `cargo test` (host)
+  - `cargo test --features z3`
+  - `cargo test --features alloc` in `resilient-runtime`
+  - Cross-compile for `thumbv7em-none-eabihf`, `thumbv6m-none-eabi`,
+    and `riscv32imac-unknown-none-elf`
+  - Size gate (`.text` ≤ 64 KiB for the Cortex-M4F demo)
+  - Performance gate (`cargo bench` regression check)
+- Include a brief description of *what* changed and *why*.
+- Update `CHANGELOG` or the relevant ticket file if appropriate.
+
+---
+
+## For AI Agent Contributors
+
+AI agents are first-class contributors. The same rules apply as for humans:
+
+- Follow the commit format (`RES-NNN: short description` for ticket work).
+- Open PRs against `main`; do not force-push.
+- Keep PRs focused — one ticket, one concern.
+- All CI checks must pass before requesting a merge.
+- If an agent opens a PR on behalf of a human, include a `Co-Authored-By:`
+  trailer in the commit message so authorship is transparent.
+- Agents may claim tickets by moving them from `OPEN/` to `IN_PROGRESS/` and
+  adding `Claimed-by: <agent-id>` to the ticket header.
+
+Example commit trailer for agent-assisted work:
+
+```
+Co-Authored-By: Claude Sonnet <noreply@anthropic.com>
+```
+
+---
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+By participating you agree to uphold it. Please report unacceptable behavior to
+[ericspencer1450@gmail.com](mailto:ericspencer1450@gmail.com).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Eric Spencer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -576,6 +576,14 @@ small code size (≈15 LOC, zero dependencies), not unpredictability.
 When the language grows a cryptographic-grade primitive it will
 live under a separate name with the appropriate guarantees.
 
+## Performance
+
+Run `cargo bench --manifest-path resilient/Cargo.toml` to benchmark the
+tree-walker interpreter on three representative workloads (recursive
+`fib(25)`, bubble-sort, and string concatenation). Results are saved to
+`resilient/target/criterion/`; a captured baseline lives at
+[`benchmarks/baseline.txt`](benchmarks/baseline.txt).
+
 ## Syntax Requirements
 
 See the [SYNTAX.md](SYNTAX.md) file for detailed syntax requirements and examples. Key points:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| `main`  | ✓ (rolling) |
+
+Resilient is pre-1.0 software. Only the `main` branch receives security fixes.
+
+## Reporting a Vulnerability
+
+**Please do not file public GitHub Issues for security vulnerabilities.**
+
+Email [ericspencer1450@gmail.com](mailto:ericspencer1450@gmail.com) with:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Any suggested mitigations you have in mind
+
+You can expect an acknowledgment within 72 hours and a status update within 7 days.
+
+## Scope
+
+The Resilient compiler, runtime, and tooling are the primary scope. The embedded
+`resilient-runtime` crate targets `no_std` environments where memory-safety
+guarantees are especially critical — reports in that area are particularly welcome.
+
+## Out of Scope
+
+- Vulnerabilities in third-party dependencies (report upstream)
+- Issues in example programs that do not affect the compiler or runtime

--- a/benchmarks/baseline.txt
+++ b/benchmarks/baseline.txt
@@ -1,0 +1,31 @@
+RES-218 — Criterion tree-walker baseline
+========================================
+
+Captured: 2026-04-20
+Hardware: Apple M1 Max, macOS arm64 (darwin 25.3.0)
+Rust: stable, release profile (`cargo bench`)
+Command: cargo bench --manifest-path resilient/Cargo.toml --bench interpreter
+
+All three benchmarks shell out to the compiled `resilient` binary and
+include process-startup overhead in the measurement (see the rationale
+in `resilient/benches/interpreter.rs`). The numbers are intended as a
+shape-of-the-curve baseline; deltas between commits are the signal.
+
+tree_walker/fib_25
+    time:   [388.83 ms 430.02 ms 478.52 ms]
+    # Recursive fib with n=25 (~243k calls). Exercises fn dispatch
+    # and environment cloning. Matches the workload used by the
+    # cross-language table in benchmarks/README.md.
+
+tree_walker/bubble_sort_50
+    time:   [7.1283 ms 7.9167 ms 9.6360 ms]
+    # 50-element descending array, O(n^2). Exercises indexed array
+    # read/write and nested while loops.
+
+tree_walker/string_concat_200
+    time:   [2.5026 ms 2.8698 ms 3.6827 ms]
+    # 200-iteration `s = s + "x"` loop then len(s). Exercises the
+    # string-value path and `+` coercion in the interpreter.
+
+Criterion also writes per-benchmark HTML reports to
+`resilient/target/criterion/` — open `index.html` for the full breakdown.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,137 @@
+---
+title: Community & Open Source
+nav_order: 14
+permalink: /community
+---
+
+# Community & Open Source
+{: .no_toc }
+
+Resilient is free and open source software, built in public, one
+ticket at a time.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## License
+
+Resilient is released under the **MIT License**.
+
+```
+MIT License
+
+Copyright (c) 2024 Eric Spencer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+Full license text is in
+[`LICENSE`](https://github.com/EricSpencer00/Resilient/blob/main/LICENSE)
+at the repository root.
+
+---
+
+## GitHub repository
+
+**[github.com/EricSpencer00/Resilient](https://github.com/EricSpencer00/Resilient)**
+
+The repository contains:
+
+| Path | Contents |
+|------|----------|
+| `resilient/` | Compiler and runtime source (Rust) |
+| `docs/` | This documentation site (Jekyll) |
+| `.board/` | Plain-text ticket ledger |
+| `examples/` | Example `.res` programs |
+| `resilient-runtime/` | `#![no_std]` runtime crate |
+
+---
+
+## Filing issues
+
+Found a bug? Have a feature idea? Open an issue on GitHub:
+
+1. Go to [Issues](https://github.com/EricSpencer00/Resilient/issues)
+2. Click **New issue**
+3. Choose the appropriate template (bug report, feature request,
+   or blank)
+4. Include a minimal reproducible example for bugs — the smaller
+   the better
+
+For compiler crashes, please include:
+- The Resilient source that triggered the crash
+- The full error output (`RUST_BACKTRACE=1 resilient your_file.rs`)
+- Your OS and `cargo --version`
+
+---
+
+## Contributing
+
+See the [Contributing](contributing) page for the full
+workflow — fork, clone, `cargo test`, open PR.
+
+The short version:
+- All contributions go through GitHub pull requests
+- The CI workflow (tests + fmt + clippy + perf gate) is the
+  acceptance bar
+- Work is tracked through the
+  [`.board/`](https://github.com/EricSpencer00/Resilient/tree/main/.board)
+  ticket system with `RES-NNN` identifiers
+
+---
+
+## AI agents welcome
+
+Resilient is designed with automated contributors in mind. The
+ticket system is machine-readable plain text, the test suite
+gives a deterministic pass/fail signal, and the contribution
+workflow requires no human-only interaction beyond opening a PR.
+
+Agents of any kind — code generation assistants, autonomous
+coding agents, or CI bots — are welcome to:
+
+- Pick up a `good first issue` or `.board/` ticket
+- Submit a PR that passes `cargo test && cargo fmt --check && cargo clippy`
+- Report bugs by opening a GitHub issue with a reproducible example
+
+The same quality bar applies to everyone: green tests, clean
+diffs, and a clear explanation of what changed and why.
+
+---
+
+## Roadmap and vision
+
+Resilient is being built incrementally through the ticket system.
+The current focus is on:
+
+- Expanding JIT coverage (while loops, closures, structs)
+- Growing the error code registry
+- Strengthening the Z3 contract prover
+- Improving the LSP experience
+
+Follow along in
+[`.board/`](https://github.com/EricSpencer00/Resilient/tree/main/.board)
+or watch the repository on GitHub to stay current.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,129 @@
+---
+title: Contributing
+nav_order: 13
+permalink: /contributing
+---
+
+# Contributing to Resilient
+{: .no_toc }
+
+Whether you are a human engineer or an AI agent — welcome. Every
+ticket landed, every test added, and every bug report filed makes
+Resilient more reliable for everyone building safety-critical
+systems.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Full contributing guide
+
+The canonical reference for contribution workflow, commit
+conventions, code style, and the ticket system lives at
+[`CONTRIBUTING.md`](https://github.com/EricSpencer00/Resilient/blob/main/CONTRIBUTING.md)
+in the repository root. What follows is the quick-start version.
+
+---
+
+## Quick start
+
+### 1. Fork and clone
+
+```bash
+# Fork on GitHub first, then:
+git clone https://github.com/<your-username>/Resilient.git
+cd Resilient
+```
+
+### 2. Verify everything passes
+
+```bash
+cd resilient
+cargo test
+```
+
+All tests should be green before you write a single line. If
+something is already broken, open an issue rather than working
+around it.
+
+### 3. Make your change
+
+Create a branch, make focused commits, keep the test suite green.
+
+```bash
+git checkout -b my-fix
+# ... edit files ...
+cargo test
+cargo fmt --check
+cargo clippy -- -D warnings
+```
+
+### 4. Open a pull request
+
+Push your branch and open a PR against `main`. Fill in the PR
+template — a short description of *what* changed and *why* is
+all that's needed. The CI workflow runs the full test matrix and
+the perf gate automatically.
+
+---
+
+## The ticket system
+
+Resilient tracks work in [`.board/`](https://github.com/EricSpencer00/Resilient/tree/main/.board)
+— a plain-text ticket ledger checked into the repository. Each
+ticket is a small Markdown file with a unique `RES-NNN` ID.
+
+- **Claiming a ticket**: comment on the GitHub issue or PR that
+  references the ticket, or add a `claimed_by` line to the file.
+- **Landing a ticket**: your PR title or commit message should
+  reference the ticket ID (e.g. `RES-042: add float division`).
+- **Opening a ticket**: file a GitHub issue with a clear problem
+  statement; a maintainer will assign it a `RES-NNN` ID.
+
+---
+
+## AI agents welcome
+
+Resilient is intentionally designed with automated contributors
+in mind. The ticket system is machine-readable, the test suite
+is the authoritative acceptance signal, and CI is the gatekeeper.
+Agents should follow the same workflow as humans: claim a ticket,
+make a targeted change, pass `cargo test`, open a PR.
+
+If you are an AI agent running in a sandboxed environment, the
+minimum required commands are:
+
+```bash
+cargo test            # acceptance gate
+cargo fmt             # style gate
+cargo clippy          # lint gate
+```
+
+---
+
+## Good first issues
+
+Look for issues tagged
+[`good first issue`](https://github.com/EricSpencer00/Resilient/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+on GitHub. These are scoped tasks with clear acceptance criteria
+and no deep context dependencies.
+
+---
+
+## Where to get help
+
+- **GitHub Discussions** — questions, design ideas, and
+  feedback: [Discussions](https://github.com/EricSpencer00/Resilient/discussions)
+- **GitHub Issues** — bug reports and concrete feature requests:
+  [Issues](https://github.com/EricSpencer00/Resilient/issues)
+- **PR comments** — for questions scoped to a specific change
+
+Thank you for contributing. Every improvement — no matter how
+small — moves Resilient closer to the goal: code that can be
+trusted in the places where failure isn't an option.

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,6 +112,20 @@ clauses become runtime asserts.
 | Language Server (LSP) | ✅ opt-in | `--features lsp --lsp` |
 | `#![no_std]` runtime | ✅ stable | sibling `resilient-runtime/` crate |
 
+## Open source
+
+Resilient is free and open source software released under the
+**MIT License**. Contributions from humans and AI agents are
+equally welcome — the ticket system in
+[`.board/`](https://github.com/EricSpencer00/Resilient/tree/main/.board)
+is designed to be machine-readable, and `cargo test` is the
+authoritative acceptance gate.
+
+[Contributing guide](contributing){: .btn .btn-outline .mr-2 }
+[Community & Open Source](community){: .btn .btn-outline }
+
+---
+
 ## Where next?
 
 - **New here?** → [Getting Started](getting-started)
@@ -124,4 +138,5 @@ clauses become runtime asserts.
 - **DO-178C / ISO 26262 / IEC 61508 / MISRA?** → [Certification and Safety Standards](certification)
 - **Setting up your editor?** → [LSP / Editor Integration](lsp)
 - **Looking for a tool (fmt, lint, verify-cert, REPL, fuzz, ...)?** → [Tooling Reference](tooling)
-- **Contributing?** → [`.board/`](https://github.com/EricSpencer00/Resilient/tree/main/.board) on GitHub
+- **Contributing?** → [Contributing guide](contributing) and [`.board/`](https://github.com/EricSpencer00/Resilient/tree/main/.board) on GitHub
+- **License, community, open source?** → [Community & Open Source](community)

--- a/docs/superpowers/plans/2026-04-19-ffi-phase-1-tree-walker.md
+++ b/docs/superpowers/plans/2026-04-19-ffi-phase-1-tree-walker.md
@@ -1,0 +1,1876 @@
+# FFI Phase 1 (Tree-walker MVP) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a working FFI for the tree-walker interpreter on `std` hosts (Linux/macOS) plus the static-registry path on `no_std`, without touching the bytecode VM or JIT yet.
+
+**Architecture:** A new `Node::Extern` AST node parses `extern "lib" { fn ... }` blocks. A new `resilient/src/ffi.rs` module owns library resolution via `libloading` (on `std`) and a shared `ForeignSignature` type. A generated trampoline table turns Resilient `Value` arguments into C-ABI calls through `extern "C" fn` function pointers. A new `Value::Foreign` variant makes a resolved foreign symbol callable just like a normal fn. `resilient-runtime` gains a zero-alloc `StaticRegistry` behind an `ffi-static` feature for embedded use.
+
+**Tech Stack:** Rust 1.80+, `libloading = "0.8"` (std only), Resilient's existing hand-rolled parser + tree-walker, `cargo test` as the test harness.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-ffi-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+- `resilient/src/ffi.rs` — loader module. Owns `FfiType`, `ForeignSignature`, `ForeignLoader`, `FfiError`, and the public entry points the driver calls at program load.
+- `resilient/src/ffi_trampolines.rs` — generated table of `extern "C" fn` shims for every (arity 0–8, return type ∈ {Int, Float, Bool, Str, Void}) combination. Hand-rolled via macros for v1; can be moved to `build.rs` codegen later.
+- `resilient-runtime/src/ffi_static.rs` — no_std static registry (`StaticRegistry`, `register_foreign`, `lookup`).
+- `resilient/examples/ffi_libm.res` + `ffi_libm.expected.txt` — end-to-end example calling `libm::sqrt`.
+- `resilient/tests/ffi/lib_testhelper.c` — tiny C file compiled by a `build.rs` into `libresilient_ffi_testhelper.{so,dylib,dll}` for integration tests.
+- `resilient/build.rs` — compiles the test helper C file when `cfg(test)`.
+
+### Modified files
+
+- `resilient/src/main.rs` — new `Node::Extern` variant; parser branch off `parse_statement`; typechecker rejections; `Value::Foreign` variant; tree-walker dispatch; driver wiring to resolve externs after `expand_uses`.
+- `resilient/src/verifier_z3.rs` — `@trusted` extern `ensures` piped in as SMT assumptions at call sites.
+- `resilient/Cargo.toml` — `libloading` dep gated on `ffi` feature (default on).
+- `resilient-runtime/src/lib.rs` — `pub mod ffi_static;` behind `ffi-static` feature.
+- `resilient-runtime/Cargo.toml` — `ffi-static` feature + size-variant features (`ffi-static-64`, `ffi-static-256`, `ffi-static-1024`).
+- `SYNTAX.md` — FFI section.
+- `docs/` (Jekyll) — FFI page.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0: Create working branch**
+
+```bash
+cd /Users/eric/GitHub/Resilient
+git checkout -b ffi-phase-1-tree-walker
+```
+
+- [ ] **Step 0.1: Confirm baseline is green**
+
+Run: `cd resilient && cargo test && cd ../resilient-runtime && cargo test && cd ..`
+Expected: all tests pass on both crates.
+
+---
+
+## Task 1: AST node for `extern` blocks
+
+**Files:**
+- Modify: `resilient/src/main.rs` — add `Node::Extern` variant + `ExternDecl` struct near `Node::Use`
+
+- [ ] **Step 1: Add failing parser test**
+
+Add to the `#[cfg(test)] mod parser_tests` block (find existing parser tests around `use "path"` coverage — search for `expand_is_a_noop`). New test:
+
+```rust
+#[test]
+fn parses_empty_extern_block() {
+    let (program, errs) = crate::parse(r#"extern "libm.so.6" { }"#);
+    assert!(errs.is_empty(), "parse errors: {:?}", errs);
+    let stmts = match &program {
+        crate::Node::Program(s) => s,
+        _ => unreachable!(),
+    };
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0].node {
+        crate::Node::Extern { library, decls, .. } => {
+            assert_eq!(library, "libm.so.6");
+            assert!(decls.is_empty());
+        }
+        other => panic!("expected Node::Extern, got {:?}", other),
+    }
+}
+```
+
+- [ ] **Step 2: Run test, expect compilation failure**
+
+Run: `cd resilient && cargo test parses_empty_extern_block 2>&1 | head -20`
+Expected: compile error — `Node::Extern` not defined.
+
+- [ ] **Step 3: Define the AST node and struct**
+
+In `resilient/src/main.rs`, add next to `Node::Use` (around line 944):
+
+```rust
+    /// FFI v1: `extern "libname" { fn ... }` block. Each inner
+    /// declaration is an `ExternDecl`. Resolved by the driver
+    /// (after `expand_uses`) into `Value::Foreign` bindings in
+    /// the global environment.
+    Extern {
+        library: String,
+        decls: Vec<ExternDecl>,
+        span: span::Span,
+    },
+```
+
+Add below the `Node` enum (before the next `impl` block):
+
+```rust
+/// FFI v1: one foreign fn declaration inside an `extern` block.
+#[derive(Debug, Clone)]
+pub struct ExternDecl {
+    /// The name used in Resilient source (e.g. `sine`).
+    pub resilient_name: String,
+    /// The C symbol to look up. Defaults to `resilient_name`; overridden
+    /// by `fn NAME(...) = "C_NAME";`.
+    pub c_name: String,
+    /// (type, name) pairs — matches `Node::Function::parameters`.
+    pub parameters: Vec<(String, String)>,
+    /// Resilient type name; `"Void"` for unit return.
+    pub return_type: String,
+    pub requires: Vec<Node>,
+    pub ensures: Vec<Node>,
+    /// `@trusted` — `ensures` is assumed, not checked.
+    pub trusted: bool,
+    pub span: span::Span,
+}
+```
+
+Update all `match` arms on `Node` that get exhaustiveness errors — for v1 most will be `Node::Extern { .. } => Ok(Value::Void)` (the interpreter) or a no-op for `typecheck`/`verifier`/`compiler`. Keep those stubbed for now; real logic lands in Tasks 4–8.
+
+- [ ] **Step 4: Add lexer `Extern` keyword**
+
+Search for `"use" => Token::Use` (around line 600). Add before it:
+
+```rust
+                        "extern" => Token::Extern,
+```
+
+Add `Extern` to the `Token` enum (search for `Use,` around line 105) and its display (search for `Token::Use =>` around line 218):
+
+```rust
+    Extern,
+```
+```rust
+            Token::Extern => "`extern`".to_string(),
+```
+
+- [ ] **Step 5: Run test again to verify parser branch is missing**
+
+Run: `cd resilient && cargo test parses_empty_extern_block 2>&1 | tail -20`
+Expected: test compiles but **fails at parse** — the parser doesn't dispatch on `Token::Extern` yet. The error will be a parser error complaining about `extern` as an unexpected token.
+
+- [ ] **Step 6: Commit the AST skeleton**
+
+```bash
+cd /Users/eric/GitHub/Resilient
+git add resilient/src/main.rs
+git commit -m "FFI: add Node::Extern AST variant and ExternDecl struct (no parser yet)"
+```
+
+---
+
+## Task 2: Parser — empty `extern` block
+
+**Files:**
+- Modify: `resilient/src/main.rs` — new `parse_extern_block` method; dispatch from `parse_statement`
+
+- [ ] **Step 1: Wire up dispatch in parse_statement**
+
+Find `Token::Use => self.parse_use_statement()` (line ~1451). Add above it:
+
+```rust
+            Token::Extern => self.parse_extern_block(),
+```
+
+- [ ] **Step 2: Implement `parse_extern_block` for the empty case**
+
+Place it next to `parse_use_statement` (around line 2629). Start minimal:
+
+```rust
+    /// FFI v1: `extern "lib" { decl; decl; ... }`.
+    /// Each decl is parsed by `parse_extern_decl`.
+    fn parse_extern_block(&mut self) -> Option<Node> {
+        let extern_span = self.current_span();
+        self.advance(); // consume `extern`
+
+        // Library descriptor.
+        let library = match &self.current_token {
+            Token::StringLiteral(s) => {
+                let s = s.clone();
+                self.advance();
+                s
+            }
+            other => {
+                self.error(format!(
+                    "expected string literal after `extern`, got {}",
+                    self.token_display(other)
+                ));
+                return None;
+            }
+        };
+
+        // `{`
+        if !matches!(self.current_token, Token::LBrace) {
+            self.error(format!(
+                "expected `{{` after `extern \"{}\"`, got {}",
+                library,
+                self.token_display(&self.current_token)
+            ));
+            return None;
+        }
+        self.advance();
+
+        let mut decls: Vec<ExternDecl> = Vec::new();
+        while !matches!(self.current_token, Token::RBrace | Token::Eof) {
+            if let Some(d) = self.parse_extern_decl() {
+                decls.push(d);
+            } else {
+                // Recovery: skip to next `;` or `}`.
+                while !matches!(
+                    self.current_token,
+                    Token::Semicolon | Token::RBrace | Token::Eof
+                ) {
+                    self.advance();
+                }
+                if matches!(self.current_token, Token::Semicolon) {
+                    self.advance();
+                }
+            }
+        }
+
+        if matches!(self.current_token, Token::RBrace) {
+            self.advance();
+        }
+
+        Some(Node::Extern {
+            library,
+            decls,
+            span: extern_span,
+        })
+    }
+
+    /// Stub — real implementation lands in Task 3.
+    fn parse_extern_decl(&mut self) -> Option<ExternDecl> {
+        self.error("FFI: extern fn declarations not yet implemented".to_string());
+        None
+    }
+```
+
+Helpers `self.current_span()` and `self.token_display(...)` already exist in this file — if the names differ, search the parser for similar error-reporting sites and match the local convention.
+
+- [ ] **Step 3: Run test, expect pass**
+
+Run: `cd resilient && cargo test parses_empty_extern_block -- --exact`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resilient/src/main.rs
+git commit -m "FFI: parse empty extern block (library descriptor only)"
+```
+
+---
+
+## Task 3: Parser — `extern fn` declarations with arity, alias, contracts
+
+**Files:**
+- Modify: `resilient/src/main.rs` — `parse_extern_decl`
+
+- [ ] **Step 1: Add failing tests for the full decl syntax**
+
+```rust
+#[test]
+fn parses_extern_fn_with_primitive_types() {
+    let src = r#"extern "libm.so.6" { fn sqrt(x: Float) -> Float; }"#;
+    let (program, errs) = crate::parse(src);
+    assert!(errs.is_empty(), "{:?}", errs);
+    let decls = match &program {
+        crate::Node::Program(s) => match &s[0].node {
+            crate::Node::Extern { decls, .. } => decls.clone(),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    };
+    assert_eq!(decls.len(), 1);
+    assert_eq!(decls[0].resilient_name, "sqrt");
+    assert_eq!(decls[0].c_name, "sqrt");
+    assert_eq!(decls[0].parameters, vec![("Float".into(), "x".into())]);
+    assert_eq!(decls[0].return_type, "Float");
+}
+
+#[test]
+fn parses_extern_fn_with_c_name_alias() {
+    let src = r#"extern "libm.so.6" { fn sine(x: Float) -> Float = "sin"; }"#;
+    let (program, _) = crate::parse(src);
+    let decls = match &program {
+        crate::Node::Program(s) => match &s[0].node {
+            crate::Node::Extern { decls, .. } => decls.clone(),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    };
+    assert_eq!(decls[0].resilient_name, "sine");
+    assert_eq!(decls[0].c_name, "sin");
+}
+
+#[test]
+fn parses_extern_fn_with_contracts() {
+    let src = r#"
+        extern "libm.so.6" {
+            fn sqrt(x: Float) -> Float
+                requires(x >= 0.0)
+                ensures(result >= 0.0);
+        }
+    "#;
+    let (program, errs) = crate::parse(src);
+    assert!(errs.is_empty(), "{:?}", errs);
+    let decls = match &program {
+        crate::Node::Program(s) => match &s[0].node {
+            crate::Node::Extern { decls, .. } => decls.clone(),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    };
+    assert_eq!(decls[0].requires.len(), 1);
+    assert_eq!(decls[0].ensures.len(), 1);
+    assert!(!decls[0].trusted);
+}
+
+#[test]
+fn parses_trusted_extern_fn() {
+    let src = r#"extern "libfoo" { @trusted fn f() -> Int; }"#;
+    let (program, errs) = crate::parse(src);
+    assert!(errs.is_empty(), "{:?}", errs);
+    let decls = match &program {
+        crate::Node::Program(s) => match &s[0].node {
+            crate::Node::Extern { decls, .. } => decls.clone(),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    };
+    assert!(decls[0].trusted);
+}
+```
+
+- [ ] **Step 2: Run all four, expect failures**
+
+Run: `cd resilient && cargo test parses_extern_fn parses_trusted_extern 2>&1 | tail`
+Expected: all FAIL (the stub returns `None` and emits a parse error).
+
+- [ ] **Step 3: Implement parse_extern_decl**
+
+Replace the stub:
+
+```rust
+    fn parse_extern_decl(&mut self) -> Option<ExternDecl> {
+        // Optional `@trusted` prefix. Parser already treats `@` as
+        // attribute-start elsewhere; we handle the trusted case inline
+        // here instead of going through parse_attributed_item so the
+        // attribute scope is clearly limited to extern fn.
+        let mut trusted = false;
+        if matches!(self.current_token, Token::At) {
+            self.advance();
+            match &self.current_token {
+                Token::Identifier(id) if id == "trusted" => {
+                    trusted = true;
+                    self.advance();
+                }
+                other => {
+                    self.error(format!(
+                        "unknown attribute in extern block: @{}",
+                        self.token_display(other)
+                    ));
+                    return None;
+                }
+            }
+        }
+
+        // `fn`
+        let decl_span = self.current_span();
+        if !matches!(self.current_token, Token::Function) {
+            self.error(format!(
+                "expected `fn` inside extern block, got {}",
+                self.token_display(&self.current_token)
+            ));
+            return None;
+        }
+        self.advance();
+
+        // Name.
+        let resilient_name = match &self.current_token {
+            Token::Identifier(n) => {
+                let n = n.clone();
+                self.advance();
+                n
+            }
+            other => {
+                self.error(format!("expected fn name, got {}", self.token_display(other)));
+                return None;
+            }
+        };
+
+        // Parameters — reuse existing parse_function_parameters.
+        let parameters = self.parse_function_parameters();
+
+        // Return type `-> T`. Required for extern fns in v1.
+        if !matches!(self.current_token, Token::Arrow) {
+            self.error("extern fn requires an explicit `-> TYPE` return annotation".into());
+            return None;
+        }
+        self.advance();
+        let return_type = match &self.current_token {
+            Token::Identifier(t) => {
+                let t = t.clone();
+                self.advance();
+                t
+            }
+            other => {
+                self.error(format!(
+                    "expected return type, got {}",
+                    self.token_display(other)
+                ));
+                return None;
+            }
+        };
+
+        // Optional `= "c_name"` alias.
+        let c_name = if matches!(self.current_token, Token::Eq) {
+            self.advance();
+            match &self.current_token {
+                Token::StringLiteral(s) => {
+                    let s = s.clone();
+                    self.advance();
+                    s
+                }
+                other => {
+                    self.error(format!(
+                        "expected string literal after `=` (C symbol name), got {}",
+                        self.token_display(other)
+                    ));
+                    return None;
+                }
+            }
+        } else {
+            resilient_name.clone()
+        };
+
+        // Optional `requires(...)` and `ensures(...)`. Reuse the existing
+        // parse_function_contracts so the grammar stays identical.
+        let (requires, ensures) = self.parse_function_contracts();
+
+        // Terminator `;`.
+        if !matches!(self.current_token, Token::Semicolon) {
+            self.error(format!(
+                "expected `;` at end of extern fn declaration, got {}",
+                self.token_display(&self.current_token)
+            ));
+            return None;
+        }
+        self.advance();
+
+        Some(ExternDecl {
+            resilient_name,
+            c_name,
+            parameters,
+            return_type,
+            requires,
+            ensures,
+            trusted,
+            span: decl_span,
+        })
+    }
+```
+
+- [ ] **Step 4: Run all four new tests — expect pass**
+
+Run: `cd resilient && cargo test parses_extern parses_trusted -- --nocapture`
+Expected: all PASS.
+
+- [ ] **Step 5: Run full crate test suite to catch regressions**
+
+Run: `cd resilient && cargo test`
+Expected: all existing tests still pass; new ones pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resilient/src/main.rs
+git commit -m "FFI: parse extern fn decls with aliases, contracts, and @trusted"
+```
+
+---
+
+## Task 4: Typechecker — accept extern blocks, reject non-primitive FFI types, reject `@pure` on extern
+
+**Files:**
+- Modify: `resilient/src/typechecker.rs` — walk `Node::Extern` and validate each decl
+
+- [ ] **Step 1: Add failing typechecker tests**
+
+Find the existing typechecker integration tests (search for `fn typecheck` in `typechecker.rs`; if tests live in `main.rs` under `mod typechecker_tests`, add them there).
+
+```rust
+#[test]
+fn typecheck_rejects_array_param_in_extern() {
+    let src = r#"extern "libfoo" { fn f(xs: Array) -> Int; }"#;
+    let errs = typecheck_source(src);
+    assert!(
+        errs.iter().any(|e| e.contains("Array") && e.contains("extern")),
+        "expected type-error about Array in extern, got {:?}",
+        errs
+    );
+}
+
+#[test]
+fn typecheck_accepts_primitive_extern() {
+    let src = r#"extern "libm" { fn sqrt(x: Float) -> Float; }"#;
+    let errs = typecheck_source(src);
+    assert!(errs.is_empty(), "unexpected errors: {:?}", errs);
+}
+
+#[test]
+fn typecheck_accepts_void_return_in_extern() {
+    let src = r#"extern "libfoo" { fn noop() -> Void; }"#;
+    let errs = typecheck_source(src);
+    assert!(errs.is_empty(), "unexpected errors: {:?}", errs);
+}
+```
+
+(If no `typecheck_source` helper exists, wrap the parse + typecheck call inline.)
+
+- [ ] **Step 2: Run — expect failures**
+
+Run: `cd resilient && cargo test typecheck_rejects_array_param_in_extern typecheck_accepts_primitive_extern typecheck_accepts_void_return_in_extern`
+Expected: all FAIL (typechecker ignores `Node::Extern` entirely today).
+
+- [ ] **Step 3: Handle Node::Extern in the typechecker**
+
+In `typechecker.rs`, find the main `check_node` / `check_stmt` match (whichever dispatches on `Node` variants). Add:
+
+```rust
+            Node::Extern { decls, .. } => {
+                for d in decls {
+                    // Primitives only in v1.
+                    const PRIMS: &[&str] = &["Int", "Float", "Bool", "String"];
+                    for (ty, name) in &d.parameters {
+                        if !PRIMS.contains(&ty.as_str()) {
+                            self.errors.push(format!(
+                                "FFI: parameter `{}` has type `{}`; \
+                                 extern fn supports only {} in v1",
+                                name, ty, PRIMS.join(", ")
+                            ));
+                        }
+                    }
+                    const RET_PRIMS: &[&str] = &["Int", "Float", "Bool", "String", "Void"];
+                    if !RET_PRIMS.contains(&d.return_type.as_str()) {
+                        self.errors.push(format!(
+                            "FFI: return type `{}` not supported in v1 (allowed: {})",
+                            d.return_type,
+                            RET_PRIMS.join(", ")
+                        ));
+                    }
+                }
+                Ok(())
+            }
+```
+
+Wire the exhaustiveness match on `Node::Extern` anywhere else the compiler walks the AST (the ImplBlock / Use pattern is a good template — search for `Node::Use { .. } =>` and mirror).
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cd resilient && cargo test typecheck_rejects_array typecheck_accepts_primitive typecheck_accepts_void`
+Expected: PASS.
+
+- [ ] **Step 5: Add purity-rejection test**
+
+```rust
+#[test]
+fn typecheck_rejects_pure_on_extern() {
+    // `@pure` applied to an extern decl must be a type error.
+    let src = r#"extern "libfoo" { @pure fn f() -> Int; }"#;
+    let (_, parse_errs) = crate::parse(src);
+    // @pure isn't a known extern attribute — the PARSER will reject.
+    assert!(
+        parse_errs.iter().any(|e| e.contains("attribute")),
+        "expected parse error about @pure attribute, got {:?}",
+        parse_errs
+    );
+}
+```
+
+Run: `cd resilient && cargo test typecheck_rejects_pure_on_extern`
+Expected: PASS (the `@trusted`-only branch in Task 3 already rejects unknown attributes).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resilient/src/typechecker.rs resilient/src/main.rs
+git commit -m "FFI: typechecker rejects non-primitive types and @pure on extern decls"
+```
+
+---
+
+## Task 5: Loader module skeleton (`resilient/src/ffi.rs`)
+
+**Files:**
+- Create: `resilient/src/ffi.rs`
+- Modify: `resilient/src/main.rs` — `mod ffi;`
+- Modify: `resilient/Cargo.toml` — `ffi` feature with `libloading` dep
+
+- [ ] **Step 1: Add the ffi feature + dep**
+
+In `resilient/Cargo.toml` under `[features]` (add the section if missing):
+
+```toml
+[features]
+default = ["ffi"]
+ffi = ["dep:libloading"]
+
+[dependencies]
+libloading = { version = "0.8", optional = true }
+```
+
+- [ ] **Step 2: Create the module skeleton**
+
+Create `resilient/src/ffi.rs`:
+
+```rust
+//! FFI v1 loader. Resolves extern symbols declared by `Node::Extern`
+//! blocks ahead of evaluation so the tree-walker can dispatch in O(1).
+//!
+//! Two backends share one API:
+//! - `std` / `cfg(feature = "ffi")`: dynamic loading via `libloading`.
+//! - `no_std` / `resilient-runtime` with `ffi-static`: a static
+//!   registry populated by the embedder. Lives in `resilient-runtime`
+//!   and is not referenced here — this module is host-only.
+
+use crate::ExternDecl;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FfiType {
+    Int,
+    Float,
+    Bool,
+    Str,
+    Void,
+}
+
+impl FfiType {
+    pub fn from_resilient(name: &str) -> Option<Self> {
+        match name {
+            "Int" => Some(FfiType::Int),
+            "Float" => Some(FfiType::Float),
+            "Bool" => Some(FfiType::Bool),
+            "String" => Some(FfiType::Str),
+            "Void" => Some(FfiType::Void),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ForeignSignature {
+    pub params: Vec<FfiType>,
+    pub ret: FfiType,
+}
+
+impl ForeignSignature {
+    pub fn from_decl(decl: &ExternDecl) -> Result<Self, FfiError> {
+        let mut params = Vec::with_capacity(decl.parameters.len());
+        for (ty, _) in &decl.parameters {
+            params.push(
+                FfiType::from_resilient(ty)
+                    .ok_or_else(|| FfiError::UnsupportedType(ty.clone()))?,
+            );
+        }
+        let ret = FfiType::from_resilient(&decl.return_type)
+            .ok_or_else(|| FfiError::UnsupportedType(decl.return_type.clone()))?;
+        if params.len() > 8 {
+            return Err(FfiError::ArityTooLarge {
+                name: decl.resilient_name.clone(),
+                got: params.len(),
+            });
+        }
+        Ok(Self { params, ret })
+    }
+}
+
+#[derive(Debug)]
+pub enum FfiError {
+    LibNotFound { library: String, underlying: String },
+    SymbolNotFound { library: String, symbol: String },
+    UnsupportedType(String),
+    ArityTooLarge { name: String, got: usize },
+    /// `--no-default-features` build asked to load a dynamic library.
+    FfiDisabled,
+    /// `@static` descriptor used on an `std` host without a registered
+    /// backend. (v1 treats this as an error; a future ticket may let
+    /// the std build register static fns too.)
+    StaticOnlyUnavailable { library: String },
+}
+
+impl std::fmt::Display for FfiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FfiError::LibNotFound { library, underlying } => {
+                write!(f, "FFI: cannot open library `{}`: {}", library, underlying)
+            }
+            FfiError::SymbolNotFound { library, symbol } => {
+                write!(f, "FFI: symbol `{}` not found in `{}`", symbol, library)
+            }
+            FfiError::UnsupportedType(ty) => {
+                write!(f, "FFI: type `{}` is not supported in v1", ty)
+            }
+            FfiError::ArityTooLarge { name, got } => {
+                write!(f, "FFI: extern fn `{}` has {} params; v1 supports up to 8", name, got)
+            }
+            FfiError::FfiDisabled => {
+                write!(f, "FFI: this build was compiled without --features ffi")
+            }
+            FfiError::StaticOnlyUnavailable { library } => {
+                write!(f, "FFI: library descriptor `{}` requires a static registry, not available in this build", library)
+            }
+        }
+    }
+}
+
+impl std::error::Error for FfiError {}
+
+/// A resolved extern symbol. The raw `*const ()` is cast to a concrete
+/// `extern "C" fn(...)` type at call time via `ffi_trampolines`.
+pub struct ForeignSymbol {
+    pub name: String,
+    pub ptr: *const (),
+    pub sig: ForeignSignature,
+}
+
+// SAFETY: ForeignSymbol holds a raw C function pointer that outlives
+// the Library it came from (we also hold the Library in the loader
+// so it never drops while symbols are in use). The pointer itself
+// is Send + Sync on every supported platform.
+unsafe impl Send for ForeignSymbol {}
+unsafe impl Sync for ForeignSymbol {}
+
+#[cfg(feature = "ffi")]
+pub use dynamic::ForeignLoader;
+
+#[cfg(not(feature = "ffi"))]
+pub use disabled::ForeignLoader;
+
+#[cfg(feature = "ffi")]
+mod dynamic {
+    use super::*;
+    use std::collections::HashMap;
+
+    pub struct ForeignLoader {
+        libs: HashMap<String, libloading::Library>,
+        syms: HashMap<String, std::sync::Arc<ForeignSymbol>>,
+    }
+
+    impl ForeignLoader {
+        pub fn new() -> Self {
+            Self { libs: HashMap::new(), syms: HashMap::new() }
+        }
+
+        pub fn resolve_block(
+            &mut self,
+            library: &str,
+            decls: &[ExternDecl],
+        ) -> Result<(), FfiError> {
+            if library == "@static" {
+                return Err(FfiError::StaticOnlyUnavailable {
+                    library: library.to_string(),
+                });
+            }
+            // dlopen (or cached).
+            if !self.libs.contains_key(library) {
+                let lib = unsafe { libloading::Library::new(library) }.map_err(|e| {
+                    FfiError::LibNotFound {
+                        library: library.to_string(),
+                        underlying: e.to_string(),
+                    }
+                })?;
+                self.libs.insert(library.to_string(), lib);
+            }
+            let lib = self.libs.get(library).unwrap();
+            for d in decls {
+                let sig = ForeignSignature::from_decl(d)?;
+                let raw: libloading::Symbol<*const ()> =
+                    unsafe { lib.get(d.c_name.as_bytes()) }.map_err(|_| {
+                        FfiError::SymbolNotFound {
+                            library: library.to_string(),
+                            symbol: d.c_name.clone(),
+                        }
+                    })?;
+                let sym = ForeignSymbol {
+                    name: d.resilient_name.clone(),
+                    ptr: *raw,
+                    sig,
+                };
+                self.syms
+                    .insert(d.resilient_name.clone(), std::sync::Arc::new(sym));
+            }
+            Ok(())
+        }
+
+        pub fn lookup(&self, name: &str) -> Option<std::sync::Arc<ForeignSymbol>> {
+            self.syms.get(name).cloned()
+        }
+    }
+
+    impl Default for ForeignLoader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+}
+
+#[cfg(not(feature = "ffi"))]
+mod disabled {
+    use super::*;
+
+    pub struct ForeignLoader;
+    impl ForeignLoader {
+        pub fn new() -> Self { Self }
+        pub fn resolve_block(
+            &mut self,
+            _library: &str,
+            _decls: &[ExternDecl],
+        ) -> Result<(), FfiError> {
+            Err(FfiError::FfiDisabled)
+        }
+        pub fn lookup(&self, _name: &str) -> Option<std::sync::Arc<ForeignSymbol>> {
+            None
+        }
+    }
+    impl Default for ForeignLoader {
+        fn default() -> Self { Self::new() }
+    }
+}
+```
+
+- [ ] **Step 3: Register the module**
+
+In `resilient/src/main.rs`, near the existing `mod imports;`:
+
+```rust
+mod ffi;
+```
+
+- [ ] **Step 4: Add a loader unit test**
+
+Append to `resilient/src/ffi.rs`:
+
+```rust
+#[cfg(test)]
+#[cfg(feature = "ffi")]
+mod tests {
+    use super::*;
+    use crate::{span::Span, ExternDecl};
+
+    fn decl(name: &str, c: &str, params: Vec<(&str, &str)>, ret: &str) -> ExternDecl {
+        ExternDecl {
+            resilient_name: name.to_string(),
+            c_name: c.to_string(),
+            parameters: params
+                .into_iter()
+                .map(|(t, n)| (t.to_string(), n.to_string()))
+                .collect(),
+            return_type: ret.to_string(),
+            requires: Vec::new(),
+            ensures: Vec::new(),
+            trusted: false,
+            span: Span::default(),
+        }
+    }
+
+    #[test]
+    fn missing_library_is_a_clean_error_not_a_panic() {
+        let mut loader = ForeignLoader::new();
+        let err = loader
+            .resolve_block("libnope_not_a_real_library.so", &[])
+            .expect_err("should fail");
+        matches!(err, FfiError::LibNotFound { .. });
+    }
+
+    #[test]
+    fn signature_rejects_unsupported_types() {
+        let d = decl("f", "f", vec![("Array", "xs")], "Int");
+        let err = ForeignSignature::from_decl(&d).expect_err("must reject Array");
+        matches!(err, FfiError::UnsupportedType(ref s) if s == "Array");
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd resilient && cargo test --features ffi`
+Expected: all green, including the new `ffi::tests`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resilient/src/ffi.rs resilient/src/main.rs resilient/Cargo.toml
+git commit -m "FFI: loader module with libloading (std only, behind `ffi` feature)"
+```
+
+---
+
+## Task 6: Trampoline table (the C-ABI call layer)
+
+**Files:**
+- Create: `resilient/src/ffi_trampolines.rs`
+- Modify: `resilient/src/main.rs` — `mod ffi_trampolines;` (feature-gated)
+
+- [ ] **Step 1: Create the module with macro-generated trampolines**
+
+```rust
+//! FFI v1: trampolines dispatch a resolved `ForeignSymbol` to a real
+//! C function pointer of the right type. One trampoline per (arity,
+//! return type) combination — 9 arities (0..=8) × 5 return types
+//! (Int, Float, Bool, Str, Void) = 45 shims.
+//!
+//! Input `Value`s are converted to C ABI scalars here. Output C
+//! scalars are converted back to `Value`. String marshalling uses
+//! `(*const u8, usize)` — the trampoline holds the Resilient String's
+//! UTF-8 bytes live for the duration of the call via a local borrow.
+#![cfg(feature = "ffi")]
+
+use crate::ffi::{FfiType, ForeignSignature, ForeignSymbol};
+use crate::{RResult, Value};
+
+/// C-ABI representation of each Resilient primitive.
+#[derive(Copy, Clone)]
+#[repr(C)]
+union CArg {
+    i: i64,
+    f: f64,
+    b: bool,
+    s: CStr,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+struct CStr {
+    ptr: *const u8,
+    len: usize,
+}
+
+/// Entry point. Dispatches on arity + return type to one of the
+/// 45 monomorphized trampolines below. Out-of-range arity is a clean
+/// error (the loader already gated on 8; this is belt-and-suspenders).
+pub fn call_foreign(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
+    if args.len() != sym.sig.params.len() {
+        return Err(format!(
+            "FFI: arity mismatch calling `{}`: expected {}, got {}",
+            sym.name, sym.sig.params.len(), args.len()
+        ));
+    }
+
+    // Typecheck args against the signature.
+    for (i, (arg, want)) in args.iter().zip(sym.sig.params.iter()).enumerate() {
+        let actual = ffi_type_of_value(arg);
+        if actual != Some(*want) {
+            return Err(format!(
+                "FFI: type mismatch calling `{}` arg #{}: expected {:?}, got {:?}",
+                sym.name, i, want, arg
+            ));
+        }
+    }
+
+    dispatch(sym, args)
+}
+
+fn ffi_type_of_value(v: &Value) -> Option<FfiType> {
+    match v {
+        Value::Int(_) => Some(FfiType::Int),
+        Value::Float(_) => Some(FfiType::Float),
+        Value::Bool(_) => Some(FfiType::Bool),
+        Value::String(_) => Some(FfiType::Str),
+        _ => None,
+    }
+}
+
+/// Dispatch to the correct trampoline. The inner helpers are
+/// macro-generated below.
+fn dispatch(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
+    macro_rules! arms {
+        ($($arity:literal),*) => {
+            match (args.len(), sym.sig.ret) {
+                $(
+                    ($arity, FfiType::Int)   => paste_ident!(call_, $arity, _int)(sym, args),
+                    ($arity, FfiType::Float) => paste_ident!(call_, $arity, _float)(sym, args),
+                    ($arity, FfiType::Bool)  => paste_ident!(call_, $arity, _bool)(sym, args),
+                    ($arity, FfiType::Str)   => paste_ident!(call_, $arity, _str)(sym, args),
+                    ($arity, FfiType::Void)  => paste_ident!(call_, $arity, _void)(sym, args),
+                )*
+                (n, _) => Err(format!("FFI: arity {} not supported in v1 (max 8)", n)),
+            }
+        };
+    }
+    // Rust's macro_rules can't paste tokens without the `paste` crate.
+    // For v1 we spell out the 45 arms by hand — simpler than adding a
+    // build dep. Keep the generated code self-contained.
+    dispatch_explicit(sym, args)
+}
+
+// --- Explicit dispatch table ---
+//
+// Each `call_N_T` converts `args` into CArgs, transmutes the symbol
+// pointer to an `extern "C" fn(T1, ..., TN) -> Tret`, calls it, and
+// converts the return into a `Value`.
+//
+// Generating 45 functions by hand is tedious but low-risk. They are
+// identical shape; only the parameter/return types differ.
+fn dispatch_explicit(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
+    use FfiType::*;
+    let params: &[FfiType] = &sym.sig.params;
+    let ret = sym.sig.ret;
+
+    // Extract scalars up front.
+    let mut ints: [i64; 8] = [0; 8];
+    let mut floats: [f64; 8] = [0.0; 8];
+    let mut bools: [bool; 8] = [false; 8];
+    let mut strs: [CStr; 8] = [CStr { ptr: std::ptr::null(), len: 0 }; 8];
+    // Keep borrowed string bytes alive for the call.
+    let mut live_strs: Vec<&[u8]> = Vec::with_capacity(args.len());
+    for (i, (arg, want)) in args.iter().zip(params.iter()).enumerate() {
+        match (arg, want) {
+            (Value::Int(v), Int)       => ints[i] = *v,
+            (Value::Float(v), Float)   => floats[i] = *v,
+            (Value::Bool(v), Bool)     => bools[i] = *v,
+            (Value::String(s), Str) => {
+                let bytes = s.as_bytes();
+                live_strs.push(bytes);
+                strs[i] = CStr { ptr: bytes.as_ptr(), len: bytes.len() };
+            }
+            _ => return Err(format!(
+                "FFI internal: arg #{} type {:?} / ffi {:?} mismatch", i, arg, want
+            )),
+        }
+    }
+
+    // Per-shape dispatch. Only arity 0..=2 shown; extend to 8 in code.
+    // For parity with v1 scope this table handles the common cases;
+    // arities 3..8 are generated by copy-paste-replace below during
+    // implementation. Keep the conversion style IDENTICAL.
+    unsafe {
+        Ok(match (params, ret) {
+            // Arity 0
+            (&[], Int)   => Value::Int(std::mem::transmute::<_, extern "C" fn() -> i64>(sym.ptr)()),
+            (&[], Float) => Value::Float(std::mem::transmute::<_, extern "C" fn() -> f64>(sym.ptr)()),
+            (&[], Bool)  => Value::Bool(std::mem::transmute::<_, extern "C" fn() -> bool>(sym.ptr)()),
+            (&[], Void)  => { std::mem::transmute::<_, extern "C" fn()>(sym.ptr)(); Value::Void }
+
+            // Arity 1 — one per primitive IN, one per primitive OUT.
+            (&[Int], Int)     => Value::Int(std::mem::transmute::<_, extern "C" fn(i64) -> i64>(sym.ptr)(ints[0])),
+            (&[Int], Float)   => Value::Float(std::mem::transmute::<_, extern "C" fn(i64) -> f64>(sym.ptr)(ints[0])),
+            (&[Int], Bool)    => Value::Bool(std::mem::transmute::<_, extern "C" fn(i64) -> bool>(sym.ptr)(ints[0])),
+            (&[Int], Void)    => { std::mem::transmute::<_, extern "C" fn(i64)>(sym.ptr)(ints[0]); Value::Void }
+            (&[Float], Int)   => Value::Int(std::mem::transmute::<_, extern "C" fn(f64) -> i64>(sym.ptr)(floats[0])),
+            (&[Float], Float) => Value::Float(std::mem::transmute::<_, extern "C" fn(f64) -> f64>(sym.ptr)(floats[0])),
+            (&[Float], Bool)  => Value::Bool(std::mem::transmute::<_, extern "C" fn(f64) -> bool>(sym.ptr)(floats[0])),
+            (&[Float], Void)  => { std::mem::transmute::<_, extern "C" fn(f64)>(sym.ptr)(floats[0]); Value::Void }
+            (&[Bool], Int)    => Value::Int(std::mem::transmute::<_, extern "C" fn(bool) -> i64>(sym.ptr)(bools[0])),
+            (&[Bool], Bool)   => Value::Bool(std::mem::transmute::<_, extern "C" fn(bool) -> bool>(sym.ptr)(bools[0])),
+            (&[Bool], Void)   => { std::mem::transmute::<_, extern "C" fn(bool)>(sym.ptr)(bools[0]); Value::Void }
+
+            // Arity 2 — only the combinations v1 needs for the test
+            // helper + libm examples are enumerated explicitly.
+            // Extending to the full Cartesian product is mechanical:
+            // the `ffi_completeness_check` test (Step 2) will fail
+            // loudly when a caller hits a missing arm, so grow this
+            // table as real examples demand.
+            (&[Float, Float], Float) => Value::Float(
+                std::mem::transmute::<_, extern "C" fn(f64, f64) -> f64>(sym.ptr)(floats[0], floats[1])
+            ),
+            (&[Int, Int], Int) => Value::Int(
+                std::mem::transmute::<_, extern "C" fn(i64, i64) -> i64>(sym.ptr)(ints[0], ints[1])
+            ),
+
+            // Fallback.
+            _ => return Err(format!(
+                "FFI: no trampoline for signature ({:?}) -> {:?} (v1 coverage: extend dispatch_explicit)",
+                params, ret
+            )),
+        })
+    }
+}
+
+// Touch live_strs so rustc sees them borrowed through the call.
+// (Strictly not necessary — the `bytes` borrow is what keeps them
+// alive — but this line makes the intent obvious at review time.)
+#[allow(dead_code)]
+fn _keep_alive(_: &[&[u8]]) {}
+```
+
+**Important:** The table above covers arity 0–2 for the primitives the first tests need. Later tickets extend it mechanically. For Phase 1 this is ENOUGH to call `libm::sqrt`, `pow`, `sin`, `cos`. A regression test in Task 8 asserts the missing-arm path returns a clean error rather than panicking.
+
+- [ ] **Step 2: Wire into main.rs**
+
+In `resilient/src/main.rs`:
+
+```rust
+#[cfg(feature = "ffi")]
+mod ffi_trampolines;
+```
+
+Add `paste_ident!` is not used in the final code — delete the scratch `macro_rules` block before compiling. (It's in the draft above only for illustration; the `dispatch_explicit` path is what runs.)
+
+- [ ] **Step 3: Compile check**
+
+Run: `cd resilient && cargo build --features ffi`
+Expected: clean build. Fix any unused-import warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resilient/src/ffi_trampolines.rs resilient/src/main.rs
+git commit -m "FFI: trampoline table covering arity 0-2 primitives"
+```
+
+---
+
+## Task 7: `Value::Foreign` variant + tree-walker dispatch
+
+**Files:**
+- Modify: `resilient/src/main.rs` — `Value::Foreign` variant; `register_foreign` after `register_builtins`; call dispatch in `apply_function`
+
+- [ ] **Step 1: Add the new Value variant**
+
+In the `enum Value` block (around line 4002):
+
+```rust
+    /// FFI v1: resolved foreign symbol, callable from Resilient source.
+    /// The Arc holds both the resolved ptr and the signature; the
+    /// loader owns the backing `Library`.
+    #[cfg(feature = "ffi")]
+    Foreign {
+        name: &'static str,
+        symbol: std::sync::Arc<crate::ffi::ForeignSymbol>,
+        requires: Vec<Node>,
+        ensures: Vec<Node>,
+        trusted: bool,
+    },
+```
+
+Update `Debug`, `Display`, and any exhaustiveness `match`es on `Value` to include the new variant — mirror the pattern used for `Value::Builtin`.
+
+- [ ] **Step 2: Add failing test for dispatching a foreign call**
+
+In `main.rs`'s integration tests (the module that runs whole programs through `run_source`):
+
+```rust
+#[test]
+#[cfg(all(feature = "ffi", any(target_os = "linux", target_os = "macos")))]
+fn can_call_cos_from_libm() {
+    #[cfg(target_os = "macos")]
+    let lib = r#"extern "libSystem.dylib" { fn cos(x: Float) -> Float; }"#;
+    #[cfg(target_os = "linux")]
+    let lib = r#"extern "libm.so.6" { fn cos(x: Float) -> Float; }"#;
+    let src = format!("{}\nfn main() {{ println(cos(0.0)); }}", lib);
+    let out = run_source_capture(&src).expect("program should run");
+    assert!(out.starts_with("1"), "cos(0.0) should be ~1.0, got {}", out);
+}
+```
+
+(If no `run_source_capture` helper exists, mirror the test pattern already used for println coverage.)
+
+- [ ] **Step 3: Run — expect failure**
+
+Run: `cd resilient && cargo test can_call_cos_from_libm --features ffi`
+Expected: FAIL — program runs but `cos` resolves to "undefined identifier" because Task 8 hasn't wired the loader yet.
+
+- [ ] **Step 4: Skip for now, commit Value variant**
+
+This test is held failing until Task 8. Commit the variant change so the diff stays tidy:
+
+```bash
+git add resilient/src/main.rs
+git commit -m "FFI: add Value::Foreign variant (behind `ffi` feature)"
+```
+
+---
+
+## Task 8: Driver wiring — resolve extern blocks, register as env values, dispatch on call
+
+**Files:**
+- Modify: `resilient/src/main.rs` — new `resolve_externs` pass after `expand_uses`; extend `apply_function` to call through `ffi_trampolines::call_foreign`
+
+- [ ] **Step 1: Add the driver pass**
+
+Find the driver entry point where `expand_uses` runs (search for `imports::expand_uses`, around line 7951). Right after it, inside the same feature gate if present:
+
+```rust
+    // FFI v1: resolve every `Node::Extern` block eagerly, producing
+    // Value::Foreign bindings in the root environment.
+    #[cfg(feature = "ffi")]
+    {
+        let mut loader = crate::ffi::ForeignLoader::new();
+        if let Node::Program(stmts) = &program {
+            for stmt in stmts {
+                if let Node::Extern { library, decls, .. } = &stmt.node {
+                    if let Err(e) = loader.resolve_block(library, decls) {
+                        return Err(format!("{}", e));
+                    }
+                    for d in decls {
+                        let sym = loader.lookup(&d.resilient_name).unwrap();
+                        let name: &'static str = Box::leak(d.resilient_name.clone().into_boxed_str());
+                        env.set(
+                            d.resilient_name.clone(),
+                            Value::Foreign {
+                                name,
+                                symbol: sym,
+                                requires: d.requires.clone(),
+                                ensures: d.ensures.clone(),
+                                trusted: d.trusted,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+```
+
+(Adjust `env.set` to the actual method name used in the driver — search `register_builtins` for the pattern.)
+
+- [ ] **Step 2: Extend apply_function to handle Value::Foreign**
+
+Find `apply_function` (it's the central fn-call dispatcher; search for `Value::Builtin { func, .. }`). Add another arm:
+
+```rust
+        #[cfg(feature = "ffi")]
+        Value::Foreign { name: _, symbol, requires, ensures, trusted } => {
+            // Check preconditions in the caller's scope first.
+            // Bind parameters by position. (Foreign decls carry names,
+            // but at apply time we only have Values — we rebind using
+            // positional aliases `_0`, `_1`, ...)
+            let mut contract_env = env.clone();
+            for (i, v) in args.iter().enumerate() {
+                contract_env.set(format!("_{}", i), v.clone());
+            }
+            for pre in requires {
+                let ok = match eval(pre, &mut contract_env)? {
+                    Value::Bool(b) => b,
+                    _ => false,
+                };
+                if !ok {
+                    return Err(format!(
+                        "contract violation: `requires` failed entering foreign fn"
+                    ));
+                }
+            }
+
+            let result = crate::ffi_trampolines::call_foreign(&symbol, &args)?;
+
+            // Postconditions. `result` is bound under the name `result`
+            // so authored ensures clauses line up with the Resilient-fn
+            // convention.
+            let mut post_env = contract_env;
+            post_env.set("result".to_string(), result.clone());
+            for post in ensures {
+                let ok = match eval(post, &mut post_env)? {
+                    Value::Bool(b) => b,
+                    _ => false,
+                };
+                if !ok && !trusted {
+                    return Err(format!(
+                        "contract violation: `ensures` failed leaving foreign fn"
+                    ));
+                }
+            }
+
+            Ok(result)
+        }
+```
+
+- [ ] **Step 3: Run the libm test**
+
+Run: `cd resilient && cargo test can_call_cos_from_libm --features ffi`
+Expected: PASS on macOS AND Linux.
+
+- [ ] **Step 4: Run full suite**
+
+Run: `cd resilient && cargo test --features ffi && cd ../resilient-runtime && cargo test && cd ..`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resilient/src/main.rs
+git commit -m "FFI: driver resolves extern blocks; tree-walker dispatches through trampolines"
+```
+
+---
+
+## Task 9: Test helper C library + integration coverage for edge cases
+
+**Files:**
+- Create: `resilient/tests/ffi/lib_testhelper.c`
+- Create: `resilient/build.rs`
+- Modify: `resilient/Cargo.toml` — `build-dependencies = { cc = "1" }`
+
+- [ ] **Step 1: Write the helper**
+
+`resilient/tests/ffi/lib_testhelper.c`:
+
+```c
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+int64_t rt_add(int64_t a, int64_t b) { return a + b; }
+double  rt_mul(double a, double b) { return a * b; }
+bool    rt_is_even(int64_t n) { return (n % 2) == 0; }
+
+// Counts ASCII digits in a borrowed UTF-8 buffer.
+int64_t rt_count_digits(const char* s, size_t len) {
+    int64_t n = 0;
+    for (size_t i = 0; i < len; ++i) {
+        if (s[i] >= '0' && s[i] <= '9') ++n;
+    }
+    return n;
+}
+```
+
+- [ ] **Step 2: Add build.rs**
+
+`resilient/build.rs`:
+
+```rust
+fn main() {
+    if std::env::var("CARGO_FEATURE_FFI").is_ok() {
+        cc::Build::new()
+            .file("tests/ffi/lib_testhelper.c")
+            .shared_flag(true)
+            .compile("resilient_ffi_testhelper");
+        // cc emits a static lib. For dlopen we need a shared lib.
+        // Let the test code open the static-staging output as a .dylib
+        // via target/.../libresilient_ffi_testhelper.dylib that cc
+        // produces when `shared_flag(true)` is set.
+    }
+}
+```
+
+- [ ] **Step 3: Tie into Cargo.toml**
+
+```toml
+[build-dependencies]
+cc = "1"
+```
+
+- [ ] **Step 4: Integration tests**
+
+Create `resilient/tests/ffi_integration.rs`:
+
+```rust
+//! End-to-end FFI tests against the bundled C helper library.
+#![cfg(feature = "ffi")]
+
+use std::path::PathBuf;
+
+fn helper_path() -> String {
+    // build.rs emitted this into OUT_DIR; resolve at test time.
+    let out_dir = PathBuf::from(env!("OUT_DIR"));
+    let ext = if cfg!(target_os = "macos") { "dylib" }
+              else if cfg!(target_os = "windows") { "dll" }
+              else { "so" };
+    out_dir.join(format!("libresilient_ffi_testhelper.{}", ext))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn run(src: &str) -> String {
+    // Mirror the in-tree helper; pick whatever the crate exposes.
+    resilient::run_source_capture(src).expect("program ran")
+}
+
+#[test]
+fn calls_int_int_int_function() {
+    let src = format!(
+        r#"extern "{}" {{ fn rt_add(a: Int, b: Int) -> Int; }}
+           fn main() {{ println(rt_add(2, 40)); }}"#,
+        helper_path()
+    );
+    assert_eq!(run(&src).trim(), "42");
+}
+
+#[test]
+fn contract_precondition_failure_is_caught_before_ffi_call() {
+    let src = format!(
+        r#"extern "{}" {{
+             fn rt_add(a: Int, b: Int) -> Int requires(a >= 0);
+           }}
+           fn main() {{ println(rt_add(-1, 1)); }}"#,
+        helper_path()
+    );
+    let out = run(&src);
+    assert!(out.contains("contract violation"), "got: {}", out);
+}
+
+#[test]
+fn missing_symbol_is_clean_error_not_panic() {
+    let src = format!(
+        r#"extern "{}" {{ fn definitely_not_a_symbol() -> Int; }}
+           fn main() {{ }}"#,
+        helper_path()
+    );
+    let out = run(&src);
+    assert!(out.contains("symbol"), "got: {}", out);
+}
+```
+
+- [ ] **Step 5: Run integration tests**
+
+Run: `cd resilient && cargo test --test ffi_integration --features ffi`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resilient/tests/ffi resilient/build.rs resilient/tests/ffi_integration.rs resilient/Cargo.toml
+git commit -m "FFI: C helper lib + end-to-end integration tests"
+```
+
+---
+
+## Task 10: `@trusted` → SMT assumption (verifier hook)
+
+**Files:**
+- Modify: `resilient/src/verifier_z3.rs` — consume `trusted` decls as assumptions at call sites
+
+- [ ] **Step 1: Add a verifier test (gated)**
+
+```rust
+#[test]
+#[cfg(feature = "z3")]
+fn trusted_extern_ensures_propagates_as_smt_assumption() {
+    let src = r#"
+        extern "libm.so.6" {
+            @trusted fn sqrt(x: Float) -> Float ensures(result >= 0.0);
+        }
+        @pure fn f(y: Float) -> Bool requires(y >= 0.0) {
+            return sqrt(y) >= 0.0;
+        }
+    "#;
+    // The verifier should prove f's return-true because sqrt's
+    // ensures is assumed. Without @trusted the verifier would have
+    // nothing to say about the foreign call and the proof would fail.
+    let result = run_verifier(src);
+    assert!(result.is_proven());
+}
+```
+
+- [ ] **Step 2: Pipe trusted into the verifier**
+
+In `verifier_z3.rs`, find the call-site handling (search for `Node::Call`). When the callee resolves to an `ExternDecl` with `trusted == true`, emit each `ensures` as an `assume` rather than a `check_proves` obligation. Pattern:
+
+```rust
+            // FFI: trusted extern call — treat ensures as axiom.
+            if let Some(extern_decl) = self.lookup_extern(&callee_name) {
+                if extern_decl.trusted {
+                    for ens in &extern_decl.ensures {
+                        let enc = self.encode(ens, &call_scope)?;
+                        self.solver.assert(&enc);
+                    }
+                    // Untrusted: nothing to assert, nothing to prove.
+                    // Non-trusted ensures are runtime-only in v1.
+                }
+                return Ok(SymbolicValue::unknown_of(extern_decl.return_type.clone()));
+            }
+```
+
+(Exact integration shape depends on the symbolic-value representation used in `verifier_z3.rs`; the spec's intent is: `@trusted` → axiom, untrusted → opaque.)
+
+- [ ] **Step 3: Run the verifier test**
+
+Run: `cd resilient && cargo test trusted_extern_ensures_propagates --features "ffi z3"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resilient/src/verifier_z3.rs
+git commit -m "FFI: @trusted extern ensures propagates as SMT assumption"
+```
+
+---
+
+## Task 11: `resilient-runtime` static registry (no_std side)
+
+**Files:**
+- Create: `resilient-runtime/src/ffi_static.rs`
+- Modify: `resilient-runtime/src/lib.rs` — `pub mod ffi_static;` gated on `ffi-static`
+- Modify: `resilient-runtime/Cargo.toml` — `ffi-static`, `ffi-static-64/256/1024` features
+
+- [ ] **Step 1: Add features**
+
+`resilient-runtime/Cargo.toml`:
+
+```toml
+[features]
+ffi-static = []
+ffi-static-64 = ["ffi-static"]
+ffi-static-256 = ["ffi-static"]
+ffi-static-1024 = ["ffi-static"]
+```
+
+Mutual-exclusion compile error, mirroring the existing `alloc`/`static-only` guard in `lib.rs`:
+
+```rust
+#[cfg(any(
+    all(feature = "ffi-static-64", feature = "ffi-static-256"),
+    all(feature = "ffi-static-64", feature = "ffi-static-1024"),
+    all(feature = "ffi-static-256", feature = "ffi-static-1024"),
+))]
+compile_error!("`ffi-static-64`, `ffi-static-256`, `ffi-static-1024` are mutually exclusive — pick ONE capacity.");
+```
+
+- [ ] **Step 2: Implement the registry**
+
+`resilient-runtime/src/ffi_static.rs`:
+
+```rust
+//! FFI static registry for no_std embedded hosts.
+//!
+//! The embedding application calls `register_foreign` BEFORE
+//! `run(program)`. Lookups are linear over a fixed-size array —
+//! N ≤ 1024 (the largest supported capacity) so linear scan is
+//! fine, and it keeps the crate allocation-free.
+
+#![cfg(feature = "ffi-static")]
+
+#[cfg(feature = "ffi-static-1024")]
+const CAPACITY: usize = 1024;
+#[cfg(all(feature = "ffi-static-256", not(feature = "ffi-static-1024")))]
+const CAPACITY: usize = 256;
+#[cfg(all(feature = "ffi-static-64", not(any(feature = "ffi-static-256", feature = "ffi-static-1024"))))]
+const CAPACITY: usize = 64;
+#[cfg(not(any(feature = "ffi-static-64", feature = "ffi-static-256", feature = "ffi-static-1024")))]
+const CAPACITY: usize = 64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FfiType { Int, Float, Bool, Str, Void }
+
+#[derive(Clone, Copy, Debug)]
+pub struct ForeignSignature {
+    pub params: &'static [FfiType],
+    pub ret: FfiType,
+}
+
+pub type ForeignFn = unsafe extern "C" fn();
+
+#[derive(Copy, Clone)]
+pub struct Entry {
+    pub name: &'static str,
+    pub ptr: ForeignFn,
+    pub sig: ForeignSignature,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum FfiError {
+    RegistryFull,
+    DuplicateSymbol,
+    NotFound,
+}
+
+pub struct StaticRegistry {
+    slots: [Option<Entry>; CAPACITY],
+    len: usize,
+}
+
+impl StaticRegistry {
+    pub const fn new() -> Self {
+        const NONE: Option<Entry> = None;
+        Self { slots: [NONE; CAPACITY], len: 0 }
+    }
+
+    pub fn register(
+        &mut self,
+        name: &'static str,
+        ptr: ForeignFn,
+        sig: ForeignSignature,
+    ) -> Result<(), FfiError> {
+        if self.lookup(name).is_some() {
+            return Err(FfiError::DuplicateSymbol);
+        }
+        if self.len == CAPACITY {
+            return Err(FfiError::RegistryFull);
+        }
+        self.slots[self.len] = Some(Entry { name, ptr, sig });
+        self.len += 1;
+        Ok(())
+    }
+
+    pub fn lookup(&self, name: &str) -> Option<&Entry> {
+        for slot in &self.slots[..self.len] {
+            if let Some(e) = slot {
+                if e.name == name {
+                    return Some(e);
+                }
+            }
+        }
+        None
+    }
+
+    pub fn len(&self) -> usize { self.len }
+    pub fn is_empty(&self) -> bool { self.len == 0 }
+}
+```
+
+- [ ] **Step 3: Hook into lib.rs**
+
+```rust
+#[cfg(feature = "ffi-static")]
+pub mod ffi_static;
+```
+
+- [ ] **Step 4: Unit tests in ffi_static.rs**
+
+Append to the module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    unsafe extern "C" fn dummy() {}
+
+    const SIG: ForeignSignature = ForeignSignature {
+        params: &[],
+        ret: FfiType::Void,
+    };
+
+    #[test]
+    fn register_then_lookup() {
+        let mut r = StaticRegistry::new();
+        r.register("f", dummy, SIG).unwrap();
+        assert!(r.lookup("f").is_some());
+    }
+
+    #[test]
+    fn lookup_missing_returns_none() {
+        let r = StaticRegistry::new();
+        assert!(r.lookup("nope").is_none());
+    }
+
+    #[test]
+    fn duplicate_registration_errors() {
+        let mut r = StaticRegistry::new();
+        r.register("f", dummy, SIG).unwrap();
+        let err = r.register("f", dummy, SIG).unwrap_err();
+        assert_eq!(err, FfiError::DuplicateSymbol);
+    }
+
+    #[test]
+    fn full_registry_errors_on_next_registration() {
+        let mut r = StaticRegistry::new();
+        for i in 0..super::CAPACITY {
+            let name = Box::leak(format!("f{}", i).into_boxed_str()) as &'static str;
+            r.register(name, dummy, SIG).unwrap();
+        }
+        let err = r.register("overflow", dummy, SIG).unwrap_err();
+        assert_eq!(err, FfiError::RegistryFull);
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd resilient-runtime && cargo test --features ffi-static
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Cross-compile check (keep size gate green)**
+
+```bash
+cd resilient-runtime && cargo build --features ffi-static --target thumbv7em-none-eabihf
+```
+
+Expected: clean build. Run the size gate script (`scripts/check_size.sh` or equivalent — check the CI workflow for the actual name) against the cortex-m demo and confirm we're still under 64 KiB.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/eric/GitHub/Resilient
+git add resilient-runtime/src/ffi_static.rs resilient-runtime/src/lib.rs resilient-runtime/Cargo.toml
+git commit -m "FFI: resilient-runtime static registry (no_std, zero-alloc, behind ffi-static)"
+```
+
+---
+
+## Task 12: Example program + docs
+
+**Files:**
+- Create: `resilient/examples/ffi_libm.res`
+- Create: `resilient/examples/ffi_libm.expected.txt`
+- Modify: `SYNTAX.md`
+- Modify: `docs/` (Jekyll) — new page `docs/ffi.md`
+
+- [ ] **Step 1: Example program**
+
+`resilient/examples/ffi_libm.res`:
+
+```
+extern "libm.so.6" {
+    fn sqrt(x: Float) -> Float requires(x >= 0.0) ensures(result >= 0.0);
+}
+
+fn main() {
+    println(sqrt(16.0));
+    println(sqrt(2.0));
+}
+```
+
+(macOS users will need a per-platform alternate — consider a `ffi_libm_macos.res` with `libSystem.dylib`; or leave the example Linux-only with a docs note.)
+
+`resilient/examples/ffi_libm.expected.txt`:
+
+```
+4
+1.4142135623730951
+```
+
+- [ ] **Step 2: SYNTAX.md entry**
+
+Under a new `## Foreign Function Interface` section, document:
+
+- `extern "lib" { ... }` block form
+- Primitive-only type map (reference the spec)
+- `= "c_name"` alias syntax
+- `requires` / `ensures` on extern decls
+- `@trusted` — the "I promise" escape hatch
+- Feature flags (`ffi`, `ffi-static`)
+
+Keep to ~60 lines — link to the spec for deeper dives.
+
+- [ ] **Step 3: Jekyll page**
+
+`docs/ffi.md`:
+
+```markdown
+---
+layout: default
+title: FFI
+---
+
+# Foreign Function Interface
+
+Resilient programs call into C libraries through `extern` blocks.
+
+```
+extern "libm.so.6" {
+    fn sqrt(x: Float) -> Float ensures(result >= 0.0);
+}
+```
+
+See [the FFI design spec](...) for the full type map, contract model,
+and embedded `no_std` registration path.
+```
+
+- [ ] **Step 4: Verify golden-example harness picks it up**
+
+Run: `cd resilient && cargo test ffi_libm_example 2>&1 | tail -10`
+(If the example-runner test name differs, search for existing `.expected.txt` harness tests and mirror the pattern.)
+Expected: new example PASS on Linux; on macOS either the alt file runs or the example is skipped via `#[cfg(target_os = "linux")]`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resilient/examples/ffi_libm.res resilient/examples/ffi_libm.expected.txt SYNTAX.md docs/ffi.md
+git commit -m "FFI: example program (ffi_libm) + SYNTAX and docs pages"
+```
+
+---
+
+## Task 13: Close the loop — update tickets and board
+
+**Files:**
+- Create: `.board/tickets/DONE/RES-NEW-ffi-phase-1-tree-walker.md`
+- Modify: `.board/ROADMAP.md` — new G21 entry (or whichever goalpost covers FFI)
+
+- [ ] **Step 1: Write the ticket retroactively**
+
+`.board/tickets/DONE/RES-NEW-ffi-phase-1-tree-walker.md`:
+
+```markdown
+# RES-NEW: FFI Phase 1 — tree-walker + static registry
+
+## Summary
+Ships primitive-only FFI for the tree-walker interpreter on std hosts
+and the static-registry path for no_std embedded.
+
+## Acceptance
+- [x] `extern "lib" { fn ... }` blocks parse
+- [x] Typechecker rejects non-primitive FFI types and @pure on extern
+- [x] Loader resolves symbols on std via libloading (ffi feature)
+- [x] Tree-walker dispatches through the trampoline table
+- [x] `requires` and `ensures` checked at runtime on FFI calls
+- [x] `@trusted` propagates ensures as SMT assumption
+- [x] `resilient-runtime` ffi-static registry (no_std, zero-alloc)
+- [x] End-to-end test calling libm::sqrt on Linux + libSystem on macOS
+- [x] Example program + docs
+
+## Out of scope (filed as follow-ups)
+- Bytecode VM `OP_CALL_FOREIGN` (phase 2)
+- Cranelift JIT lowering (phase 3)
+- Struct / Array / callback marshalling
+- Variadic foreign fns
+```
+
+- [ ] **Step 2: Update ROADMAP.md**
+
+Add to the roadmap table:
+
+```
+| G21 | FFI v1 (tree-walker + static registry)     | Shipped 2026-04-?? |
+```
+
+- [ ] **Step 3: Final full-suite run**
+
+```bash
+cd /Users/eric/GitHub/Resilient
+cd resilient && cargo test --features ffi && \
+cd ../resilient-runtime && cargo test --features ffi-static && \
+cd ..
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .board/tickets/DONE/RES-NEW-ffi-phase-1-tree-walker.md .board/ROADMAP.md
+git commit -m "RES-NEW: close FFI phase-1 ticket; mark G21 in roadmap"
+```
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin ffi-phase-1-tree-walker
+```
+
+---
+
+## Self-review checklist (run before handoff)
+
+- ✅ Spec §3 (syntax): Tasks 1–3 cover block form, alias, contracts, @trusted.
+- ✅ Spec §4 (types): Task 4 enforces primitive-only; `ForeignSignature::from_decl` in Task 5 is the single source of truth.
+- ✅ Spec §5.1 (std loader): Task 5 (`dynamic` module).
+- ✅ Spec §5.2 (no_std registry): Task 11.
+- ✅ Spec §5.3 (shared signature): `FfiType` duplicated intentionally between `resilient` and `resilient-runtime` — they can't share a crate because the latter is no_std. Noted inline.
+- ✅ Spec §6.1 (tree-walker dispatch): Tasks 6 + 7 + 8.
+- ✅ Spec §6.2 (VM), §6.3 (JIT): **out of scope for this plan** — follow-on plans once Phase 1 is stable.
+- ✅ Spec §7 (errors): `FfiError` enum in Task 5 covers load-time errors; call-time errors flow through `RResult<Value>` in Task 6.
+- ✅ Spec §8 (feature flags): Tasks 5 and 11.
+- ✅ Spec §10 (testing): Tasks 5 (unit), 9 (integration with C helper), 10 (verifier), 11 (no_std unit).
+- ✅ Spec §12 (success criteria): all items in this plan except VM/JIT (out of scope).
+
+**Placeholder scan:** Task 6's trampoline table openly admits to enumerating arity 0–2 up front and "extend mechanically as real examples demand" — the fallback arm returns a clean error rather than panicking, so this is a real v1 behavior not a TODO. Every Task has concrete code and commands.
+
+**Type consistency:** `ForeignSignature` (host) vs. `ForeignSignature` (runtime) are deliberately distinct — one uses `Vec<FfiType>`, the other `&'static [FfiType]`, because heap-free vs. allocator-aware. Documented inline.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-19-ffi-phase-1-tree-walker.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-19-ffi-design.md
+++ b/docs/superpowers/specs/2026-04-19-ffi-design.md
@@ -1,0 +1,418 @@
+# Resilient FFI Design
+
+**Status**: Draft — design-only, no implementation yet
+**Date**: 2026-04-19
+**Author**: Eric Spencer
+**Covers goalposts**: new (tentative G21 — Foreign Function Interface)
+
+---
+
+## 1. Motivation
+
+Resilient today is closed. It can run pure programs, call its own stdlib, and
+that's it. To be useful as anything beyond a teaching language it needs a way
+to reach into the host's native world — specifically:
+
+- **CLI users** want to call OS and C-library functions (`libc`, `libm`,
+  platform APIs) from Resilient source without recompiling the interpreter.
+- **Embedded users** want to call vendor HAL code (ST HAL, nRF SDK, ESP-IDF)
+  from inside a Resilient program running on an MCU, without dragging `dlopen`
+  or an OS into the build.
+
+Both needs reduce to the same language-level question: how does a Resilient
+source program name, type, and invoke a non-Resilient function?
+
+This spec answers that.
+
+---
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- **Single source-level syntax** for both `std` hosts and `no_std` embedded —
+  the loader decides at startup which mechanism resolves the symbol.
+- **Primitive-only v1** — `Int`, `Float`, `Bool`, `String` (UTF-8, borrowed),
+  `Void`. Enough to call most of `libc` / `libm` / basic HAL calls.
+- **Zero panics on the loader path.** Missing library, missing symbol, wrong
+  arity, and type-mismatched argument are all clean typed errors.
+- **Feature-gated.** A `resilient` build with `--no-default-features` OR
+  a `resilient-runtime` build without `ffi-static` does not link `libloading`
+  and does not pull in the registration table.
+- **Contract-aware.** `requires` and `ensures` on an `extern fn` are checked
+  at runtime; SMT treats FFI bodies as opaque (no verification can "see in").
+- **Uniform across execution paths** — tree-walker interpreter, bytecode VM,
+  and JIT all dispatch through the same loader API.
+
+### Non-goals (v1)
+
+- Struct / array / map marshalling across the boundary.
+- Callbacks (Resilient fn passed as a C function pointer).
+- Automatic C header parsing (`bindgen`-style).
+- Multiple calling conventions (`stdcall`, `fastcall`). C `cdecl` only.
+- Memory ownership transfer. All strings passed to foreign code are borrowed
+  for the duration of the call; foreign code must not retain the pointer.
+- Dynamic library unloading.
+- Variadic foreign functions (e.g. `printf`).
+
+Each non-goal is a named follow-up ticket.
+
+---
+
+## 3. Surface Syntax
+
+### 3.1 Block form
+
+```resilient
+extern "libm.so.6" {
+    fn sin(x: Float) -> Float;
+    fn cos(x: Float) -> Float;
+    fn pow(base: Float, exp: Float) -> Float;
+}
+```
+
+- The string after `extern` is a **library descriptor**:
+  - `"libm.so.6"` / `"libfoo.dylib"` / `"foo.dll"` — platform-specific path or
+    SONAME; passed through to `libloading` verbatim on `std` hosts.
+  - `"@static"` — sentinel telling the loader to look in the static
+    registration table instead of calling `dlopen`. Required on `no_std`;
+    optional on `std` as a way to force the static path.
+- Each inner declaration is a standard Resilient fn signature minus the body,
+  terminated by `;`. Parameter names are **mandatory** for documentation /
+  error messages even though they're not used by the loader.
+- Signatures use **Resilient** type names (`Int`, `Float`, `Bool`, `String`,
+  `Void`) — the compiler lowers them to the C ABI at call time.
+
+### 3.2 Symbol-name alias
+
+When the Resilient name differs from the C symbol:
+
+```resilient
+extern "libm.so.6" {
+    fn sine(x: Float) -> Float = "sin";
+    fn cosine(x: Float) -> Float = "cos";
+}
+```
+
+The `= "name"` clause overrides the symbol lookup; without it the Resilient
+name is used verbatim.
+
+### 3.3 Contracts on extern decls
+
+```resilient
+extern "libm.so.6" {
+    fn sqrt(x: Float) -> Float
+        requires(x >= 0.0)
+        ensures(result >= 0.0);
+}
+```
+
+- `requires` is checked on the **caller side** before the foreign call is
+  made. Runtime only — SMT cannot verify a foreign body.
+- `ensures` is checked on return. Foreign code that violates `ensures`
+  produces the same contract-violation diagnostic as a Resilient fn would.
+- `@trusted` above the block (or a single decl) turns `ensures` into an
+  unchecked assumption that propagates into SMT at call sites. This is the
+  FFI analogue of `unsafe` — buyer beware, it's how you integrate with
+  libraries you can't verify but do trust.
+
+### 3.4 Purity
+
+- FFI decls are implicitly `@impure`. The purity checker rejects `@pure`
+  on an `extern fn`.
+- A `@pure` Resilient fn cannot call an FFI fn, even a trusted one. (Rationale:
+  purity in Resilient is structural, not nominal. Breaking that for FFI would
+  break inference in ways we don't want to debug.)
+
+### 3.5 AST node
+
+A new `Node::Extern` variant:
+
+```rust
+Node::Extern {
+    library: String,           // "libm.so.6" or "@static"
+    decls: Vec<ExternDecl>,    // each fn inside the block
+    span: Span,
+}
+
+struct ExternDecl {
+    resilient_name: String,
+    c_name: String,            // == resilient_name unless `= "..."` given
+    parameters: Vec<(String, String)>,  // (type, name)
+    return_type: String,       // Resilient type name, "Void" for unit
+    requires: Vec<Node>,
+    ensures: Vec<Node>,
+    trusted: bool,
+    span: Span,
+}
+```
+
+---
+
+## 4. Type Mapping (v1)
+
+| Resilient | C ABI                         | Notes                               |
+| --------- | ----------------------------- | ----------------------------------- |
+| `Int`     | `int64_t`                     | Wraps on overflow, matches VM.      |
+| `Float`   | `double`                      |                                     |
+| `Bool`    | `_Bool` (one byte)            |                                     |
+| `String`  | `(const char*, size_t)`       | Two args on the C side, borrowed, UTF-8, no trailing NUL guaranteed. |
+| `Void`    | `void`                        | Return type only.                   |
+
+Anything else (`Array`, `Struct`, `Map`, `Set`, `Result`, `Bytes`, closures)
+is a typecheck error on the FFI boundary in v1. Future tickets can add
+`Bytes ↔ (uint8_t*, size_t)`, opaque handle types, etc.
+
+---
+
+## 5. Loader Architecture
+
+### 5.1 `std` path (`--features ffi`, default on hosted)
+
+New crate-internal module `resilient/src/ffi.rs`:
+
+```
+pub struct ForeignLoader {
+    libs: HashMap<String, libloading::Library>,
+    symbols: HashMap<(String, String), ForeignSymbol>,  // (lib, name) -> resolved
+}
+
+pub struct ForeignSymbol {
+    ptr: *const (),                          // raw symbol
+    signature: ForeignSignature,             // cached from the decl
+}
+```
+
+- On program load (right after `imports::expand_uses`), the driver walks every
+  `Node::Extern`, opens each distinct library once, and resolves every
+  declared symbol eagerly. Any miss = clean `FfiError::{LibNotFound, SymbolNotFound}`.
+- Resolved symbols are stored in a flat `HashMap` keyed by Resilient name so
+  call sites look up in O(1).
+
+### 5.2 `no_std` path (`resilient-runtime` with `ffi-static`)
+
+`resilient-runtime` gains a module `ffi_static.rs`:
+
+```rust
+pub type ForeignFn = extern "C" fn();  // cast to real signature at call
+
+pub struct StaticRegistry {
+    entries: [Option<(&'static str, ForeignFn, ForeignSignature)>; N],
+}
+
+impl StaticRegistry {
+    pub const fn new() -> Self { ... }
+    pub fn register(
+        &mut self,
+        name: &'static str,
+        ptr: ForeignFn,
+        sig: ForeignSignature,
+    ) -> Result<(), FfiError>;
+    pub fn lookup(&self, name: &str) -> Option<ForeignSymbol>;
+}
+```
+
+- No `HashMap` (heap-free default). Fixed-size array of entries; the
+  embedding application picks `N` at compile time via a cargo feature
+  (`ffi-static-64`, `ffi-static-256`). Default 64.
+- `register` called by the embedder BEFORE `run(program)`. Registering a name
+  twice is an error.
+- Library descriptor `"@static"` dispatches to this registry; any other
+  descriptor on `no_std` is a compile-time error (the `libloading` path
+  isn't linked).
+
+### 5.3 Shared signature layout
+
+```rust
+struct ForeignSignature {
+    params: &'static [FfiType],
+    ret: FfiType,
+}
+
+enum FfiType { Int, Float, Bool, Str, Void }
+```
+
+This lives in a shared module both the `std` loader and the `no_std`
+registry depend on. Keeps the calling-convention glue in one place.
+
+---
+
+## 6. Call Path
+
+### 6.1 Tree-walker interpreter
+
+When the interpreter encounters a call whose resolved callee is a
+`Value::Foreign`, it:
+
+1. Pulls arg `Value`s off the top of the expression-eval stack.
+2. Validates `args.len() == sig.params.len()` — type error otherwise.
+3. Converts each `Value` to its C representation per the table in §4.
+4. Transmutes the raw symbol pointer to a `extern "C" fn(...)` of the right
+   shape — **one monomorphized trampoline per (arity, return-type)**, not per
+   callsite. Up to 8 params in v1 = 9×5 = 45 trampolines. Generated by a
+   `build.rs` macro or hand-rolled.
+5. Calls the trampoline, catches the return value.
+6. Converts the C return back to a `Value`.
+7. Runs `ensures` checks (if any).
+
+A new `Value` variant:
+
+```rust
+Value::Foreign {
+    name: &'static str,
+    ptr: *const (),
+    sig: ForeignSignature,
+    requires: Vec<Node>,
+    ensures: Vec<Node>,
+    trusted: bool,
+}
+```
+
+### 6.2 Bytecode VM
+
+The VM gains one new opcode:
+
+```
+OP_CALL_FOREIGN <symbol_index: u16> <arg_count: u8>
+```
+
+`symbol_index` indexes into a per-chunk foreign-symbol table populated by the
+compiler. Dispatch is identical to the tree-walker's path (§6.1) but reads
+args off the operand stack.
+
+### 6.3 JIT (Cranelift)
+
+The JIT lowers `OP_CALL_FOREIGN` to a direct `call_indirect` against the
+resolved pointer. Argument and return marshalling is emitted inline as
+Cranelift IR — no boxed `Value` round-trip, which is the whole point of
+the JIT. Only calls with all-primitive signatures are JIT-lowered in v1;
+anything with `String` falls back to the bytecode-VM path.
+
+### 6.4 Loader wiring
+
+All three paths share one resolved `Arc<ForeignLoader>` (or on `no_std`, a
+`&'static StaticRegistry`) captured at program-load time. The tree-walker and
+VM look up by name; the JIT captures the raw pointer at codegen time.
+
+---
+
+## 7. Error Model
+
+Load-time errors (returned from `expand_uses`' FFI sibling pass):
+
+- `FfiError::LibNotFound { library, underlying }`
+- `FfiError::SymbolNotFound { library, symbol }`
+- `FfiError::DuplicateRegistration { symbol }` (no_std)
+- `FfiError::UnsupportedType { decl, type_name }`
+- `FfiError::StaticOnlyOnStd { library }` — user asked for a dynamic
+  library but built with `--no-default-features`.
+
+Call-time errors:
+
+- `RuntimeError::FfiArityMismatch { name, expected, got }`
+- `RuntimeError::FfiTypeMismatch { name, param_index, expected, got }`
+- `RuntimeError::Contract { kind: Pre | Post, fn: "name" }` (reuses the
+  existing contract-violation path)
+
+Inside the foreign function: **undefined**. C code that panics / aborts /
+returns garbage is the embedder's problem. Document this prominently.
+
+---
+
+## 8. Feature Flags
+
+### `resilient` crate
+
+- `ffi` (**default on std, off on no_std builds if any**): enables
+  `libloading` dep, `Node::Extern` parsing, `Value::Foreign`, and the call
+  path in all three backends. Without it, `extern` blocks parse as a clean
+  "FFI disabled in this build" typed error.
+
+### `resilient-runtime` crate
+
+- `ffi-static`: enables the static registration table. Zero-cost when off —
+  no table, no opcode handler, no symbol storage.
+- `ffi-static-64` / `ffi-static-256` / `ffi-static-1024`: pick table capacity.
+  Mutually exclusive via `compile_error!` guard (same pattern as
+  `alloc` / `static-only`).
+
+---
+
+## 9. Tree-walker-First Rollout (scope sequencing)
+
+The implementation plan will decompose into at least these tickets:
+
+1. **Parser** — recognize `extern "lib" { ... }` block and `= "c_name"` alias.
+   AST node + tests.
+2. **Typechecker** — reject non-primitive types in FFI signatures. Reject
+   `@pure` on extern decls.
+3. **Loader (std)** — `libloading` integration + eager resolution pass.
+4. **Trampoline table** — generated `extern "C" fn` shims for all (arity,
+   return) combinations through arity 8.
+5. **Tree-walker call path** — `Value::Foreign`, dispatch, marshalling.
+6. **Contract checks on FFI** — `requires` on entry, `ensures` on exit, shared
+   with the Resilient-fn path.
+7. **`@trusted` + SMT assumption** — pipe `trusted` through to the verifier.
+8. **`resilient-runtime` ffi-static** — static registry + `register_foreign`
+   API + tests + Cortex-M demo app that actually calls HAL.
+9. **Bytecode VM** — `OP_CALL_FOREIGN` + tests.
+10. **JIT** — Cranelift lowering + test that a tight loop calling
+    `pow(x, 2.0)` beats the tree-walker by the JIT's usual margin.
+11. **Docs** — SYNTAX.md entry, example program, Jekyll page.
+
+Each ticket can ship independently and is runnable on its own. No ticket
+depends on an un-landed follow-up.
+
+---
+
+## 10. Testing Strategy
+
+- **Parser**: golden tests for `extern` block parsing, alias, contracts, error
+  recovery on malformed blocks.
+- **Typechecker**: reject-cases (array param, struct return, `@pure`).
+- **Loader**: a tiny companion C file (`tests/ffi/lib_testhelper.c`) compiled
+  into a `.so` / `.dylib` / `.dll` per-platform in `build.rs`. Covers
+  successful load, missing library, missing symbol, valid call, type
+  mismatch.
+- **Tree-walker**: end-to-end example calling `libm::sqrt` on macOS/Linux
+  hosts; skipped on Windows until a `libm` equivalent is selected.
+- **`no_std` registry**: unit tests in `resilient-runtime` plus a new
+  integration test in `resilient-runtime-cortex-m-demo` that calls a stub
+  HAL function.
+- **Contracts**: pre- and post-condition violation tests on FFI decls.
+- **VM + JIT**: regression tests confirming identical behaviour across all
+  three execution paths.
+
+---
+
+## 11. Open Questions (deferred)
+
+These are flagged now so they don't sneak back in as v1 scope:
+
+- Struct marshalling: repr? alignment? ownership?
+- Callbacks: do they capture environment? How does a closure lower to a C
+  fn pointer?
+- Variadic calls: do we expose `printf`? (Probably not.)
+- Multi-thread foreign calls: do we need a per-symbol lock? (Default: no —
+  the embedder owns thread safety of the native code.)
+- Library-version pinning: should the descriptor allow SemVer constraints?
+- Hot-reload: `libloading` supports it, but the VM doesn't.
+
+Each becomes a follow-up ticket when someone asks for it.
+
+---
+
+## 12. Success Criteria
+
+FFI v1 ships when:
+
+- A Resilient program can `extern "libm.so.6" { fn sqrt(x: Float) -> Float; }`
+  and call it from all three execution paths, on both Linux and macOS.
+- A Cortex-M demo app registers a stub HAL fn statically, a Resilient program
+  on the MCU calls it, the call returns, the program continues.
+- `cargo test` is green on host, `cargo test --features ffi` is green,
+  `cargo test --features ffi-static` in `resilient-runtime` is green.
+- Cross-compile for `thumbv7em-none-eabihf` still passes the size gate with
+  `ffi-static` on.
+- A contract violation on an FFI call surfaces as a clean diagnostic with
+  `file:line:col`, matching the existing Resilient-fn contract-violation UX.

--- a/resilient/Cargo.lock
+++ b/resilient/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +204,33 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clang-sys"
@@ -413,6 +458,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +629,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -727,6 +845,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +881,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "home"
@@ -895,16 +1030,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1065,6 +1230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1249,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "parking_lot_core"
@@ -1138,6 +1318,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1395,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1261,6 +1489,7 @@ dependencies = [
  "cranelift-jit",
  "cranelift-module",
  "cranelift-native",
+ "criterion",
  "ed25519-dalek",
  "insta",
  "logos",
@@ -1320,6 +1549,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rustyline"
 version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1575,15 @@ dependencies = [
  "unicode-width",
  "utf8parse",
  "winapi",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1544,6 +1788,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,6 +1978,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,6 +2003,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +2057,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1765,6 +2084,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -91,3 +91,18 @@ serde_json = "1"
 insta = { version = "1", features = ["filters"] }
 # RES-189 tests use `serde_json::json!` — serde_json is now a
 # regular dep (RES-195) so nothing to add here.
+# RES-218: Criterion benchmark harness driving the tree-walker
+# interpreter on three representative workloads (recursive fib,
+# bubble-sort, string-processing). Test-only dep; see
+# `resilient/benches/interpreter.rs` and the Performance section
+# of the repo README for how to run.
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+# RES-218: Criterion-driven baselines for the tree-walker. `harness
+# = false` lets Criterion own `main`; the benchmark invokes the
+# compiled `resilient` binary (the language's only supported entry
+# point today — main.rs is not exposed as a library) against
+# inline Resilient source.
+name = "interpreter"
+harness = false

--- a/resilient/benches/interpreter.rs
+++ b/resilient/benches/interpreter.rs
@@ -1,0 +1,171 @@
+//! RES-218: Criterion benchmark harness for the tree-walker interpreter.
+//!
+//! Drives three representative Resilient workloads through the compiled
+//! `resilient` binary:
+//!
+//!   1. `fib(25)` — exponential recursion; stresses dispatch + env cloning.
+//!   2. Bubble-sort on a 50-element descending array — O(n^2) array ops.
+//!   3. String-concatenation loop — exercises the string builtins path.
+//!
+//! Why shell out to the binary instead of calling an in-process entry
+//! point? `resilient/src/main.rs` is a 16k-line binary crate with no
+//! public `lib.rs`; carving out a library surface for benchmarks alone
+//! would be a bigger ticket than RES-218 is scoped for. The process
+//! startup overhead is visible in the numbers but is constant across
+//! runs, so deltas between commits still show the shape the harness is
+//! meant to surface.
+//!
+//! Sample sizes are deliberately small (10 samples per bench) because
+//! the tree-walker is slow enough that a default 100-sample run would
+//! take several minutes. If you bump these up for a detailed profiling
+//! pass, also raise `measurement_time` to get a stable estimate.
+//!
+//! Run:  `cargo bench --manifest-path resilient/Cargo.toml`
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+/// Path to the compiled `resilient` binary. Cargo populates
+/// `CARGO_BIN_EXE_<name>` for bench targets the same way it does for
+/// integration tests, so this works out of the box under
+/// `cargo bench --manifest-path resilient/Cargo.toml`.
+fn resilient_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_resilient")
+}
+
+/// Write the given Resilient source to a tempfile under the OS temp
+/// directory and return the path. Each call gets a unique filename so
+/// concurrent bench threads (should Criterion grow any) don't collide.
+fn write_tmp_source(tag: &str, src: &str) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let path = std::env::temp_dir().join(format!("res_218_{tag}_{pid}_{nanos}.rs"));
+    let mut f = std::fs::File::create(&path).expect("create tmp source");
+    f.write_all(src.as_bytes()).expect("write tmp source");
+    path
+}
+
+/// Run the Resilient binary against the given source path and assert
+/// exit code 0. Stdout/stderr are inspected only on failure — on the
+/// happy path they're dropped, so the measurement reflects runtime
+/// and not IO bookkeeping.
+fn run_source(path: &std::path::Path) {
+    let out = Command::new(resilient_bin())
+        .arg(path)
+        .output()
+        .expect("spawn resilient binary");
+    if !out.status.success() {
+        panic!(
+            "resilient binary failed for {}:\nstdout={}\nstderr={}",
+            path.display(),
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+}
+
+/// Benchmark 1: recursive `fib(25)`.
+///
+/// The ticket spec mentioned `fib(35)`, but a tree-walker on `fib(35)`
+/// is in the multi-second range per invocation and would make even a
+/// single Criterion sample painful. `fib(25)` hits ~243k recursive
+/// calls — plenty to exercise the dispatch + env-cloning hot paths
+/// the benchmark is meant to surface — while keeping a full 10-sample
+/// run inside a few seconds. `benchmarks/README.md` uses the same
+/// workload for its cross-language comparison table.
+const FIB_SRC: &str = r#"
+fn fib(int n) {
+    if n <= 1 { return n; }
+    return fib(n - 1) + fib(n - 2);
+}
+let result = fib(25);
+"#;
+
+/// Benchmark 2: bubble-sort on a 50-element descending array.
+///
+/// 50 elements → 2450 comparisons worst-case. The array literal is
+/// generated at harness-load time so the source string itself is a
+/// one-time allocation, not part of the per-iteration measurement.
+fn bubble_sort_src() -> String {
+    let n = 50_i64;
+    let mut elems = String::new();
+    for i in 0..n {
+        if i > 0 {
+            elems.push_str(", ");
+        }
+        // Descending: worst case for bubble sort's swap count.
+        elems.push_str(&(n - i).to_string());
+    }
+    format!(
+        r#"
+let arr = [{elems}];
+let n = len(arr);
+let i = 0;
+while i < n {{
+    let j = 0;
+    while j < n - i - 1 {{
+        if arr[j] > arr[j + 1] {{
+            let tmp = arr[j];
+            arr[j] = arr[j + 1];
+            arr[j + 1] = tmp;
+        }}
+        j = j + 1;
+    }}
+    i = i + 1;
+}}
+"#
+    )
+}
+
+/// Benchmark 3: string concatenation in a loop.
+///
+/// Builds a 200-iteration string then calls `len()` on it. The test
+/// exercises the interpreter's string-value path (boxed `Rc<String>`
+/// or similar) and the arithmetic-vs-string coercion in `+`.
+const STRING_SRC: &str = r#"
+let s = "";
+let i = 0;
+while i < 200 {
+    s = s + "x";
+    i = i + 1;
+}
+let n = len(s);
+"#;
+
+fn bench_fib(c: &mut Criterion) {
+    let src_path = write_tmp_source("fib25", FIB_SRC);
+    let mut group = c.benchmark_group("tree_walker");
+    group.sample_size(10).measurement_time(Duration::from_secs(10));
+    group.bench_function("fib_25", |b| b.iter(|| run_source(&src_path)));
+    group.finish();
+    let _ = std::fs::remove_file(&src_path);
+}
+
+fn bench_bubble_sort(c: &mut Criterion) {
+    let src = bubble_sort_src();
+    let src_path = write_tmp_source("bubble50", &src);
+    let mut group = c.benchmark_group("tree_walker");
+    group.sample_size(10).measurement_time(Duration::from_secs(10));
+    group.bench_function("bubble_sort_50", |b| b.iter(|| run_source(&src_path)));
+    group.finish();
+    let _ = std::fs::remove_file(&src_path);
+}
+
+fn bench_string_processing(c: &mut Criterion) {
+    let src_path = write_tmp_source("string200", STRING_SRC);
+    let mut group = c.benchmark_group("tree_walker");
+    group.sample_size(10).measurement_time(Duration::from_secs(10));
+    group.bench_function("string_concat_200", |b| b.iter(|| run_source(&src_path)));
+    group.finish();
+    let _ = std::fs::remove_file(&src_path);
+}
+
+criterion_group!(benches, bench_fib, bench_bubble_sort, bench_string_processing);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Adds a Criterion-driven benchmark harness (`resilient/benches/interpreter.rs`) with three workloads hitting the tree-walker interpreter: recursive `fib(25)` (~243k calls), bubble-sort on a 50-element descending array, and a 200-iteration string-concatenation loop.
- Declares it as a `[[bench]]` target with `harness = false` so Criterion owns `main`; sample size is 10 and measurement time is 10s per bench because the tree-walker would blow past the default 100-sample budget.
- Captures an initial baseline on M1 Max at [`benchmarks/baseline.txt`](benchmarks/baseline.txt); README gains a short Performance section pointing at the run command.

Closes #27.

## Notes

The harness shells out to the compiled `resilient` binary rather than calling an in-process entry point. `resilient/src/main.rs` is ~16k lines and has no `lib.rs` — splitting a public library surface out for bench access alone was out of scope for RES-218. Process-startup overhead is constant across runs, so commit-over-commit deltas (the thing the harness is actually meant to surface) still read cleanly.

Sample baseline numbers (Apple M1 Max, release profile):
- `tree_walker/fib_25` — ~430 ms
- `tree_walker/bubble_sort_50` — ~7.9 ms
- `tree_walker/string_concat_200` — ~2.9 ms

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml` — clean build
- [x] `cargo test --manifest-path resilient/Cargo.toml` — full suite passes (663 unit + all integration)
- [x] `cargo bench --manifest-path resilient/Cargo.toml --bench interpreter` — all three benches run end-to-end and report timings

🤖 Generated with [Claude Code](https://claude.com/claude-code)