### PR TITLE
MGR: agent infra — issue templates, release workflow, CONTRIBUTING

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-ready-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/agent-ready-ticket.yml
@@ -1,0 +1,75 @@
+name: Agent-Ready Ticket
+description: A well-scoped task structured for autonomous AI agents (or humans) to pick up and implement
+labels: ["enhancement", "ticket", "agent-ready"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for new work items. The more specific the acceptance criteria, the easier it is for an agent to pick up and implement correctly.
+  - type: input
+    id: ticket-id
+    attributes:
+      label: Ticket ID
+      description: Next RES-NNN number (check .board/tickets/ for the current max)
+      placeholder: "RES-NNN"
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should exist or work after this ticket is done? One paragraph.
+    validations:
+      required: true
+  - type: textarea
+    id: files-to-touch
+    attributes:
+      label: Files / modules to touch
+      description: List the files or modules an implementor should read and modify
+      placeholder: |
+        - resilient/src/main.rs — add CLI subcommand
+        - resilient/tests/foo_smoke.rs — add integration test
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Concrete pass/fail checks. Each item should be verifiable by running a command or reading code.
+      placeholder: |
+        - [ ] `cargo test foo_` passes
+        - [ ] `resilient foo --help` prints usage to stdout and exits 0
+        - [ ] No new clippy warnings
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: Explicitly name things NOT to do in this ticket
+  - type: dropdown
+    id: roadmap-goal
+    attributes:
+      label: Roadmap goal
+      description: Which roadmap goalpost does this serve? (see .board/ROADMAP.md)
+      options:
+        - G1 — Hello World
+        - G2 — Arithmetic
+        - G3 — Control flow
+        - G4 — Functions
+        - G5 — Strings
+        - G6 — Structs
+        - G7 — Pattern matching
+        - G8 — Modules
+        - G9 — Effect system
+        - G10 — Type inference
+        - G11 — LSP
+        - G12 — Verifier
+        - G13 — Package manager
+        - G14 — Embedded runtime
+        - G15 — JIT
+        - G16 — FFI
+        - G17 — Concurrency
+        - G18 — Self-hosting
+        - G19 — Stability
+        - G20 — Release
+        - G21+ — Future
+        - Infra / tooling (no roadmap goal)

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,35 @@
+name: Bug Report
+description: Something is broken or behaves unexpectedly
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Write this Resilient program: ...
+        2. Run: resilient foo.res
+        3. Expected: ...
+        4. Got: ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - OS: macOS 14 / Ubuntu 24.04
+        - Rust: 1.78.0
+        - resilient version: main @ abc1234
+  - type: textarea
+    id: extra
+    attributes:
+      label: Extra context
+      description: Logs, backtrace, related issues

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion / questions
+    url: https://github.com/EricSpencer00/Resilient/discussions
+    about: Ask questions, share ideas, or discuss the language

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (for aarch64-linux)
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (native)
+        if: "!matrix.cross"
+        run: cargo build --release --locked --target ${{ matrix.target }}
+        working-directory: resilient
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --locked --target ${{ matrix.target }}
+        working-directory: resilient
+
+      - name: Package
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME:-manual}"
+          TARGET="${{ matrix.target }}"
+          BINARY="resilient/target/${TARGET}/release/resilient"
+          ARCHIVE="resilient-${TAG}-${TARGET}.tar.gz"
+          strip "$BINARY" 2>/dev/null || true
+          tar czf "$ARCHIVE" -C "$(dirname "$BINARY")" "$(basename "$BINARY")"
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  release:
+    name: create GitHub release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "Resilient ${{ github.ref_name }}" \
+            --generate-notes \
+            artifacts/*.tar.gz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,9 +284,97 @@ Keep PRs small and focused — one ticket per PR is ideal.
 
 ---
 
+## Releases
+
+Releases are cut by pushing a semver tag (`vMAJOR.MINOR.PATCH`) to `main`:
+
+```bash
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+This triggers two workflows automatically:
+- **release** — builds native binaries for Linux (amd64 + arm64) and macOS (amd64 + arm64), creates a GitHub Release with auto-generated notes and attached archives.
+- **release-image** — builds and pushes a multi-arch Docker image to `ghcr.io/ericspencer00/resilient`.
+
+Pre-releases use a tag like `v0.3.0-alpha.1` — the Docker image gets tagged but not promoted to `latest`.
+
+---
+
 ## For AI Agent Contributors
 
-AI agents are first-class contributors. The same rules apply as for humans:
+AI agents (Claude Code, OpenHands, Codex, Devin, and others) are first-class
+contributors. The same rules apply as for humans, plus a few agent-specific
+notes to help you orient quickly.
+
+### Quick Start for agents
+
+1. **Find work** — Browse `.board/tickets/OPEN/` in the repo or GitHub Issues
+   filtered by `agent-ready`:
+   <https://github.com/EricSpencer00/Resilient/issues?q=is%3Aissue+is%3Aopen+label%3Aagent-ready>
+   Each `agent-ready` issue was filed with the *Agent-Ready Ticket* template
+   and includes a Goal, explicit Acceptance Criteria, and a list of files to
+   touch — everything you need to start without further clarification.
+
+2. **Claim it** — Move the ticket file and add your agent ID:
+   ```bash
+   git mv .board/tickets/OPEN/RES-NNN-*.md .board/tickets/IN_PROGRESS/
+   # edit the file: add  Claimed-by: <agent-id>  to the header
+   git commit -m "RES-NNN: claim ticket"
+   ```
+
+3. **Branch** — Work on a branch named after the ticket:
+   ```bash
+   git checkout -b res-NNN-short-title
+   ```
+
+4. **Implement** — Read the ticket's "Files / modules to touch" list. Run the
+   acceptance criteria commands as you go.
+
+5. **Verify before pushing**:
+   ```bash
+   cargo fmt --all
+   cargo clippy --all-targets -- -D warnings
+   cargo test --manifest-path resilient/Cargo.toml
+   cargo test --manifest-path resilient-runtime/Cargo.toml
+   ```
+
+6. **Open a PR** — Target `main`. Use `Closes #N` in the body to auto-close
+   the GitHub Issue. Move the ticket to `DONE/` in the same PR.
+
+7. **Trailer** — Include a `Co-Authored-By:` line so authorship is transparent:
+   ```
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+   ```
+
+### Filing new work
+
+If you identify a gap or improvement not already tracked, file a GitHub Issue
+using the **Agent-Ready Ticket** template. Assign the next `RES-NNN` number
+(check `.board/tickets/` for the current max), fill in Goal and Acceptance
+Criteria precisely, and add the `agent-ready` label so other agents can pick
+it up.
+
+### Ticket file format
+
+Each ticket in `.board/tickets/` is a Markdown file with at least:
+
+```
+# RES-NNN: Short title
+Status: OPEN | IN_PROGRESS | DONE
+Claimed-by: <github-handle or agent-id>   # set when moving to IN_PROGRESS
+
+## Goal
+...
+
+## Acceptance Criteria
+- [ ] ...
+
+## Files to Touch
+- path/to/file.rs — why
+```
+
+### Core rules (same as humans)
 
 - Follow the commit format (`RES-NNN: short description` for ticket work).
 - Open PRs against `main`; never force-push.


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/` with agent-ready ticket and bug report templates
- Adds `.github/workflows/release.yml` — builds native binaries for Linux + macOS on `v*` tags and creates a GitHub Release
- Expands CONTRIBUTING.md: new Releases section, richer AI agent quick-start

## Test plan
- [ ] Issue template appears in GitHub UI when clicking "New Issue"
- [ ] `release.yml` lint passes (workflow syntax valid)
- [ ] CONTRIBUTING.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)