### PR TITLE
RES-212: pkg init creates resilient.toml; run reads package name from manifest

### DIFF
--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8169,18 +8169,54 @@ fn dispatch_pkg_subcommand(args: &[String]) -> Option<i32> {
         return None;
     }
     match args.get(2).map(|s| s.as_str()) {
+        // RES-212: explicit `--help` / `-h` / `help` emits the
+        // subcommand catalog on stdout so callers can pipe it into
+        // pagers / docs without stderr muddying the stream.
+        Some("--help") | Some("-h") | Some("help") => {
+            print_pkg_help();
+            Some(0)
+        }
         Some("init") => {
-            // `pkg init <name>` — the only subcommand for now.
-            // Future `pkg add`, `pkg build`, etc. will branch here.
-            let name = match args.get(3) {
-                Some(n) => n.as_str(),
-                None => {
+            // `pkg init [<name>] [--name <n>]`. Both forms are
+            // accepted; if both are supplied the last one on the
+            // command line wins, which matches how most CLI parsers
+            // resolve the conflict. Future `pkg add`, `pkg build`,
+            // etc. will branch here.
+            let mut name: Option<String> = None;
+            let mut i = 3;
+            while i < args.len() {
+                let a = &args[i];
+                if a == "--help" || a == "-h" {
+                    print_pkg_init_help();
+                    return Some(0);
+                } else if a == "--name" {
+                    i += 1;
+                    if i >= args.len() {
+                        eprintln!("Error: --name requires an argument");
+                        return Some(2);
+                    }
+                    name = Some(args[i].clone());
+                } else if let Some(v) = a.strip_prefix("--name=") {
+                    name = Some(v.to_string());
+                } else if a.starts_with("--") {
+                    eprintln!("Error: unknown flag `{}` to `pkg init`", a);
+                    return Some(2);
+                } else if name.is_none() {
+                    // First positional wins as the project name —
+                    // preserves the RES-205 invocation shape.
+                    name = Some(a.clone());
+                } else {
                     eprintln!(
-                        "Error: {}",
-                        pkg_init::PkgInitError::MissingName
+                        "Error: unexpected extra argument `{}` to `pkg init`",
+                        a
                     );
                     return Some(2);
                 }
+                i += 1;
+            }
+            let Some(name) = name else {
+                eprintln!("Error: {}", pkg_init::PkgInitError::MissingName);
+                return Some(2);
             };
             let cwd = match env::current_dir() {
                 Ok(p) => p,
@@ -8189,13 +8225,9 @@ fn dispatch_pkg_subcommand(args: &[String]) -> Option<i32> {
                     return Some(2);
                 }
             };
-            match pkg_init::scaffold_in(&cwd, name) {
+            match pkg_init::scaffold_in(&cwd, &name) {
                 Ok(scaffold) => {
-                    println!(
-                        "Created {} at {}",
-                        name,
-                        scaffold.root.display()
-                    );
+                    println!("Created {} at {}", name, scaffold.root.display());
                     for p in &scaffold.wrote {
                         println!("  wrote {}", p.display());
                     }
@@ -8212,16 +8244,73 @@ fn dispatch_pkg_subcommand(args: &[String]) -> Option<i32> {
         }
         Some(other) => {
             eprintln!(
-                "Error: unknown pkg subcommand `{}`. Known: init",
+                "Error: unknown pkg subcommand `{}`. Known: init. \
+                 Run `resilient pkg --help` for usage.",
                 other
             );
             Some(2)
         }
         None => {
-            eprintln!("Error: `resilient pkg` requires a subcommand. Known: init");
+            // Bare `resilient pkg` — surface the help catalog
+            // instead of bailing with a cryptic error. Exit 2 still
+            // (usage error) so shell scripts treat it as a failed
+            // invocation.
+            print_pkg_help_to_stderr();
             Some(2)
         }
     }
+}
+
+/// RES-212: `resilient pkg --help` output. Lists the known
+/// subcommands so new users don't have to grep source.
+fn print_pkg_help() {
+    println!(
+        "resilient pkg — package-manager subcommands\n\
+         \n\
+         USAGE:\n    \
+             resilient pkg <subcommand> [options]\n\
+         \n\
+         SUBCOMMANDS:\n    \
+             init    Scaffold a new project (resilient.toml + src/main.rs + .gitignore)\n    \
+             help    Show this message\n\
+         \n\
+         Run `resilient pkg init --help` for subcommand-specific options."
+    );
+}
+
+/// Same as `print_pkg_help` but writes to stderr. Used when the
+/// user invoked `resilient pkg` with no subcommand — we still want
+/// to be helpful, but the exit code is non-zero so the stream that
+/// carries the catalog matches the failure channel.
+fn print_pkg_help_to_stderr() {
+    eprintln!(
+        "resilient pkg — package-manager subcommands\n\
+         \n\
+         USAGE:\n    \
+             resilient pkg <subcommand> [options]\n\
+         \n\
+         SUBCOMMANDS:\n    \
+             init    Scaffold a new project (resilient.toml + src/main.rs + .gitignore)\n    \
+             help    Show this message\n\
+         \n\
+         Error: `resilient pkg` requires a subcommand."
+    );
+}
+
+/// `resilient pkg init --help`. Focused on the init-specific
+/// flags so users don't have to read the top-level catalog twice.
+fn print_pkg_init_help() {
+    println!(
+        "resilient pkg init — scaffold a new project\n\
+         \n\
+         USAGE:\n    \
+             resilient pkg init <name>\n    \
+             resilient pkg init --name <n>\n\
+         \n\
+         Creates `<name>/resilient.toml`, `<name>/src/main.rs`, and\n\
+         `<name>/.gitignore`. Refuses to overwrite an existing manifest\n\
+         or scaffold into a non-empty directory."
+    );
 }
 
 /// RES-194: `resilient verify-cert <dir> [--pubkey <path>]`.
@@ -9108,7 +9197,22 @@ fn main() {
                     return;
                 }
                 Err(e) => {
-                    eprintln!("Error: {}", e);
+                    // RES-212: when a `resilient.toml` manifest
+                    // sits above the source file, prefix the error
+                    // with `[<package-name>] ` so multi-project
+                    // workflows can tell which package bailed. We
+                    // search upward from the source's parent dir
+                    // (cargo-style); absence is silent.
+                    let pkg = std::path::Path::new(filename)
+                        .canonicalize()
+                        .ok()
+                        .and_then(|p| pkg_init::find_manifest_upwards(&p))
+                        .and_then(|m| pkg_init::read_package_name(&m));
+                    if let Some(name) = pkg {
+                        eprintln!("Error: [{}] {}", name, e);
+                    } else {
+                        eprintln!("Error: {}", e);
+                    }
                     std::process::exit(1);
                 }
             }

--- a/resilient/src/pkg_init.rs
+++ b/resilient/src/pkg_init.rs
@@ -1,16 +1,18 @@
-//! RES-205: `resilient pkg init <name>` — scaffolds a minimal project.
+//! RES-205 / RES-212: `resilient pkg init [<name>] [--name <n>]` —
+//! scaffolds a minimal project.
 //!
-//! Not a full package manager (follow-ups under G?? will handle deps,
-//! build graph, publish). This module just lays down three files so a
-//! new user has something to run:
+//! Not a full package manager (follow-ups will handle deps, build
+//! graph, publish). This module just lays down three files so a new
+//! user has something to run:
 //!
-//! - `Resilient.toml`  — manifest with `[package]` table
+//! - `resilient.toml`  — manifest with `[package]` and `[dependencies]`
 //! - `src/main.rs`     — hello-world entry point
 //! - `.gitignore`      — ignore build artifacts
 //!
 //! Design rules:
-//! - **Refuse to clobber.** If the target directory already exists and
-//!   is non-empty, bail. Fresh directory creation is allowed.
+//! - **Refuse to clobber.** If `resilient.toml` already exists in the
+//!   target, bail — don't overwrite a user's manifest silently.
+//!   Empty-directory scaffolding is still allowed.
 //! - **Two-phase fallback** isn't worth the complexity — if any of the
 //!   three writes fails mid-stream, we surface the error and stop; the
 //!   user can re-run after fixing whatever blocked us.
@@ -18,6 +20,16 @@
 //!   clear this is a "breaking-changes window" field rather than a
 //!   compiler version. `2026-04` matches today's manager date; future
 //!   editions will bump monotonically.
+//!
+//! RES-212 additions on top of RES-205:
+//! - Manifest file is now lowercase `resilient.toml` (was `Resilient.toml`).
+//! - Manifest carries `author = "..."` and an empty `[dependencies]`
+//!   table so downstream tooling has a stable shape to target.
+//! - `--name foo` flag supported as a non-interactive alternative to
+//!   the positional `<name>` arg (handled in the CLI dispatcher).
+//! - A tiny `read_package_name` helper lives here so the run path can
+//!   surface the package name in error messages without dragging in a
+//!   full TOML parser.
 
 use std::fs;
 use std::io;
@@ -26,6 +38,16 @@ use std::path::{Path, PathBuf};
 /// The edition string embedded in freshly-generated manifests. A
 /// date rather than a semver — see module doc-comment.
 pub const DEFAULT_EDITION: &str = "2026-04";
+
+/// Default author string stamped into generated manifests when the
+/// caller didn't supply one. Kept generic because `pkg init` can't
+/// reliably discover the user's identity cross-platform (no git
+/// config read, no `whoami` probe — both are footguns under sandbox).
+pub const DEFAULT_AUTHOR: &str = "unknown";
+
+/// Canonical manifest filename (lowercase per RES-212). Exposed as a
+/// constant so the run path, tests, and future tooling all agree.
+pub const MANIFEST_FILENAME: &str = "resilient.toml";
 
 /// Result of scaffolding. Carries the directory we created so the
 /// CLI can print a helpful "cd into it and run" line on success.
@@ -47,6 +69,10 @@ pub enum PkgInitError {
     InvalidName(String),
     /// Target directory exists and is non-empty.
     DirectoryNotEmpty(PathBuf),
+    /// `resilient.toml` already exists at the target — refuse to
+    /// clobber the user's manifest even when the dir is otherwise
+    /// empty (RES-212 idempotency guard).
+    ManifestExists(PathBuf),
     /// Something went wrong on disk — surface the `io::Error`.
     Io(io::Error),
 }
@@ -63,7 +89,7 @@ impl std::fmt::Display for PkgInitError {
             Self::MissingName => write!(
                 f,
                 "`resilient pkg init` requires a project name: \
-                 `resilient pkg init <name>`"
+                 `resilient pkg init <name>` or `resilient pkg init --name <n>`"
             ),
             Self::InvalidName(n) => write!(
                 f,
@@ -75,6 +101,12 @@ impl std::fmt::Display for PkgInitError {
                 f,
                 "refusing to scaffold into `{}`: directory already \
                  exists and is non-empty",
+                p.display()
+            ),
+            Self::ManifestExists(p) => write!(
+                f,
+                "refusing to overwrite existing manifest `{}`: \
+                 remove it first if you really want to reinitialize",
                 p.display()
             ),
             Self::Io(e) => write!(f, "i/o error: {}", e),
@@ -111,17 +143,22 @@ fn validate_name(name: &str) -> Result<(), PkgInitError> {
 /// - Non-existent target → create it and the three files.
 /// - Existing empty target → reuse and create the three files.
 /// - Existing non-empty target → `Err(DirectoryNotEmpty)`, no writes.
+/// - Pre-existing `resilient.toml` at the target → `Err(ManifestExists)`,
+///   even if the directory itself is otherwise empty.
 ///
 /// Returns the paths of every file we wrote in the order written.
 pub fn scaffold_in(parent: &Path, name: &str) -> Result<Scaffold, PkgInitError> {
     validate_name(name)?;
     let root = parent.join(name);
 
-    // Directory-state check. If it exists and has any entries,
-    // refuse — users can opt in to "merge into empty dir" by
-    // creating an empty dir first; a non-empty dir is opt-out
-    // territory.
+    // Directory-state checks. Manifest-exists wins over the general
+    // non-empty-dir error so callers get a sharper message — the
+    // idempotency guard is the common case ("I already ran init").
     if root.exists() {
+        let manifest_path = root.join(MANIFEST_FILENAME);
+        if manifest_path.exists() {
+            return Err(PkgInitError::ManifestExists(manifest_path));
+        }
         let is_non_empty = fs::read_dir(&root)?.next().is_some();
         if is_non_empty {
             return Err(PkgInitError::DirectoryNotEmpty(root));
@@ -135,8 +172,8 @@ pub fn scaffold_in(parent: &Path, name: &str) -> Result<Scaffold, PkgInitError> 
 
     // Write manifest. Keep formatting byte-for-byte stable so the
     // unit test can assert verbatim.
-    let manifest_path = root.join("Resilient.toml");
-    let manifest = render_manifest(name);
+    let manifest_path = root.join(MANIFEST_FILENAME);
+    let manifest = render_manifest(name, DEFAULT_AUTHOR);
     fs::write(&manifest_path, manifest)?;
 
     // Write hello-world entry point. The `int _d` param is the
@@ -158,15 +195,23 @@ pub fn scaffold_in(parent: &Path, name: &str) -> Result<Scaffold, PkgInitError> 
     })
 }
 
-/// Render the `Resilient.toml` body. Pure — factored out so tests
+/// Render the `resilient.toml` body. Pure — factored out so tests
 /// can assert on the exact bytes without an on-disk round-trip.
-pub fn render_manifest(name: &str) -> String {
+///
+/// `author` is injected so tests can stamp in a known value; the
+/// CLI passes `DEFAULT_AUTHOR` unless the user supplied their own
+/// in some future flag.
+pub fn render_manifest(name: &str, author: &str) -> String {
     format!(
         "[package]\n\
          name = \"{name}\"\n\
          version = \"0.1.0\"\n\
-         edition = \"{edition}\"\n",
+         author = \"{author}\"\n\
+         edition = \"{edition}\"\n\
+         \n\
+         [dependencies]\n",
         name = name,
+        author = author,
         edition = DEFAULT_EDITION,
     )
 }
@@ -191,6 +236,93 @@ fn main(int _d) {\n    println(\"Hello, world!\");\n    return 0;\n}\nmain(0);\n
 pub fn render_gitignore() -> &'static str {
     "target/\n\
      cert/\n"
+}
+
+/// RES-212: minimal TOML-ish reader for the `[package].name` field.
+///
+/// Intentionally hand-rolled to keep the compiler's dep tree small.
+/// We don't need a general TOML parser — just scan for a `name = "..."`
+/// line that appears under the `[package]` table and before any
+/// subsequent `[section]` header. Returns `None` when the file
+/// doesn't exist, can't be read, or doesn't contain a parseable
+/// `name`. Callers treat `None` as "no manifest, fall back to the
+/// raw filename."
+///
+/// Supported shape (lenient on whitespace):
+/// ```toml
+/// [package]
+/// name = "my-project"
+/// version = "0.1.0"
+/// ```
+///
+/// NOT supported (by design — these would drag in a real parser):
+/// - Multi-line basic strings (`"""..."""`).
+/// - Literal strings (`'...'`).
+/// - Escape sequences inside the name (`"\u0041"` stays raw).
+/// - Inline tables.
+///
+/// The manifests this function reads are the ones we write in
+/// `render_manifest`, so the tight shape is fine in practice.
+pub fn read_package_name(manifest_path: &Path) -> Option<String> {
+    let contents = fs::read_to_string(manifest_path).ok()?;
+    let mut in_package = false;
+    for raw in contents.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix('[') {
+            // New section header. Enter `[package]`, leave anything
+            // else.
+            let header = rest.trim_end_matches(']').trim();
+            in_package = header == "package";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        // Look for `name = "..."`. Split on the first `=`.
+        let Some((key, val)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "name" {
+            continue;
+        }
+        // Expect `"..."` (double-quoted basic string).
+        let v = val.trim().strip_prefix('"')?;
+        // Tolerate a trailing comment: `name = "foo" # …`.
+        let end = v.find('"')?;
+        let name = &v[..end];
+        if name.is_empty() {
+            return None;
+        }
+        return Some(name.to_string());
+    }
+    None
+}
+
+/// RES-212: walk upward from `start` looking for a sibling
+/// `resilient.toml`. Returns the manifest path if one is found.
+///
+/// `resilient run path/to/file.res` conventionally lives inside a
+/// project; rather than require the user to be in the project root,
+/// we search `start`, `start/..`, … up to the filesystem root. This
+/// matches how cargo finds `Cargo.toml`.
+pub fn find_manifest_upwards(start: &Path) -> Option<PathBuf> {
+    let mut dir = if start.is_file() {
+        start.parent()?.to_path_buf()
+    } else {
+        start.to_path_buf()
+    };
+    loop {
+        let candidate = dir.join(MANIFEST_FILENAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -218,7 +350,7 @@ mod tests {
         assert_eq!(out.root, parent.join("my-proj"));
         assert_eq!(out.wrote.len(), 3);
         // Every promised file exists.
-        assert!(parent.join("my-proj/Resilient.toml").exists());
+        assert!(parent.join("my-proj/resilient.toml").exists());
         assert!(parent.join("my-proj/src/main.rs").exists());
         assert!(parent.join("my-proj/.gitignore").exists());
 
@@ -229,13 +361,30 @@ mod tests {
     fn manifest_contents_match_template() {
         let parent = tmp_parent("manifest");
         scaffold_in(&parent, "cool_proj").expect("scaffold");
-        let got = fs::read_to_string(parent.join("cool_proj/Resilient.toml"))
+        let got = fs::read_to_string(parent.join("cool_proj/resilient.toml"))
             .expect("read manifest");
         let expected = format!(
-            "[package]\nname = \"cool_proj\"\nversion = \"0.1.0\"\nedition = \"{}\"\n",
+            "[package]\nname = \"cool_proj\"\nversion = \"0.1.0\"\nauthor = \"{}\"\nedition = \"{}\"\n\n[dependencies]\n",
+            DEFAULT_AUTHOR,
             DEFAULT_EDITION,
         );
         assert_eq!(got, expected);
+        let _ = fs::remove_dir_all(&parent);
+    }
+
+    #[test]
+    fn manifest_includes_dependencies_table() {
+        // Separate assertion so a future template change that drops
+        // `[dependencies]` fails loudly rather than silently.
+        let parent = tmp_parent("deps");
+        scaffold_in(&parent, "projdeps").expect("scaffold");
+        let got = fs::read_to_string(parent.join("projdeps/resilient.toml"))
+            .expect("read manifest");
+        assert!(
+            got.contains("[dependencies]"),
+            "missing [dependencies] table in: {got}"
+        );
+        assert!(got.contains("author = "), "missing author field in: {got}");
         let _ = fs::remove_dir_all(&parent);
     }
 
@@ -280,7 +429,31 @@ mod tests {
             "preexisting content",
         );
         // AND no manifest was written.
-        assert!(!target.join("Resilient.toml").exists());
+        assert!(!target.join("resilient.toml").exists());
+        let _ = fs::remove_dir_all(&parent);
+    }
+
+    #[test]
+    fn scaffold_refuses_when_manifest_already_exists() {
+        // RES-212 idempotency guard: a pre-existing `resilient.toml`
+        // should trigger `ManifestExists`, distinct from the
+        // general non-empty-dir error. This lets the CLI print a
+        // sharper message and hint at removing the file.
+        let parent = tmp_parent("manifest_exists");
+        let target = parent.join("already");
+        fs::create_dir(&target).unwrap();
+        fs::write(
+            target.join("resilient.toml"),
+            "[package]\nname = \"already\"\n",
+        )
+        .unwrap();
+
+        let err = scaffold_in(&parent, "already")
+            .expect_err("scaffold should refuse");
+        assert!(
+            matches!(err, PkgInitError::ManifestExists(_)),
+            "unexpected error: {:?}", err
+        );
         let _ = fs::remove_dir_all(&parent);
     }
 
@@ -292,7 +465,7 @@ mod tests {
         let target = parent.join("fresh");
         fs::create_dir(&target).unwrap();
         scaffold_in(&parent, "fresh").expect("scaffold should succeed");
-        assert!(target.join("Resilient.toml").exists());
+        assert!(target.join("resilient.toml").exists());
         let _ = fs::remove_dir_all(&parent);
     }
 
@@ -339,5 +512,56 @@ mod tests {
         assert!(validate_name("foo-bar").is_ok());
         assert!(validate_name("Foo.Bar").is_ok());
         assert!(validate_name("proj123").is_ok());
+    }
+
+    #[test]
+    fn read_package_name_picks_up_field() {
+        let parent = tmp_parent("readname");
+        scaffold_in(&parent, "pkg_read_ok").expect("scaffold");
+        let name =
+            read_package_name(&parent.join("pkg_read_ok/resilient.toml"))
+                .expect("should find name");
+        assert_eq!(name, "pkg_read_ok");
+        let _ = fs::remove_dir_all(&parent);
+    }
+
+    #[test]
+    fn read_package_name_ignores_unrelated_sections() {
+        // `name = "…"` inside a non-`[package]` section must not be
+        // reported; otherwise a future `[dependencies]` entry like
+        // `name = "sqlite"` would masquerade as the package name.
+        let parent = tmp_parent("readname_unrelated");
+        let manifest = parent.join("m.toml");
+        fs::write(
+            &manifest,
+            "[dependencies]\nname = \"not-the-package\"\n\n[package]\nname = \"real\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read_package_name(&manifest).as_deref(),
+            Some("real"),
+        );
+        let _ = fs::remove_dir_all(&parent);
+    }
+
+    #[test]
+    fn read_package_name_missing_file_is_none() {
+        let p = std::env::temp_dir().join("definitely-not-here-912374.toml");
+        assert!(read_package_name(&p).is_none());
+    }
+
+    #[test]
+    fn find_manifest_upwards_walks_parents() {
+        // Set up parent/proj/resilient.toml and start from
+        // parent/proj/src/nested/ — the search should climb up.
+        let parent = tmp_parent("walkup");
+        let proj = parent.join("proj");
+        let nested = proj.join("src/nested");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(proj.join("resilient.toml"), "[package]\nname = \"p\"\n")
+            .unwrap();
+        let found = find_manifest_upwards(&nested).expect("should find");
+        assert_eq!(found, proj.join("resilient.toml"));
+        let _ = fs::remove_dir_all(&parent);
     }
 }

--- a/resilient/tests/pkg_init_smoke.rs
+++ b/resilient/tests/pkg_init_smoke.rs
@@ -1,4 +1,4 @@
-//! RES-205: integration test for the `resilient pkg init <name>`
+//! RES-205 / RES-212: integration test for the `resilient pkg init`
 //! subcommand. Spawns the real binary inside a scratch parent
 //! directory, asserts the expected file layout, and checks that the
 //! manifest + gitignore have the templated content.
@@ -49,13 +49,13 @@ fn pkg_init_creates_project_skeleton() {
     // Expected layout.
     let root = parent.join("hello_res");
     assert!(root.is_dir(), "project root {} missing", root.display());
-    assert!(root.join("Resilient.toml").is_file(), "manifest missing");
+    assert!(root.join("resilient.toml").is_file(), "manifest missing");
     assert!(root.join("src/main.rs").is_file(), "entry point missing");
     assert!(root.join(".gitignore").is_file(), "gitignore missing");
 
-    // Manifest content — pin [package] + name to catch template
-    // drift.
-    let manifest = std::fs::read_to_string(root.join("Resilient.toml"))
+    // Manifest content — pin [package] + name + [dependencies] to
+    // catch template drift.
+    let manifest = std::fs::read_to_string(root.join("resilient.toml"))
         .expect("read manifest");
     assert!(manifest.contains("[package]"), "missing [package]: {manifest}");
     assert!(
@@ -69,6 +69,14 @@ fn pkg_init_creates_project_skeleton() {
     assert!(
         manifest.contains("edition = "),
         "missing edition in: {manifest}"
+    );
+    assert!(
+        manifest.contains("author = "),
+        "missing author field in: {manifest}"
+    );
+    assert!(
+        manifest.contains("[dependencies]"),
+        "missing [dependencies] table in: {manifest}"
     );
 
     // Entry point has the hello-world greeting.
@@ -85,6 +93,89 @@ fn pkg_init_creates_project_skeleton() {
     assert!(gi.contains("target/"), "missing target/ in: {gi}");
     assert!(gi.contains("cert/"), "missing cert/ in: {gi}");
 
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
+fn pkg_init_accepts_name_flag() {
+    // RES-212: the `--name foo` flag is the non-interactive path
+    // for automation. Equivalent to the positional `pkg init foo`.
+    let parent = tmp_parent("nameflag");
+    let output = Command::new(bin())
+        .args(["pkg", "init", "--name", "via_flag"])
+        .current_dir(&parent)
+        .output()
+        .expect("spawn resilient pkg init --name");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let root = parent.join("via_flag");
+    let manifest = std::fs::read_to_string(root.join("resilient.toml"))
+        .expect("read manifest");
+    assert!(
+        manifest.contains(r#"name = "via_flag""#),
+        "missing name in: {manifest}"
+    );
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
+fn pkg_init_name_flag_equals_form() {
+    // `--name=foo` should work identically to `--name foo`.
+    let parent = tmp_parent("nameeq");
+    let output = Command::new(bin())
+        .args(["pkg", "init", "--name=via_equals"])
+        .current_dir(&parent)
+        .output()
+        .expect("spawn resilient pkg init --name=");
+    assert!(output.status.success(), "stderr: {}",
+        String::from_utf8_lossy(&output.stderr));
+    assert!(parent.join("via_equals/resilient.toml").exists());
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
+fn pkg_init_errors_on_existing_manifest() {
+    // RES-212 idempotency guard: if `resilient.toml` already lives
+    // in the target, we bail with `ManifestExists`, not the general
+    // non-empty-dir error. The stderr should hint at the remove-
+    // then-reinit recovery path.
+    let parent = tmp_parent("existing_manifest");
+    let target = parent.join("seeded");
+    std::fs::create_dir(&target).unwrap();
+    std::fs::write(
+        target.join("resilient.toml"),
+        "[package]\nname = \"seeded\"\n",
+    )
+    .unwrap();
+
+    let output = Command::new(bin())
+        .args(["pkg", "init", "seeded"])
+        .current_dir(&parent)
+        .output()
+        .expect("spawn resilient pkg init");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit. stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("existing manifest") || stderr.contains("overwrite"),
+        "expected existing-manifest diagnostic, got stderr: {stderr}"
+    );
+    // Pre-existing manifest content untouched.
+    assert_eq!(
+        std::fs::read_to_string(target.join("resilient.toml")).unwrap(),
+        "[package]\nname = \"seeded\"\n",
+    );
     let _ = std::fs::remove_dir_all(&parent);
 }
 
@@ -122,7 +213,7 @@ fn pkg_init_errors_on_nonempty_directory() {
     );
     // And no manifest was written.
     assert!(
-        !target.join("Resilient.toml").exists(),
+        !target.join("resilient.toml").exists(),
         "manifest leaked into non-empty dir"
     );
 
@@ -151,6 +242,52 @@ fn pkg_init_missing_name_errors() {
 }
 
 #[test]
+fn pkg_help_lists_subcommands() {
+    // RES-212: `resilient pkg --help` should print a catalog of
+    // subcommands and exit 0.
+    let parent = tmp_parent("help");
+    let output = Command::new(bin())
+        .args(["pkg", "--help"])
+        .current_dir(&parent)
+        .output()
+        .expect("spawn resilient pkg --help");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("init"),
+        "help output missing `init` subcommand: {stdout}"
+    );
+    assert!(
+        stdout.to_lowercase().contains("subcommand"),
+        "help output missing subcommand marker: {stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
+fn pkg_bare_prints_help_on_stderr() {
+    // `resilient pkg` with no subcommand is a usage error (exit 2)
+    // but we still print the subcommand list to stderr so users can
+    // self-correct without a second invocation.
+    let parent = tmp_parent("bare_pkg");
+    let output = Command::new(bin())
+        .arg("pkg")
+        .current_dir(&parent)
+        .output()
+        .expect("spawn resilient pkg");
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("init"), "expected init in stderr: {stderr}");
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
 fn pkg_unknown_subcommand_errors() {
     // `resilient pkg whatever` should bail gracefully with a
     // "known subcommands" hint rather than hitting the compiler
@@ -168,5 +305,51 @@ fn pkg_unknown_subcommand_errors() {
         stderr.contains("unknown pkg subcommand") || stderr.contains("floofnicate"),
         "expected error naming the bad verb, got: {stderr}"
     );
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
+fn run_prefixes_errors_with_package_name() {
+    // RES-212: when a `resilient.toml` manifest sits beside the
+    // source file (or up a parent chain), a failing `resilient run`
+    // should prefix the stderr diagnostic with `[<package-name>] `.
+    //
+    // We deliberately write a source file that references an
+    // undefined identifier so the interpreter / compiler fails
+    // fast — no need to exercise a full error path.
+    let parent = tmp_parent("run_pkg_prefix");
+    let proj = parent.join("broken_proj");
+    std::fs::create_dir_all(proj.join("src")).unwrap();
+    std::fs::write(
+        proj.join("resilient.toml"),
+        "[package]\nname = \"my_pkg_212\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    // Reference an undefined identifier so runtime / compile bails.
+    let src_path = proj.join("src/main.rs");
+    std::fs::write(
+        &src_path,
+        "fn main(int _d) {\n    println(not_a_real_thing);\n    return 0;\n}\nmain(0);\n",
+    )
+    .unwrap();
+
+    let output = Command::new(bin())
+        .arg(&src_path)
+        .current_dir(&proj)
+        .output()
+        .expect("spawn resilient run");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit from broken program. stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[my_pkg_212]"),
+        "expected [my_pkg_212] package-name prefix in stderr: {stderr}"
+    );
+
     let _ = std::fs::remove_dir_all(&parent);
 }


### PR DESCRIPTION
## Summary
- Renames scaffolded manifest to lowercase `resilient.toml`; adds `author` and empty `[dependencies]` table to the template.
- `resilient pkg init` now accepts `--name <n>` / `--name=<n>` non-interactively and refuses to clobber a pre-existing manifest with a dedicated `ManifestExists` error.
- `resilient pkg --help` / `pkg help` / bare `resilient pkg` surface a subcommand catalog.
- `resilient <file>` walks upward from the source to find a `resilient.toml`; when present, runtime errors are prefixed with `[<package-name>] ` so multi-project workflows can tell which package bailed. Manifest reader is a tiny hand-rolled scanner (no TOML crate added).

## Test plan
- [x] `cargo test --manifest-path resilient/Cargo.toml` (669 unit + all integration tests pass)
- [x] `cargo clippy --manifest-path resilient/Cargo.toml -- -D warnings` (clean)
- [x] New integration coverage in `tests/pkg_init_smoke.rs`: `--name` flag (spaced + `=`), idempotency guard, help text, and run-time error prefix with package name.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)