### PR TITLE
MGR: add RES-219 and RES-220 tickets; label existing issues agent-ready

### DIFF
--- a/.board/tickets/OPEN/RES-219-github-release-binary-builds.md
+++ b/.board/tickets/OPEN/RES-219-github-release-binary-builds.md
@@ -1,0 +1,43 @@
+---
+id: RES-219
+title: GitHub release workflow — native binary builds for Linux + macOS
+status: OPEN
+labels: [infra, release]
+roadmap: G20
+---
+
+## Goal
+
+When a maintainer pushes a semver tag (`vMAJOR.MINOR.PATCH`) to `main`, GitHub
+Actions should automatically build native `resilient` binaries for four
+platforms and attach them to a new GitHub Release with auto-generated release
+notes.
+
+## Platforms
+
+| Target | OS | Archive |
+|---|---|---|
+| `x86_64-unknown-linux-gnu` | ubuntu-latest | `.tar.gz` |
+| `aarch64-unknown-linux-gnu` | ubuntu-latest (via `cross`) | `.tar.gz` |
+| `x86_64-apple-darwin` | macos-latest | `.tar.gz` |
+| `aarch64-apple-darwin` | macos-latest | `.tar.gz` |
+
+## Files to touch
+
+- `.github/workflows/release.yml` — create this file
+- `CONTRIBUTING.md` — add a "Releases" section explaining how to cut a release
+
+## Acceptance criteria
+
+- [ ] `release.yml` triggers on `v*` tag pushes
+- [ ] All four platform binaries build successfully
+- [ ] A GitHub Release is created with the tag name as the title
+- [ ] Each `.tar.gz` is attached to the release as a downloadable asset
+- [ ] `CONTRIBUTING.md` explains the tag → release workflow
+- [ ] The workflow does NOT fail for `workflow_dispatch` dry-runs
+
+## Out of scope
+
+- crates.io publishing
+- Windows binaries
+- Code signing

--- a/.board/tickets/OPEN/RES-220-agent-ready-issue-templates.md
+++ b/.board/tickets/OPEN/RES-220-agent-ready-issue-templates.md
@@ -1,0 +1,35 @@
+---
+id: RES-220
+title: GitHub issue templates + agent-ready label for autonomous contributor pipeline
+status: OPEN
+labels: [infra, dx]
+roadmap: G20
+---
+
+## Goal
+
+Make it easy for autonomous AI agents (Claude Code, OpenClaw, Codex, etc.) and
+human contributors to discover well-scoped work and file new tickets in a
+structured format that agents can parse and act on.
+
+## Files to touch
+
+- `.github/ISSUE_TEMPLATE/agent-ready-ticket.yml` — structured template for new tickets
+- `.github/ISSUE_TEMPLATE/bug-report.yml` — bug report template
+- `.github/ISSUE_TEMPLATE/config.yml` — disable blank issues, add discussion link
+- `CONTRIBUTING.md` — expand "For AI Agent Contributors" section with quick-start checklist
+- `.board/tickets/OPEN/` — add this ticket file
+
+## Acceptance criteria
+
+- [ ] GitHub "New Issue" UI shows two template choices: "Agent-Ready Ticket" and "Bug Report"
+- [ ] Agent-ready template fields: Ticket ID, Goal, Files to touch, Acceptance criteria, Out of scope, Roadmap goal
+- [ ] Existing 14 open issues carry the `agent-ready` label
+- [ ] CONTRIBUTING.md "For AI Agent Contributors" includes a numbered quick-start checklist
+- [ ] `good-first-issue` and `agent-ready` labels exist in the repo
+
+## Out of scope
+
+- Auto-assigning issues to agents
+- Bot auto-triage
+- Changes to the .board/ ticket file format


### PR DESCRIPTION
## Summary
- Adds `.board/tickets/OPEN/RES-219-github-release-binary-builds.md`
- Adds `.board/tickets/OPEN/RES-220-agent-ready-issue-templates.md`
- Labels all 14 existing open GitHub issues with `agent-ready`
- Creates GitHub Issues #39 (RES-219) and #40 (RES-220)

## Test plan
- [ ] Both ticket files present in OPEN/
- [ ] GitHub Issues created for RES-219 and RES-220
- [ ] All 14 existing issues carry `agent-ready` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)