### PR TITLE
RES-216: FFI Callback type (Phase 1 stub)

### DIFF
--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -51,14 +51,15 @@ extern "LIBRARY_PATH" {
 
 Only primitive types are supported in FFI Phase 1:
 
-| Resilient   | C ABI            |
-|-------------|------------------|
-| `Int`       | `int64_t`        |
-| `Float`     | `double`         |
-| `Bool`      | `bool`           |
-| `String`    | not yet supported |
-| `Void`      | `void`           |
-| `OpaquePtr` | `void*` (opaque) |
+| Resilient   | C ABI                                          |
+|-------------|------------------------------------------------|
+| `Int`       | `int64_t`                                      |
+| `Float`     | `double`                                       |
+| `Bool`      | `bool`                                         |
+| `String`    | not yet supported                              |
+| `Void`      | `void`                                         |
+| `OpaquePtr` | `void*` (opaque)                               |
+| `Callback`  | C function pointer (Phase 1 stub — see below)  |
 
 At most 8 parameters per extern function.
 
@@ -103,6 +104,26 @@ Trampoline coverage today:
 
 Higher arities extend mechanically by adding an arm to
 `dispatch_explicit` in `ffi_trampolines.rs`.
+
+### `Callback` — Phase 1 stub
+
+Callback types are recognised in FFI declarations:
+
+```
+extern "libfoo.so" {
+    fn register_handler(cb: Callback) -> Void;
+}
+```
+
+Passing a Resilient function as `Callback` is stubbed in Phase 1 and returns
+a clean error:
+
+```
+FFI: extern fn `register_handler` uses a Callback parameter; callbacks
+require the trampoline feature (planned for Phase 2)
+```
+
+Real trampoline support is planned for Phase 2 (bytecode VM).
 
 ## Contracts
 

--- a/resilient/src/ffi.rs
+++ b/resilient/src/ffi.rs
@@ -28,6 +28,12 @@ pub enum FfiType {
     /// `sqlite3*`, etc. without teaching the language about their
     /// layout.
     OpaquePtr,
+    /// RES-216: a Resilient function reference passed to C as a
+    /// function pointer. Phase 1 parses and recognises this type but
+    /// calling an extern fn with a `Callback` argument returns
+    /// `FfiError::CallbackNotYetSupported`. Full trampoline support is
+    /// planned for Phase 2 (bytecode VM).
+    Callback,
 }
 
 impl FfiType {
@@ -39,6 +45,7 @@ impl FfiType {
             "String" => Some(FfiType::Str),
             "Void" => Some(FfiType::Void),
             "OpaquePtr" => Some(FfiType::OpaquePtr),
+            "Callback" => Some(FfiType::Callback),
             _ => None,
         }
     }
@@ -117,6 +124,13 @@ pub enum FfiError {
     StaticOnlyUnavailable {
         library: String,
     },
+    /// RES-216: the extern signature declared a `Callback` parameter
+    /// and a call attempted to use it. Phase 1 recognises the type
+    /// but cannot yet build a stable C function pointer from a
+    /// Resilient closure; Phase 2 (bytecode VM) adds real trampolines.
+    CallbackNotYetSupported {
+        name: String,
+    },
 }
 
 impl std::fmt::Display for FfiError {
@@ -149,6 +163,13 @@ impl std::fmt::Display for FfiError {
                     f,
                     "FFI: library descriptor `{}` requires a static registry, not available in this build",
                     library
+                )
+            }
+            FfiError::CallbackNotYetSupported { name } => {
+                write!(
+                    f,
+                    "FFI: extern fn `{}` uses a Callback parameter; callbacks require the trampoline feature (planned for Phase 2)",
+                    name
                 )
             }
         }
@@ -393,6 +414,26 @@ mod tests {
             "got {:?}",
             err
         );
+    }
+
+    #[test]
+    fn ffi_type_recognises_callback() {
+        // RES-216: the Callback type is recognised at declaration time.
+        assert_eq!(FfiType::from_resilient("Callback"), Some(FfiType::Callback));
+        let d = decl("register", "register", vec![("Callback", "cb")], "Void");
+        let sig = ForeignSignature::from_decl(&d).expect("Callback must parse");
+        assert_eq!(sig.params, vec![FfiType::Callback]);
+        assert_eq!(sig.ret, FfiType::Void);
+    }
+
+    #[test]
+    fn callback_error_display_mentions_phase_2() {
+        let err = FfiError::CallbackNotYetSupported {
+            name: "register_handler".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("register_handler"), "msg = {}", msg);
+        assert!(msg.contains("Phase 2"), "msg = {}", msg);
     }
 }
 

--- a/resilient/src/ffi_trampolines.rs
+++ b/resilient/src/ffi_trampolines.rs
@@ -12,7 +12,7 @@
 //! Unsupported signatures return a clean error referencing the
 //! `(params, ret)` tuple that was missing, so extending the table
 //! is mechanical when new call shapes appear.
-use crate::ffi::{FfiType, ForeignSymbol};
+use crate::ffi::{FfiError, FfiType, ForeignSymbol};
 use crate::{RResult, Value};
 
 #[allow(dead_code)]
@@ -33,6 +33,16 @@ pub fn call_foreign(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
             sym.sig.params.len(),
             args.len()
         ));
+    }
+
+    // RES-216: reject Callback arguments with a clean, discoverable error.
+    // Phase 1 recognises the type in extern signatures but cannot yet
+    // construct a stable C function pointer from a Resilient closure.
+    if sym.sig.params.contains(&FfiType::Callback) || sym.sig.ret == FfiType::Callback {
+        return Err(FfiError::CallbackNotYetSupported {
+            name: sym.name.clone(),
+        }
+        .to_string());
     }
 
     for (i, (arg, want)) in args.iter().zip(sym.sig.params.iter()).enumerate() {
@@ -362,6 +372,33 @@ mod tests {
             Value::OpaquePtr(h) => assert_eq!(h.0 as usize, 0xDEAD_BEEF),
             other => panic!("expected OpaquePtr, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn call_foreign_rejects_callback_argument_as_phase_1_stub() {
+        // RES-216: calling an extern fn that declared a `Callback`
+        // parameter must return a clean, documented error — not
+        // silently do nothing and not panic.
+        let sig = ForeignSignature {
+            params: vec![FfiType::Callback],
+            ret: FfiType::Void,
+        };
+        let sym = ForeignSymbol {
+            name: "register_handler".to_string(),
+            // Pointer value is irrelevant; we must short-circuit before dispatch.
+            ptr: sum_two_ints as *const (),
+            sig,
+        };
+        // Pass a Resilient Int as a placeholder for the callback value;
+        // the Callback branch must fire before type-matching happens.
+        let err =
+            call_foreign(&sym, &[Value::Int(0)]).expect_err("Callback arg must be rejected in v1");
+        assert!(
+            err.contains("Callback") && err.contains("Phase 2"),
+            "got {}",
+            err
+        );
+        assert!(err.contains("register_handler"), "got {}", err);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `FfiType::Callback` so Resilient extern signatures can declare C function-pointer parameters
- Phase 1 recognises and parses the type end-to-end; calling an extern fn with a `Callback` returns a clean `FfiError::CallbackNotYetSupported` pointing at Phase 2 (bytecode VM) for real trampoline support
- Documents the stub behaviour in `docs/ffi.md` and adds three tests covering recognition, error display, and end-to-end short-circuit

Closes #25.

## Why a stub?
A real callback requires synthesising a stable `extern "C" fn` at a known address that re-enters the Resilient evaluator — not possible in safe Rust for a tree-walker. The honest Phase 1 deliverable is: the type exists in the language, signatures parse, and a crystal-clear error fires the moment someone tries to actually hand a closure to C.

## Test plan
- [x] `cargo build --manifest-path resilient/Cargo.toml` (clean, no new warnings)
- [x] `cargo test --manifest-path resilient/Cargo.toml --features ffi` (685 unit + all integration tests pass, including 3 new)
- [x] `cargo test --manifest-path resilient/Cargo.toml` (no-feature build passes)
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --features ffi -- -D warnings` (no new warnings; one pre-existing error in `main.rs` not related to this change)

New tests:
- `ffi::tests::ffi_type_recognises_callback` — `from_resilient("Callback")` + `ForeignSignature::from_decl` accepts a `Callback` param
- `ffi::tests::callback_error_display_mentions_phase_2` — error message shape
- `ffi_trampolines::tests::call_foreign_rejects_callback_argument_as_phase_1_stub` — end-to-end short-circuit, names the symbol, mentions Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)