### PR TITLE
RES-133a: assume() — parser, AST, and runtime

### DIFF
--- a/.board/tickets/IN_PROGRESS/RES-133-assume-annotation.md
+++ b/.board/tickets/IN_PROGRESS/RES-133-assume-annotation.md
@@ -1,11 +1,12 @@
 ---
 id: RES-133
 title: `assume(p);` annotation surfaces facts to the SMT context
-state: OPEN
+state: IN_PROGRESS
 priority: P3
 goalpost: G9
 created: 2026-04-17
 owner: executor
+Claimed-by: Claude Sonnet 4.6 (RES-133a scope: parser + AST + runtime only)
 ---
 
 ## Summary

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -604,6 +604,7 @@ fn node_line(n: &Node) -> Option<u32> {
         | Node::Extern { span, .. }
         | Node::LiveBlock { span, .. }
         | Node::Assert { span, .. }
+        | Node::Assume { span, .. }
         | Node::Match { span, .. }
         | Node::StructDecl { span, .. }
         | Node::StructLiteral { span, .. }
@@ -631,6 +632,7 @@ fn node_kind(n: &Node) -> &'static str {
         Node::Function { .. } => "Function",
         Node::LiveBlock { .. } => "LiveBlock",
         Node::Assert { .. } => "Assert",
+        Node::Assume { .. } => "Assume",
         Node::Block { .. } => "Block",
         Node::LetStatement { .. } => "LetStatement",
         Node::StaticLet { .. } => "StaticLet",

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -328,6 +328,16 @@ impl Formatter {
                 self.write(");");
                 self.newline();
             }
+            Node::Assume { condition, message, .. } => {
+                self.write("assume(");
+                self.fmt_expr(condition);
+                if let Some(m) = message {
+                    self.write(", ");
+                    self.fmt_expr(m);
+                }
+                self.write(");");
+                self.newline();
+            }
             Node::Block { stmts, .. } => {
                 self.write("{");
                 self.newline();
@@ -632,6 +642,7 @@ impl Formatter {
             | Node::ForInStatement { .. }
             | Node::LiveBlock { .. }
             | Node::Assert { .. }
+            | Node::Assume { .. }
             | Node::LetStatement { .. }
             | Node::StaticLet { .. }
             | Node::Assignment { .. }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -253,6 +253,7 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             }
         }
         Node::Assert { condition, .. } => walk(condition, bound, free),
+        Node::Assume { condition, .. } => walk(condition, bound, free),
 
         // ---- Expressions ----
         Node::PrefixExpression { right, .. } => walk(right, bound, free),

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -83,6 +83,7 @@ enum Token {
     Let,
     Live,
     Assert,
+    Assume,
     If,
     Else,
     Return,
@@ -211,6 +212,7 @@ impl Token {
             Token::Let => "`let`".to_string(),
             Token::Live => "`live`".to_string(),
             Token::Assert => "`assert`".to_string(),
+            Token::Assume => "`assume`".to_string(),
             Token::If => "`if`".to_string(),
             Token::Else => "`else`".to_string(),
             Token::Return => "`return`".to_string(),
@@ -594,6 +596,7 @@ impl Lexer {
                         "let" => Token::Let,
                         "live" => Token::Live,
                         "assert" => Token::Assert,
+                        "assume" => Token::Assume,
                         "if" => Token::If,
                         "else" => Token::Else,
                         "return" => Token::Return,
@@ -1055,6 +1058,15 @@ enum Node {
         #[allow(dead_code)]
         span: span::Span,
     },
+    /// RES-133a: `assume(expr);` — like assert at runtime but signals
+    /// verifier intent ("trust me, this holds"). Runtime halts with
+    /// "assume violated at line:col" when the predicate is false.
+    Assume {
+        condition: Box<Node>,
+        message: Option<Box<Node>>,
+        #[allow(dead_code)]
+        span: span::Span,
+    },
     /// RES-087: converted from tuple form so it can carry the span
     /// of the opening `{` (consumed in follow-ups).
     Block {
@@ -1508,6 +1520,7 @@ impl Parser {
             Token::Return => Some(self.parse_return_statement()),
             Token::Live => Some(self.parse_live_block()),
             Token::Assert => Some(self.parse_assert()),
+            Token::Assume => Some(self.parse_assume()),
             Token::If => Some(self.parse_if_statement()),
             Token::While => Some(self.parse_while_statement()),
             Token::For => Some(self.parse_for_in_statement()),
@@ -3276,7 +3289,47 @@ impl Parser {
             span: self.span_at_current()
         }
     }
-    
+
+    /// RES-133a: `assume(expr[, msg]);` — same grammar as assert.
+    fn parse_assume(&mut self) -> Node {
+        self.next_token(); // skip 'assume'
+
+        if self.current_token != Token::LeftParen {
+            let tok = self.current_token.clone();
+            self.record_error(format!("Expected '(' after 'assume', found {}", tok));
+            return Node::Assume {
+                condition: Box::new(Node::BooleanLiteral { value: true, span: span::Span::default() }),
+                message: None,
+                span: self.span_at_current(),
+            };
+        }
+
+        self.next_token(); // skip '('
+
+        let condition = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: true, span: span::Span::default() });
+        self.next_token(); // advance past last token of expression
+
+        let message = if self.current_token == Token::Comma {
+            self.next_token(); // skip ','
+            let msg = self.parse_expression(0).unwrap_or(Node::StringLiteral { value: String::new(), span: span::Span::default() });
+            self.next_token();
+            Some(Box::new(msg))
+        } else {
+            None
+        };
+
+        if self.current_token != Token::RightParen {
+            let tok = self.current_token.clone();
+            self.record_error(format!("Expected ')' after assume condition, found {}", tok));
+        }
+
+        Node::Assume {
+            condition: Box::new(condition),
+            message,
+            span: self.span_at_current(),
+        }
+    }
+
     fn parse_if_statement(&mut self) -> Node {
         let stmt_span = self.span_at_current();
         self.next_token(); // Skip 'if'
@@ -6628,6 +6681,7 @@ impl Interpreter {
                     .to_string(),
             ),
             Node::Assert { condition, message, .. } => self.eval_assert(condition, message),
+            Node::Assume { condition, message, .. } => self.eval_assume(condition, message),
             Node::Block { stmts: statements, .. } => self.eval_block_statement(statements),
             Node::LetStatement { name, value, .. } => {
                 let val = self.eval(value)?;
@@ -7354,6 +7408,32 @@ impl Interpreter {
 
             return Err(format!(
                 "ASSERTION ERROR: {}\n  - {}",
+                error_message, detail
+            ));
+        }
+
+        Ok(Value::Void)
+    }
+
+    /// RES-133a: runtime evaluation of `assume(expr[, msg])`.
+    /// Semantics identical to assert — halts with "assume violated" when false.
+    fn eval_assume(&mut self, condition: &Node, message: &Option<Box<Node>>) -> RResult<Value> {
+        let condition_value = self.eval(condition)?;
+
+        if !self.is_truthy(&condition_value) {
+            let error_message = if let Some(msg) = message {
+                match self.eval(msg)? {
+                    Value::String(s) => s,
+                    other => format!("Assumption failed with message: {}", other),
+                }
+            } else {
+                "Assumption failed".to_string()
+            };
+
+            let detail = self.format_assert_detail(condition, &condition_value);
+
+            return Err(format!(
+                "ASSUME VIOLATED: {}\n  - {}",
                 error_message, detail
             ));
         }
@@ -8168,7 +8248,7 @@ fn classify_lex_token(
 
     let (ty, modifiers) = match tok {
         // Keywords.
-        Token::Function | Token::Let | Token::Live | Token::Assert
+        Token::Function | Token::Let | Token::Live | Token::Assert | Token::Assume
         | Token::If | Token::Else | Token::Return | Token::Static
         | Token::While | Token::For | Token::In
         | Token::Requires | Token::Ensures | Token::Invariant
@@ -14825,6 +14905,44 @@ mod tests {
             "expected both operands in error, got: {}",
             err
         );
+    }
+
+    // --- RES-133a: assume() tests ---
+
+    #[test]
+    fn assume_passes_when_true() {
+        let src = "let x = 5; assume(x > 0); assume(x > 0, \"x must be positive\");";
+        let (p, _e) = parse(src);
+        let mut interp = Interpreter::new();
+        interp.eval(&p).unwrap();
+    }
+
+    #[test]
+    fn assume_halts_when_false() {
+        let src = "let x = -1; assume(x > 0);";
+        let (p, _e) = parse(src);
+        let mut interp = Interpreter::new();
+        let err = interp.eval(&p).unwrap_err();
+        assert!(err.contains("ASSUME VIOLATED"), "expected ASSUME VIOLATED, got: {}", err);
+    }
+
+    #[test]
+    fn assume_halts_with_custom_message() {
+        let src = "assume(false, \"sensor offline\");";
+        let (p, _e) = parse(src);
+        let mut interp = Interpreter::new();
+        let err = interp.eval(&p).unwrap_err();
+        assert!(err.contains("ASSUME VIOLATED"), "{}", err);
+        assert!(err.contains("sensor offline"), "{}", err);
+    }
+
+    #[test]
+    fn assume_before_assert_composes() {
+        // assume establishes a fact; subsequent code can use it normally
+        let src = "let x = 10; assume(x > 0); assert(x > 0);";
+        let (p, _e) = parse(src);
+        let mut interp = Interpreter::new();
+        interp.eval(&p).unwrap();
     }
 
     #[test]

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1171,7 +1171,7 @@ impl TypeChecker {
                 if condition_type != Type::Bool && condition_type != Type::Any {
                     return Err(format!("Assert condition must be a boolean, got {}", condition_type));
                 }
-                
+
                 // Message, if present, should be a string
                 if let Some(msg) = message {
                     let msg_type = self.check_node(msg)?;
@@ -1179,7 +1179,22 @@ impl TypeChecker {
                         return Err(format!("Assert message must be a string, got {}", msg_type));
                     }
                 }
-                
+
+                Ok(Type::Void)
+            },
+
+            // RES-133a: assume has the same type rules as assert
+            Node::Assume { condition, message, .. } => {
+                let condition_type = self.check_node(condition)?;
+                if condition_type != Type::Bool && condition_type != Type::Any {
+                    return Err(format!("Assume condition must be a boolean, got {}", condition_type));
+                }
+                if let Some(msg) = message {
+                    let msg_type = self.check_node(msg)?;
+                    if msg_type != Type::String && msg_type != Type::Any {
+                        return Err(format!("Assume message must be a string, got {}", msg_type));
+                    }
+                }
                 Ok(Type::Void)
             },
             
@@ -2115,6 +2130,9 @@ fn check_body_purity(
         Node::Assert { condition, .. } => {
             check_body_purity(condition, fn_name, pure_fns)?;
         }
+        Node::Assume { condition, .. } => {
+            check_body_purity(condition, fn_name, pure_fns)?;
+        }
         Node::LiveBlock { .. } => {
             // live-blocks retry on failure — that's observable,
             // non-pure behaviour by construction.
@@ -2368,6 +2386,7 @@ fn body_reaches_io(
             body_reaches_io(iterable, effects) || body_reaches_io(body, effects)
         }
         Node::Assert { condition, .. } => body_reaches_io(condition, effects),
+        Node::Assume { condition, .. } => body_reaches_io(condition, effects),
         Node::LiveBlock { body, invariants, .. } => {
             // A `live` block is NOT intrinsically IO (retries on
             // failure observe error state, but not IO per the


### PR DESCRIPTION
## Summary

- Adds `assume(expr[, msg]);` as a first-class statement in Resilient
- Runtime semantics: identical to `assert` — halts with `ASSUME VIOLATED: ...` when the predicate is false
- Wired into all five phases that do exhaustive `Node` matching: typechecker, compiler, formatter, free_vars, and the interpreter

## What this covers (RES-133a scope)

- Lexer token `Token::Assume`
- `Node::Assume { condition, message, span }` AST variant
- `parse_assume` — mirrors `parse_assert` grammar exactly
- `eval_assume` — same logic as `eval_assert` with `ASSUME VIOLATED` prefix
- Typechecker: bool condition + optional string message; purity + IO analysis
- 4 unit tests: passes-when-true, halts-when-false, custom message, compose with assert

## What this does NOT cover

- **RES-133b** — verifier context threading (`z3_prove_with_cert` assumption stack): requires a separate refactor
- **RES-133c** — `assume(false)` dead-code warning: requires warning channel (RES-221)

## Test evidence

```
$ cargo test --manifest-path resilient/Cargo.toml 2>&1 | grep assume
test tests::assume_halts_with_custom_message ... ok
test tests::assume_halts_when_false ... ok
test tests::assume_before_assert_composes ... ok
test tests::assume_passes_when_true ... ok
```

- [x] `cargo build` clean
- [x] `cargo test` — all tests pass (0 failures)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Ticket `.board/tickets/IN_PROGRESS/RES-133-assume-annotation.md` updated with `Claimed-by`

Closes #133

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>