### PR TITLE
MGR: exclude superpowers/ from Jekyll — fix Deploy Docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -58,3 +58,4 @@ exclude:
   - "*.lock"
   - vendor/
   - node_modules/
+  - superpowers/


### PR DESCRIPTION
## Summary
- Adds `superpowers/` to Jekyll's `exclude:` list in `docs/_config.yml`
- These are internal planning/spec files with raw Rust `{{` in code blocks that Liquid misparses
- Fixes: Deploy Docs / build failing with Liquid SyntaxError

## Test plan
- [ ] Deploy Docs workflow should pass on this PR
- [ ] Public docs site content unchanged (superpowers/ was never intended to be published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)