### PR TITLE
RES-217: emit partial-proof warning when Z3 returns Unknown/timeout

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -478,6 +478,30 @@ lexer panic on any input — everything surfaces as a recoverable
 error. A program that fails to parse or evaluate exits non-zero, so
 CI and shell pipelines can branch on success.
 
+### Partial proofs (Z3 `Unknown`) — RES-217
+
+When a `requires` or `ensures` clause falls to the Z3 backend and the
+solver answers `Unknown` (either hitting the per-query timeout set by
+`--verifier-timeout-ms` or legitimately failing to decide the
+obligation — typical for nonlinear integer arithmetic), the
+typechecker emits a structured warning and keeps the runtime check:
+
+```
+warning[partial-proof]: Z3 returned Unknown for assertion at foo.rs:12:18 — proof is incomplete
+```
+
+Compilation still succeeds — the obligation downgrades silently to a
+runtime assertion — but the warning gives CI and review tooling a
+stable `[partial-proof]` tag to grep for, plus a precise
+`<file>:<line>:<col>` pointer to the offending clause.
+
+The warning is **on by default**. Pass `--no-warn-unverified` to
+suppress it (useful for CI pipelines that already gate on separate
+verification signals); pass `--warn-unverified` to opt in explicitly
+even though that matches the default. The pre-existing per-function
+`hint: proof timed out after <N>ms …` line is independent and
+unaffected by this flag.
+
 ## Compiling and Running
 
 ```bash

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -7914,6 +7914,7 @@ fn execute_file(
     use_vm: bool,
     use_jit: bool,
     verifier_timeout_ms: u32,
+    warn_unverified: bool,
 ) -> RResult<()> {
     let contents = fs::read_to_string(filename)
         .map_err(|e| format!("Error reading file: {}", e))?;
@@ -7963,7 +7964,11 @@ fn execute_file(
             // value. A fresh `TypeChecker::new()` defaults to 5000;
             // passing the CLI value through keeps the flag
             // meaningful on the `--typecheck` / `--audit` paths.
-            .with_verifier_timeout_ms(verifier_timeout_ms);
+            .with_verifier_timeout_ms(verifier_timeout_ms)
+            // RES-217: `--no-warn-unverified` flips this off; the
+            // default (on) surfaces `warning[partial-proof]`
+            // diagnostics whenever Z3 returns Unknown.
+            .with_warn_unverified(warn_unverified);
         // RES-080: pass the source filename so per-statement errors
         // are prefixed with `<file>:<line>:<col>:`.
         match tc.check_program_with_source(&program, filename) {
@@ -8833,6 +8838,11 @@ fn main() {
     // RES-137: per-query Z3 solver timeout in milliseconds. 0 means
     // "no timeout". Default 5000 matches the ticket's recommendation.
     let mut verifier_timeout_ms: u32 = 5000;
+    // RES-217: emit `warning[partial-proof]` when Z3 returns Unknown
+    // (timeout or genuine unknown). Default ON so partial proofs are
+    // never silent; `--no-warn-unverified` suppresses them for CI
+    // pipelines that deliberately accept best-effort verification.
+    let mut warn_unverified: bool = true;
     // RES-150: `--seed <u64>` pins the RNG seed for determinism.
     // `None` → fall back to clock-derived seed at startup.
     let mut seed_override: Option<u64> = None;
@@ -8924,6 +8934,17 @@ fn main() {
                     );
                     std::process::exit(2);
                 });
+            } else if arg == "--warn-unverified" {
+                // RES-217: explicit opt-in (also the default). Keeps
+                // the flag discoverable in `--help` and in scripts
+                // that want to be explicit about relying on the
+                // partial-proof diagnostic.
+                warn_unverified = true;
+            } else if arg == "--no-warn-unverified" {
+                // RES-217: suppress `warning[partial-proof]` output.
+                // Intended for CI pipelines that already gate on
+                // verification signals and don't want the noise.
+                warn_unverified = false;
             } else if arg == "--seed" {
                 // RES-150: `--seed <u64>` pins the SplitMix64 PRNG.
                 // Reproducible runs: same seed → same sequence.
@@ -9082,6 +9103,7 @@ fn main() {
                 use_vm,
                 use_jit,
                 verifier_timeout_ms,
+                warn_unverified,
             );
             // RES-174: print cache stats on exit whenever the
             // flag is set, regardless of whether the run

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -439,6 +439,59 @@ fn z3_prove_with_cert(
     (None, None, None, false)
 }
 
+/// RES-217: best-effort span for a contract clause. Mirrors
+/// the helper in `infer::expr_span` — duplicated here so the
+/// typechecker stays independent of the inference module's
+/// feature gating. Nodes outside the supported expression
+/// subset fall back to a default (line-0) span, which the
+/// warning formatter detects and prints `<unknown>` for.
+fn clause_span(node: &Node) -> Span {
+    match node {
+        Node::IntegerLiteral { span, .. }
+        | Node::FloatLiteral { span, .. }
+        | Node::StringLiteral { span, .. }
+        | Node::BooleanLiteral { span, .. }
+        | Node::Identifier { span, .. }
+        | Node::InfixExpression { span, .. }
+        | Node::PrefixExpression { span, .. }
+        | Node::CallExpression { span, .. }
+        | Node::TryExpression { span, .. } => *span,
+        _ => Span::default(),
+    }
+}
+
+/// RES-217: format + print the partial-proof warning to stderr.
+/// The message follows the ticket's mandated shape:
+///
+/// ```text
+/// warning[partial-proof]: Z3 returned Unknown for assertion at <file>:<line>:<col> — proof is incomplete
+/// ```
+///
+/// `source_path` is the typechecker's recorded file path (set
+/// by `check_program_with_source`); an empty string falls back
+/// to `<unknown>` so REPL / unit-test callers still produce a
+/// readable line. Spans whose `start.line` is 0 (synthetic
+/// clauses, e.g. REPL-constructed AST) print `<unknown>` for
+/// the position — avoiding misleading `:0:0`.
+#[cfg_attr(not(feature = "z3"), allow(dead_code))]
+fn emit_partial_proof_warning(source_path: &str, clause: &Node) {
+    let span = clause_span(clause);
+    let file = if source_path.is_empty() {
+        "<unknown>"
+    } else {
+        source_path
+    };
+    let location = if span.start.line == 0 {
+        format!("{}:<unknown>", file)
+    } else {
+        format!("{}:{}:{}", file, span.start.line, span.start.column)
+    };
+    eprintln!(
+        "warning[partial-proof]: Z3 returned Unknown for assertion at {} \u{2014} proof is incomplete",
+        location
+    );
+}
+
 /// RES-071: a single SMT-LIB2 proof certificate that the typechecker
 /// captured when Z3 successfully discharged a contract obligation.
 /// Filename on disk: `{fn_name}__{kind}__{idx}.smt2`.
@@ -482,6 +535,21 @@ pub struct TypeChecker {
     /// Unknown — treated as "not proven" rather than an error, so
     /// compilation continues with the runtime check retained.
     verifier_timeout_ms: u32,
+    /// RES-217: when `true`, Z3 returning `Unknown` (timeout or
+    /// undecidable theory) emits a `warning[partial-proof]`
+    /// diagnostic to stderr that names the specific assertion
+    /// and its source position. Defaults to `true`; the driver
+    /// flips it off via `--no-warn-unverified` when CI noise is
+    /// unwanted. Independent of the pre-existing `hint: proof
+    /// timed out ...` line, which is the per-fn diagnostic about
+    /// the `--verifier-timeout-ms` budget.
+    warn_unverified: bool,
+    /// RES-217: source path threaded from
+    /// `check_program_with_source` so the partial-proof warning
+    /// can print `<file>:<line>:<col>`. Empty when the caller
+    /// used the `check_program` shim (REPL / unit tests); the
+    /// warning falls back to `<unknown>` in that case.
+    source_path: String,
     /// RES-189: inferred types for unannotated `let` bindings,
     /// accumulated during the walk. The LSP backend reads this
     /// after `check_program_with_source` to produce inlay hints.
@@ -768,6 +836,10 @@ impl TypeChecker {
             type_aliases: HashMap::new(),
             // RES-137: ticket's default is 5 seconds per query.
             verifier_timeout_ms: 5000,
+            // RES-217: partial-proof warnings on by default.
+            warn_unverified: true,
+            // RES-217: populated by `check_program_with_source`.
+            source_path: String::new(),
             // RES-189: populated during LetStatement handling.
             let_type_hints: Vec::new(),
         }
@@ -782,7 +854,18 @@ impl TypeChecker {
         self.verifier_timeout_ms = ms;
         self
     }
-    
+
+    /// RES-217: toggle partial-proof warnings. When `true`
+    /// (default), Z3 `Unknown` verdicts surface as
+    /// `warning[partial-proof]: Z3 returned Unknown for
+    /// assertion at <file>:<line>:<col> — proof is incomplete`.
+    /// The driver flips this to `false` on `--no-warn-unverified`
+    /// for CI runs that want a quieter stderr.
+    pub fn with_warn_unverified(mut self, on: bool) -> Self {
+        self.warn_unverified = on;
+        self
+    }
+
     pub fn check_program(&mut self, program: &Node) -> Result<Type, String> {
         // Backwards-compatible thin shim: callers that don't have a
         // source path (REPL, unit tests) keep the original signature.
@@ -802,6 +885,9 @@ impl TypeChecker {
         program: &Node,
         source_path: &str,
     ) -> Result<Type, String> {
+        // RES-217: stash the source path for partial-proof
+        // warnings that want to print `<file>:<line>:<col>`.
+        self.source_path = source_path.to_string();
         match program {
             Node::Program(statements) => {
                 // RES-061: pre-pass to register every top-level Function
@@ -946,6 +1032,15 @@ impl TypeChecker {
                                 "hint: proof timed out after {}ms — runtime check retained (fn {})",
                                 self.verifier_timeout_ms, name
                             );
+                        }
+                        // RES-217: any unresolved verdict (timeout OR a
+                        // genuine Z3 `Unknown`) is a partial proof. Emit
+                        // the structured diagnostic so CI / LSP tooling
+                        // can discover the specific assertion via a
+                        // stable `[partial-proof]` tag. Suppressed with
+                        // `--no-warn-unverified`.
+                        if verdict.is_none() && self.warn_unverified {
+                            emit_partial_proof_warning(&self.source_path, clause);
                         }
                         decl_counterexample = cx;
                     }
@@ -1719,6 +1814,17 @@ impl TypeChecker {
                                 eprintln!(
                                     "hint: proof timed out after {}ms — runtime check retained (call to fn {})",
                                     self.verifier_timeout_ms, callee_name
+                                );
+                            }
+                            // RES-217: any unresolved verdict (timeout
+                            // OR a genuine Z3 `Unknown`) is a partial
+                            // proof. Emit the structured diagnostic
+                            // with the specific assertion's source
+                            // position; suppressed on
+                            // `--no-warn-unverified`.
+                            if verdict.is_none() && self.warn_unverified {
+                                emit_partial_proof_warning(
+                                    &self.source_path, clause,
                                 );
                             }
                             if matches!(verdict, Some(true))

--- a/resilient/tests/examples_smoke.rs
+++ b/resilient/tests/examples_smoke.rs
@@ -652,6 +652,99 @@ fn bytecode_jit_runs_while_loop() {
     let _ = std::fs::remove_file(&tmp);
 }
 
+/// RES-217: helper — write a temp program whose requires-clause is a
+/// nonlinear integer predicate Z3 cannot resolve in 1ms. The contract
+/// `a*a*a + b*b*b != 9*a*b*b + 3` (Mordell-curve-like form) forces the
+/// NIA engine into a non-trivial search; with `--verifier-timeout-ms 1`
+/// it reliably hits the timeout on every platform we run CI on.
+#[cfg(feature = "z3")]
+fn write_partial_proof_program(tag: &str) -> std::path::PathBuf {
+    use std::io::Write;
+    let tmp = std::env::temp_dir().join(format!(
+        "res_217_{}_{}.rs",
+        tag,
+        std::process::id()
+    ));
+    let src = "\
+fn check(int a, int b)
+    requires a * a * a + b * b * b != 9 * a * b * b + 3
+{
+    return;
+}
+
+fn main() {
+    check(1, 2);
+}
+
+main();
+";
+    let mut f = std::fs::File::create(&tmp).expect("create tmp");
+    f.write_all(src.as_bytes()).unwrap();
+    tmp
+}
+
+#[test]
+#[cfg(feature = "z3")]
+fn partial_proof_warning_fires_on_z3_timeout() {
+    // RES-217: when Z3 returns Unknown (here forced by a 1ms budget
+    // on a nonlinear-int obligation), the typechecker must emit the
+    // structured `warning[partial-proof]:` line pointing at the
+    // specific assertion's source position. Compilation still
+    // succeeds and the runtime check is retained.
+    let tmp = write_partial_proof_program("timeout");
+    let output = Command::new(bin())
+        .arg("--typecheck")
+        .arg("--verifier-timeout-ms")
+        .arg("1")
+        .arg(&tmp)
+        .output()
+        .expect("spawn resilient --typecheck");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning[partial-proof]:"),
+        "expected partial-proof warning in stderr; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Z3 returned Unknown for assertion at"),
+        "expected canonical warning body; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("proof is incomplete"),
+        "expected warning suffix; got:\n{stderr}"
+    );
+    // File path and line:col should be present (not `<unknown>`).
+    let tmp_str = tmp.to_string_lossy();
+    assert!(
+        stderr.contains(tmp_str.as_ref()),
+        "expected source path in warning; got:\n{stderr}"
+    );
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[test]
+#[cfg(feature = "z3")]
+fn no_warn_unverified_suppresses_partial_proof_warning() {
+    // RES-217: `--no-warn-unverified` silences the structured
+    // warning even when Z3 times out. The per-fn `hint:` line
+    // (pre-RES-217 diagnostic) is still emitted — the two are
+    // intentionally independent signals.
+    let tmp = write_partial_proof_program("suppressed");
+    let output = Command::new(bin())
+        .arg("--typecheck")
+        .arg("--verifier-timeout-ms")
+        .arg("1")
+        .arg("--no-warn-unverified")
+        .arg(&tmp)
+        .output()
+        .expect("spawn resilient --typecheck --no-warn-unverified");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("warning[partial-proof]:"),
+        "partial-proof warning should be suppressed; got:\n{stderr}"
+    );
+    let _ = std::fs::remove_file(&tmp);
+}
+
 #[test]
 fn minimal_rs_runs_end_to_end() {
     // After RES-003 (println) and RES-008 (string+primitive coercion)


### PR DESCRIPTION
## Summary

- Z3 `Unknown` verdicts (timeout or genuinely undecidable obligations) now emit a structured `warning[partial-proof]:` diagnostic pointing at the specific assertion's source position. Compilation still succeeds; the runtime check is retained.
- New flags: `--warn-unverified` (default on) / `--no-warn-unverified` (opt-out, for CI pipelines that gate on separate verification signals).
- Warning is independent of the pre-existing per-function `hint: proof timed out ...` line — the two carry different information (hint is per-fn + timeout-only; `warning[partial-proof]` is per-clause + covers genuine Unknown).

## Details

- `TypeChecker` gains two fields (`warn_unverified`, `source_path`) and one builder (`with_warn_unverified`). The source path is threaded from `check_program_with_source` so the warning can print `<file>:<line>:<col>`.
- Both contract-check sites (decl-time requires/ensures fold and call-site requires) emit the warning when the verdict is `None` after Z3 ran — capturing both timeout and non-timeout Unknown paths.
- Synthetic clauses (AST constructed with line-0 spans, e.g. REPL unit tests) fall back to `<unknown>` for the position rather than a misleading `:0:0`.

## Format

```
warning[partial-proof]: Z3 returned Unknown for assertion at foo.rs:12:18 — proof is incomplete
```

## Test plan

- [x] `partial_proof_warning_fires_on_z3_timeout`: nonlinear-int contract (`a*a*a + b*b*b != 9*a*b*b + 3`) with `--verifier-timeout-ms 1` — warning appears with the canonical shape and correct source path.
- [x] `no_warn_unverified_suppresses_partial_proof_warning`: same program with `--no-warn-unverified` — warning is absent; the per-fn `hint:` line is still emitted.
- [x] `cargo test --features z3` — 756+ tests pass.
- [x] `cargo test` (no z3) — 724+ tests pass; the two new tests are `#[cfg(feature = "z3")]`-gated.
- [x] `cargo clippy --features z3 --all-targets -- -D warnings` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.

Closes #26.