### PR TITLE
RES-127: tuple types + destructuring let

### DIFF
--- a/.board/tickets/IN_PROGRESS/RES-127-tuple-types.md
+++ b/.board/tickets/IN_PROGRESS/RES-127-tuple-types.md
@@ -1,11 +1,12 @@
 ---
 id: RES-127
 title: Tuple types `(Int, String)` with inference and destructuring let
-state: OPEN
+state: IN_PROGRESS
 priority: P3
 goalpost: G7
 created: 2026-04-17
 owner: executor
+claimed-by: Claude
 ---
 
 ## Summary

--- a/resilient-span/src/lib.rs
+++ b/resilient-span/src/lib.rs
@@ -32,7 +32,11 @@ pub struct Pos {
 
 impl Pos {
     pub const fn new(line: usize, column: usize, offset: usize) -> Self {
-        Self { line, column, offset }
+        Self {
+            line,
+            column,
+            offset,
+        }
     }
 }
 
@@ -60,14 +64,25 @@ impl Span {
     /// that don't correspond to anything in the source (e.g. an
     /// implicit `return ();` injected at end-of-block).
     pub const fn point(pos: Pos) -> Self {
-        Self { start: pos, end: pos }
+        Self {
+            start: pos,
+            end: pos,
+        }
     }
 
     /// Span covering both `self` and `other`. The result starts at the
     /// earlier of the two starts and ends at the later of the two ends.
     pub fn union(self, other: Span) -> Span {
-        let start = if self.start.offset <= other.start.offset { self.start } else { other.start };
-        let end = if self.end.offset >= other.end.offset { self.end } else { other.end };
+        let start = if self.start.offset <= other.start.offset {
+            self.start
+        } else {
+            other.start
+        };
+        let end = if self.end.offset >= other.end.offset {
+            self.end
+        } else {
+            other.end
+        };
         Span { start, end }
     }
 
@@ -84,7 +99,11 @@ impl Span {
 impl fmt::Display for Span {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.start.line == self.end.line {
-            write!(f, "{}:{}-{}", self.start.line, self.start.column, self.end.column)
+            write!(
+                f,
+                "{}:{}-{}",
+                self.start.line, self.start.column, self.end.column
+            )
         } else {
             write!(f, "{}-{}", self.start, self.end)
         }
@@ -105,11 +124,17 @@ impl<T> Spanned<T> {
     }
 
     pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Spanned<U> {
-        Spanned { node: f(self.node), span: self.span }
+        Spanned {
+            node: f(self.node),
+            span: self.span,
+        }
     }
 
     pub fn as_ref(&self) -> Spanned<&T> {
-        Spanned { node: &self.node, span: self.span }
+        Spanned {
+            node: &self.node,
+            span: self.span,
+        }
     }
 }
 

--- a/resilient/benches/interpreter.rs
+++ b/resilient/benches/interpreter.rs
@@ -142,7 +142,9 @@ let n = len(s);
 fn bench_fib(c: &mut Criterion) {
     let src_path = write_tmp_source("fib25", FIB_SRC);
     let mut group = c.benchmark_group("tree_walker");
-    group.sample_size(10).measurement_time(Duration::from_secs(10));
+    group
+        .sample_size(10)
+        .measurement_time(Duration::from_secs(10));
     group.bench_function("fib_25", |b| b.iter(|| run_source(&src_path)));
     group.finish();
     let _ = std::fs::remove_file(&src_path);
@@ -152,7 +154,9 @@ fn bench_bubble_sort(c: &mut Criterion) {
     let src = bubble_sort_src();
     let src_path = write_tmp_source("bubble50", &src);
     let mut group = c.benchmark_group("tree_walker");
-    group.sample_size(10).measurement_time(Duration::from_secs(10));
+    group
+        .sample_size(10)
+        .measurement_time(Duration::from_secs(10));
     group.bench_function("bubble_sort_50", |b| b.iter(|| run_source(&src_path)));
     group.finish();
     let _ = std::fs::remove_file(&src_path);
@@ -161,11 +165,18 @@ fn bench_bubble_sort(c: &mut Criterion) {
 fn bench_string_processing(c: &mut Criterion) {
     let src_path = write_tmp_source("string200", STRING_SRC);
     let mut group = c.benchmark_group("tree_walker");
-    group.sample_size(10).measurement_time(Duration::from_secs(10));
+    group
+        .sample_size(10)
+        .measurement_time(Duration::from_secs(10));
     group.bench_function("string_concat_200", |b| b.iter(|| run_source(&src_path)));
     group.finish();
     let _ = std::fs::remove_file(&src_path);
 }
 
-criterion_group!(benches, bench_fib, bench_bubble_sort, bench_string_processing);
+criterion_group!(
+    benches,
+    bench_fib,
+    bench_bubble_sort,
+    bench_string_processing
+);
 criterion_main!(benches);

--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -281,7 +281,11 @@ impl std::fmt::Display for CompileError {
             CompileError::UnknownFunction(n) => {
                 write!(f, "bytecode compile: unknown function: {}", n)
             }
-            CompileError::ArityMismatch { callee, expected, got } => write!(
+            CompileError::ArityMismatch {
+                callee,
+                expected,
+                got,
+            } => write!(
                 f,
                 "bytecode compile: call to {} has {} args, expected {}",
                 callee, got, expected
@@ -338,7 +342,10 @@ mod tests {
     #[test]
     fn compile_error_display_is_descriptive() {
         let e = CompileError::Unsupported("struct decl");
-        assert_eq!(e.to_string(), "bytecode compile: unsupported construct: struct decl");
+        assert_eq!(
+            e.to_string(),
+            "bytecode compile: unsupported construct: struct decl"
+        );
     }
 
     // ---------- RES-169a: skeleton closure opcodes ----------
@@ -347,8 +354,15 @@ mod tests {
     fn res169a_make_closure_constructs_with_payload() {
         // Sanity: the variant accepts both operands. Not yet
         // emitted by the compiler — RES-169b will add that.
-        let op = Op::MakeClosure { fn_idx: 7, upvalue_count: 3 };
-        if let Op::MakeClosure { fn_idx, upvalue_count } = op {
+        let op = Op::MakeClosure {
+            fn_idx: 7,
+            upvalue_count: 3,
+        };
+        if let Op::MakeClosure {
+            fn_idx,
+            upvalue_count,
+        } = op
+        {
             assert_eq!(fn_idx, 7);
             assert_eq!(upvalue_count, 3);
         } else {
@@ -370,7 +384,10 @@ mod tests {
     fn res169a_closure_ops_are_copy() {
         // `Op` derives Copy — adding new variants must not break
         // that, because the VM dispatch reads `*op` per step.
-        let a = Op::MakeClosure { fn_idx: 0, upvalue_count: 0 };
+        let a = Op::MakeClosure {
+            fn_idx: 0,
+            upvalue_count: 0,
+        };
         let b = a; // copy, not move
         assert_eq!(a, b);
     }
@@ -399,7 +416,13 @@ mod tests {
         // verbatim. No semantic expectation yet (the VM returns
         // Unsupported on dispatch); RES-169b/c make these live.
         let mut c = Chunk::new();
-        let a = c.emit(Op::MakeClosure { fn_idx: 1, upvalue_count: 2 }, 10);
+        let a = c.emit(
+            Op::MakeClosure {
+                fn_idx: 1,
+                upvalue_count: 2,
+            },
+            10,
+        );
         let b = c.emit(Op::LoadUpvalue(0), 11);
         assert_eq!(a, 0);
         assert_eq!(b, 1);

--- a/resilient/src/cert_sign.rs
+++ b/resilient/src/cert_sign.rs
@@ -28,9 +28,9 @@
 use std::fs;
 use std::path::Path;
 
-use ed25519_dalek::{Signature, SigningKey, Verifier, VerifyingKey};
-use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, SIGNATURE_LENGTH};
 use ed25519_dalek::ed25519::signature::Signer;
+use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, SIGNATURE_LENGTH};
+use ed25519_dalek::{Signature, SigningKey, Verifier, VerifyingKey};
 use sha2::{Digest, Sha256};
 
 /// RES-194: the public key committed alongside the binary. The
@@ -59,25 +59,19 @@ const PEM_PRIV_END: &str = "-----END ED25519 PRIVATE KEY-----";
 /// signature after the fact. `cert.sig` is specifically excluded
 /// too (signing the signature would be a chicken-and-egg issue).
 pub fn compute_cert_payload(dir: &Path) -> Result<Vec<u8>, String> {
-    let rd = fs::read_dir(dir).map_err(|e| {
-        format!("could not read cert directory {}: {}", dir.display(), e)
-    })?;
+    let rd = fs::read_dir(dir)
+        .map_err(|e| format!("could not read cert directory {}: {}", dir.display(), e))?;
     let mut entries: Vec<_> = rd
         .filter_map(|r| r.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .ends_with(".smt2")
-        })
+        .filter(|e| e.file_name().to_string_lossy().ends_with(".smt2"))
         .map(|e| e.path())
         .collect();
     entries.sort();
 
     let mut payload = Vec::new();
     for (i, p) in entries.iter().enumerate() {
-        let body = fs::read(p).map_err(|e| {
-            format!("could not read cert file {}: {}", p.display(), e)
-        })?;
+        let body =
+            fs::read(p).map_err(|e| format!("could not read cert file {}: {}", p.display(), e))?;
         if i > 0 {
             payload.push(b'\n');
         }
@@ -117,22 +111,20 @@ pub fn verify_payload(
 /// ASCII file with the `BEGIN ED25519 PUBLIC KEY` markers and a
 /// hex-encoded 32-byte body. Whitespace is ignored.
 pub fn parse_public_key_pem(pem: &str) -> Result<[u8; PUBLIC_KEY_LENGTH], String> {
-    parse_hex_pem(pem, PEM_PUB_BEGIN, PEM_PUB_END, PUBLIC_KEY_LENGTH)
-        .map(|v| {
-            let mut out = [0u8; PUBLIC_KEY_LENGTH];
-            out.copy_from_slice(&v);
-            out
-        })
+    parse_hex_pem(pem, PEM_PUB_BEGIN, PEM_PUB_END, PUBLIC_KEY_LENGTH).map(|v| {
+        let mut out = [0u8; PUBLIC_KEY_LENGTH];
+        out.copy_from_slice(&v);
+        out
+    })
 }
 
 /// RES-194: parse our mini-PEM for a private key.
 pub fn parse_private_key_pem(pem: &str) -> Result<[u8; SECRET_KEY_LENGTH], String> {
-    parse_hex_pem(pem, PEM_PRIV_BEGIN, PEM_PRIV_END, SECRET_KEY_LENGTH)
-        .map(|v| {
-            let mut out = [0u8; SECRET_KEY_LENGTH];
-            out.copy_from_slice(&v);
-            out
-        })
+    parse_hex_pem(pem, PEM_PRIV_BEGIN, PEM_PRIV_END, SECRET_KEY_LENGTH).map(|v| {
+        let mut out = [0u8; SECRET_KEY_LENGTH];
+        out.copy_from_slice(&v);
+        out
+    })
 }
 
 /// Internal: shared mini-PEM parser for public + private keys.
@@ -157,7 +149,9 @@ fn parse_hex_pem(
     if hex.len() != expected_len * 2 {
         return Err(format!(
             "expected {} hex chars ({}-byte key), got {}",
-            expected_len * 2, expected_len, hex.len()
+            expected_len * 2,
+            expected_len,
+            hex.len()
         ));
     }
     hex_decode(&hex)
@@ -203,7 +197,8 @@ pub fn parse_signature_hex(s: &str) -> Result<[u8; SIGNATURE_LENGTH], String> {
     if hex.len() != SIGNATURE_LENGTH * 2 {
         return Err(format!(
             "expected {} hex chars (64-byte signature), got {}",
-            SIGNATURE_LENGTH * 2, hex.len()
+            SIGNATURE_LENGTH * 2,
+            hex.len()
         ));
     }
     let v = hex_decode(&hex)?;
@@ -326,7 +321,10 @@ pub fn format_manifest_json(m: &Manifest) -> String {
         })
         .collect();
     let mut root = serde_json::Map::new();
-    root.insert("program".into(), serde_json::Value::String(m.program.clone()));
+    root.insert(
+        "program".into(),
+        serde_json::Value::String(m.program.clone()),
+    );
     root.insert("obligations".into(), serde_json::Value::Array(obligations));
     serde_json::to_string_pretty(&serde_json::Value::Object(root))
         .unwrap_or_else(|_| "{}".to_string())
@@ -337,9 +335,11 @@ pub fn format_manifest_json(m: &Manifest) -> String {
 /// ignores) extra fields so future schema versions don't break
 /// old verifiers.
 pub fn parse_manifest_json(s: &str) -> Result<Manifest, String> {
-    let v: serde_json::Value = serde_json::from_str(s)
-        .map_err(|e| format!("manifest.json isn't valid JSON: {}", e))?;
-    let obj = v.as_object().ok_or("manifest.json root must be an object")?;
+    let v: serde_json::Value =
+        serde_json::from_str(s).map_err(|e| format!("manifest.json isn't valid JSON: {}", e))?;
+    let obj = v
+        .as_object()
+        .ok_or("manifest.json root must be an object")?;
     let program = obj
         .get("program")
         .and_then(|v| v.as_str())
@@ -389,7 +389,10 @@ pub fn parse_manifest_json(s: &str) -> Result<Manifest, String> {
             sig,
         });
     }
-    Ok(Manifest { program, obligations })
+    Ok(Manifest {
+        program,
+        obligations,
+    })
 }
 
 #[cfg(test)]
@@ -485,7 +488,10 @@ mod manifest_tests {
     fn parse_rejects_malformed_obligation() {
         let json = r#"{"program": "x.rs", "obligations": [{"fn": "f"}]}"#;
         let err = parse_manifest_json(json).unwrap_err();
-        assert!(err.contains("kind") || err.contains("obligation"), "error was: {err}");
+        assert!(
+            err.contains("kind") || err.contains("obligation"),
+            "error was: {err}"
+        );
     }
 
     #[test]
@@ -626,10 +632,7 @@ mod tests {
 
     #[test]
     fn pem_rejects_wrong_length() {
-        let bad = format!(
-            "{}\n{}\n{}\n",
-            PEM_PUB_BEGIN, "aabb", PEM_PUB_END
-        );
+        let bad = format!("{}\n{}\n{}\n", PEM_PUB_BEGIN, "aabb", PEM_PUB_END);
         let err = parse_public_key_pem(&bad).unwrap_err();
         assert!(err.contains("hex chars"), "error was: {err}");
     }
@@ -651,8 +654,7 @@ mod tests {
     #[test]
     fn embedded_public_key_parses() {
         // The committed `cert_key.pem` must always be valid.
-        parse_public_key_pem(EMBEDDED_PUBLIC_KEY_PEM)
-            .expect("embedded key must parse");
+        parse_public_key_pem(EMBEDDED_PUBLIC_KEY_PEM).expect("embedded key must parse");
     }
 
     #[test]
@@ -660,11 +662,7 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!(
-            "res_certsign_{}_{}",
-            std::process::id(),
-            n
-        ));
+        let dir = std::env::temp_dir().join(format!("res_certsign_{}_{}", std::process::id(), n));
         fs::create_dir_all(&dir).unwrap();
         // Two files, written in reverse alphabetical order — the
         // payload must still sort them.
@@ -685,11 +683,8 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!(
-            "res_certsign_e2e_{}_{}",
-            std::process::id(),
-            n
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("res_certsign_e2e_{}_{}", std::process::id(), n));
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join("foo__requires__0.smt2"), b"(assert true)\n").unwrap();
         fs::write(dir.join("foo__ensures__0.smt2"), b"(assert false)\n").unwrap();

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -38,7 +38,10 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
     let mut fn_index: HashMap<String, u16> = HashMap::new();
     let mut next_fn_idx: u16 = 0;
     for spanned in stmts {
-        if let Node::Function { name, parameters, .. } = &spanned.node {
+        if let Node::Function {
+            name, parameters, ..
+        } = &spanned.node
+        {
             if parameters.len() > u8::MAX as usize {
                 return Err(CompileError::Unsupported("fn with >255 params"));
             }
@@ -53,7 +56,13 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
     // Pass 2: compile each function body in declaration order.
     let mut functions: Vec<Function> = Vec::new();
     for spanned in stmts {
-        if let Node::Function { name, parameters, body, .. } = &spanned.node {
+        if let Node::Function {
+            name,
+            parameters,
+            body,
+            ..
+        } = &spanned.node
+        {
             let arity = parameters.len() as u8;
             let mut chunk = Chunk::new();
             // Parameters occupy locals 0..arity. Map each param name
@@ -78,8 +87,7 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
                 // line, not just the line of the enclosing fn.
                 // Falls back to the fn's outer line when the
                 // statement node has no span (synthetic).
-                let line = node_line(stmt)
-                    .unwrap_or(spanned.span.start.line as u32);
+                let line = node_line(stmt).unwrap_or(spanned.span.start.line as u32);
                 compile_stmt_in_fn(
                     stmt,
                     &mut chunk,
@@ -189,12 +197,19 @@ fn compile_stmt(
         // Nested `a[i][j] = v` is RES-171c; here we explicitly
         // reject non-Identifier targets so the compile error is
         // descriptive rather than a silent miscompile.
-        Node::IndexAssignment { target, index, value, .. } => {
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
             let local_name = match target.as_ref() {
                 Node::Identifier { name, .. } => name.clone(),
-                _ => return Err(CompileError::Unsupported(
-                    "nested index assignment (RES-171c)",
-                )),
+                _ => {
+                    return Err(CompileError::Unsupported(
+                        "nested index assignment (RES-171c)",
+                    ));
+                }
             };
             let slot = *locals
                 .get(&local_name)
@@ -235,7 +250,12 @@ fn compile_control_flow(
             }
             Ok(())
         }
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             // cond
             compile_expr(condition, chunk, locals, fn_index, line)?;
             // JumpIfFalse to else-or-end (placeholder 0 offset)
@@ -259,7 +279,9 @@ fn compile_control_flow(
             }
             Ok(())
         }
-        Node::WhileStatement { condition, body, .. } => {
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
             let loop_start = chunk.code.len();
             compile_expr(condition, chunk, locals, fn_index, line)?;
             let jif = chunk.emit(Op::JumpIfFalse(0), line);
@@ -333,12 +355,19 @@ fn compile_stmt_in_fn(
         // `Return`, the other `ReturnFromCall`); extracting a
         // shared helper is overkill for RES-171a but a candidate
         // cleanup when RES-171c expands this path.
-        Node::IndexAssignment { target, index, value, .. } => {
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
             let local_name = match target.as_ref() {
                 Node::Identifier { name, .. } => name.clone(),
-                _ => return Err(CompileError::Unsupported(
-                    "nested index assignment (RES-171c)",
-                )),
+                _ => {
+                    return Err(CompileError::Unsupported(
+                        "nested index assignment (RES-171c)",
+                    ));
+                }
             };
             let slot = *locals
                 .get(&local_name)
@@ -372,7 +401,12 @@ fn compile_control_flow_in_fn(
             }
             Ok(())
         }
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             compile_expr(condition, chunk, locals, fn_index, line)?;
             let jif = chunk.emit(Op::JumpIfFalse(0), line);
             compile_stmt_in_fn(consequence, chunk, locals, next_local, fn_index, line)?;
@@ -389,7 +423,9 @@ fn compile_control_flow_in_fn(
             }
             Ok(())
         }
-        Node::WhileStatement { condition, body, .. } => {
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
             let loop_start = chunk.code.len();
             compile_expr(condition, chunk, locals, fn_index, line)?;
             let jif = chunk.emit(Op::JumpIfFalse(0), line);
@@ -430,19 +466,28 @@ fn compile_expr(
             chunk.emit(Op::LoadLocal(idx), line);
             Ok(())
         }
-        Node::PrefixExpression { operator, right, .. } if operator == "-" => {
+        Node::PrefixExpression {
+            operator, right, ..
+        } if operator == "-" => {
             compile_expr(right, chunk, locals, fn_index, line)?;
             chunk.emit(Op::Neg, line);
             Ok(())
         }
         // RES-083: logical negation.
-        Node::PrefixExpression { operator, right, .. } if operator == "!" => {
+        Node::PrefixExpression {
+            operator, right, ..
+        } if operator == "!" => {
             compile_expr(right, chunk, locals, fn_index, line)?;
             chunk.emit(Op::Not, line);
             Ok(())
         }
         // RES-083: short-circuit && desugars to `if lhs { rhs } else { false }`.
-        Node::InfixExpression { left, operator, right, .. } if operator == "&&" => {
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } if operator == "&&" => {
             compile_expr(left, chunk, locals, fn_index, line)?;
             let jif = chunk.emit(Op::JumpIfFalse(0), line);
             compile_expr(right, chunk, locals, fn_index, line)?;
@@ -457,7 +502,12 @@ fn compile_expr(
             Ok(())
         }
         // RES-083: short-circuit || desugars to `if !lhs { rhs } else { true }`.
-        Node::InfixExpression { left, operator, right, .. } if operator == "||" => {
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } if operator == "||" => {
             compile_expr(left, chunk, locals, fn_index, line)?;
             // Negate lhs so JumpIfFalse skips to "true" when lhs is truthy.
             chunk.emit(Op::Not, line);
@@ -474,7 +524,12 @@ fn compile_expr(
             chunk.patch_jump(jmp_end, end)?;
             Ok(())
         }
-        Node::InfixExpression { left, operator, right, .. } => {
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => {
             compile_expr(left, chunk, locals, fn_index, line)?;
             compile_expr(right, chunk, locals, fn_index, line)?;
             let op = match operator.as_str() {
@@ -499,7 +554,11 @@ fn compile_expr(
         // calls where the callee is a bare `Identifier` — indirect
         // call through a function value (closures, lambdas) is out
         // of scope here.
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             let callee_name = match function.as_ref() {
                 Node::Identifier { name: n, .. } => n.clone(),
                 _ => return Err(CompileError::Unsupported("indirect call")),
@@ -525,7 +584,12 @@ fn compile_expr(
             for item in items {
                 compile_expr(item, chunk, locals, fn_index, line)?;
             }
-            chunk.emit(Op::MakeArray { len: items.len() as u16 }, line);
+            chunk.emit(
+                Op::MakeArray {
+                    len: items.len() as u16,
+                },
+                line,
+            );
             Ok(())
         }
         // RES-171a: `target[index]` read → push target, push index,
@@ -561,9 +625,7 @@ fn node_line(n: &Node) -> Option<u32> {
         | Node::ForInStatement { span, .. } => span.start.line as u32,
 
         // Block + ExpressionStatement (RES-087, tuple→struct).
-        Node::Block { span, .. } | Node::ExpressionStatement { span, .. } => {
-            span.start.line as u32
-        }
+        Node::Block { span, .. } | Node::ExpressionStatement { span, .. } => span.start.line as u32,
 
         // Leaves (RES-078).
         Node::IntegerLiteral { span, .. }
@@ -597,6 +659,11 @@ fn node_line(n: &Node) -> Option<u32> {
 
         // RES-155: struct destructure let carries the `let` keyword span.
         Node::LetDestructureStruct { span, .. } => span.start.line as u32,
+
+        // RES-127: tuple nodes carry a span.
+        Node::TupleLiteral { span, .. }
+        | Node::TupleIndex { span, .. }
+        | Node::LetDestructureTuple { span, .. } => span.start.line as u32,
 
         // Structural variants (RES-088).
         Node::Function { span, .. }
@@ -750,7 +817,7 @@ impl StructRegistry {
             _ => {
                 return Err(CompileError::Unsupported(
                     "struct registry requires a Program root",
-                ))
+                ));
             }
         };
         let mut entries: HashMap<String, StructRegistryEntry> = HashMap::new();
@@ -851,7 +918,12 @@ mod tests {
     fn compile_let_emits_store_local() {
         let p = parse_one("let x = 7;");
         let prog = compile(&p).unwrap();
-        assert!(prog.main.code.iter().any(|op| matches!(op, Op::StoreLocal(0))));
+        assert!(
+            prog.main
+                .code
+                .iter()
+                .any(|op| matches!(op, Op::StoreLocal(0)))
+        );
     }
 
     #[test]
@@ -908,8 +980,17 @@ mod tests {
         assert_eq!(f.arity, 1);
         // Inside the body, `n` is local 0. The emitted code should
         // LoadLocal(0) twice before Mul.
-        let load_count = f.chunk.code.iter().filter(|op| matches!(op, Op::LoadLocal(0))).count();
-        assert_eq!(load_count, 2, "expected two LoadLocal(0) for n*n: {:?}", f.chunk.code);
+        let load_count = f
+            .chunk
+            .code
+            .iter()
+            .filter(|op| matches!(op, Op::LoadLocal(0)))
+            .count();
+        assert_eq!(
+            load_count, 2,
+            "expected two LoadLocal(0) for n*n: {:?}",
+            f.chunk.code
+        );
     }
 
     #[test]
@@ -934,12 +1015,14 @@ mod tests {
 
     #[test]
     fn res170a_single_struct_registers_with_type_id_zero() {
-        let p = parse_one(r#"
+        let p = parse_one(
+            r#"
             struct Point {
                 int x,
                 int y,
             }
-        "#);
+        "#,
+        );
         let reg = StructRegistry::from_program(&p).unwrap();
         let pt = reg.get("Point").expect("Point should be registered");
         assert_eq!(pt.name, "Point");
@@ -949,17 +1032,22 @@ mod tests {
 
     #[test]
     fn res170a_field_names_preserve_declaration_order() {
-        let p = parse_one(r#"
+        let p = parse_one(
+            r#"
             struct Rec {
                 int c,
                 int a,
                 int b,
             }
-        "#);
+        "#,
+        );
         let reg = StructRegistry::from_program(&p).unwrap();
         let r = reg.get("Rec").unwrap();
         // Source order is c, a, b — NOT alphabetical.
-        assert_eq!(r.fields, vec!["c".to_string(), "a".to_string(), "b".to_string()]);
+        assert_eq!(
+            r.fields,
+            vec!["c".to_string(), "a".to_string(), "b".to_string()]
+        );
         assert_eq!(r.field_index("c"), Some(0));
         assert_eq!(r.field_index("a"), Some(1));
         assert_eq!(r.field_index("b"), Some(2));
@@ -976,11 +1064,13 @@ mod tests {
 
     #[test]
     fn res170a_multiple_structs_get_sequential_type_ids() {
-        let p = parse_one(r#"
+        let p = parse_one(
+            r#"
             struct A { int x, }
             struct B { int y, }
             struct C { int z, }
-        "#);
+        "#,
+        );
         let reg = StructRegistry::from_program(&p).unwrap();
         assert_eq!(reg.get("A").unwrap().type_id, 0);
         assert_eq!(reg.get("B").unwrap().type_id, 1);
@@ -990,10 +1080,12 @@ mod tests {
 
     #[test]
     fn res170a_duplicate_struct_name_errors() {
-        let p = parse_one(r#"
+        let p = parse_one(
+            r#"
             struct Dup { int x, }
             struct Dup { int y, }
-        "#);
+        "#,
+        );
         let err = StructRegistry::from_program(&p).unwrap_err();
         match err {
             CompileError::DuplicateStructName(n) => assert_eq!(n, "Dup"),
@@ -1010,10 +1102,12 @@ mod tests {
 
     #[test]
     fn res170a_resolve_roundtrips_type_id_and_field_index() {
-        let p = parse_one(r#"
+        let p = parse_one(
+            r#"
             struct First  { int a, }
             struct Second { int x, bool y, int z, }
-        "#);
+        "#,
+        );
         let reg = StructRegistry::from_program(&p).unwrap();
         assert_eq!(reg.resolve("First", "a"), Some((0, 0)));
         assert_eq!(reg.resolve("Second", "x"), Some((1, 0)));
@@ -1028,12 +1122,14 @@ mod tests {
     fn res170a_registry_coexists_with_let_and_fn_decls() {
         // Realistic program: mixed struct / fn / let statements at
         // top level. The registry must pick up only the structs.
-        let p = parse_one(r#"
+        let p = parse_one(
+            r#"
             let start = 0;
             struct P { int x, int y, }
             fn add(int a, int b) -> int { return a + b; }
             struct Q { bool flag, }
-        "#);
+        "#,
+        );
         let reg = StructRegistry::from_program(&p).unwrap();
         assert_eq!(reg.len(), 2);
         assert_eq!(reg.get("P").unwrap().type_id, 0);

--- a/resilient/src/diag.rs
+++ b/resilient/src/diag.rs
@@ -251,11 +251,7 @@ impl Diagnostic {
 
     /// Fluent builder: append a secondary note with its own
     /// span. Chainable; called once per note.
-    pub fn with_note(
-        mut self,
-        span: Span,
-        message: impl Into<String>,
-    ) -> Self {
+    pub fn with_note(mut self, span: Span, message: impl Into<String>) -> Self {
         self.notes.push((span, message.into()));
         self
     }
@@ -293,10 +289,7 @@ pub fn format_diagnostic_terminal(src: &str, diag: &Diagnostic) -> String {
     // shaped. Without a code, drop the brackets.
     match &diag.code {
         Some(code) => {
-            out.push_str(&format!(
-                "{}[{}]: {}\n",
-                diag.severity, code, diag.message
-            ));
+            out.push_str(&format!("{}[{}]: {}\n", diag.severity, code, diag.message));
         }
         None => {
             out.push_str(&format!("{}: {}\n", diag.severity, diag.message));
@@ -325,11 +318,7 @@ fn render_span_snippet(src: &str, span: Span) -> String {
     // The first line is "`:` " (level empty + msg empty collapses
     // to "`: `"); drop it. If for any reason the helper returns
     // something unexpected, fall back to the raw output.
-    full.lines()
-        .skip(1)
-        .collect::<Vec<_>>()
-        .join("\n")
-        + "\n"
+    full.lines().skip(1).collect::<Vec<_>>().join("\n") + "\n"
 }
 
 #[cfg(test)]
@@ -463,11 +452,7 @@ mod tests {
 
     #[test]
     fn diagnostic_new_leaves_optional_fields_empty() {
-        let d = Diagnostic::new(
-            Severity::Error,
-            span(1, 1, 1, 2),
-            "oops",
-        );
+        let d = Diagnostic::new(Severity::Error, span(1, 1, 1, 2), "oops");
         assert_eq!(d.severity, Severity::Error);
         assert_eq!(d.message, "oops");
         assert!(d.code.is_none());
@@ -490,28 +475,22 @@ mod tests {
     #[test]
     fn terminal_renderer_includes_severity_code_and_message() {
         let src = "let x = 1\n";
-        let d = Diagnostic::new(
-            Severity::Error,
-            span(1, 10, 1, 10),
-            "expected `;`",
-        )
-        .with_code(DiagCode::new("E0007"));
+        let d = Diagnostic::new(Severity::Error, span(1, 10, 1, 10), "expected `;`")
+            .with_code(DiagCode::new("E0007"));
         let out = format_diagnostic_terminal(src, &d);
-        assert!(out.contains("error[E0007]: expected `;`"),
-            "header wrong: {}", out);
-        assert!(out.contains("let x = 1"),
-            "source context missing: {}", out);
+        assert!(
+            out.contains("error[E0007]: expected `;`"),
+            "header wrong: {}",
+            out
+        );
+        assert!(out.contains("let x = 1"), "source context missing: {}", out);
         assert!(out.contains("^"), "caret missing: {}", out);
     }
 
     #[test]
     fn terminal_renderer_without_code_drops_brackets() {
         let src = "let x = 1\n";
-        let d = Diagnostic::new(
-            Severity::Warning,
-            span(1, 1, 1, 3),
-            "unused binding",
-        );
+        let d = Diagnostic::new(Severity::Warning, span(1, 1, 1, 3), "unused binding");
         let out = format_diagnostic_terminal(src, &d);
         assert!(
             out.starts_with("warning: unused binding"),
@@ -531,20 +510,26 @@ mod tests {
         let src = "let x = 1;\nlet x = 2;\n";
         let primary = span(2, 5, 2, 6);
         let note_span = span(1, 5, 1, 6);
-        let d = Diagnostic::new(
-            Severity::Error,
-            primary,
-            "shadows previous binding",
-        )
-        .with_note(note_span, "previous definition here");
+        let d = Diagnostic::new(Severity::Error, primary, "shadows previous binding")
+            .with_note(note_span, "previous definition here");
         let out = format_diagnostic_terminal(src, &d);
-        assert!(out.contains("error: shadows previous binding"),
-            "primary header missing: {}", out);
-        assert!(out.contains("note: previous definition here"),
-            "note header missing: {}", out);
+        assert!(
+            out.contains("error: shadows previous binding"),
+            "primary header missing: {}",
+            out
+        );
+        assert!(
+            out.contains("note: previous definition here"),
+            "note header missing: {}",
+            out
+        );
         // Both source lines should appear (primary + note
         // snippets).
-        assert!(out.contains("let x = 2;"), "primary snippet missing: {}", out);
+        assert!(
+            out.contains("let x = 2;"),
+            "primary snippet missing: {}",
+            out
+        );
         assert!(out.contains("let x = 1;"), "note snippet missing: {}", out);
     }
 
@@ -557,8 +542,11 @@ mod tests {
             "consider renaming to `_x`",
         );
         let out = format_diagnostic_terminal(src, &d);
-        assert!(out.starts_with("hint: consider renaming to `_x`"),
-            "header wrong: {}", out);
+        assert!(
+            out.starts_with("hint: consider renaming to `_x`"),
+            "header wrong: {}",
+            out
+        );
     }
 
     #[test]
@@ -566,12 +554,8 @@ mod tests {
         // Clone + PartialEq derives exercised — matters for
         // downstream tests that want to assert on the full
         // Diagnostic value shape.
-        let d1 = Diagnostic::new(
-            Severity::Warning,
-            span(1, 1, 1, 5),
-            "x",
-        )
-        .with_code(DiagCode::new("W0001"));
+        let d1 = Diagnostic::new(Severity::Warning, span(1, 1, 1, 5), "x")
+            .with_code(DiagCode::new("W0001"));
         let d2 = d1.clone();
         assert_eq!(d1, d2);
     }
@@ -722,8 +706,7 @@ mod codes_tests {
     fn res206a_codes_are_distinct_strings() {
         // Sanity: no two codes accidentally share a string.
         let all = codes::all();
-        let mut seen: Vec<String> =
-            all.iter().map(|c| c.as_str().to_string()).collect();
+        let mut seen: Vec<String> = all.iter().map(|c| c.as_str().to_string()).collect();
         let before = seen.len();
         seen.sort();
         seen.dedup();
@@ -778,14 +761,13 @@ mod codes_tests {
         // parse / identifier / type / runtime / contract bands
         // must all remain represented.
         let all = codes::all();
-        let strs: Vec<String> =
-            all.iter().map(|c| c.as_str().to_string()).collect();
+        let strs: Vec<String> = all.iter().map(|c| c.as_str().to_string()).collect();
         for expected in &[
             "E0001", "E0002", "E0003", // parse
             "E0004", "E0005", "E0006", // name resolution
-            "E0007",                   // type
-            "E0008", "E0009",          // runtime
-            "E0010",                   // contracts
+            "E0007", // type
+            "E0008", "E0009", // runtime
+            "E0010", // contracts
         ] {
             assert!(
                 strs.iter().any(|s| s == expected),

--- a/resilient/src/disasm.rs
+++ b/resilient/src/disasm.rs
@@ -57,8 +57,7 @@ use crate::bytecode::{Chunk, Op, Program};
 pub fn disassemble(program: &Program, out: &mut String) -> std::fmt::Result {
     // Build a function-index → name map so `Call(i)` operands can
     // include a readable comment.
-    let fn_names: Vec<&str> =
-        program.functions.iter().map(|f| f.name.as_str()).collect();
+    let fn_names: Vec<&str> = program.functions.iter().map(|f| f.name.as_str()).collect();
 
     // Main chunk first.
     writeln!(out, "=== main ===")?;
@@ -66,8 +65,11 @@ pub fn disassemble(program: &Program, out: &mut String) -> std::fmt::Result {
 
     // Each user function, in declaration order.
     for func in &program.functions {
-        writeln!(out, "=== fn {} (arity={}, locals={}) ===",
-            func.name, func.arity, func.local_count)?;
+        writeln!(
+            out,
+            "=== fn {} (arity={}, locals={}) ===",
+            func.name, func.arity, func.local_count
+        )?;
         disassemble_chunk(&func.chunk, &fn_names, out)?;
     }
     Ok(())
@@ -75,11 +77,7 @@ pub fn disassemble(program: &Program, out: &mut String) -> std::fmt::Result {
 
 /// Disassemble a single chunk: constants block, then code block.
 /// Chunk-scoped — `fn_names` passed in for `Call` comment rendering.
-fn disassemble_chunk(
-    chunk: &Chunk,
-    fn_names: &[&str],
-    out: &mut String,
-) -> std::fmt::Result {
+fn disassemble_chunk(chunk: &Chunk, fn_names: &[&str], out: &mut String) -> std::fmt::Result {
     // Constants section.
     if chunk.constants.is_empty() {
         writeln!(out, "constants: (none)")?;
@@ -163,7 +161,10 @@ fn write_op(
         // closure opcodes. RES-169b/c will make these emittable
         // and executable; the format mirrors how the VM will
         // ultimately interpret the operands.
-        Op::MakeClosure { fn_idx, upvalue_count } => {
+        Op::MakeClosure {
+            fn_idx,
+            upvalue_count,
+        } => {
             write!(out, "MakeClosure {} {}", fn_idx, upvalue_count)?;
             if let Some(name) = fn_names.get(fn_idx as usize) {
                 write!(out, "  ; -> {}", name)?;
@@ -181,16 +182,23 @@ fn write_op(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bytecode::{Chunk, Function, Op, Program};
     use crate::Value;
+    use crate::bytecode::{Chunk, Function, Op, Program};
 
     fn mk_chunk(code: Vec<Op>, constants: Vec<Value>, lines: Vec<u32>) -> Chunk {
-        Chunk { code, constants, line_info: lines }
+        Chunk {
+            code,
+            constants,
+            line_info: lines,
+        }
     }
 
     /// Build a Program with the given main chunk and no user fns.
     fn prog_main_only(main: Chunk) -> Program {
-        Program { main, functions: Vec::new() }
+        Program {
+            main,
+            functions: Vec::new(),
+        }
     }
 
     #[test]
@@ -245,11 +253,7 @@ mod tests {
     #[test]
     fn disassemble_renders_call_with_function_name() {
         let program = Program {
-            main: mk_chunk(
-                vec![Op::Call(0), Op::Return],
-                vec![],
-                vec![5, 5],
-            ),
+            main: mk_chunk(vec![Op::Call(0), Op::Return], vec![], vec![5, 5]),
             functions: vec![Function {
                 name: "my_fn".to_string(),
                 arity: 0,
@@ -325,7 +329,10 @@ mod tests {
     fn res169a_make_closure_renders_with_operands() {
         let program = prog_main_only(mk_chunk(
             vec![
-                Op::MakeClosure { fn_idx: 0, upvalue_count: 2 },
+                Op::MakeClosure {
+                    fn_idx: 0,
+                    upvalue_count: 2,
+                },
                 Op::Return,
             ],
             vec![],
@@ -360,7 +367,13 @@ mod tests {
     fn res169a_make_closure_with_named_fn_renders_pointer() {
         let program = Program {
             main: mk_chunk(
-                vec![Op::MakeClosure { fn_idx: 0, upvalue_count: 1 }, Op::Return],
+                vec![
+                    Op::MakeClosure {
+                        fn_idx: 0,
+                        upvalue_count: 1,
+                    },
+                    Op::Return,
+                ],
                 vec![],
                 vec![1, 1],
             ),

--- a/resilient/src/ffi.rs
+++ b/resilient/src/ffi.rs
@@ -383,21 +383,11 @@ mod tests {
     #[test]
     fn signature_accepts_opaque_ptr() {
         // RES-215: OpaquePtr is a real FFI type in signatures.
-        let d = decl(
-            "alloc_point",
-            "alloc_point",
-            vec![],
-            "OpaquePtr",
-        );
+        let d = decl("alloc_point", "alloc_point", vec![], "OpaquePtr");
         let sig = ForeignSignature::from_decl(&d).expect("OpaquePtr must parse");
         assert_eq!(sig.ret, FfiType::OpaquePtr);
 
-        let d = decl(
-            "free_point",
-            "free_point",
-            vec![("OpaquePtr", "p")],
-            "Void",
-        );
+        let d = decl("free_point", "free_point", vec![("OpaquePtr", "p")], "Void");
         let sig = ForeignSignature::from_decl(&d).expect("OpaquePtr arg must parse");
         assert_eq!(sig.params, vec![FfiType::OpaquePtr]);
         assert_eq!(sig.ret, FfiType::Void);

--- a/resilient/src/ffi_trampolines.rs
+++ b/resilient/src/ffi_trampolines.rs
@@ -181,17 +181,20 @@ fn dispatch_explicit(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
             }
 
             // ---- RES-215: OpaquePtr arms (arity 0 and 1) ----
-            (&[], OpaquePtr) => Value::OpaquePtr(crate::ffi::OpaquePtrHandle(
-                std::mem::transmute::<*const (), extern "C" fn() -> *mut core::ffi::c_void>(
-                    sym.ptr,
-                )(),
-            )),
-            (&[OpaquePtr], OpaquePtr) => Value::OpaquePtr(crate::ffi::OpaquePtrHandle(
-                std::mem::transmute::<
+            (&[], OpaquePtr) => {
+                Value::OpaquePtr(crate::ffi::OpaquePtrHandle(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn() -> *mut core::ffi::c_void,
+                >(sym.ptr)()))
+            }
+            (&[OpaquePtr], OpaquePtr) => {
+                Value::OpaquePtr(crate::ffi::OpaquePtrHandle(std::mem::transmute::<
                     *const (),
                     extern "C" fn(*mut core::ffi::c_void) -> *mut core::ffi::c_void,
-                >(sym.ptr)(ptrs[0]),
-            )),
+                >(sym.ptr)(
+                    ptrs[0]
+                )))
+            }
             (&[OpaquePtr], Int) => Value::Int(std::mem::transmute::<
                 *const (),
                 extern "C" fn(*mut core::ffi::c_void) -> i64,
@@ -329,8 +332,7 @@ mod tests {
             sig,
         };
         let sentinel = 0x1234_5678_usize as *mut core::ffi::c_void;
-        let out =
-            call_foreign(&sym, &[Value::OpaquePtr(OpaquePtrHandle(sentinel))]).expect("ok");
+        let out = call_foreign(&sym, &[Value::OpaquePtr(OpaquePtrHandle(sentinel))]).expect("ok");
         match out {
             Value::OpaquePtr(h) => assert_eq!(h.0, sentinel),
             other => panic!("expected OpaquePtr, got {:?}", other),
@@ -351,8 +353,7 @@ mod tests {
             sig,
         };
         let sentinel = 0x42_usize as *mut core::ffi::c_void;
-        let out =
-            call_foreign(&sym, &[Value::OpaquePtr(OpaquePtrHandle(sentinel))]).expect("ok");
+        let out = call_foreign(&sym, &[Value::OpaquePtr(OpaquePtrHandle(sentinel))]).expect("ok");
         assert!(matches!(out, Value::Int(0x42)), "got {:?}", out);
     }
 

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -29,9 +29,9 @@
 //   This is a known deficiency documented in `docs/tooling.md` and
 //   is the top follow-up for the next formatter ticket.
 
+use crate::BackoffConfig;
 use crate::Node;
 use crate::Pattern;
-use crate::BackoffConfig;
 
 /// Canonical indent width, in spaces.
 const INDENT: &str = "    ";
@@ -46,7 +46,11 @@ pub struct Formatter {
 
 impl Formatter {
     pub fn new() -> Self {
-        Self { out: String::new(), depth: 0, at_line_start: true }
+        Self {
+            out: String::new(),
+            depth: 0,
+            at_line_start: true,
+        }
     }
 
     /// Entry point. Formats a `Node::Program` (or any top-level
@@ -140,7 +144,13 @@ impl Formatter {
                 self.newline();
             }
             Node::Function {
-                name, parameters, body, requires, ensures, return_type, ..
+                name,
+                parameters,
+                body,
+                requires,
+                ensures,
+                return_type,
+                ..
             } => {
                 self.fmt_function(
                     Some(name),
@@ -163,7 +173,11 @@ impl Formatter {
                 self.write("}");
                 self.newline();
             }
-            Node::ImplBlock { struct_name, methods, .. } => {
+            Node::ImplBlock {
+                struct_name,
+                methods,
+                ..
+            } => {
                 self.write(&format!("impl {} {{", struct_name));
                 self.newline();
                 self.indent();
@@ -181,7 +195,12 @@ impl Formatter {
                 self.write(&format!("type {} = {};", name, target));
                 self.newline();
             }
-            Node::LetStatement { name, value, type_annot, .. } => {
+            Node::LetStatement {
+                name,
+                value,
+                type_annot,
+                ..
+            } => {
                 let ann = match type_annot {
                     Some(t) => format!(": {}", t),
                     None => String::new(),
@@ -198,7 +217,11 @@ impl Formatter {
                 self.newline();
             }
             Node::LetDestructureStruct {
-                struct_name, fields, has_rest, value, ..
+                struct_name,
+                fields,
+                has_rest,
+                value,
+                ..
             } => {
                 self.write(&format!("let {} {{ ", struct_name));
                 let mut parts: Vec<String> = Vec::new();
@@ -214,6 +237,15 @@ impl Formatter {
                 }
                 self.write(&parts.join(", "));
                 self.write(" } = ");
+                self.fmt_expr(value);
+                self.write(";");
+                self.newline();
+            }
+            // RES-127: `let (x, y) = expr;` tuple destructure.
+            Node::LetDestructureTuple { names, value, .. } => {
+                self.write("let (");
+                self.write(&names.join(", "));
+                self.write(") = ");
                 self.fmt_expr(value);
                 self.write(";");
                 self.newline();
@@ -236,7 +268,12 @@ impl Formatter {
                     self.newline();
                 }
             },
-            Node::IfStatement { condition, consequence, alternative, .. } => {
+            Node::IfStatement {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
                 self.write("if ");
                 self.fmt_expr(condition);
                 self.write(" ");
@@ -253,7 +290,12 @@ impl Formatter {
                     self.newline();
                 }
             }
-            Node::WhileStatement { condition, body, invariants, .. } => {
+            Node::WhileStatement {
+                condition,
+                body,
+                invariants,
+                ..
+            } => {
                 self.write("while ");
                 self.fmt_expr(condition);
                 if !invariants.is_empty() {
@@ -274,7 +316,13 @@ impl Formatter {
                     self.newline();
                 }
             }
-            Node::ForInStatement { name, iterable, body, invariants, .. } => {
+            Node::ForInStatement {
+                name,
+                iterable,
+                body,
+                invariants,
+                ..
+            } => {
                 self.write(&format!("for {} in ", name));
                 self.fmt_expr(iterable);
                 if !invariants.is_empty() {
@@ -295,7 +343,13 @@ impl Formatter {
                     self.newline();
                 }
             }
-            Node::LiveBlock { body, invariants, backoff, timeout, .. } => {
+            Node::LiveBlock {
+                body,
+                invariants,
+                backoff,
+                timeout,
+                ..
+            } => {
                 self.write("live");
                 if let Some(bo) = backoff {
                     self.write(&format!(
@@ -318,7 +372,9 @@ impl Formatter {
                     self.newline();
                 }
             }
-            Node::Assert { condition, message, .. } => {
+            Node::Assert {
+                condition, message, ..
+            } => {
                 self.write("assert(");
                 self.fmt_expr(condition);
                 if let Some(m) = message {
@@ -328,7 +384,9 @@ impl Formatter {
                 self.write(");");
                 self.newline();
             }
-            Node::Assume { condition, message, .. } => {
+            Node::Assume {
+                condition, message, ..
+            } => {
                 self.write("assume(");
                 self.fmt_expr(condition);
                 if let Some(m) = message {
@@ -490,16 +548,27 @@ impl Formatter {
                 }
                 self.write("\"");
             }
-            Node::PrefixExpression { operator, right, .. } => {
+            Node::PrefixExpression {
+                operator, right, ..
+            } => {
                 self.write(operator);
                 self.fmt_expr(right);
             }
-            Node::InfixExpression { left, operator, right, .. } => {
+            Node::InfixExpression {
+                left,
+                operator,
+                right,
+                ..
+            } => {
                 self.fmt_expr(left);
                 self.write(&format!(" {} ", operator));
                 self.fmt_expr(right);
             }
-            Node::CallExpression { function, arguments, .. } => {
+            Node::CallExpression {
+                function,
+                arguments,
+                ..
+            } => {
                 self.fmt_expr(function);
                 self.write("(");
                 for (i, a) in arguments.iter().enumerate() {
@@ -518,7 +587,12 @@ impl Formatter {
                 self.fmt_expr(target);
                 self.write(&format!(".{}", field));
             }
-            Node::FieldAssignment { target, field, value, .. } => {
+            Node::FieldAssignment {
+                target,
+                field,
+                value,
+                ..
+            } => {
                 self.fmt_expr(target);
                 self.write(&format!(".{} = ", field));
                 self.fmt_expr(value);
@@ -529,7 +603,12 @@ impl Formatter {
                 self.fmt_expr(index);
                 self.write("]");
             }
-            Node::IndexAssignment { target, index, value, .. } => {
+            Node::IndexAssignment {
+                target,
+                index,
+                value,
+                ..
+            } => {
                 self.fmt_expr(target);
                 self.write("[");
                 self.fmt_expr(index);
@@ -588,7 +667,12 @@ impl Formatter {
                 self.write("}");
             }
             Node::FunctionLiteral {
-                parameters, body, requires, ensures, return_type, ..
+                parameters,
+                body,
+                requires,
+                ensures,
+                return_type,
+                ..
             } => {
                 // Anonymous fn inside an expression context: reuse the
                 // shared function-renderer with `name = None`.
@@ -601,7 +685,9 @@ impl Formatter {
                     body,
                 );
             }
-            Node::Match { scrutinee, arms, .. } => {
+            Node::Match {
+                scrutinee, arms, ..
+            } => {
                 self.write("match ");
                 self.fmt_expr(scrutinee);
                 self.write(" {");
@@ -634,6 +720,25 @@ impl Formatter {
                     self.write(&format!("{}ns", nanos));
                 }
             }
+            // RES-127: tuple literal `(e1, e2, …)`.
+            Node::TupleLiteral { items, .. } => {
+                self.write("(");
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.fmt_expr(it);
+                }
+                if items.len() == 1 {
+                    self.write(",");
+                }
+                self.write(")");
+            }
+            // RES-127: `t.N` positional index.
+            Node::TupleIndex { tuple, index, .. } => {
+                self.fmt_expr(tuple);
+                self.write(&format!(".{}", index));
+            }
             // Statement-shaped nodes that ended up in expression
             // position: degrade gracefully to their statement form.
             Node::Block { .. }
@@ -655,6 +760,7 @@ impl Formatter {
             | Node::Use { .. }
             | Node::Extern { .. }
             | Node::LetDestructureStruct { .. }
+            | Node::LetDestructureTuple { .. }
             | Node::Program(_) => {
                 self.fmt_stmt(node);
             }
@@ -744,8 +850,7 @@ fn f(int x) -> int {
     /// Golden: function contracts land indented under the signature.
     #[test]
     fn fmt_function_contracts() {
-        let src =
-            "fn safe_div(int a, int b) -> int requires b != 0 ensures result * b == a { return a / b; }";
+        let src = "fn safe_div(int a, int b) -> int requires b != 0 ensures result * b == a { return a / b; }";
         let (program, errs) = parse(src);
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let out = Formatter::format(&program);
@@ -783,8 +888,16 @@ struct Point {
         let (program, errs) = parse(src);
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let out = Formatter::format(&program);
-        assert!(out.contains("live {"), "expected brace on same line: {}", out);
-        assert!(out.contains("    live {"), "expected indented live block: {}", out);
+        assert!(
+            out.contains("live {"),
+            "expected brace on same line: {}",
+            out
+        );
+        assert!(
+            out.contains("    live {"),
+            "expected indented live block: {}",
+            out
+        );
     }
 
     /// Property: formatting is idempotent — formatting twice yields
@@ -796,7 +909,12 @@ struct Point {
         assert!(errs.is_empty());
         let once = Formatter::format(&p1);
         let (p2, errs2) = parse(&once);
-        assert!(errs2.is_empty(), "re-parse failed: {:?}\nsource was:\n{}", errs2, once);
+        assert!(
+            errs2.is_empty(),
+            "re-parse failed: {:?}\nsource was:\n{}",
+            errs2,
+            once
+        );
         let twice = Formatter::format(&p2);
         assert_eq!(once, twice, "formatter is not idempotent");
     }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -122,13 +122,18 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
                 // Note: we add the binder AFTER walking the stmt
                 // itself so the RHS sees the outer scope.
                 match s {
-                    Node::LetStatement { name, .. }
-                    | Node::StaticLet { name, .. } => {
+                    Node::LetStatement { name, .. } | Node::StaticLet { name, .. } => {
                         bound.insert(name.clone());
                     }
                     Node::LetDestructureStruct { fields, .. } => {
                         for (_, local) in fields {
                             bound.insert(local.clone());
+                        }
+                    }
+                    // RES-127: tuple destructure binds each name.
+                    Node::LetDestructureTuple { names, .. } => {
+                        for n in names {
+                            bound.insert(n.clone());
                         }
                     }
                     _ => {}
@@ -208,6 +213,11 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
         Node::LetDestructureStruct { value, .. } => {
             walk(value, bound, free);
         }
+        // RES-127: `let (x, y) = expr;` — RHS evaluated in outer scope;
+        // binders added by the enclosing block after this walk returns.
+        Node::LetDestructureTuple { value, .. } => {
+            walk(value, bound, free);
+        }
         Node::Assignment { name, value, .. } => {
             // LHS is a read of `name` in Resilient's scoping model —
             // you can't assign to a name you haven't declared.
@@ -222,21 +232,37 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             }
         }
         Node::ExpressionStatement { expr, .. } => walk(expr, bound, free),
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             walk(condition, bound, free);
             walk(consequence, bound, free);
             if let Some(a) = alternative {
                 walk(a, bound, free);
             }
         }
-        Node::WhileStatement { condition, body, invariants, .. } => {
+        Node::WhileStatement {
+            condition,
+            body,
+            invariants,
+            ..
+        } => {
             walk(condition, bound, free);
             for inv in invariants {
                 walk(inv, bound, free);
             }
             walk(body, bound, free);
         }
-        Node::ForInStatement { name, iterable, body, invariants, .. } => {
+        Node::ForInStatement {
+            name,
+            iterable,
+            body,
+            invariants,
+            ..
+        } => {
             walk(iterable, bound, free);
             let snapshot = bound.len();
             bound.insert(name.clone());
@@ -246,7 +272,9 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             walk(body, bound, free);
             truncate_to(bound, snapshot);
         }
-        Node::LiveBlock { body, invariants, .. } => {
+        Node::LiveBlock {
+            body, invariants, ..
+        } => {
             walk(body, bound, free);
             for inv in invariants {
                 walk(inv, bound, free);
@@ -261,7 +289,11 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             walk(left, bound, free);
             walk(right, bound, free);
         }
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             walk(function, bound, free);
             for a in arguments {
                 walk(a, bound, free);
@@ -272,7 +304,12 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             walk(target, bound, free);
             walk(index, bound, free);
         }
-        Node::IndexAssignment { target, index, value, .. } => {
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
             walk(target, bound, free);
             walk(index, bound, free);
             walk(value, bound, free);
@@ -287,6 +324,14 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
                 walk(i, bound, free);
             }
         }
+        // RES-127: tuple literal — walk each element.
+        Node::TupleLiteral { items, .. } => {
+            for i in items {
+                walk(i, bound, free);
+            }
+        }
+        // RES-127: `t.N` — walk the target.
+        Node::TupleIndex { tuple, .. } => walk(tuple, bound, free),
         Node::StructLiteral { fields, .. } => {
             for (_, v) in fields {
                 walk(v, bound, free);
@@ -303,7 +348,9 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
                 walk(i, bound, free);
             }
         }
-        Node::Match { scrutinee, arms, .. } => {
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
             walk(scrutinee, bound, free);
             for (pat, guard, body) in arms {
                 let snapshot = bound.len();
@@ -388,15 +435,24 @@ mod tests {
     use crate::span::Span;
 
     fn ident(name: &str) -> Node {
-        Node::Identifier { name: name.into(), span: Span::default() }
+        Node::Identifier {
+            name: name.into(),
+            span: Span::default(),
+        }
     }
 
     fn int_lit(v: i64) -> Node {
-        Node::IntegerLiteral { value: v, span: Span::default() }
+        Node::IntegerLiteral {
+            value: v,
+            span: Span::default(),
+        }
     }
 
     fn bool_lit(v: bool) -> Node {
-        Node::BooleanLiteral { value: v, span: Span::default() }
+        Node::BooleanLiteral {
+            value: v,
+            span: Span::default(),
+        }
     }
 
     fn parse_program(src: &str) -> Node {
@@ -775,10 +831,7 @@ mod tests {
         // `new Point { x: a, y: b }` — both `a` and `b` free.
         let lit = Node::StructLiteral {
             name: "Point".into(),
-            fields: vec![
-                ("x".into(), ident("a")),
-                ("y".into(), ident("b")),
-            ],
+            fields: vec![("x".into(), ident("a")), ("y".into(), ident("b"))],
             span: Span::default(),
         };
         assert_eq!(free_vars(&lit), as_set(["a", "b"]));
@@ -791,7 +844,10 @@ mod tests {
         // is actually visited.
         let stmt = Node::WhileStatement {
             condition: Box::new(ident("cond")),
-            body: Box::new(Node::Block { stmts: Vec::new(), span: Span::default() }),
+            body: Box::new(Node::Block {
+                stmts: Vec::new(),
+                span: Span::default(),
+            }),
             invariants: vec![Node::InfixExpression {
                 left: Box::new(ident("p")),
                 operator: ">=".into(),

--- a/resilient/src/imports.rs
+++ b/resilient/src/imports.rs
@@ -22,7 +22,7 @@
 //! Those are intentional follow-ups; this is the foundation.
 
 use crate::span::Spanned;
-use crate::{parse, Node};
+use crate::{Node, parse};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/resilient/src/infer.rs
+++ b/resilient/src/infer.rs
@@ -48,11 +48,11 @@
 
 use std::collections::HashMap;
 
+use crate::Node;
 use crate::diag::{DiagCode, Diagnostic, Severity};
 use crate::span::Span;
 use crate::typechecker::Type;
 use crate::unify::{Substitution, UnifyError};
-use crate::Node;
 
 /// RES-120: one type-inference error.
 ///
@@ -135,7 +135,10 @@ impl Scheme {
     /// uniformly treat monomorphic + polymorphic bindings the
     /// same way.
     pub fn monotype(ty: Type) -> Self {
-        Self { vars: Vec::new(), ty }
+        Self {
+            vars: Vec::new(),
+            ty,
+        }
     }
 }
 
@@ -153,11 +156,20 @@ fn collect_ftv(ty: &Type, out: &mut std::collections::HashSet<u32>) {
         Type::Var(v) => {
             out.insert(*v);
         }
-        Type::Function { params, return_type } => {
+        Type::Function {
+            params,
+            return_type,
+        } => {
             for p in params {
                 collect_ftv(p, out);
             }
             collect_ftv(return_type, out);
+        }
+        // RES-127: recurse through tuple elements.
+        Type::Tuple(elems) => {
+            for e in elems {
+                collect_ftv(e, out);
+            }
         }
         // Primitive / opaque types have no type variables.
         Type::Int
@@ -203,7 +215,10 @@ pub fn generalize(env: &HashMap<String, Type>, ty: &Type) -> Scheme {
     // Diff, sorted for deterministic output.
     let mut vars: Vec<u32> = ty_vars.difference(&env_vars).copied().collect();
     vars.sort();
-    Scheme { vars, ty: ty.clone() }
+    Scheme {
+        vars,
+        ty: ty.clone(),
+    }
 }
 
 impl Inferer {
@@ -238,10 +253,15 @@ impl Inferer {
 fn substitute_vars(ty: &Type, map: &HashMap<u32, Type>) -> Type {
     match ty {
         Type::Var(v) => map.get(v).cloned().unwrap_or_else(|| ty.clone()),
-        Type::Function { params, return_type } => Type::Function {
+        Type::Function {
+            params,
+            return_type,
+        } => Type::Function {
             params: params.iter().map(|p| substitute_vars(p, map)).collect(),
             return_type: Box::new(substitute_vars(return_type, map)),
         },
+        // RES-127: substitute through tuple elements.
+        Type::Tuple(elems) => Type::Tuple(elems.iter().map(|e| substitute_vars(e, map)).collect()),
         other => other.clone(),
     }
 }
@@ -276,19 +296,20 @@ impl Inferer {
     /// from declared parameter types and collecting + solving
     /// type constraints. Returns the final substitution or a
     /// non-empty `Vec<Diagnostic>` on failure.
-    pub fn infer_function(
-        &mut self,
-        func: &Node,
-    ) -> Result<Substitution, Vec<Diagnostic>> {
+    pub fn infer_function(&mut self, func: &Node) -> Result<Substitution, Vec<Diagnostic>> {
         let (parameters, body) = match func {
-            Node::Function { parameters, body, .. } => (parameters, body),
+            Node::Function {
+                parameters, body, ..
+            } => (parameters, body),
             _ => {
-                return Err(vec![Diagnostic::new(
-                    Severity::Error,
-                    Span::default(),
-                    "infer_function expects a Node::Function",
-                )
-                .with_code(T0006_UNSUPPORTED.clone())]);
+                return Err(vec![
+                    Diagnostic::new(
+                        Severity::Error,
+                        Span::default(),
+                        "infer_function expects a Node::Function",
+                    )
+                    .with_code(T0006_UNSUPPORTED.clone()),
+                ]);
             }
         };
 
@@ -321,7 +342,12 @@ impl Inferer {
                     self.infer_stmt(s, errs);
                 }
             }
-            Node::LetStatement { name, value, type_annot, span } => {
+            Node::LetStatement {
+                name,
+                value,
+                type_annot,
+                span,
+            } => {
                 let value_ty = match self.infer_expr(value) {
                     Ok(t) => t,
                     Err(e) => {
@@ -338,10 +364,7 @@ impl Inferer {
                     errs.push(unify_error_to_diag(
                         e,
                         *span,
-                        format!(
-                            "let {}: {} — annotation doesn't match value",
-                            name, ann
-                        ),
+                        format!("let {}: {} — annotation doesn't match value", name, ann),
                     ));
                 }
                 // Non-primitive annotations are ignored by the
@@ -360,7 +383,12 @@ impl Inferer {
                     errs.push(e);
                 }
             }
-            Node::IfStatement { condition, consequence, alternative, .. } => {
+            Node::IfStatement {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
                 match self.infer_expr(condition) {
                     Ok(ct) => {
                         if let Err(e) = self.subst.unify(&ct, &Type::Bool) {
@@ -378,7 +406,9 @@ impl Inferer {
                     self.infer_stmt(a, errs);
                 }
             }
-            Node::WhileStatement { condition, body, .. } => {
+            Node::WhileStatement {
+                condition, body, ..
+            } => {
                 match self.infer_expr(condition) {
                     Ok(ct) => {
                         if let Err(e) = self.subst.unify(&ct, &Type::Bool) {
@@ -410,24 +440,29 @@ impl Inferer {
             Node::FloatLiteral { .. } => Ok(Type::Float),
             Node::BooleanLiteral { .. } => Ok(Type::Bool),
             Node::StringLiteral { .. } => Ok(Type::String),
-            Node::Identifier { name, span } => self
-                .env
-                .get(name)
-                .cloned()
-                .ok_or_else(|| {
-                    Diagnostic::new(
-                        Severity::Error,
-                        *span,
-                        format!("identifier `{}` not in scope", name),
-                    )
-                    .with_code(T0005_UNBOUND.clone())
-                }),
-            Node::InfixExpression { left, operator, right, span } => {
+            Node::Identifier { name, span } => self.env.get(name).cloned().ok_or_else(|| {
+                Diagnostic::new(
+                    Severity::Error,
+                    *span,
+                    format!("identifier `{}` not in scope", name),
+                )
+                .with_code(T0005_UNBOUND.clone())
+            }),
+            Node::InfixExpression {
+                left,
+                operator,
+                right,
+                span,
+            } => {
                 let lt = self.infer_expr(left)?;
                 let rt = self.infer_expr(right)?;
                 self.infer_infix_op(&lt, &rt, operator, *span)
             }
-            Node::PrefixExpression { operator, right, span } => {
+            Node::PrefixExpression {
+                operator,
+                right,
+                span,
+            } => {
                 let rt = self.infer_expr(right)?;
                 self.infer_prefix_op(&rt, operator, *span)
             }
@@ -502,18 +537,10 @@ impl Inferer {
             // Bitwise + shifts: both operands Int; result Int.
             "&" | "|" | "^" | "<<" | ">>" => {
                 self.subst.unify(lt, &Type::Int).map_err(|e| {
-                    unify_error_to_diag(
-                        e,
-                        span,
-                        format!("operator `{}` requires int operands", op),
-                    )
+                    unify_error_to_diag(e, span, format!("operator `{}` requires int operands", op))
                 })?;
                 self.subst.unify(rt, &Type::Int).map_err(|e| {
-                    unify_error_to_diag(
-                        e,
-                        span,
-                        format!("operator `{}` requires int operands", op),
-                    )
+                    unify_error_to_diag(e, span, format!("operator `{}` requires int operands", op))
                 })?;
                 Ok(Type::Int)
             }
@@ -526,20 +553,11 @@ impl Inferer {
         }
     }
 
-    fn infer_prefix_op(
-        &mut self,
-        rt: &Type,
-        op: &str,
-        span: Span,
-    ) -> Result<Type, Diagnostic> {
+    fn infer_prefix_op(&mut self, rt: &Type, op: &str, span: Span) -> Result<Type, Diagnostic> {
         match op {
             "!" => {
                 self.subst.unify(rt, &Type::Bool).map_err(|e| {
-                    unify_error_to_diag(
-                        e,
-                        span,
-                        "prefix `!` requires a bool operand".into(),
-                    )
+                    unify_error_to_diag(e, span, "prefix `!` requires a bool operand".into())
                 })?;
                 Ok(Type::Bool)
             }
@@ -729,11 +747,10 @@ mod tests {
 
     #[test]
     fn int_plus_float_fails_unification() {
-        let errs = infer_err(
-            "fn f(int a, float b) { let s = a + b; return s; }\n",
-        );
+        let errs = infer_err("fn f(int a, float b) { let s = a + b; return s; }\n");
         assert!(
-            errs.iter().any(|d| d.code == Some(T0002_PRIMITIVE_MISMATCH)),
+            errs.iter()
+                .any(|d| d.code == Some(T0002_PRIMITIVE_MISMATCH)),
             "expected T0002, got {:?}",
             errs,
         );
@@ -741,9 +758,7 @@ mod tests {
 
     #[test]
     fn int_plus_bool_fails() {
-        let errs = infer_err(
-            "fn f(int a, bool b) { let s = a + b; return s; }\n",
-        );
+        let errs = infer_err("fn f(int a, bool b) { let s = a + b; return s; }\n");
         assert!(!errs.is_empty());
     }
 
@@ -751,16 +766,12 @@ mod tests {
 
     #[test]
     fn bool_and_bool_returns_bool() {
-        let _ = infer_ok(
-            "fn f(bool a, bool b) { let r = a && b; return r; }\n",
-        );
+        let _ = infer_ok("fn f(bool a, bool b) { let r = a && b; return r; }\n");
     }
 
     #[test]
     fn int_and_bool_fails() {
-        let errs = infer_err(
-            "fn f(int a, bool b) { let r = a && b; return r; }\n",
-        );
+        let errs = infer_err("fn f(int a, bool b) { let r = a && b; return r; }\n");
         assert!(!errs.is_empty());
     }
 
@@ -768,8 +779,7 @@ mod tests {
 
     #[test]
     fn int_equal_int_returns_bool() {
-        let src =
-            "fn f(int a, int b) { let r = a == b; return r; }\n";
+        let src = "fn f(int a, int b) { let r = a == b; return r; }\n";
         let func = first_function(src);
         let mut inf = Inferer::new();
         inf.infer_function(&func).expect("ok");
@@ -778,9 +788,7 @@ mod tests {
 
     #[test]
     fn int_lt_string_fails() {
-        let errs = infer_err(
-            "fn f(int a, string b) { let r = a < b; return r; }\n",
-        );
+        let errs = infer_err("fn f(int a, string b) { let r = a < b; return r; }\n");
         assert!(!errs.is_empty());
     }
 
@@ -797,9 +805,7 @@ mod tests {
 
     #[test]
     fn bitwise_on_bool_fails() {
-        let errs = infer_err(
-            "fn f(bool a, bool b) { let r = a & b; return r; }\n",
-        );
+        let errs = infer_err("fn f(bool a, bool b) { let r = a & b; return r; }\n");
         assert!(!errs.is_empty());
     }
 
@@ -839,7 +845,8 @@ mod tests {
     fn let_annotation_conflicts_with_value() {
         let errs = infer_err("fn f() { let x: int = true; return x; }\n");
         assert!(
-            errs.iter().any(|d| d.code == Some(T0002_PRIMITIVE_MISMATCH)),
+            errs.iter()
+                .any(|d| d.code == Some(T0002_PRIMITIVE_MISMATCH)),
             "expected primitive-mismatch T0002, got {:?}",
             errs,
         );
@@ -849,17 +856,13 @@ mod tests {
 
     #[test]
     fn if_condition_must_be_bool() {
-        let errs = infer_err(
-            "fn f(int x) { if x { return 1; } else { return 2; } }\n",
-        );
+        let errs = infer_err("fn f(int x) { if x { return 1; } else { return 2; } }\n");
         assert!(!errs.is_empty());
     }
 
     #[test]
     fn while_condition_must_be_bool() {
-        let errs = infer_err(
-            "fn f(int x) { while x { let y = 1; } return 0; }\n",
-        );
+        let errs = infer_err("fn f(int x) { while x { let y = 1; } return 0; }\n");
         assert!(!errs.is_empty());
     }
 
@@ -923,10 +926,7 @@ mod tests {
 
     #[test]
     fn free_type_vars_collects_var_id() {
-        assert_eq!(
-            free_type_vars(&Type::Var(3)),
-            [3].into_iter().collect(),
-        );
+        assert_eq!(free_type_vars(&Type::Var(3)), [3].into_iter().collect(),);
     }
 
     #[test]
@@ -1008,7 +1008,10 @@ mod tests {
         // the same var — but distinct across instantiations.
         fn unwrap_fn(t: &Type) -> (&Type, &Type) {
             match t {
-                Type::Function { params, return_type } => (&params[0], return_type),
+                Type::Function {
+                    params,
+                    return_type,
+                } => (&params[0], return_type),
                 _ => panic!("expected Fn, got {:?}", t),
             }
         }
@@ -1043,7 +1046,11 @@ mod tests {
         };
         let mut inf = Inferer::new();
         let t = inf.instantiate(&scheme);
-        if let Type::Function { params, return_type } = t {
+        if let Type::Function {
+            params,
+            return_type,
+        } = t
+        {
             // Var(2) survives unchanged.
             assert_eq!(params[1], Type::Var(2));
             // Var(1) becomes a fresh var (matches
@@ -1069,7 +1076,10 @@ mod tests {
         let mut inf = Inferer::new();
         let inst = inf.instantiate(&scheme);
         match inst {
-            Type::Function { ref params, ref return_type } => {
+            Type::Function {
+                ref params,
+                ref return_type,
+            } => {
                 assert_eq!(params.len(), 1);
                 // Structure preserved.
                 assert_eq!(&params[0], return_type.as_ref());

--- a/resilient/src/jit_backend.rs
+++ b/resilient/src/jit_backend.rs
@@ -148,21 +148,26 @@ fn count_nodes(n: &Node) -> usize {
         | Node::StructDecl { .. } => 0,
         Node::PrefixExpression { right, .. } => count_nodes(right),
         Node::InfixExpression { left, right, .. } => count_nodes(left) + count_nodes(right),
-        Node::CallExpression { function, arguments, .. } => {
-            count_nodes(function) + arguments.iter().map(count_nodes).sum::<usize>()
-        }
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => count_nodes(function) + arguments.iter().map(count_nodes).sum::<usize>(),
         Node::ReturnStatement { value, .. } => value.as_ref().map_or(0, |v| count_nodes(v)),
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             count_nodes(condition)
                 + count_nodes(consequence)
                 + alternative.as_ref().map_or(0, |a| count_nodes(a))
         }
-        Node::WhileStatement { condition, body, .. } => {
-            count_nodes(condition) + count_nodes(body)
-        }
-        Node::ForInStatement { iterable, body, .. } => {
-            count_nodes(iterable) + count_nodes(body)
-        }
+        Node::WhileStatement {
+            condition, body, ..
+        } => count_nodes(condition) + count_nodes(body),
+        Node::ForInStatement { iterable, body, .. } => count_nodes(iterable) + count_nodes(body),
         Node::LetStatement { value, .. }
         | Node::StaticLet { value, .. }
         | Node::Assignment { value, .. } => count_nodes(value),
@@ -196,7 +201,12 @@ fn has_disqualifying_construct(n: &Node) -> bool {
         Node::ReturnStatement { value, .. } => value
             .as_ref()
             .is_some_and(|v| has_disqualifying_construct(v)),
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             has_disqualifying_construct(condition)
                 || has_disqualifying_construct(consequence)
                 || alternative
@@ -319,18 +329,29 @@ fn write_canon_node(buf: &mut Vec<u8>, node: &Node) {
             buf.push(3);
             write_str(buf, name);
         }
-        Node::InfixExpression { left, operator, right, .. } => {
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => {
             buf.push(4);
             write_str(buf, operator);
             write_canon_node(buf, left);
             write_canon_node(buf, right);
         }
-        Node::PrefixExpression { operator, right, .. } => {
+        Node::PrefixExpression {
+            operator, right, ..
+        } => {
             buf.push(5);
             write_str(buf, operator);
             write_canon_node(buf, right);
         }
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             buf.push(6);
             write_canon_node(buf, function);
             write_u32(buf, arguments.len() as u32);
@@ -348,7 +369,12 @@ fn write_canon_node(buf: &mut Vec<u8>, node: &Node) {
                 None => buf.push(0),
             }
         }
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             buf.push(8);
             write_canon_node(buf, condition);
             write_canon_node(buf, consequence);
@@ -360,7 +386,9 @@ fn write_canon_node(buf: &mut Vec<u8>, node: &Node) {
                 None => buf.push(0),
             }
         }
-        Node::WhileStatement { condition, body, .. } => {
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
             buf.push(9);
             write_canon_node(buf, condition);
             write_canon_node(buf, body);
@@ -429,12 +457,9 @@ impl JitCache {
 /// Drop glue; read by `--jit-cache-stats` on program exit.
 /// Relaxed ordering — these are diagnostic counters, not a
 /// synchronization primitive.
-static GLOBAL_JIT_HITS: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
-static GLOBAL_JIT_MISSES: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
-static GLOBAL_JIT_COMPILES: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
+static GLOBAL_JIT_HITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static GLOBAL_JIT_MISSES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static GLOBAL_JIT_COMPILES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Read the process-wide JIT cache counters. Returns `(hits,
 /// misses, compiles)`. Called by the CLI's `--jit-cache-stats`
@@ -493,8 +518,7 @@ fn make_module() -> Result<JITModule, JitError> {
     flag_builder
         .set("is_pic", "false")
         .map_err(|e| JitError::IsaInit(e.to_string()))?;
-    let isa_builder = cranelift_native::builder()
-        .map_err(|e| JitError::IsaInit(e.to_string()))?;
+    let isa_builder = cranelift_native::builder().map_err(|e| JitError::IsaInit(e.to_string()))?;
     let isa = isa_builder
         .finish(settings::Flags::new(flag_builder))
         .map_err(|e| JitError::IsaInit(e.to_string()))?;
@@ -655,22 +679,10 @@ pub(crate) mod runtime_shims {
 /// without duplicating wiring, and so RES-167 (builtin calls —
 /// `len`, `push`, etc.) can reuse the same registration seam.
 fn register_runtime_symbols(builder: &mut JITBuilder) {
-    builder.symbol(
-        "res_array_new",
-        runtime_shims::res_array_new as *const u8,
-    );
-    builder.symbol(
-        "res_array_get",
-        runtime_shims::res_array_get as *const u8,
-    );
-    builder.symbol(
-        "res_array_set",
-        runtime_shims::res_array_set as *const u8,
-    );
-    builder.symbol(
-        "res_array_free",
-        runtime_shims::res_array_free as *const u8,
-    );
+    builder.symbol("res_array_new", runtime_shims::res_array_new as *const u8);
+    builder.symbol("res_array_get", runtime_shims::res_array_get as *const u8);
+    builder.symbol("res_array_set", runtime_shims::res_array_set as *const u8);
+    builder.symbol("res_array_free", runtime_shims::res_array_free as *const u8);
     // RES-167a: register the JIT-side builtin shims alongside the
     // array runtime shims. Both surfaces use the same absolute-
     // address `JITBuilder::symbol` mechanism, so piggy-backing on
@@ -775,26 +787,28 @@ pub(crate) fn jit_builtin_table() -> &'static [JitBuiltinSig] {
     // non-const bit is the `as *const u8` coercion.
     use jit_builtins::*;
     static TABLE: std::sync::OnceLock<[JitBuiltinSig; 3]> = std::sync::OnceLock::new();
-    TABLE.get_or_init(|| [
-        JitBuiltinSig {
-            name: "abs",
-            symbol: "res_jit_abs",
-            arity: 1,
-            addr: res_jit_abs as *const u8,
-        },
-        JitBuiltinSig {
-            name: "max",
-            symbol: "res_jit_max",
-            arity: 2,
-            addr: res_jit_max as *const u8,
-        },
-        JitBuiltinSig {
-            name: "min",
-            symbol: "res_jit_min",
-            arity: 2,
-            addr: res_jit_min as *const u8,
-        },
-    ])
+    TABLE.get_or_init(|| {
+        [
+            JitBuiltinSig {
+                name: "abs",
+                symbol: "res_jit_abs",
+                arity: 1,
+                addr: res_jit_abs as *const u8,
+            },
+            JitBuiltinSig {
+                name: "max",
+                symbol: "res_jit_max",
+                arity: 2,
+                addr: res_jit_max as *const u8,
+            },
+            JitBuiltinSig {
+                name: "min",
+                symbol: "res_jit_min",
+                arity: 2,
+                addr: res_jit_min as *const u8,
+            },
+        ]
+    })
 }
 
 /// RES-167a: look up a JIT builtin by the Resilient source-level
@@ -851,21 +865,23 @@ fn run_internal(program: &Node) -> Result<(i64, JitCache), JitError> {
     let mut function_arities: HashMap<String, usize> = HashMap::new();
     // RES-175: per-name AST map so the leaf-fn inliner can
     // re-lower a callee's body at each qualifying call site.
-    let mut fn_asts: HashMap<String, (Vec<(String, String)>, Node)> =
-        HashMap::new();
+    let mut fn_asts: HashMap<String, (Vec<(String, String)>, Node)> = HashMap::new();
     // Names of functions whose bodies we need to compile (the
     // "primary" for each unique AST hash). Aliases skip compile.
     let mut primaries: Vec<String> = Vec::new();
     for spanned in stmts {
-        if let Node::Function { name, parameters, body, requires, ensures, .. } =
-            &spanned.node
+        if let Node::Function {
+            name,
+            parameters,
+            body,
+            requires,
+            ensures,
+            ..
+        } = &spanned.node
         {
             // RES-175: stash the AST up-front — independent of
             // whether this fn becomes a cache alias or a primary.
-            fn_asts.insert(
-                name.clone(),
-                (parameters.clone(), (**body).clone()),
-            );
+            fn_asts.insert(name.clone(), (parameters.clone(), (**body).clone()));
             let h = fn_hash(parameters, requires, ensures, body);
             if let Some(existing) = cache.map.get(&h).copied() {
                 // Cache hit — reuse the FuncId under the new name.
@@ -894,7 +910,13 @@ fn run_internal(program: &Node) -> Result<(i64, JitCache), JitError> {
     // Aliases skip this loop — their FuncId points at the primary's
     // compiled code, so calls to them dispatch to the same entry.
     for spanned in stmts {
-        if let Node::Function { name, parameters, body, .. } = &spanned.node {
+        if let Node::Function {
+            name,
+            parameters,
+            body,
+            ..
+        } = &spanned.node
+        {
             if !primaries.contains(name) {
                 continue;
             }
@@ -979,9 +1001,7 @@ pub fn run(program: &Node) -> Result<i64, JitError> {
 /// captures ONLY the numbers this run produced, so parallel
 /// test execution doesn't pollute the delta.
 #[cfg(test)]
-pub(crate) fn run_with_stats(
-    program: &Node,
-) -> Result<(i64, u32, u32, u32), JitError> {
+pub(crate) fn run_with_stats(program: &Node) -> Result<(i64, u32, u32, u32), JitError> {
     let (result, cache) = run_internal(program)?;
     Ok((result, cache.hits, cache.misses, cache.compiles))
 }
@@ -1195,12 +1215,21 @@ fn try_lower_tail_call(
     module: &mut JITModule,
 ) -> Result<bool, JitError> {
     // Bail if we're not inside a function (e.g. top-level `main`).
-    let Some(target) = ctx.tco_target else { return Ok(false); };
-    let Some(current) = ctx.current_fn.clone() else { return Ok(false); };
+    let Some(target) = ctx.tco_target else {
+        return Ok(false);
+    };
+    let Some(current) = ctx.current_fn.clone() else {
+        return Ok(false);
+    };
 
     // Shape: ReturnStatement's value must be a direct call to the
     // enclosing function with matching arity.
-    let Node::CallExpression { function, arguments, .. } = expr else {
+    let Node::CallExpression {
+        function,
+        arguments,
+        ..
+    } = expr
+    else {
         return Ok(false);
     };
     let Node::Identifier { name, .. } = function.as_ref() else {
@@ -1288,7 +1317,9 @@ fn compile_node_list(
 ) -> Result<bool, JitError> {
     for node in stmts {
         match node {
-            Node::ReturnStatement { value: Some(expr), .. } => {
+            Node::ReturnStatement {
+                value: Some(expr), ..
+            } => {
                 // RES-168: try TCO first. On a qualifying tail
                 // call, `try_lower_tail_call` emits the back-edge
                 // jump and we skip the regular `return_` below.
@@ -1307,7 +1338,12 @@ fn compile_node_list(
                 bcx.ins().return_(&[v]);
                 return Ok(true);
             }
-            Node::IfStatement { condition, consequence, alternative, .. } => {
+            Node::IfStatement {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
                 let if_terminated = lower_if_statement(
                     condition,
                     consequence,
@@ -1368,10 +1404,10 @@ fn compile_node_list(
             // emitted. `body_block` and `exit_block` each have one
             // predecessor and can be sealed immediately after
             // `switch_to_block`.
-            Node::WhileStatement { condition, body, .. } => {
-                let while_terminated = lower_while_statement(
-                    condition, body, bcx, ctx, module,
-                )?;
+            Node::WhileStatement {
+                condition, body, ..
+            } => {
+                let while_terminated = lower_while_statement(condition, body, bcx, ctx, module)?;
                 if while_terminated {
                     return Ok(true);
                 }
@@ -1551,7 +1587,12 @@ fn lower_block_or_stmt(
             let refs: Vec<&Node> = stmts.iter().collect();
             compile_node_list(&refs, bcx, ctx, module)
         }
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             // RES-103: an if "terminates" only if both arms did.
             // Otherwise the merge block is now active and the
             // surrounding block's caller may want to keep walking.
@@ -1564,7 +1605,9 @@ fn lower_block_or_stmt(
                 module,
             )
         }
-        Node::ReturnStatement { value: Some(expr), .. } => {
+        Node::ReturnStatement {
+            value: Some(expr), ..
+        } => {
             // RES-168: same TCO hook as compile_node_list — any
             // `return <self>(args)` in a function body is lowered
             // as a back-edge jump, regardless of whether it's
@@ -1614,7 +1657,11 @@ fn lower_expr(
         // the current builder's func, then emit `call`. Indirect
         // calls (function value, method, closure) are not yet
         // supported.
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             let callee_name = match function.as_ref() {
                 Node::Identifier { name, .. } => name.clone(),
                 _ => {
@@ -1633,11 +1680,7 @@ fn lower_expr(
                     return Err(JitError::Unsupported("call to unknown function"));
                 }
             };
-            let expected_arity = ctx
-                .function_arities
-                .get(&callee_name)
-                .copied()
-                .unwrap_or(0);
+            let expected_arity = ctx.function_arities.get(&callee_name).copied().unwrap_or(0);
             if arguments.len() != expected_arity {
                 return Err(JitError::Unsupported(
                     "call arity mismatch (declared params vs actual args)",
@@ -1650,13 +1693,8 @@ fn lower_expr(
             // expansion), lower the body in-place instead of
             // emitting an indirect call. See
             // `try_lower_inline_call` for the mechanics.
-            if let Some((callee_params, callee_body)) =
-                ctx.fn_asts.get(&callee_name).cloned()
-                && is_trivial_leaf(
-                    &callee_body,
-                    &callee_name,
-                    ctx.current_fn.as_deref(),
-                )
+            if let Some((callee_params, callee_body)) = ctx.fn_asts.get(&callee_name).cloned()
+                && is_trivial_leaf(&callee_body, &callee_name, ctx.current_fn.as_deref())
                 && ctx.inline_return_target.is_none()
             {
                 return try_lower_inline_call(
@@ -1691,7 +1729,12 @@ fn lower_expr(
         // a future ticket should emit a runtime check that traps or
         // returns a sentinel. For now this matches what the bytecode
         // VM does WITHOUT line attribution on the JIT path.
-        Node::InfixExpression { left, operator, right, .. } => {
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => {
             let op_str = operator.as_str();
             // Validate first so we can short-circuit Unsupported
             // before recursing into the operands.
@@ -2238,9 +2281,8 @@ mod tests {
         // Composes RES-104 (let bindings) with RES-105 (calls):
         // local feeds into the call, call result feeds into a
         // trailing arith op.
-        let p = parse_program(
-            "fn square(int x) { return x * x; } let y = 5; return square(y) + 1;",
-        );
+        let p =
+            parse_program("fn square(int x) { return x * x; } let y = 5; return square(y) + 1;");
         assert_eq!(run(&p).unwrap(), 26);
     }
 
@@ -2413,7 +2455,10 @@ mod tests {
             JitError::Unsupported("test").to_string(),
             "jit: unsupported: test"
         );
-        assert_eq!(JitError::EmptyProgram.to_string(), "jit: program has no top-level return");
+        assert_eq!(
+            JitError::EmptyProgram.to_string(),
+            "jit: program has no top-level return"
+        );
         assert_eq!(
             JitError::IsaInit("foo".into()).to_string(),
             "jit: ISA init failed: foo"
@@ -2436,9 +2481,7 @@ mod tests {
 
     #[test]
     fn jit_while_counts_to_ten() {
-        let p = parse_program(
-            "let i = 0; while (i < 10) { i = i + 1; } return i;",
-        );
+        let p = parse_program("let i = 0; while (i < 10) { i = i + 1; } return i;");
         assert_eq!(run(&p).unwrap(), 10);
     }
 
@@ -2538,9 +2581,7 @@ mod tests {
         // arity-mismatch error path — not TCO. Gives us a
         // regression check that TCO doesn't accidentally
         // consume these mistakes silently.
-        let p = parse_program(
-            "fn f(int n) { return f(n, 0); } return f(1);",
-        );
+        let p = parse_program("fn f(int n) { return f(n, 0); } return f(1);");
         // Regular path: declared 1 param, called with 2 → the
         // JIT's existing arity check rejects.
         match run(&p).unwrap_err() {
@@ -2578,7 +2619,9 @@ mod tests {
 
     #[test]
     fn jit_cache_hit_on_duplicate_fn_body() {
-        let _g = JIT_CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = JIT_CACHE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Two fns with identical bodies (different names) should
         // produce the same AST hash, so the second declaration is
         // a cache hit — same FuncId, no second compile. Calls to
@@ -2597,7 +2640,9 @@ mod tests {
 
     #[test]
     fn jit_cache_miss_on_distinct_bodies() {
-        let _g = JIT_CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = JIT_CACHE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Two fns with different bodies → no hit; both compile.
         let p = parse_program(
             "fn f(int n) { return n * 2; } \
@@ -2613,7 +2658,9 @@ mod tests {
 
     #[test]
     fn jit_cache_ignores_span_differences() {
-        let _g = JIT_CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = JIT_CACHE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Spans differ across the two fn decls (the second one
         // is on a different source line), but the hash is
         // span-stripped — so they still collide and the cache
@@ -2635,7 +2682,9 @@ mod tests {
 
     #[test]
     fn jit_cache_three_way_alias() {
-        let _g = JIT_CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = JIT_CACHE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Three fns, same body → first compiles, next two hit.
         let p = parse_program(
             "fn a(int n) { return n + 1; } \
@@ -2858,7 +2907,9 @@ mod tests {
 
     #[test]
     fn jit_cache_global_stats_accumulate_across_runs() {
-        let _g = JIT_CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = JIT_CACHE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Two sequential `run()` calls — the global counters
         // should reflect AT LEAST this test's contribution (1
         // hit + 2 misses + 2 compiles). Other tests in the same
@@ -2909,12 +2960,14 @@ mod tests {
     #[test]
     fn res165a_two_int_fields_have_natural_offsets() {
         // Point { int x, int y } — x@0, y@8, size 16, align 8.
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             struct Point {
                 int x,
                 int y,
             }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         let pt = layouts.get("Point").expect("Point layout missing");
         assert_eq!(pt.fields.len(), 2);
@@ -2934,12 +2987,14 @@ mod tests {
         // S { bool b, int x } — b@0 (1 byte), then 7 bytes of
         // padding, x@8. Struct align is 8 (inherited from `int`),
         // total size 16.
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             struct S {
                 bool b,
                 int x,
             }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         let s = layouts.get("S").expect("S layout missing");
         assert_eq!(s.fields[0].name, "b");
@@ -2958,12 +3013,14 @@ mod tests {
         // T { int x, bool b } — x@0, b@8. Struct align 8, so
         // total size rounds up from 9 to 16 for arrays-of-T to
         // tile correctly.
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             struct T {
                 int x,
                 bool b,
             }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         let t = layouts.get("T").expect("T layout missing");
         assert_eq!(t.fields[0].offset, 0);
@@ -2976,13 +3033,15 @@ mod tests {
     fn res165a_all_bool_fields_stay_byte_aligned() {
         // B { bool a, bool b, bool c } — a@0, b@1, c@2. Align 1,
         // so no trailing padding; total size 3.
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             struct B {
                 bool a,
                 bool b,
                 bool c,
             }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         let b = layouts.get("B").expect("B layout missing");
         assert_eq!(b.fields[0].offset, 0);
@@ -2996,12 +3055,14 @@ mod tests {
     fn res165a_float_field_uses_f64_ty() {
         // Mix of float + int.  Both are 8-byte aligned, so no
         // padding between them.
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             struct V {
                 float x,
                 int n,
             }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         let v = layouts.get("V").expect("V layout missing");
         assert_eq!(v.fields[0].name, "x");
@@ -3017,12 +3078,14 @@ mod tests {
     #[test]
     fn res165a_i32_field_uses_i32_ty_and_4_byte_align() {
         // Two i32s pack tightly at 4-byte alignment.
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             struct Pair32 {
                 i32 a,
                 i32 b,
             }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         let pr = layouts.get("Pair32").expect("Pair32 layout missing");
         assert_eq!(pr.fields[0].ty, types::I32);
@@ -3047,10 +3110,12 @@ mod tests {
 
     #[test]
     fn res165a_multiple_struct_decls_are_all_cached() {
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             struct A { int x, }
             struct B { bool flag, }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         assert_eq!(layouts.len(), 2);
         assert!(layouts.contains_key("A"));
@@ -3066,13 +3131,15 @@ mod tests {
 
     #[test]
     fn res165a_field_by_name_lookup_roundtrips() {
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             struct R {
                 int a,
                 int b,
                 bool c,
             }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         let r = layouts.get("R").unwrap();
         assert_eq!(r.field("a").unwrap().offset, 0);
@@ -3087,16 +3154,18 @@ mod tests {
         // user struct, an array type) maps to a machine-pointer
         // I64. Regression guard for the fallback branch in
         // `cranelift_ty_for`.
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             struct Node {
                 int tag,
                 Mystery payload,
             }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         let n = layouts.get("Node").unwrap();
-        assert_eq!(n.fields[0].ty, types::I64);   // int
-        assert_eq!(n.fields[1].ty, types::I64);   // pointer fallback
+        assert_eq!(n.fields[0].ty, types::I64); // int
+        assert_eq!(n.fields[1].ty, types::I64); // pointer fallback
         assert_eq!(n.fields[1].offset, 8);
         assert_eq!(n.total_size, 16);
     }
@@ -3106,11 +3175,13 @@ mod tests {
         // A realistic program has let bindings, fn decls, and
         // struct decls intermixed at the top level. The collector
         // must pick up the struct and ignore the rest.
-        let p = parse_program(r#"
+        let p = parse_program(
+            r#"
             let start = 0;
             struct P { int x, int y, }
             fn pack(int a, int b) -> int { return a + b; }
-        "#);
+        "#,
+        );
         let layouts = collect_struct_layouts(&p);
         assert_eq!(layouts.len(), 1);
         let pt = layouts.get("P").unwrap();
@@ -3133,9 +3204,7 @@ mod tests {
     // `register_runtime_symbols` wiring to catch a regression where
     // symbol registration accidentally breaks module construction.
 
-    use super::runtime_shims::{
-        res_array_free, res_array_get, res_array_new, res_array_set,
-    };
+    use super::runtime_shims::{res_array_free, res_array_get, res_array_new, res_array_set};
 
     #[test]
     fn res166a_array_new_returns_nonnull_for_positive_len() {
@@ -3284,7 +3353,7 @@ mod tests {
     // ============================================================
 
     use super::jit_builtins::{res_jit_abs, res_jit_max, res_jit_min};
-    use super::{lookup_jit_builtin, jit_builtin_table};
+    use super::{jit_builtin_table, lookup_jit_builtin};
 
     #[test]
     fn res167a_abs_positive_is_unchanged() {
@@ -3367,7 +3436,10 @@ mod tests {
         let names: Vec<&str> = jit_builtin_table().iter().map(|b| b.name).collect();
         let mut sorted = names.clone();
         sorted.sort();
-        assert_eq!(names, sorted, "jit builtin table must stay alphabetically sorted");
+        assert_eq!(
+            names, sorted,
+            "jit builtin table must stay alphabetically sorted"
+        );
     }
 
     #[test]

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -41,47 +41,82 @@ use crate::span::{Pos, Span};
 enum Tok {
     // --- two-char operators (must precede their single-char prefixes
     // at the logos level via longer-match priority) ---
-    #[token("==")] EqEq,
-    #[token("!=")] NotEq,
-    #[token("<=")] LessEq,
-    #[token(">=")] GreaterEq,
-    #[token("&&")] AndAnd,
-    #[token("||")] OrOr,
-    #[token("<<")] ShlShl,
-    #[token(">>")] ShrShr,
-    #[token("=>")] FatArrow,
-    #[token("->")] Arrow,
+    #[token("==")]
+    EqEq,
+    #[token("!=")]
+    NotEq,
+    #[token("<=")]
+    LessEq,
+    #[token(">=")]
+    GreaterEq,
+    #[token("&&")]
+    AndAnd,
+    #[token("||")]
+    OrOr,
+    #[token("<<")]
+    ShlShl,
+    #[token(">>")]
+    ShrShr,
+    #[token("=>")]
+    FatArrow,
+    #[token("->")]
+    Arrow,
     // RES-149: set-literal opener `#{`. Must precede any lone-`#`
     // handling so logos prefers the longer match.
-    #[token("#{")] HashLBrace,
+    #[token("#{")]
+    HashLBrace,
 
     // --- single-char operators & punctuation ---
-    #[token("+")] Plus,
-    #[token("-")] Minus,
-    #[token("*")] Star,
-    #[token("/")] Slash,
-    #[token("%")] Percent,
-    #[token("=")] Assign,
-    #[token("&")] Amp,
-    #[token("|")] Pipe,
-    #[token("^")] Caret,
-    #[token(">")] Gt,
-    #[token("<")] Lt,
-    #[token("!")] Bang,
-    #[token("(")] LParen,
-    #[token(")")] RParen,
-    #[token("{")] LBrace,
-    #[token("}")] RBrace,
-    #[token("[")] LBracket,
-    #[token("]")] RBracket,
-    #[token(",")] Comma,
-    #[token(";")] Semi,
-    #[token(":")] Colon,
-    #[token(".")] Dot,
-    #[token("?")] Question,
+    #[token("+")]
+    Plus,
+    #[token("-")]
+    Minus,
+    #[token("*")]
+    Star,
+    #[token("/")]
+    Slash,
+    #[token("%")]
+    Percent,
+    #[token("=")]
+    Assign,
+    #[token("&")]
+    Amp,
+    #[token("|")]
+    Pipe,
+    #[token("^")]
+    Caret,
+    #[token(">")]
+    Gt,
+    #[token("<")]
+    Lt,
+    #[token("!")]
+    Bang,
+    #[token("(")]
+    LParen,
+    #[token(")")]
+    RParen,
+    #[token("{")]
+    LBrace,
+    #[token("}")]
+    RBrace,
+    #[token("[")]
+    LBracket,
+    #[token("]")]
+    RBracket,
+    #[token(",")]
+    Comma,
+    #[token(";")]
+    Semi,
+    #[token(":")]
+    Colon,
+    #[token(".")]
+    Dot,
+    #[token("?")]
+    Question,
     // RES-191: attribute prefix (`@pure`, etc.). Emitted as a bare
     // `@`; the parser reads the following identifier.
-    #[token("@")] At,
+    #[token("@")]
+    At,
 
     // --- block comments: skip via callback ---
     #[regex(r"/\*", block_comment)]
@@ -114,38 +149,62 @@ enum Tok {
     BytesLit(Vec<u8>),
 
     // --- keywords ---
-    #[token("fn")] Fn,
-    #[token("let")] Let,
-    #[token("live")] Live,
-    #[token("assert")] Assert,
-    #[token("if")] If,
-    #[token("else")] Else,
-    #[token("return")] Return,
-    #[token("static")] Static,
-    #[token("while")] While,
-    #[token("for")] For,
-    #[token("in")] In,
-    #[token("requires")] Requires,
-    #[token("ensures")] Ensures,
-    #[token("invariant")] Invariant,
-    #[token("struct")] Struct,
-    #[token("new")] New,
-    #[token("match")] Match,
-    #[token("use")] Use,
+    #[token("fn")]
+    Fn,
+    #[token("let")]
+    Let,
+    #[token("live")]
+    Live,
+    #[token("assert")]
+    Assert,
+    #[token("if")]
+    If,
+    #[token("else")]
+    Else,
+    #[token("return")]
+    Return,
+    #[token("static")]
+    Static,
+    #[token("while")]
+    While,
+    #[token("for")]
+    For,
+    #[token("in")]
+    In,
+    #[token("requires")]
+    Requires,
+    #[token("ensures")]
+    Ensures,
+    #[token("invariant")]
+    Invariant,
+    #[token("struct")]
+    Struct,
+    #[token("new")]
+    New,
+    #[token("match")]
+    Match,
+    #[token("use")]
+    Use,
     // RES-158: `impl <Struct> { ... }` keyword. Added alongside the
     // hand-rolled lexer's `"impl" => Token::Impl` kw arm so feature
     // parity is preserved.
-    #[token("impl")] Impl,
+    #[token("impl")]
+    Impl,
     // RES-128: `type <Name> = <Target>;` alias keyword. Same parity
     // requirement as above.
-    #[token("type")] Type,
-    #[token("true")] True,
-    #[token("false")] False,
-    #[token("_")] Underscore,
+    #[token("type")]
+    Type,
+    #[token("true")]
+    True,
+    #[token("false")]
+    False,
+    #[token("_")]
+    Underscore,
     // RES-163: `default` is a reserved alias for `_` at the top of
     // a match arm. Must precede the `Ident` regex so logos picks
     // the keyword arm over the identifier arm.
-    #[token("default")] Default,
+    #[token("default")]
+    Default,
 
     // --- identifiers ---
     // Split into two arms so bare `_` is handled by the `#[token]`

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -22,7 +22,7 @@
 //! - The module exports `check(program, source) -> Vec<Lint>`.
 //!   Main wires that into the `lint <file>` subcommand.
 
-use crate::{span::Span, Node, Pattern};
+use crate::{Node, Pattern, span::Span};
 
 /// RES-198: one lint hit.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -110,7 +110,9 @@ pub fn format_lint(l: &Lint, path: &str) -> String {
 // shadow-aware analysis is a follow-up.
 
 fn run_l0001_unused_local(program: &Node, out: &mut Vec<Lint>) {
-    let Node::Program(stmts) = program else { return };
+    let Node::Program(stmts) = program else {
+        return;
+    };
     for spanned in stmts {
         if let Node::Function { body, .. } = &spanned.node {
             let mut lets: Vec<(String, Span)> = Vec::new();
@@ -118,8 +120,7 @@ fn run_l0001_unused_local(program: &Node, out: &mut Vec<Lint>) {
             if lets.is_empty() {
                 continue;
             }
-            let mut used: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
+            let mut used: std::collections::HashSet<String> = std::collections::HashSet::new();
             collect_identifier_reads_in(body, &mut used);
             for (name, span) in &lets {
                 if name.starts_with('_') {
@@ -144,11 +145,15 @@ fn run_l0001_unused_local(program: &Node, out: &mut Vec<Lint>) {
 
 fn collect_lets_in(node: &Node, out: &mut Vec<(String, Span)>) {
     match node {
-        Node::LetStatement { name, value, span, .. } => {
+        Node::LetStatement {
+            name, value, span, ..
+        } => {
             out.push((name.clone(), *span));
             collect_lets_in(value, out);
         }
-        Node::StaticLet { name, value, span, .. } => {
+        Node::StaticLet {
+            name, value, span, ..
+        } => {
             out.push((name.clone(), *span));
             collect_lets_in(value, out);
         }
@@ -157,14 +162,21 @@ fn collect_lets_in(node: &Node, out: &mut Vec<(String, Span)>) {
                 collect_lets_in(s, out);
             }
         }
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             collect_lets_in(condition, out);
             collect_lets_in(consequence, out);
             if let Some(a) = alternative {
                 collect_lets_in(a, out);
             }
         }
-        Node::WhileStatement { condition, body, .. } => {
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
             collect_lets_in(condition, out);
             collect_lets_in(body, out);
         }
@@ -173,7 +185,9 @@ fn collect_lets_in(node: &Node, out: &mut Vec<(String, Span)>) {
             collect_lets_in(body, out);
         }
         Node::LiveBlock { body, .. } => collect_lets_in(body, out),
-        Node::Match { scrutinee, arms, .. } => {
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
             collect_lets_in(scrutinee, out);
             for (_, guard, arm_body) in arms {
                 if let Some(g) = guard {
@@ -186,16 +200,12 @@ fn collect_lets_in(node: &Node, out: &mut Vec<(String, Span)>) {
     }
 }
 
-fn collect_identifier_reads_in(
-    node: &Node,
-    out: &mut std::collections::HashSet<String>,
-) {
+fn collect_identifier_reads_in(node: &Node, out: &mut std::collections::HashSet<String>) {
     match node {
         Node::Identifier { name, .. } => {
             out.insert(name.clone());
         }
-        Node::LetStatement { value, .. }
-        | Node::StaticLet { value, .. } => {
+        Node::LetStatement { value, .. } | Node::StaticLet { value, .. } => {
             collect_identifier_reads_in(value, out);
         }
         Node::ReturnStatement { value: Some(v), .. } => {
@@ -208,14 +218,21 @@ fn collect_identifier_reads_in(
         Node::ExpressionStatement { expr, .. } => {
             collect_identifier_reads_in(expr, out);
         }
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             collect_identifier_reads_in(condition, out);
             collect_identifier_reads_in(consequence, out);
             if let Some(a) = alternative {
                 collect_identifier_reads_in(a, out);
             }
         }
-        Node::WhileStatement { condition, body, .. } => {
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
             collect_identifier_reads_in(condition, out);
             collect_identifier_reads_in(body, out);
         }
@@ -228,7 +245,9 @@ fn collect_identifier_reads_in(
                 collect_identifier_reads_in(s, out);
             }
         }
-        Node::LiveBlock { body, invariants, .. } => {
+        Node::LiveBlock {
+            body, invariants, ..
+        } => {
             collect_identifier_reads_in(body, out);
             for inv in invariants {
                 collect_identifier_reads_in(inv, out);
@@ -241,7 +260,11 @@ fn collect_identifier_reads_in(
         Node::PrefixExpression { right, .. } => {
             collect_identifier_reads_in(right, out);
         }
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             collect_identifier_reads_in(function, out);
             for a in arguments {
                 collect_identifier_reads_in(a, out);
@@ -254,7 +277,12 @@ fn collect_identifier_reads_in(
             collect_identifier_reads_in(target, out);
             collect_identifier_reads_in(index, out);
         }
-        Node::IndexAssignment { target, index, value, .. } => {
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
             collect_identifier_reads_in(target, out);
             collect_identifier_reads_in(index, out);
             collect_identifier_reads_in(value, out);
@@ -276,7 +304,9 @@ fn collect_identifier_reads_in(
                 collect_identifier_reads_in(v, out);
             }
         }
-        Node::Match { scrutinee, arms, .. } => {
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
             collect_identifier_reads_in(scrutinee, out);
             for (_, guard, arm_body) in arms {
                 if let Some(g) = guard {
@@ -321,7 +351,9 @@ fn walk_matches(node: &Node, out: &mut Vec<Lint>) {
                 walk_matches(s, out);
             }
         }
-        Node::Match { scrutinee, arms, .. } => {
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
             // Find the first arm whose pattern is a bare wildcard.
             // Report subsequent arms at the arm body's span (the
             // closest accessible position — `Pattern` itself
@@ -340,15 +372,15 @@ fn walk_matches(node: &Node, out: &mut Vec<Lint>) {
                 if saw_wild {
                     let arm_span = span_of(arm_body);
                     let (line, col) = match arm_span {
-                        Some(s) if s.start.line > 0 => {
-                            (s.start.line as u32, s.start.column as u32)
-                        }
+                        Some(s) if s.start.line > 0 => (s.start.line as u32, s.start.column as u32),
                         _ => (scrut_line, scrut_col),
                     };
                     out.push(Lint {
                         code: "L0002".into(),
                         severity: Severity::Warning,
-                        message: "arm is unreachable — an earlier `_` arm already matches everything".into(),
+                        message:
+                            "arm is unreachable — an earlier `_` arm already matches everything"
+                                .into(),
                         line,
                         column: col,
                     });
@@ -359,14 +391,21 @@ fn walk_matches(node: &Node, out: &mut Vec<Lint>) {
                 }
             }
         }
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             walk_matches(condition, out);
             walk_matches(consequence, out);
             if let Some(a) = alternative {
                 walk_matches(a, out);
             }
         }
-        Node::WhileStatement { condition, body, .. } => {
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
             walk_matches(condition, out);
             walk_matches(body, out);
         }
@@ -377,7 +416,9 @@ fn walk_matches(node: &Node, out: &mut Vec<Lint>) {
         Node::LiveBlock { body, .. } => walk_matches(body, out),
         Node::LetStatement { value, .. }
         | Node::StaticLet { value, .. }
-        | Node::ReturnStatement { value: Some(value), .. } => {
+        | Node::ReturnStatement {
+            value: Some(value), ..
+        } => {
             walk_matches(value, out);
         }
         Node::ExpressionStatement { expr, .. } => walk_matches(expr, out),
@@ -386,7 +427,11 @@ fn walk_matches(node: &Node, out: &mut Vec<Lint>) {
             walk_matches(right, out);
         }
         Node::PrefixExpression { right, .. } => walk_matches(right, out),
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             walk_matches(function, out);
             for a in arguments {
                 walk_matches(a, out);
@@ -411,12 +456,15 @@ fn run_l0003_self_comparison(program: &Node, out: &mut Vec<Lint>) {
 }
 
 fn walk_self_comparisons(node: &Node, out: &mut Vec<Lint>) {
-    if let Node::InfixExpression { left, operator, right, span } = node
+    if let Node::InfixExpression {
+        left,
+        operator,
+        right,
+        span,
+    } = node
         && (operator == "==" || operator == "!=")
-        && let (
-            Node::Identifier { name: ln, .. },
-            Node::Identifier { name: rn, .. },
-        ) = (left.as_ref(), right.as_ref())
+        && let (Node::Identifier { name: ln, .. }, Node::Identifier { name: rn, .. }) =
+            (left.as_ref(), right.as_ref())
         && ln == rn
     {
         let always = if operator == "==" {
@@ -427,10 +475,7 @@ fn walk_self_comparisons(node: &Node, out: &mut Vec<Lint>) {
         out.push(Lint {
             code: "L0003".into(),
             severity: Severity::Warning,
-            message: format!(
-                "comparing `{}` to itself is {} (likely a typo)",
-                ln, always
-            ),
+            message: format!("comparing `{}` to itself is {} (likely a typo)", ln, always),
             line: span.start.line as u32,
             column: span.start.column as u32,
         });
@@ -455,7 +500,13 @@ fn run_l0004_mixed_and_or(program: &Node, out: &mut Vec<Lint>) {
 }
 
 fn walk_and_or(node: &Node, out: &mut Vec<Lint>) {
-    if let Node::InfixExpression { left, operator, right, span } = node {
+    if let Node::InfixExpression {
+        left,
+        operator,
+        right,
+        span,
+    } = node
+    {
         let opposite = match operator.as_str() {
             "&&" => Some("||"),
             "||" => Some("&&"),
@@ -528,12 +579,15 @@ fn span_of(node: &Node) -> Option<Span> {
 // returns today).
 
 fn run_l0005_redundant_return(program: &Node, out: &mut Vec<Lint>) {
-    let Node::Program(stmts) = program else { return };
+    let Node::Program(stmts) = program else {
+        return;
+    };
     for spanned in stmts {
         if let Node::Function { body, .. } = &spanned.node
-            && let Node::Block { stmts: body_stmts, .. } = body.as_ref()
-            && let Some(Node::ReturnStatement { value: None, span }) =
-                body_stmts.last()
+            && let Node::Block {
+                stmts: body_stmts, ..
+            } = body.as_ref()
+            && let Some(Node::ReturnStatement { value: None, span }) = body_stmts.last()
         {
             out.push(Lint {
                 code: "L0005".into(),
@@ -558,7 +612,12 @@ fn recurse_children<F: FnMut(&Node)>(node: &Node, f: &mut F) {
                 f(&s.node);
             }
         }
-        Node::Function { body, requires, ensures, .. } => {
+        Node::Function {
+            body,
+            requires,
+            ensures,
+            ..
+        } => {
             f(body);
             for r in requires {
                 f(r);
@@ -572,19 +631,25 @@ fn recurse_children<F: FnMut(&Node)>(node: &Node, f: &mut F) {
                 f(s);
             }
         }
-        Node::LetStatement { value, .. }
-        | Node::StaticLet { value, .. } => f(value),
+        Node::LetStatement { value, .. } | Node::StaticLet { value, .. } => f(value),
         Node::ReturnStatement { value: Some(v), .. } => f(v),
         Node::Assignment { value, .. } => f(value),
         Node::ExpressionStatement { expr, .. } => f(expr),
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             f(condition);
             f(consequence);
             if let Some(a) = alternative {
                 f(a);
             }
         }
-        Node::WhileStatement { condition, body, .. } => {
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
             f(condition);
             f(body);
         }
@@ -592,7 +657,9 @@ fn recurse_children<F: FnMut(&Node)>(node: &Node, f: &mut F) {
             f(iterable);
             f(body);
         }
-        Node::LiveBlock { body, invariants, .. } => {
+        Node::LiveBlock {
+            body, invariants, ..
+        } => {
             f(body);
             for inv in invariants {
                 f(inv);
@@ -603,14 +670,20 @@ fn recurse_children<F: FnMut(&Node)>(node: &Node, f: &mut F) {
             f(right);
         }
         Node::PrefixExpression { right, .. } => f(right),
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             f(function);
             for a in arguments {
                 f(a);
             }
         }
         Node::TryExpression { expr, .. } => f(expr),
-        Node::Match { scrutinee, arms, .. } => {
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
             f(scrutinee);
             for (_, guard, arm_body) in arms {
                 if let Some(g) = guard {
@@ -623,7 +696,12 @@ fn recurse_children<F: FnMut(&Node)>(node: &Node, f: &mut F) {
             f(target);
             f(index);
         }
-        Node::IndexAssignment { target, index, value, .. } => {
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
             f(target);
             f(index);
             f(value);
@@ -662,15 +740,14 @@ fn collect_allow_comments(source: &str) -> std::collections::HashSet<(u32, Strin
     let mut out = std::collections::HashSet::new();
     for (i, raw) in source.lines().enumerate() {
         let line_no = (i as u32) + 1;
-        let Some(pos) = raw.find("// resilient: allow") else { continue };
+        let Some(pos) = raw.find("// resilient: allow") else {
+            continue;
+        };
         let tail = &raw[pos + "// resilient: allow".len()..];
         // Collect every LXXXX token on the rest of the line.
         for word in tail.split(|c: char| c == ',' || c.is_whitespace()) {
             let w = word.trim();
-            if w.starts_with('L')
-                && w.len() == 5
-                && w.chars().skip(1).all(|c| c.is_ascii_digit())
-            {
+            if w.starts_with('L') && w.len() == 5 && w.chars().skip(1).all(|c| c.is_ascii_digit()) {
                 out.insert((line_no + 1, w.to_string()));
             }
         }
@@ -727,13 +804,15 @@ mod tests {
 
     #[test]
     fn l0002_fires_on_arm_after_wildcard() {
-        let src = "fn f(int n) {\n    return match n {\n        _ => 0,\n        1 => 1,\n    };\n}\n";
+        let src =
+            "fn f(int n) {\n    return match n {\n        _ => 0,\n        1 => 1,\n    };\n}\n";
         assert!(codes(src).contains(&"L0002".to_string()));
     }
 
     #[test]
     fn l0002_silent_when_wildcard_is_last() {
-        let src = "fn f(int n) {\n    return match n {\n        1 => 1,\n        _ => 0,\n    };\n}\n";
+        let src =
+            "fn f(int n) {\n    return match n {\n        1 => 1,\n        _ => 0,\n    };\n}\n";
         assert!(!codes(src).contains(&"L0002".to_string()));
     }
 
@@ -776,13 +855,15 @@ mod tests {
 
     #[test]
     fn l0004_fires_on_and_or_mix() {
-        let src = "fn f(bool a, bool b, bool c) {\n    if a && b || c { return 1; }\n    return 0;\n}\n";
+        let src =
+            "fn f(bool a, bool b, bool c) {\n    if a && b || c { return 1; }\n    return 0;\n}\n";
         assert!(codes(src).contains(&"L0004".to_string()));
     }
 
     #[test]
     fn l0004_silent_on_same_op() {
-        let src = "fn f(bool a, bool b, bool c) {\n    if a && b && c { return 1; }\n    return 0;\n}\n";
+        let src =
+            "fn f(bool a, bool b, bool c) {\n    if a && b && c { return 1; }\n    return 0;\n}\n";
         assert!(!codes(src).contains(&"L0004".to_string()));
     }
 
@@ -863,12 +944,14 @@ mod tests {
 
     #[test]
     fn lints_sorted_by_line_column() {
-        let src = "fn f(int x) {\n    if x == x { return 1; }\n    let unused = 42;\n    return 0;\n}\n";
+        let src =
+            "fn f(int x) {\n    if x == x { return 1; }\n    let unused = 42;\n    return 0;\n}\n";
         let out = lint(src);
         for pair in out.windows(2) {
             assert!(
                 (pair[0].line, pair[0].column) <= (pair[1].line, pair[1].column),
-                "lint order: {:?}", out,
+                "lint order: {:?}",
+                out,
             );
         }
     }

--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -34,7 +34,7 @@ use tower_lsp::lsp_types::{
 };
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
-use crate::{builtin_names, compute_semantic_tokens, parse, typechecker, Node};
+use crate::{Node, builtin_names, compute_semantic_tokens, parse, typechecker};
 
 /// RES-186: one workspace-level symbol entry. A flat vec of these
 /// is the backend's search index — substring filter at query time,
@@ -256,10 +256,7 @@ fn span_to_range(span: crate::span::Span) -> Range {
 /// This lookup is O(tokens). A cached-source document is small
 /// enough that re-lexing on each hover request is cheap — faster
 /// than the HashMap operation that reads it.
-pub(crate) fn hover_literal_at(
-    src: &str,
-    pos: Position,
-) -> Option<(&'static str, Range)> {
+pub(crate) fn hover_literal_at(src: &str, pos: Position) -> Option<(&'static str, Range)> {
     use crate::{Lexer, Token};
     let mut lex = Lexer::new(src.to_string());
     loop {
@@ -319,10 +316,7 @@ fn lex_span_contains_lsp_position(span: crate::span::Span, pos: Position) -> boo
 /// directly against the cached source and find the containing
 /// `Token::Identifier`. Caller uses the returned name to look up
 /// the definition in a `TopLevelDefMap`.
-pub(crate) fn identifier_at(
-    src: &str,
-    pos: Position,
-) -> Option<(String, Range)> {
+pub(crate) fn identifier_at(src: &str, pos: Position) -> Option<(String, Range)> {
     use crate::{Lexer, Token};
     let mut lex = Lexer::new(src.to_string());
     loop {
@@ -473,10 +467,7 @@ impl CandidateKind {
 ///
 /// When `prefix` is empty, the full candidate set (up to the cap)
 /// is returned — that's the Ctrl-Space case.
-pub(crate) fn completion_candidates(
-    program: &Node,
-    prefix: &str,
-) -> Vec<Candidate> {
+pub(crate) fn completion_candidates(program: &Node, prefix: &str) -> Vec<Candidate> {
     let mut out: Vec<Candidate> = Vec::new();
 
     // Builtins — alphabetically sorted snapshot.
@@ -504,7 +495,9 @@ pub(crate) fn completion_candidates(
     };
     for spanned in stmts {
         let (name, kind, detail) = match &spanned.node {
-            Node::Function { name, parameters, .. } => (
+            Node::Function {
+                name, parameters, ..
+            } => (
                 name.clone(),
                 CandidateKind::Function,
                 Some(format!("fn ({} params)", parameters.len())),
@@ -572,12 +565,8 @@ pub(crate) fn document_symbols_for_program(program: &Node) -> Vec<DocumentSymbol
     let mut out = Vec::new();
     for spanned in stmts {
         let symbol = match &spanned.node {
-            Node::Function { name, .. } => {
-                make_symbol(name, SymbolKind::FUNCTION, spanned.span)
-            }
-            Node::StructDecl { name, .. } => {
-                make_symbol(name, SymbolKind::STRUCT, spanned.span)
-            }
+            Node::Function { name, .. } => make_symbol(name, SymbolKind::FUNCTION, spanned.span),
+            Node::StructDecl { name, .. } => make_symbol(name, SymbolKind::STRUCT, spanned.span),
             Node::TypeAlias { name, .. } => {
                 make_symbol(name, SymbolKind::TYPE_PARAMETER, spanned.span)
             }
@@ -606,8 +595,7 @@ impl Backend {
         };
         let Some(root) = root else { return };
         let files = walk_resilient_files(&root);
-        let mut new_index: HashMap<Url, Vec<WorkspaceSymbolEntry>> =
-            HashMap::new();
+        let mut new_index: HashMap<Url, Vec<WorkspaceSymbolEntry>> = HashMap::new();
         for path in files {
             if let Some(entries) = index_file(&path) {
                 let Ok(uri) = Url::from_file_path(&path) else {
@@ -627,7 +615,9 @@ impl Backend {
 /// index build artifacts or management metadata.
 fn walk_resilient_files(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
-    let Ok(entries) = std::fs::read_dir(root) else { return out };
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return out;
+    };
     for e in entries.flatten() {
         let path = e.path();
         let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
@@ -724,7 +714,10 @@ fn semantic_tokens_legend() -> SemanticTokensLegend {
         SemanticTokenModifier::DECLARATION,
         SemanticTokenModifier::READONLY,
     ];
-    SemanticTokensLegend { token_types, token_modifiers }
+    SemanticTokensLegend {
+        token_types,
+        token_modifiers,
+    }
 }
 
 /// RES-187: the capability advertised in `initialize` — full-file
@@ -812,10 +805,12 @@ fn collect_top_level_fns(program: &Node) -> HashMap<String, Vec<String>> {
     let mut out = HashMap::new();
     if let Node::Program(stmts) = program {
         for spanned in stmts {
-            if let Node::Function { name, parameters, .. } = &spanned.node {
+            if let Node::Function {
+                name, parameters, ..
+            } = &spanned.node
+            {
                 // parameters are (type, name) — only names needed.
-                let names: Vec<String> =
-                    parameters.iter().map(|(_, n)| n.clone()).collect();
+                let names: Vec<String> = parameters.iter().map(|(_, n)| n.clone()).collect();
                 out.insert(name.clone(), names);
             }
         }
@@ -827,18 +822,19 @@ fn collect_top_level_fns(program: &Node) -> HashMap<String, Vec<String>> {
 /// `node`. For each one, if the callee is a bare identifier
 /// that's in `fns` AND the arg count matches, emit one hint per
 /// positional argument.
-fn walk_call_hints(
-    node: &Node,
-    fns: &HashMap<String, Vec<String>>,
-    out: &mut Vec<InlayHint>,
-) {
+fn walk_call_hints(node: &Node, fns: &HashMap<String, Vec<String>>, out: &mut Vec<InlayHint>) {
     match node {
         Node::Program(stmts) => {
             for s in stmts {
                 walk_call_hints(&s.node, fns, out);
             }
         }
-        Node::Function { body, requires, ensures, .. } => {
+        Node::Function {
+            body,
+            requires,
+            ensures,
+            ..
+        } => {
             walk_call_hints(body, fns, out);
             for r in requires {
                 walk_call_hints(r, fns, out);
@@ -853,7 +849,11 @@ fn walk_call_hints(
                 walk_call_hints(s, fns, out);
             }
         }
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             // First recurse into the arguments so nested calls get
             // hints too.
             for a in arguments {
@@ -890,10 +890,17 @@ fn walk_call_hints(
         }
         Node::LetStatement { value, .. }
         | Node::StaticLet { value, .. }
-        | Node::ReturnStatement { value: Some(value), .. } => {
+        | Node::ReturnStatement {
+            value: Some(value), ..
+        } => {
             walk_call_hints(value, fns, out);
         }
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             walk_call_hints(condition, fns, out);
             walk_call_hints(consequence, fns, out);
             if let Some(a) = alternative {
@@ -935,9 +942,7 @@ fn position_in_range(p: Position, range: Range) -> bool {
 /// value isn't a boolean `true`. Exported pub(crate) so unit
 /// tests can exercise the parser without an LSP round-trip.
 #[allow(dead_code)]
-pub(crate) fn read_init_param_hints_flag(
-    opts: Option<&tower_lsp::lsp_types::LSPAny>,
-) -> bool {
+pub(crate) fn read_init_param_hints_flag(opts: Option<&tower_lsp::lsp_types::LSPAny>) -> bool {
     let Some(opts) = opts else { return false };
     // Flat form.
     if let Some(v) = opts.get("resilient.inlayHints.parameters")
@@ -1008,9 +1013,7 @@ impl LanguageServer for Backend {
             .map(|f| f.uri.clone())
             .or(params.root_uri.clone())
             .and_then(|u| u.to_file_path().ok());
-        if let (Ok(mut slot), Some(p)) =
-            (self.workspace_root.lock(), root_path)
-        {
+        if let (Ok(mut slot), Some(p)) = (self.workspace_root.lock(), root_path) {
             *slot = Some(p);
         }
 
@@ -1020,9 +1023,7 @@ impl LanguageServer for Backend {
         // `{"resilient": {"inlayHints": {"parameters": true}}}`
         // (nested). Either is fine; clients vary. Absent / false →
         // parameter hints stay off.
-        let params_enabled = read_init_param_hints_flag(
-            params.initialization_options.as_ref(),
-        );
+        let params_enabled = read_init_param_hints_flag(params.initialization_options.as_ref());
         if let Ok(mut slot) = self.inlay_hint_parameters.lock() {
             *slot = params_enabled;
         }
@@ -1049,12 +1050,12 @@ impl LanguageServer for Backend {
                 // options) — the server supports the feature for any
                 // document that already has a `TextDocumentSyncKind`
                 // registered above.
-                inlay_hint_provider: Some(OneOf::Right(
-                    InlayHintServerCapabilities::Options(InlayHintOptions {
+                inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(
+                    InlayHintOptions {
                         work_done_progress_options: WorkDoneProgressOptions::default(),
                         resolve_provider: Some(false),
-                    }),
-                )),
+                    },
+                ))),
                 // RES-181a: advertise hover support. Today the handler
                 // only surfaces a type for literals (Int / Float /
                 // Bool / String / Bytes / Duration) — identifier
@@ -1143,17 +1144,16 @@ impl LanguageServer for Backend {
     /// untouched. If the save happened before the index was
     /// built, this is still safe: the lazy-build on next
     /// `workspace/symbol` call will include the saved state.
-    async fn did_save(
-        &self,
-        params: tower_lsp::lsp_types::DidSaveTextDocumentParams,
-    ) {
+    async fn did_save(&self, params: tower_lsp::lsp_types::DidSaveTextDocumentParams) {
         let uri = params.text_document.uri;
         // Re-read the file from disk. `did_save` notifications
         // carry the text only when the client opts into the
         // `TextDocumentSyncSaveOptions { include_text: true }`
         // — we registered TextDocumentSyncKind::FULL without
         // that, so walk to disk instead.
-        let Some(path) = uri.to_file_path().ok() else { return };
+        let Some(path) = uri.to_file_path().ok() else {
+            return;
+        };
         let entries = match index_file(&path) {
             Some(e) => e,
             None => return,
@@ -1324,10 +1324,7 @@ impl LanguageServer for Backend {
     ///      applies the 100-item cap.
     ///   4. Convert each `Candidate` to `CompletionItem` and wrap
     ///      as `CompletionResponse::Array`.
-    async fn completion(
-        &self,
-        params: CompletionParams,
-    ) -> JsonResult<Option<CompletionResponse>> {
+    async fn completion(&self, params: CompletionParams) -> JsonResult<Option<CompletionResponse>> {
         let uri = params.text_document_position.text_document.uri;
         let pos = params.text_document_position.position;
         let text = match self.documents_text.lock() {
@@ -1389,10 +1386,7 @@ impl LanguageServer for Backend {
     /// Filters the output by the request's `range` so clients
     /// that ask for a viewport don't pay to render the whole
     /// file's worth.
-    async fn inlay_hint(
-        &self,
-        params: InlayHintParams,
-    ) -> JsonResult<Option<Vec<InlayHint>>> {
+    async fn inlay_hint(&self, params: InlayHintParams) -> JsonResult<Option<Vec<InlayHint>>> {
         let uri = params.text_document.uri;
         let range = params.range;
 
@@ -1409,8 +1403,7 @@ impl LanguageServer for Backend {
         // collected up to the error point.
         let mut tc = typechecker::TypeChecker::new();
         let _ = tc.check_program_with_source(&program, uri.as_str());
-        let let_hints: Vec<InlayHint> =
-            tc.let_type_hints.iter().map(inlay_hint_from_let).collect();
+        let let_hints: Vec<InlayHint> = tc.let_type_hints.iter().map(inlay_hint_from_let).collect();
 
         let mut out: Vec<InlayHint> = let_hints
             .into_iter()
@@ -1601,12 +1594,8 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!(
-            "res_186_{}_{}_{}",
-            tag,
-            std::process::id(),
-            n
-        ));
+        let path =
+            std::env::temp_dir().join(format!("res_186_{}_{}_{}", tag, std::process::id(), n));
         std::fs::create_dir_all(&path).expect("create scratch dir");
         path
     }
@@ -1629,11 +1618,7 @@ mod tests {
             "fn c() { return 0; }\n",
         );
         std::fs::create_dir_all(root.join(".cache")).unwrap();
-        write_file(
-            &root.join(".cache"),
-            "d.rs",
-            "fn d() { return 0; }\n",
-        );
+        write_file(&root.join(".cache"), "d.rs", "fn d() { return 0; }\n");
         let found = walk_resilient_files(&root);
         let names: Vec<String> = found
             .iter()
@@ -1641,8 +1626,14 @@ mod tests {
             .collect();
         assert!(names.contains(&"a.rs".to_string()));
         assert!(names.contains(&"b.rs".to_string()));
-        assert!(!names.contains(&"c.rs".to_string()), "target/ must be skipped");
-        assert!(!names.contains(&"d.rs".to_string()), "dot-dirs must be skipped");
+        assert!(
+            !names.contains(&"c.rs".to_string()),
+            "target/ must be skipped"
+        );
+        assert!(
+            !names.contains(&"d.rs".to_string()),
+            "dot-dirs must be skipped"
+        );
         // Clean up.
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -1675,28 +1666,19 @@ mod tests {
                 name: "alpha".into(),
                 kind: SymbolKind::FUNCTION,
                 uri: uri.clone(),
-                range: Range::new(
-                    Position::new(0, 0),
-                    Position::new(0, 0),
-                ),
+                range: Range::new(Position::new(0, 0), Position::new(0, 0)),
             },
             WorkspaceSymbolEntry {
                 name: "AlphaBeta".into(),
                 kind: SymbolKind::FUNCTION,
                 uri: uri.clone(),
-                range: Range::new(
-                    Position::new(1, 0),
-                    Position::new(1, 0),
-                ),
+                range: Range::new(Position::new(1, 0), Position::new(1, 0)),
             },
             WorkspaceSymbolEntry {
                 name: "gamma".into(),
                 kind: SymbolKind::FUNCTION,
                 uri: uri.clone(),
-                range: Range::new(
-                    Position::new(2, 0),
-                    Position::new(2, 0),
-                ),
+                range: Range::new(Position::new(2, 0), Position::new(2, 0)),
             },
         ];
         let mut index: HashMap<Url, Vec<WorkspaceSymbolEntry>> = HashMap::new();
@@ -1734,26 +1716,47 @@ mod tests {
     fn semantic_tokens_legend_indices_match_sem_tok_constants() {
         use crate::sem_tok;
         let legend = semantic_tokens_legend();
-        assert_eq!(legend.token_types[sem_tok::KEYWORD as usize],
-                   SemanticTokenType::KEYWORD);
-        assert_eq!(legend.token_types[sem_tok::FUNCTION as usize],
-                   SemanticTokenType::FUNCTION);
-        assert_eq!(legend.token_types[sem_tok::VARIABLE as usize],
-                   SemanticTokenType::VARIABLE);
-        assert_eq!(legend.token_types[sem_tok::PARAMETER as usize],
-                   SemanticTokenType::PARAMETER);
-        assert_eq!(legend.token_types[sem_tok::TYPE as usize],
-                   SemanticTokenType::TYPE);
-        assert_eq!(legend.token_types[sem_tok::STRING as usize],
-                   SemanticTokenType::STRING);
-        assert_eq!(legend.token_types[sem_tok::NUMBER as usize],
-                   SemanticTokenType::NUMBER);
-        assert_eq!(legend.token_types[sem_tok::COMMENT as usize],
-                   SemanticTokenType::COMMENT);
-        assert_eq!(legend.token_types[sem_tok::OPERATOR as usize],
-                   SemanticTokenType::OPERATOR);
+        assert_eq!(
+            legend.token_types[sem_tok::KEYWORD as usize],
+            SemanticTokenType::KEYWORD
+        );
+        assert_eq!(
+            legend.token_types[sem_tok::FUNCTION as usize],
+            SemanticTokenType::FUNCTION
+        );
+        assert_eq!(
+            legend.token_types[sem_tok::VARIABLE as usize],
+            SemanticTokenType::VARIABLE
+        );
+        assert_eq!(
+            legend.token_types[sem_tok::PARAMETER as usize],
+            SemanticTokenType::PARAMETER
+        );
+        assert_eq!(
+            legend.token_types[sem_tok::TYPE as usize],
+            SemanticTokenType::TYPE
+        );
+        assert_eq!(
+            legend.token_types[sem_tok::STRING as usize],
+            SemanticTokenType::STRING
+        );
+        assert_eq!(
+            legend.token_types[sem_tok::NUMBER as usize],
+            SemanticTokenType::NUMBER
+        );
+        assert_eq!(
+            legend.token_types[sem_tok::COMMENT as usize],
+            SemanticTokenType::COMMENT
+        );
+        assert_eq!(
+            legend.token_types[sem_tok::OPERATOR as usize],
+            SemanticTokenType::OPERATOR
+        );
         // Modifier bit positions: bit 0 = declaration, bit 1 = readonly.
-        assert_eq!(legend.token_modifiers[0], SemanticTokenModifier::DECLARATION);
+        assert_eq!(
+            legend.token_modifiers[0],
+            SemanticTokenModifier::DECLARATION
+        );
         assert_eq!(legend.token_modifiers[1], SemanticTokenModifier::READONLY);
     }
 
@@ -1811,10 +1814,12 @@ mod tests {
             hints.len(),
             3,
             "expected 3 hints (a, c, e), got {:?}",
-            hints.iter().map(|h| (h.name_len_chars, &h.ty)).collect::<Vec<_>>(),
+            hints
+                .iter()
+                .map(|h| (h.name_len_chars, &h.ty))
+                .collect::<Vec<_>>(),
         );
-        let types: Vec<String> =
-            hints.iter().map(|h| format!("{}", h.ty)).collect();
+        let types: Vec<String> = hints.iter().map(|h| format!("{}", h.ty)).collect();
         assert_eq!(types, vec!["int", "bool", "string"]);
     }
 
@@ -1961,7 +1966,11 @@ mod tests {
         // Ticket AC: pre-seed two files, invoke the query (via the
         // helper path), assert both files' symbols are returned.
         let root = tmp_workspace("multifile");
-        write_file(&root, "mod_a.rs", "fn a_fn() { return 0; }\nstruct A_Struct { int x }\n");
+        write_file(
+            &root,
+            "mod_a.rs",
+            "fn a_fn() { return 0; }\nstruct A_Struct { int x }\n",
+        );
         write_file(&root, "mod_b.rs", "fn b_fn() { return 0; }\n");
 
         // Walk + index the whole scratch dir, reproducing what
@@ -1972,7 +1981,9 @@ mod tests {
         let mut index: std::collections::HashMap<Url, Vec<WorkspaceSymbolEntry>> =
             std::collections::HashMap::new();
         for p in files {
-            let Ok(uri) = Url::from_file_path(&p) else { continue };
+            let Ok(uri) = Url::from_file_path(&p) else {
+                continue;
+            };
             if let Some(entries) = index_file(&p) {
                 index.insert(uri, entries);
             }
@@ -1980,8 +1991,7 @@ mod tests {
 
         // All-match query: three names across two files.
         let r = filter_workspace_symbols(&index, "", 50);
-        let names: std::collections::HashSet<&str> =
-            r.iter().map(|s| s.name.as_str()).collect();
+        let names: std::collections::HashSet<&str> = r.iter().map(|s| s.name.as_str()).collect();
         assert!(names.contains("a_fn"));
         assert!(names.contains("A_Struct"));
         assert!(names.contains("b_fn"));
@@ -2113,8 +2123,8 @@ mod tests {
     fn res181a_hover_returns_range_covering_the_token() {
         // The Range returned with the hover should span the whole
         // literal. For `42` at cols 9..11 (1-indexed) = LSP 8..10.
-        let (ty, range) = hover_literal_at("let x = 42;", Position::new(0, 8))
-            .expect("expected hover");
+        let (ty, range) =
+            hover_literal_at("let x = 42;", Position::new(0, 8)).expect("expected hover");
         assert_eq!(ty, "Int");
         assert_eq!(range.start.line, 0);
         assert_eq!(range.end.line, 0);

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8,21 +8,21 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 // Import modules
-mod typechecker;
-mod repl;
-mod span;
-mod imports;
 mod bytecode;
 mod compiler;
 mod disasm;
-mod peephole;
-mod vm;
-#[cfg(feature = "z3")]
-mod verifier_z3;
-#[cfg(feature = "lsp")]
-mod lsp_server;
+mod imports;
 #[cfg(feature = "jit")]
 mod jit_backend;
+#[cfg(feature = "lsp")]
+mod lsp_server;
+mod peephole;
+mod repl;
+mod span;
+mod typechecker;
+#[cfg(feature = "z3")]
+mod verifier_z3;
+mod vm;
 // RES-108: opt-in logos-based lexer. See module docs; the feature
 // flag gates the routing so the legacy hand-rolled scanner stays
 // authoritative until RES-109 benchmarks land.
@@ -117,7 +117,7 @@ enum Token {
     Impl,
     /// RES-128: `type <Name> = <Target>;` non-nominal alias.
     Type,
-    
+
     // Literals
     Identifier(String),
     IntLiteral(i64),
@@ -132,7 +132,7 @@ enum Token {
     /// Unicode code-point at the bytes level) pass through as the
     /// literal two bytes `\` + char — see ticket Notes.
     BytesLiteral(Vec<u8>),
-    
+
     // Operators
     Plus,
     Minus,
@@ -153,7 +153,7 @@ enum Token {
     Less,
     GreaterEqual,
     LessEqual,
-    
+
     // Delimiters
     LeftParen,
     RightParen,
@@ -169,7 +169,7 @@ enum Token {
     Comma,
     Semicolon,
     Colon,
-    
+
     /// Prefix logical-not.
     Bang,
     /// RES-191: attribute prefix — `@pure`, `@inline`, etc. Only
@@ -406,7 +406,7 @@ impl Lexer {
         self.position = self.read_position;
         self.read_position += 1;
     }
-    
+
     fn peek_char(&self) -> char {
         if self.read_position >= self.input.len() {
             '\0'
@@ -414,7 +414,7 @@ impl Lexer {
             self.input[self.read_position]
         }
     }
-    
+
     fn next_token(&mut self) -> Token {
         // RES-108: under the `logos-lexer` feature, drain the pre-
         // scanned stream. Each pop also updates the legacy line/col
@@ -440,7 +440,7 @@ impl Lexer {
         self.last_token_line = self.line;
         self.last_token_column = self.column;
         self.last_token_offset = self.position;
-        
+
         let token = match self.ch {
             '=' => {
                 if self.peek_char() == '=' {
@@ -452,7 +452,7 @@ impl Lexer {
                 } else {
                     Token::Assign
                 }
-            },
+            }
             '+' => Token::Plus,
             '-' => {
                 if self.peek_char() == '>' {
@@ -461,7 +461,7 @@ impl Lexer {
                 } else {
                     Token::Minus
                 }
-            },
+            }
             '*' => Token::Multiply,
             '%' => Token::Modulo,
             '&' => {
@@ -471,7 +471,7 @@ impl Lexer {
                 } else {
                     Token::BitAnd
                 }
-            },
+            }
             '|' => {
                 if self.peek_char() == '|' {
                     self.read_char();
@@ -479,7 +479,7 @@ impl Lexer {
                 } else {
                     Token::BitOr
                 }
-            },
+            }
             '^' => Token::BitXor,
             '/' => {
                 if self.peek_char() == '/' {
@@ -509,7 +509,7 @@ impl Lexer {
                 } else {
                     Token::Divide
                 }
-            },
+            }
             '>' => {
                 if self.peek_char() == '=' {
                     self.read_char();
@@ -520,7 +520,7 @@ impl Lexer {
                 } else {
                     Token::Greater
                 }
-            },
+            }
             '<' => {
                 if self.peek_char() == '=' {
                     self.read_char();
@@ -531,7 +531,7 @@ impl Lexer {
                 } else {
                     Token::Less
                 }
-            },
+            }
             '!' => {
                 if self.peek_char() == '=' {
                     self.read_char();
@@ -539,7 +539,7 @@ impl Lexer {
                 } else {
                     Token::Bang
                 }
-            },
+            }
             '(' => Token::LeftParen,
             ')' => Token::RightParen,
             '{' => Token::LeftBrace,
@@ -555,7 +555,7 @@ impl Lexer {
                 // `self.read_char()` at the end of `next_token`
                 // advances past it naturally.
                 Token::HashLeftBrace
-            },
+            }
             // RES-038: `.` is now a real token (field access). Numeric
             // literals are still fine because read_number consumes `.`
             // before the tokenizer can dispatch here — digit check
@@ -573,7 +573,7 @@ impl Lexer {
                 self.read_char();
                 let str_value = self.read_string();
                 Token::StringLiteral(str_value)
-            },
+            }
             // RES-152: `b"..."` byte-string literal. The guard on
             // the next char distinguishes from a bare identifier
             // that starts with `b` — ASCII letters still fall
@@ -583,7 +583,7 @@ impl Lexer {
                 self.read_char(); // consume `"`; self.ch is first content byte or closing `"`
                 let bytes = self.read_bytes();
                 Token::BytesLiteral(bytes)
-            },
+            }
             '\0' => Token::Eof,
             _ => {
                 if self.is_letter(self.ch) {
@@ -683,7 +683,7 @@ impl Lexer {
         }
         self.input[position..self.position].iter().collect()
     }
-    
+
     fn read_number(&mut self) -> Token {
         // Hex (0x...) and binary (0b...) integer literals first.
         if self.ch == '0' && (self.peek_char() == 'x' || self.peek_char() == 'X') {
@@ -745,7 +745,7 @@ impl Lexer {
             }
         }
     }
-    
+
     fn read_string(&mut self) -> String {
         let _position = self.position;
         let mut result = String::new();
@@ -861,7 +861,7 @@ impl Lexer {
         }
         out
     }
-    
+
     fn is_letter(&self, ch: char) -> bool {
         // RES-114: ASCII-only identifier policy. Restrict to
         // `[A-Za-z_]` so homoglyph attacks (Cyrillic `kafa` vs
@@ -876,11 +876,11 @@ impl Lexer {
         // "identifier contains non-ASCII character".
         ch.is_ascii_alphabetic() || ch == '_'
     }
-    
+
     fn is_digit(&self, ch: char) -> bool {
         ch.is_ascii_digit()
     }
-    
+
     fn skip_whitespace(&mut self) {
         while self.ch.is_whitespace() {
             self.read_char();
@@ -934,7 +934,11 @@ pub struct BackoffConfig {
 impl BackoffConfig {
     /// Ticket defaults: `base_ms=1`, `factor=2`, `max_ms=100`.
     pub const fn default_ticket() -> Self {
-        Self { base_ms: 1, factor: 2, max_ms: 100 }
+        Self {
+            base_ms: 1,
+            factor: 2,
+            max_ms: 100,
+        }
     }
 
     /// Sleep duration for `retries` completed (retries=0 → first
@@ -1160,10 +1164,7 @@ enum Node {
     },
     /// RES-078: identifiers carry source span so diagnostics can
     /// point at the referenced name.
-    Identifier {
-        name: String,
-        span: span::Span,
-    },
+    Identifier { name: String, span: span::Span },
     /// RES-078: literal nodes carry source span so diagnostics
     /// (typechecker, verifier, VM runtime errors) can point at the
     /// offending value. The fields are unused today — RES-079 and
@@ -1286,6 +1287,34 @@ enum Node {
         has_rest: bool,
         value: Box<Node>,
         /// RES-088: span of the `let` keyword.
+        #[allow(dead_code)]
+        span: span::Span,
+    },
+    /// RES-127: `(e1, e2, …)` tuple literal in expression position.
+    /// A trailing comma distinguishes `(x,)` (single-element tuple)
+    /// from `(x)` (parenthesised expression). `()` unit is handled as
+    /// `Type::Void` at the call site; the parser never emits a zero-
+    /// element `TupleLiteral`.
+    TupleLiteral {
+        items: Vec<Node>,
+        #[allow(dead_code)]
+        span: span::Span,
+    },
+    /// RES-127: `expr.N` positional tuple access (N is a non-negative
+    /// integer literal). Parsed by extending the dotted-access path
+    /// to accept `Token::IntLiteral` after the `.`.
+    TupleIndex {
+        tuple: Box<Node>,
+        index: usize,
+        span: span::Span,
+    },
+    /// RES-127: `let (x, y) = expr;` tuple destructuring. `names`
+    /// holds the binding identifiers in source order; `value` is the
+    /// RHS expression whose runtime value must be a `Value::Tuple` of
+    /// the same arity.
+    LetDestructureTuple {
+        names: Vec<String>,
+        value: Box<Node>,
         #[allow(dead_code)]
         span: span::Span,
     },
@@ -1454,10 +1483,7 @@ impl Parser {
     /// Record an error, prefixing with the start of `current_token`
     /// so users see `line:col: Parser error: ...`.
     fn record_error(&mut self, msg: String) {
-        let full = format!(
-            "{}:{}: {}",
-            self.current_line, self.current_column, msg
-        );
+        let full = format!("{}:{}: {}", self.current_line, self.current_column, msg);
         eprintln!("\x1B[31mParser error: {}\x1B[0m", full);
         self.errors.push(full);
     }
@@ -1470,7 +1496,7 @@ impl Parser {
         self.peek_line = self.lexer.last_token_line;
         self.peek_column = self.lexer.last_token_column;
     }
-    
+
     fn parse_program(&mut self) -> Node {
         let mut program: Vec<span::Spanned<Node>> = Vec::new();
 
@@ -1481,28 +1507,18 @@ impl Parser {
             // the lexer's cursor at the moment the statement-recognizer
             // returned, which is close enough to the true end-of-stmt
             // for diagnostics (off by at most one whitespace token).
-            let start = span::Pos::new(
-                self.lexer.last_token_line,
-                self.lexer.last_token_column,
-                0,
-            );
+            let start = span::Pos::new(self.lexer.last_token_line, self.lexer.last_token_column, 0);
             if let Some(statement) = self.parse_statement() {
-                let end = span::Pos::new(
-                    self.lexer.last_token_line,
-                    self.lexer.last_token_column,
-                    0,
-                );
-                program.push(span::Spanned::new(
-                    statement,
-                    span::Span::new(start, end),
-                ));
+                let end =
+                    span::Pos::new(self.lexer.last_token_line, self.lexer.last_token_column, 0);
+                program.push(span::Spanned::new(statement, span::Span::new(start, end)));
             }
             self.next_token();
         }
 
         Node::Program(program)
     }
-    
+
     fn parse_statement(&mut self) -> Option<Node> {
         match self.current_token {
             // RES-191: `@pure` (and future attributes) prefix a
@@ -1552,8 +1568,7 @@ impl Parser {
             // `IDENT.field.more = EXPR;`. We let the expression parser
             // build the full LHS, then disambiguate at the `=`.
             Token::Identifier(_)
-                if self.peek_token == Token::LeftBracket
-                    || self.peek_token == Token::Dot =>
+                if self.peek_token == Token::LeftBracket || self.peek_token == Token::Dot =>
             {
                 Some(self.parse_maybe_index_assignment())
             }
@@ -1566,14 +1581,18 @@ impl Parser {
     /// index. Entered with current_token = the leading Identifier.
     fn parse_maybe_index_assignment(&mut self) -> Node {
         // Parse the index expression (which consumes IDENT, [, index, ]).
-        let lhs = self
-            .parse_expression(0)
-            .unwrap_or(Node::IntegerLiteral { value: 0, span: span::Span::default() });
+        let lhs = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+            value: 0,
+            span: span::Span::default(),
+        });
         // If this is an assignment, peek should be `=`.
         if self.peek_token == Token::Assign {
             self.next_token(); // move onto '='
             self.next_token(); // skip '=' to first token of RHS
-            let value = self.parse_expression(0).unwrap_or(Node::IntegerLiteral { value: 0, span: span::Span::default() });
+            let value = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+                value: 0,
+                span: span::Span::default(),
+            });
             if self.peek_token == Token::Semicolon {
                 self.next_token();
             }
@@ -1581,13 +1600,21 @@ impl Parser {
             // RES-085: pull span through so the Assignment node
             // inherits the LHS expression's span.
             match lhs {
-                Node::IndexExpression { target, index, span } => Node::IndexAssignment {
+                Node::IndexExpression {
+                    target,
+                    index,
+                    span,
+                } => Node::IndexAssignment {
                     target,
                     index,
                     value: Box::new(value),
                     span,
                 },
-                Node::FieldAccess { target, field, span } => Node::FieldAssignment {
+                Node::FieldAccess {
+                    target,
+                    field,
+                    span,
+                } => Node::FieldAssignment {
                     target,
                     field,
                     value: Box::new(value),
@@ -1617,7 +1644,10 @@ impl Parser {
         };
         self.next_token(); // move onto '='
         self.next_token(); // skip '=' to first token of RHS
-        let value = self.parse_expression(0).unwrap_or(Node::IntegerLiteral { value: 0, span: span::Span::default() });
+        let value = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+            value: 0,
+            span: span::Span::default(),
+        });
         if self.peek_token == Token::Semicolon {
             self.next_token();
         }
@@ -1654,18 +1684,13 @@ impl Parser {
             Token::Identifier(n) => n.clone(),
             other => {
                 let tok = other.clone();
-                self.record_error(format!(
-                    "Expected attribute name after '@', found {}",
-                    tok
-                ));
+                self.record_error(format!("Expected attribute name after '@', found {}", tok));
                 // Best-effort: ignore the broken attribute, try to
                 // parse whatever follows as a normal statement.
-                return self
-                    .parse_statement()
-                    .unwrap_or(Node::IntegerLiteral {
-                        value: 0,
-                        span: span::Span::default(),
-                    });
+                return self.parse_statement().unwrap_or(Node::IntegerLiteral {
+                    value: 0,
+                    span: span::Span::default(),
+                });
             }
         };
         self.next_token(); // skip attribute name
@@ -1673,10 +1698,7 @@ impl Parser {
         let pure_flag = match attr_name.as_str() {
             "pure" => true,
             other => {
-                self.record_error(format!(
-                    "Unknown attribute `@{}`. Known: @pure",
-                    other
-                ));
+                self.record_error(format!("Unknown attribute `@{}`. Known: @pure", other));
                 // Fall through — treat as if no attribute was
                 // present; the fn still parses.
                 false
@@ -1693,12 +1715,10 @@ impl Parser {
             ));
             // Best-effort recovery: parse whatever's next so the
             // rest of the file still parses.
-            return self
-                .parse_statement()
-                .unwrap_or(Node::IntegerLiteral {
-                    value: 0,
-                    span: span::Span::default(),
-                });
+            return self.parse_statement().unwrap_or(Node::IntegerLiteral {
+                value: 0,
+                span: span::Span::default(),
+            });
         }
 
         self.parse_function_with_pure(pure_flag)
@@ -1725,7 +1745,7 @@ impl Parser {
                 self.record_error(format!("Expected identifier after 'fn', found {}", tok));
                 // Return a placeholder to allow parsing to continue
                 String::from("error_function")
-            },
+            }
         };
 
         self.next_token(); // Skip name
@@ -1748,7 +1768,10 @@ impl Parser {
                 return Node::Function {
                     name,
                     parameters: Vec::new(),
-                    body: Box::new(Node::Block { stmts: Vec::new(), span: span::Span::default() }),
+                    body: Box::new(Node::Block {
+                        stmts: Vec::new(),
+                        span: span::Span::default(),
+                    }),
                     requires: Vec::new(),
                     ensures: Vec::new(),
                     return_type: None,
@@ -1785,7 +1808,10 @@ impl Parser {
         let (requires, ensures) = self.parse_function_contracts();
 
         if self.current_token != Token::LeftBrace {
-            self.record_error(format!("Expected '{{' after function parameters for '{}'", name));
+            self.record_error(format!(
+                "Expected '{{' after function parameters for '{}'",
+                name
+            ));
             // Try to recover by skipping to the opening brace
             while self.current_token != Token::LeftBrace && self.current_token != Token::Eof {
                 self.next_token();
@@ -1795,7 +1821,10 @@ impl Parser {
                 return Node::Function {
                     name,
                     parameters,
-                    body: Box::new(Node::Block { stmts: Vec::new(), span: span::Span::default() }),
+                    body: Box::new(Node::Block {
+                        stmts: Vec::new(),
+                        span: span::Span::default(),
+                    }),
                     requires,
                     ensures,
                     return_type,
@@ -1855,20 +1884,13 @@ impl Parser {
         }
 
         let mut methods: Vec<Node> = Vec::new();
-        while self.current_token != Token::RightBrace
-            && self.current_token != Token::Eof
-        {
+        while self.current_token != Token::RightBrace && self.current_token != Token::Eof {
             if self.current_token != Token::Function {
                 let tok = self.current_token.clone();
-                self.record_error(format!(
-                    "Expected 'fn' inside impl block, found {}",
-                    tok
-                ));
+                self.record_error(format!("Expected 'fn' inside impl block, found {}", tok));
                 // Best-effort recovery: skip ahead to the closing brace
                 // so the whole parse doesn't cascade.
-                while self.current_token != Token::RightBrace
-                    && self.current_token != Token::Eof
-                {
+                while self.current_token != Token::RightBrace && self.current_token != Token::Eof {
                     self.next_token();
                 }
                 break;
@@ -1887,7 +1909,11 @@ impl Parser {
         // `parse_program` loop advances past each statement's final
         // token, same as with `fn` / `struct` decls.
 
-        Node::ImplBlock { struct_name, methods, span: impl_span }
+        Node::ImplBlock {
+            struct_name,
+            methods,
+            span: impl_span,
+        }
     }
 
     /// RES-158: parse a single method inside an `impl` block. Returns
@@ -1912,10 +1938,7 @@ impl Parser {
         self.next_token(); // skip name
 
         if self.current_token != Token::LeftParen {
-            self.record_error(format!(
-                "Expected '(' after method name '{}'",
-                method_name
-            ));
+            self.record_error(format!("Expected '(' after method name '{}'", method_name));
         } else {
             self.next_token(); // skip '('
         }
@@ -1986,10 +2009,7 @@ impl Parser {
         let name = match &self.current_token {
             Token::Identifier(n) => n.clone(),
             other => {
-                self.record_error(format!(
-                    "Expected alias name after 'type', found {}",
-                    other
-                ));
+                self.record_error(format!("Expected alias name after 'type', found {}", other));
                 String::new()
             }
         };
@@ -1997,10 +2017,7 @@ impl Parser {
 
         if self.current_token != Token::Assign {
             let tok = self.current_token.clone();
-            self.record_error(format!(
-                "Expected '=' after 'type {}', found {}",
-                name, tok
-            ));
+            self.record_error(format!("Expected '=' after 'type {}', found {}", name, tok));
         } else {
             self.next_token(); // skip '='
         }
@@ -2025,7 +2042,11 @@ impl Parser {
             self.next_token();
         }
 
-        Node::TypeAlias { name, target, span: kw_span }
+        Node::TypeAlias {
+            name,
+            target,
+            span: kw_span,
+        }
     }
 
     /// Parse an optional `-> TYPE`. If present, current_token advances
@@ -2037,7 +2058,7 @@ impl Parser {
         self.next_token(); // skip '->'
         // `parse_type_annotation` leaves current_token on the token
         // after the type. Nothing more to do here.
-        self.parse_type_annotation("after '->'") 
+        self.parse_type_annotation("after '->'")
     }
 
     /// RES-157a: parse a single type annotation starting at
@@ -2063,6 +2084,45 @@ impl Parser {
                 let ty = t.clone();
                 self.next_token(); // advance past the identifier
                 Some(ty)
+            }
+            Token::LeftParen => {
+                // RES-127: `(T1, T2)` tuple type annotation. Serialise
+                // the whole thing into a single string of the form
+                // `"(T1, T2)"` so it fits the existing `Option<String>`
+                // slot. `parse_type_name_inner` in the typechecker knows
+                // how to decode this format back to `Type::Tuple`.
+                self.next_token(); // skip '('
+                // `()` → void (unit tuple).
+                if self.current_token == Token::RightParen {
+                    self.next_token(); // skip ')'
+                    return Some("()".to_string());
+                }
+                let mut parts: Vec<String> = Vec::new();
+                loop {
+                    // Trailing `)` or EOF ends the list.
+                    if matches!(self.current_token, Token::RightParen | Token::Eof) {
+                        break;
+                    }
+                    match self.parse_type_annotation(ctx) {
+                        Some(t) => parts.push(t),
+                        None => break,
+                    }
+                    if self.current_token == Token::Comma {
+                        self.next_token(); // skip ','
+                    } else {
+                        break;
+                    }
+                }
+                if self.current_token != Token::RightParen {
+                    let tok = self.current_token.clone();
+                    self.record_error(format!(
+                        "Expected `)` to close tuple type {}, found {}",
+                        ctx, tok
+                    ));
+                    return None;
+                }
+                self.next_token(); // skip ')'
+                Some(format!("({})", parts.join(", ")))
             }
             Token::LeftBracket => {
                 // `[T; N]` — fixed-size array type.
@@ -2161,13 +2221,19 @@ impl Parser {
             match self.current_token {
                 Token::Requires => {
                     self.next_token(); // skip `requires`
-                    let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: true, span: span::Span::default() });
+                    let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                        value: true,
+                        span: span::Span::default(),
+                    });
                     self.next_token(); // move past last token of expression
                     requires.push(expr);
                 }
                 Token::Ensures => {
                     self.next_token();
-                    let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: true, span: span::Span::default() });
+                    let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                        value: true,
+                        span: span::Span::default(),
+                    });
                     self.next_token();
                     ensures.push(expr);
                 }
@@ -2176,7 +2242,7 @@ impl Parser {
         }
         (requires, ensures)
     }
-    
+
     /// RES-124 (RES-124a): parse an optional `<T, U, ...>`
     /// type-parameter list. On entry, `current_token` is what
     /// sits between `fn` and the function name. If it's `<`,
@@ -2232,12 +2298,12 @@ impl Parser {
 
     fn parse_function_parameters(&mut self) -> Vec<(String, String)> {
         let mut parameters = Vec::new();
-        
+
         if self.current_token == Token::RightParen {
             self.next_token(); // Skip ')'
             return parameters;
         }
-        
+
         while self.current_token != Token::RightParen {
             // RES-157a: accept `[T; N]` as well as bare identifiers.
             // `parse_type_annotation` advances past the whole type on
@@ -2272,11 +2338,11 @@ impl Parser {
                 break;
             }
         }
-        
+
         self.next_token(); // Skip ')'
         parameters
     }
-    
+
     fn parse_block_statement(&mut self) -> Node {
         // RES-087: capture the `{` token's span before advancing.
         let brace_span = self.span_at_current();
@@ -2291,9 +2357,12 @@ impl Parser {
             self.next_token();
         }
 
-        Node::Block { stmts: statements, span: brace_span }
+        Node::Block {
+            stmts: statements,
+            span: brace_span,
+        }
     }
-    
+
     /// `static let NAME = EXPR;` — parsed into a StaticLet node. The
     /// implementation just reuses parse_let_statement after consuming
     /// the `static` keyword and enforcing that `let` follows.
@@ -2319,14 +2388,23 @@ impl Parser {
             self.record_error(format!("Expected 'in' after 'for {}', found {}", name, tok));
             return Node::ForInStatement {
                 name,
-                iterable: Box::new(Node::ArrayLiteral { items: Vec::new(), span: span::Span::default() }),
-                body: Box::new(Node::Block { stmts: Vec::new(), span: span::Span::default() }),
+                iterable: Box::new(Node::ArrayLiteral {
+                    items: Vec::new(),
+                    span: span::Span::default(),
+                }),
+                body: Box::new(Node::Block {
+                    stmts: Vec::new(),
+                    span: span::Span::default(),
+                }),
                 invariants: Vec::new(),
                 span: stmt_span,
             };
         }
         self.next_token(); // skip 'in'
-        let iterable = self.parse_expression(0).unwrap_or(Node::ArrayLiteral { items: Vec::new(), span: span::Span::default() });
+        let iterable = self.parse_expression(0).unwrap_or(Node::ArrayLiteral {
+            items: Vec::new(),
+            span: span::Span::default(),
+        });
         self.next_token(); // advance past the expression's tail (RES-014 invariant)
 
         // RES-132a: collect any `invariant EXPR` clauses that sit between
@@ -2340,7 +2418,10 @@ impl Parser {
             return Node::ForInStatement {
                 name,
                 iterable: Box::new(iterable),
-                body: Box::new(Node::Block { stmts: Vec::new(), span: span::Span::default() }),
+                body: Box::new(Node::Block {
+                    stmts: Vec::new(),
+                    span: span::Span::default(),
+                }),
                 invariants,
                 span: stmt_span,
             };
@@ -2369,9 +2450,10 @@ impl Parser {
             // criteria syntax (`while (c) invariant (p) { ... }`).
             let expr = if self.current_token == Token::LeftParen {
                 self.next_token(); // skip `(`
-                let inner = self.parse_expression(0).unwrap_or(
-                    Node::BooleanLiteral { value: true, span: span::Span::default() }
-                );
+                let inner = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                    value: true,
+                    span: span::Span::default(),
+                });
                 self.next_token(); // move past tail of inner expression
                 if self.current_token != Token::RightParen {
                     let tok = self.current_token.clone();
@@ -2384,9 +2466,10 @@ impl Parser {
                 }
                 inner
             } else {
-                let inner = self.parse_expression(0).unwrap_or(
-                    Node::BooleanLiteral { value: true, span: span::Span::default() }
-                );
+                let inner = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                    value: true,
+                    span: span::Span::default(),
+                });
                 self.next_token(); // move past tail (RES-014 invariant)
                 inner
             };
@@ -2407,7 +2490,10 @@ impl Parser {
 
         let condition = if self.current_token == Token::LeftParen {
             self.next_token();
-            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: false, span: span::Span::default() });
+            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                value: false,
+                span: span::Span::default(),
+            });
             self.next_token();
             if self.current_token != Token::RightParen {
                 let tok = self.current_token.clone();
@@ -2417,7 +2503,10 @@ impl Parser {
             }
             expr
         } else {
-            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: false, span: span::Span::default() });
+            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                value: false,
+                span: span::Span::default(),
+            });
             self.next_token();
             expr
         };
@@ -2428,10 +2517,16 @@ impl Parser {
 
         if self.current_token != Token::LeftBrace {
             let tok = self.current_token.clone();
-            self.record_error(format!("Expected '{{' after while condition, found {}", tok));
+            self.record_error(format!(
+                "Expected '{{' after while condition, found {}",
+                tok
+            ));
             return Node::WhileStatement {
                 condition: Box::new(condition),
-                body: Box::new(Node::Block { stmts: Vec::new(), span: span::Span::default() }),
+                body: Box::new(Node::Block {
+                    stmts: Vec::new(),
+                    span: span::Span::default(),
+                }),
                 invariants,
                 span: stmt_span,
             };
@@ -2454,7 +2549,10 @@ impl Parser {
             self.record_error(format!("Expected 'let' after 'static', found {}", tok));
             return Node::StaticLet {
                 name: String::new(),
-                value: Box::new(Node::IntegerLiteral { value: 0, span: span::Span::default() }),
+                value: Box::new(Node::IntegerLiteral {
+                    value: 0,
+                    span: span::Span::default(),
+                }),
                 span: stmt_span,
             };
         }
@@ -2462,7 +2560,9 @@ impl Parser {
         // returns a Node::LetStatement.
         let inner = self.parse_let_statement();
         match inner {
-            Node::LetStatement { name, value, span, .. } => Node::StaticLet { name, value, span },
+            Node::LetStatement {
+                name, value, span, ..
+            } => Node::StaticLet { name, value, span },
             other => other, // error paths return a degenerate LetStatement
         }
     }
@@ -2475,6 +2575,12 @@ impl Parser {
         let stmt_span = self.span_at_current();
         self.next_token(); // Skip 'let'
 
+        // RES-127: `let (x, y) = expr;` tuple destructuring.
+        // A `(` immediately after `let` signals this form.
+        if self.current_token == Token::LeftParen {
+            return self.parse_let_destructure_tuple(stmt_span);
+        }
+
         let name = match &self.current_token {
             Token::Identifier(name) => name.clone(),
             _ => {
@@ -2482,7 +2588,10 @@ impl Parser {
                 self.record_error(format!("Expected identifier after 'let', found {}", tok));
                 return Node::LetStatement {
                     name: String::new(),
-                    value: Box::new(Node::IntegerLiteral { value: 0, span: span::Span::default() }),
+                    value: Box::new(Node::IntegerLiteral {
+                        value: 0,
+                        span: span::Span::default(),
+                    }),
                     type_annot: None,
                     span: stmt_span,
                 };
@@ -2518,7 +2627,10 @@ impl Parser {
             ));
             return Node::LetStatement {
                 name,
-                value: Box::new(Node::IntegerLiteral { value: 0, span: span::Span::default() }),
+                value: Box::new(Node::IntegerLiteral {
+                    value: 0,
+                    span: span::Span::default(),
+                }),
                 type_annot,
                 span: stmt_span,
             };
@@ -2546,11 +2658,7 @@ impl Parser {
     /// consumed `let` and the `StructName` identifier). On exit,
     /// `current_token` sits on the last token of the value
     /// expression; `parse_statement` handles the trailing `;`.
-    fn parse_let_destructure_struct(
-        &mut self,
-        struct_name: String,
-        stmt_span: span::Span,
-    ) -> Node {
+    fn parse_let_destructure_struct(&mut self, struct_name: String, stmt_span: span::Span) -> Node {
         self.next_token(); // skip `{`
         let mut fields: Vec<(String, String)> = Vec::new();
         let mut has_rest = false;
@@ -2581,8 +2689,7 @@ impl Parser {
                     break;
                 } else {
                     self.record_error(
-                        "Expected `..` (two dots) for rest pattern, found single `.`"
-                            .to_string(),
+                        "Expected `..` (two dots) for rest pattern, found single `.`".to_string(),
                     );
                     break;
                 }
@@ -2671,12 +2778,10 @@ impl Parser {
             };
         }
         self.next_token(); // skip `=`
-        let value = self
-            .parse_expression(0)
-            .unwrap_or(Node::IntegerLiteral {
-                value: 0,
-                span: span::Span::default(),
-            });
+        let value = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+            value: 0,
+            span: span::Span::default(),
+        });
 
         if self.peek_token == Token::Semicolon {
             self.next_token();
@@ -2691,6 +2796,81 @@ impl Parser {
         }
     }
 
+    /// RES-127: parse `let (x, y, …) = expr;`.
+    /// On entry `current_token == LeftParen` (the `let` keyword has
+    /// already been consumed). On exit `current_token` is on the last
+    /// token of the value expression; the caller handles the trailing `;`.
+    fn parse_let_destructure_tuple(&mut self, stmt_span: span::Span) -> Node {
+        self.next_token(); // skip '('
+        let mut names: Vec<String> = Vec::new();
+
+        loop {
+            if self.current_token == Token::RightParen {
+                break;
+            }
+            let name = match &self.current_token {
+                Token::Identifier(n) => n.clone(),
+                _ => {
+                    let tok = self.current_token.clone();
+                    self.record_error(format!(
+                        "Expected identifier in tuple destructure, found {}",
+                        tok
+                    ));
+                    break;
+                }
+            };
+            names.push(name);
+            self.next_token(); // past identifier
+            if self.current_token == Token::Comma {
+                self.next_token(); // skip ','
+            } else {
+                break;
+            }
+        }
+
+        if self.current_token != Token::RightParen {
+            let tok = self.current_token.clone();
+            self.record_error(format!(
+                "Expected `)` to close tuple destructure, found {}",
+                tok
+            ));
+        } else {
+            self.next_token(); // skip ')'
+        }
+
+        if self.current_token != Token::Assign {
+            let tok = self.current_token.clone();
+            self.record_error(format!(
+                "Expected `=` after tuple destructure pattern, found {}",
+                tok
+            ));
+            return Node::LetDestructureTuple {
+                names,
+                value: Box::new(Node::IntegerLiteral {
+                    value: 0,
+                    span: span::Span::default(),
+                }),
+                span: stmt_span,
+            };
+        }
+        self.next_token(); // skip '='
+
+        let value = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+            value: 0,
+            span: span::Span::default(),
+        });
+
+        if self.peek_token == Token::Semicolon {
+            self.next_token();
+        }
+
+        Node::LetDestructureTuple {
+            names,
+            value: Box::new(value),
+            span: stmt_span,
+        }
+    }
+
     /// RES-073: `use "path/to/file.res";` — emits `Node::Use { path, span }`.
     /// Resolved by `imports::expand_uses` before typechecker / interpreter.
     fn parse_use_statement(&mut self) -> Option<Node> {
@@ -2700,8 +2880,7 @@ impl Parser {
             Token::StringLiteral(s) => s.clone(),
             _ => {
                 self.record_error(
-                    "Expected string literal after 'use' (e.g. `use \"helpers.res\";`)"
-                        .to_string(),
+                    "Expected string literal after 'use' (e.g. `use \"helpers.res\";`)".to_string(),
                 );
                 return None;
             }
@@ -2709,8 +2888,10 @@ impl Parser {
         if self.peek_token == Token::Semicolon {
             self.next_token();
         }
-        Some(Node::Use { path,
-            span: self.span_at_current() })
+        Some(Node::Use {
+            path,
+            span: self.span_at_current(),
+        })
     }
 
     /// FFI v1: `extern "lib" { decl; decl; ... }`.
@@ -2739,8 +2920,7 @@ impl Parser {
         if !matches!(self.current_token, Token::LeftBrace) {
             self.record_error(format!(
                 "expected `{{` after `extern \"{}\"`, got {}",
-                library,
-                self.current_token
+                library, self.current_token
             ));
             return None;
         }
@@ -2799,10 +2979,7 @@ impl Parser {
                 }
                 other => {
                     let tok = other.clone();
-                    self.record_error(format!(
-                        "unknown attribute in extern block: @{}",
-                        tok
-                    ));
+                    self.record_error(format!("unknown attribute in extern block: @{}", tok));
                     return None;
                 }
             }
@@ -2811,10 +2988,7 @@ impl Parser {
         // `fn`
         if !matches!(self.current_token, Token::Function) {
             let tok = self.current_token.clone();
-            self.record_error(format!(
-                "expected `fn` inside extern block, got {}",
-                tok
-            ));
+            self.record_error(format!("expected `fn` inside extern block, got {}", tok));
             return None;
         }
         self.next_token(); // skip `fn`
@@ -2937,10 +3111,7 @@ impl Parser {
                 }
                 other => {
                     let tok = other.clone();
-                    self.record_error(format!(
-                        "expected parameter name in extern fn, got {}",
-                        tok
-                    ));
+                    self.record_error(format!("expected parameter name in extern fn, got {}", tok));
                     break;
                 }
             };
@@ -2996,14 +3167,18 @@ impl Parser {
             self.current_token,
             Token::Semicolon | Token::RightBrace | Token::Eof
         ) {
-            return Node::ReturnStatement { value: None, span: stmt_span };
+            return Node::ReturnStatement {
+                value: None,
+                span: stmt_span,
+            };
         }
 
         let value = match self.parse_expression(0) {
             Some(expr) => Some(Box::new(expr)),
             None => {
                 self.record_error(
-                    "Expected expression after 'return' (or write 'return;' for no value)".to_string()
+                    "Expected expression after 'return' (or write 'return;' for no value)"
+                        .to_string(),
                 );
                 None
             }
@@ -3013,9 +3188,12 @@ impl Parser {
             self.next_token(); // Skip to semicolon
         }
 
-        Node::ReturnStatement { value, span: stmt_span }
+        Node::ReturnStatement {
+            value,
+            span: stmt_span,
+        }
     }
-    
+
     fn parse_live_block(&mut self) -> Node {
         self.next_token(); // Skip 'live'
 
@@ -3031,8 +3209,7 @@ impl Parser {
                 Token::Identifier(n) if n == "backoff" => {
                     if backoff.is_some() {
                         self.record_error(
-                            "duplicate `backoff(...)` clause in live block"
-                                .to_string(),
+                            "duplicate `backoff(...)` clause in live block".to_string(),
                         );
                     }
                     let cfg = self.parse_backoff_kwargs();
@@ -3043,8 +3220,7 @@ impl Parser {
                 Token::Identifier(n) if n == "within" => {
                     if timeout.is_some() {
                         self.record_error(
-                            "duplicate `within <duration>` clause in live block"
-                                .to_string(),
+                            "duplicate `within <duration>` clause in live block".to_string(),
                         );
                     }
                     let dl = self.parse_within_clause();
@@ -3061,7 +3237,10 @@ impl Parser {
         let mut invariants = Vec::new();
         while self.current_token == Token::Invariant {
             self.next_token(); // skip `invariant`
-            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: true, span: span::Span::default() });
+            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                value: true,
+                span: span::Span::default(),
+            });
             self.next_token(); // move past last token of the expression
             invariants.push(expr);
         }
@@ -3070,7 +3249,10 @@ impl Parser {
             let tok = self.current_token.clone();
             self.record_error(format!("Expected '{{' after 'live', found {}", tok));
             return Node::LiveBlock {
-                body: Box::new(Node::Block { stmts: Vec::new(), span: span::Span::default() }),
+                body: Box::new(Node::Block {
+                    stmts: Vec::new(),
+                    span: span::Span::default(),
+                }),
                 invariants,
                 backoff,
                 timeout,
@@ -3085,7 +3267,7 @@ impl Parser {
             invariants,
             backoff,
             timeout,
-            span: self.span_at_current()
+            span: self.span_at_current(),
         }
     }
 
@@ -3127,7 +3309,7 @@ impl Parser {
             "ns" => 1,
             "us" => 1_000,
             "ms" => 1_000_000,
-            "s"  => 1_000_000_000,
+            "s" => 1_000_000_000,
             other => {
                 self.record_error(format!(
                     "Unknown duration unit `{}` — expected one of `ns`, `us`, `ms`, `s`",
@@ -3144,7 +3326,10 @@ impl Parser {
         // trip).
         let nanos = raw.saturating_mul(per_unit_ns);
 
-        Some(Node::DurationLiteral { nanos, span: start_span })
+        Some(Node::DurationLiteral {
+            nanos,
+            span: start_span,
+        })
     }
 
     /// RES-139: parse `backoff(base_ms=N, factor=K, max_ms=M)` —
@@ -3161,10 +3346,7 @@ impl Parser {
         self.next_token(); // skip `backoff`
         if self.current_token != Token::LeftParen {
             let tok = self.current_token.clone();
-            self.record_error(format!(
-                "Expected '(' after 'backoff', found {}",
-                tok
-            ));
+            self.record_error(format!("Expected '(' after 'backoff', found {}", tok));
             return cfg;
         }
         self.next_token(); // skip '('
@@ -3247,15 +3429,18 @@ impl Parser {
         }
         cfg
     }
-    
+
     fn parse_assert(&mut self) -> Node {
         self.next_token(); // Skip 'assert'
-        
+
         if self.current_token != Token::LeftParen {
             let tok = self.current_token.clone();
             self.record_error(format!("Expected '(' after 'assert', found {}", tok));
             return Node::Assert {
-                condition: Box::new(Node::BooleanLiteral { value: true, span: span::Span::default() }),
+                condition: Box::new(Node::BooleanLiteral {
+                    value: true,
+                    span: span::Span::default(),
+                }),
                 message: None,
                 span: self.span_at_current(),
             };
@@ -3263,12 +3448,18 @@ impl Parser {
 
         self.next_token(); // Skip '('
 
-        let condition = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: true, span: span::Span::default() });
+        let condition = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+            value: true,
+            span: span::Span::default(),
+        });
         self.next_token(); // RES-014: advance past last token of expression
 
         let message = if self.current_token == Token::Comma {
             self.next_token(); // Skip ','
-            let msg = self.parse_expression(0).unwrap_or(Node::StringLiteral { value: String::new(), span: span::Span::default() });
+            let msg = self.parse_expression(0).unwrap_or(Node::StringLiteral {
+                value: String::new(),
+                span: span::Span::default(),
+            });
             self.next_token(); // advance past last token of message expression
             Some(Box::new(msg))
         } else {
@@ -3282,11 +3473,11 @@ impl Parser {
                 tok
             ));
         }
-        
+
         Node::Assert {
             condition: Box::new(condition),
             message,
-            span: self.span_at_current()
+            span: self.span_at_current(),
         }
     }
 
@@ -3298,7 +3489,10 @@ impl Parser {
             let tok = self.current_token.clone();
             self.record_error(format!("Expected '(' after 'assume', found {}", tok));
             return Node::Assume {
-                condition: Box::new(Node::BooleanLiteral { value: true, span: span::Span::default() }),
+                condition: Box::new(Node::BooleanLiteral {
+                    value: true,
+                    span: span::Span::default(),
+                }),
                 message: None,
                 span: self.span_at_current(),
             };
@@ -3306,12 +3500,18 @@ impl Parser {
 
         self.next_token(); // skip '('
 
-        let condition = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: true, span: span::Span::default() });
+        let condition = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+            value: true,
+            span: span::Span::default(),
+        });
         self.next_token(); // advance past last token of expression
 
         let message = if self.current_token == Token::Comma {
             self.next_token(); // skip ','
-            let msg = self.parse_expression(0).unwrap_or(Node::StringLiteral { value: String::new(), span: span::Span::default() });
+            let msg = self.parse_expression(0).unwrap_or(Node::StringLiteral {
+                value: String::new(),
+                span: span::Span::default(),
+            });
             self.next_token();
             Some(Box::new(msg))
         } else {
@@ -3320,7 +3520,10 @@ impl Parser {
 
         if self.current_token != Token::RightParen {
             let tok = self.current_token.clone();
-            self.record_error(format!("Expected ')' after assume condition, found {}", tok));
+            self.record_error(format!(
+                "Expected ')' after assume condition, found {}",
+                tok
+            ));
         }
 
         Node::Assume {
@@ -3341,36 +3544,39 @@ impl Parser {
         // must advance once to move past the expression's tail.
         let condition = if self.current_token == Token::LeftParen {
             self.next_token(); // Skip '('
-            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: false, span: span::Span::default() });
+            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                value: false,
+                span: span::Span::default(),
+            });
             self.next_token(); // Advance past last-token-of-expression
 
             if self.current_token != Token::RightParen {
                 let tok = self.current_token.clone();
-                self.record_error(format!(
-                    "Expected ')' after if condition, found {}",
-                    tok
-                ));
+                self.record_error(format!("Expected ')' after if condition, found {}", tok));
             } else {
                 self.next_token(); // Skip ')'
             }
             expr
         } else {
-            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: false, span: span::Span::default() });
+            let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                value: false,
+                span: span::Span::default(),
+            });
             self.next_token(); // Advance past last-token-of-expression
             expr
         };
 
         if self.current_token != Token::LeftBrace {
             let tok = self.current_token.clone();
-            self.record_error(format!(
-                "Expected '{{' after if condition, found {}",
-                tok
-            ));
+            self.record_error(format!("Expected '{{' after if condition, found {}", tok));
             // Recover by returning a skeleton `if` with an empty body so
             // the rest of the file can still be parsed.
             return Node::IfStatement {
                 condition: Box::new(condition),
-                consequence: Box::new(Node::Block { stmts: Vec::new(), span: span::Span::default() }),
+                consequence: Box::new(Node::Block {
+                    stmts: Vec::new(),
+                    span: span::Span::default(),
+                }),
                 alternative: None,
                 span: stmt_span,
             };
@@ -3411,18 +3617,17 @@ impl Parser {
             self.next_token(); // Skip to semicolon
         }
 
-        Some(Node::ExpressionStatement { expr: Box::new(expr), span: stmt_span })
+        Some(Node::ExpressionStatement {
+            expr: Box::new(expr),
+            span: stmt_span,
+        })
     }
-    
+
     /// RES-078: build a single-position `Span` from the lexer's
     /// current `last_token_*` state — good enough for leaf nodes
     /// where the "source range" is just wherever the token starts.
     fn span_at_current(&self) -> span::Span {
-        let pos = span::Pos::new(
-            self.lexer.last_token_line,
-            self.lexer.last_token_column,
-            0,
-        );
+        let pos = span::Pos::new(self.lexer.last_token_line, self.lexer.last_token_column, 0);
         span::Span::new(pos, pos)
     }
 
@@ -3430,18 +3635,40 @@ impl Parser {
         // Parse prefix expressions
         let tok_span = self.span_at_current();
         let mut left_expr = match &self.current_token {
-            Token::Identifier(name) => Some(Node::Identifier { name: name.clone(), span: tok_span }),
-            Token::IntLiteral(value) => Some(Node::IntegerLiteral { value: *value, span: tok_span }),
-            Token::FloatLiteral(value) => Some(Node::FloatLiteral { value: *value, span: tok_span }),
-            Token::StringLiteral(value) => Some(Node::StringLiteral { value: value.clone(), span: tok_span }),
+            Token::Identifier(name) => Some(Node::Identifier {
+                name: name.clone(),
+                span: tok_span,
+            }),
+            Token::IntLiteral(value) => Some(Node::IntegerLiteral {
+                value: *value,
+                span: tok_span,
+            }),
+            Token::FloatLiteral(value) => Some(Node::FloatLiteral {
+                value: *value,
+                span: tok_span,
+            }),
+            Token::StringLiteral(value) => Some(Node::StringLiteral {
+                value: value.clone(),
+                span: tok_span,
+            }),
             // RES-152: byte-string literal, lexed to Vec<u8>.
-            Token::BytesLiteral(value) => Some(Node::BytesLiteral { value: value.clone(), span: tok_span }),
-            Token::BoolLiteral(value) => Some(Node::BooleanLiteral { value: *value, span: tok_span }),
+            Token::BytesLiteral(value) => Some(Node::BytesLiteral {
+                value: value.clone(),
+                span: tok_span,
+            }),
+            Token::BoolLiteral(value) => Some(Node::BooleanLiteral {
+                value: *value,
+                span: tok_span,
+            }),
             // RES-012: prefix operators `!` and `-`. Precedence is higher
             // than any infix operator, so the operand consumes only the
             // tightest-binding next expression.
             Token::Bang | Token::Minus => {
-                let op = if self.current_token == Token::Bang { "!" } else { "-" };
+                let op = if self.current_token == Token::Bang {
+                    "!"
+                } else {
+                    "-"
+                };
                 // RES-084: capture the operator's span before
                 // advancing past it.
                 let op_span = self.span_at_current();
@@ -3456,17 +3683,109 @@ impl Parser {
                 })
             }
             Token::LeftParen => {
-                self.next_token(); // Skip '('
-                let expr = self.parse_expression(0);
-                if self.current_token != Token::RightParen {
-                    let tok = self.current_token.clone();
-                    self.record_error(format!(
-                        "Expected ')' closing parenthesized expression, found {}",
-                        tok
-                    ));
+                // RES-127: distinguish tuple literals from parenthesised
+                // expressions.
+                //   `(a, b)` → TupleLiteral (two or more items)
+                //   `(x,)`  → TupleLiteral (singleton — trailing comma)
+                //   `(x)`   → parenthesised expression (no trailing comma)
+                //   `()`    → unit — leave for the caller; return Void
+                //
+                // The tricky part: `parse_expression` advances
+                // `current_token` to the last token OF the sub-expression
+                // and the NEXT token (after all infix operators are folded)
+                // lands on `peek_token`. We mirror how `parse_call_arguments`
+                // works — peek for `,` after each item and advance into the
+                // next element only when we see one.
+                let paren_span = self.span_at_current();
+                self.next_token(); // skip '('
+
+                // Empty parens `()` — unit/void.
+                if self.current_token == Token::RightParen {
+                    // Zero-element TupleLiteral; typechecker maps it to Void.
+                    Some(Node::TupleLiteral {
+                        items: Vec::new(),
+                        span: paren_span,
+                    })
+                } else {
+                    // Parse the first expression (current_token moves to the
+                    // last token of `first`; peek_token is the token AFTER it).
+                    let first = match self.parse_expression(0) {
+                        Some(e) => e,
+                        None => {
+                            let tok = self.current_token.clone();
+                            self.record_error(format!(
+                                "Expected expression after `(`, found {}",
+                                tok
+                            ));
+                            return None;
+                        }
+                    };
+
+                    if self.peek_token == Token::Comma {
+                        // Tuple literal: advance to ',' then continue.
+                        self.next_token(); // current_token = ','
+                        let mut items = vec![first];
+                        loop {
+                            // Trailing comma followed by ')' ends the tuple.
+                            if self.peek_token == Token::RightParen {
+                                self.next_token(); // skip to ')'
+                                break;
+                            }
+                            self.next_token(); // skip ','
+                            match self.parse_expression(0) {
+                                Some(e) => items.push(e),
+                                None => {
+                                    let tok = self.current_token.clone();
+                                    self.record_error(format!(
+                                        "Expected expression in tuple literal, found {}",
+                                        tok
+                                    ));
+                                    break;
+                                }
+                            }
+                            // peek_token is now ',' or ')' or something else.
+                            if self.peek_token == Token::Comma {
+                                self.next_token(); // move to ','
+                            // loop continues — next iteration peeks again
+                            } else if self.peek_token == Token::RightParen {
+                                self.next_token(); // move to ')'
+                                break;
+                            } else {
+                                let tok = self.peek_token.clone();
+                                self.record_error(format!(
+                                    "Expected `,` or `)` in tuple literal, found {}",
+                                    tok
+                                ));
+                                break;
+                            }
+                        }
+                        // current_token is ')' here.
+                        if self.current_token != Token::RightParen {
+                            let tok = self.current_token.clone();
+                            self.record_error(format!(
+                                "Expected `)` to close tuple literal, found {}",
+                                tok
+                            ));
+                        }
+                        Some(Node::TupleLiteral {
+                            items,
+                            span: paren_span,
+                        })
+                    } else {
+                        // Parenthesised expression `(x)`.
+                        // peek_token after `first` must be ')'.
+                        if self.peek_token != Token::RightParen {
+                            let tok = self.peek_token.clone();
+                            self.record_error(format!(
+                                "Expected ')' closing parenthesized expression, found {}",
+                                tok
+                            ));
+                        }
+                        self.next_token(); // advance to ')'
+                        Some(first)
+                    }
                 }
-                expr
-            },
+            }
             Token::LeftBracket => Some(self.parse_array_literal()),
             // RES-148: `{"k" -> v, ...}` in expression position parses
             // as a Map literal. Map literals are only valid in
@@ -3484,7 +3803,7 @@ impl Parser {
             Token::Function => Some(self.parse_function_literal()),
             _ => None,
         };
-        
+
         // Parse infix expressions
         while self.peek_token != Token::Semicolon && precedence < self.peek_precedence() {
             let Some(current_left) = left_expr else {
@@ -3493,26 +3812,39 @@ impl Parser {
                 return None;
             };
             left_expr = match &self.peek_token {
-                Token::Plus | Token::Minus | Token::Multiply | Token::Divide | Token::Modulo |
-                Token::Equal | Token::NotEqual | Token::Less | Token::Greater |
-                Token::LessEqual | Token::GreaterEqual | Token::And | Token::Or |
-                Token::BitAnd | Token::BitOr | Token::BitXor |
-                Token::ShiftLeft | Token::ShiftRight => {
+                Token::Plus
+                | Token::Minus
+                | Token::Multiply
+                | Token::Divide
+                | Token::Modulo
+                | Token::Equal
+                | Token::NotEqual
+                | Token::Less
+                | Token::Greater
+                | Token::LessEqual
+                | Token::GreaterEqual
+                | Token::And
+                | Token::Or
+                | Token::BitAnd
+                | Token::BitOr
+                | Token::BitXor
+                | Token::ShiftLeft
+                | Token::ShiftRight => {
                     self.next_token();
                     self.parse_infix_expression(current_left)
-                },
+                }
                 Token::LeftParen => {
                     self.next_token();
                     self.parse_call_expression(current_left)
-                },
+                }
                 Token::LeftBracket => {
                     self.next_token(); // move onto '['
                     self.parse_index_expression(current_left)
-                },
+                }
                 Token::Dot => {
                     self.next_token(); // move onto '.'
                     self.parse_field_access(current_left)
-                },
+                }
                 Token::Question => {
                     // Postfix `?` — consume it and wrap.
                     // RES-086: capture the `?` token's span before
@@ -3523,14 +3855,14 @@ impl Parser {
                         expr: Box::new(current_left),
                         span: q_span,
                     })
-                },
+                }
                 _ => Some(current_left),
             };
         }
-        
+
         left_expr
     }
-    
+
     fn parse_infix_expression(&mut self, left: Node) -> Option<Node> {
         let operator = match &self.current_token {
             Token::Plus => "+".to_string(),
@@ -3559,7 +3891,7 @@ impl Parser {
                 return None;
             }
         };
-        
+
         let precedence = self.current_precedence();
         // RES-084: capture the operator's span before advancing.
         let op_span = self.span_at_current();
@@ -3587,30 +3919,27 @@ impl Parser {
             span: call_span,
         })
     }
-    
+
     fn parse_call_arguments(&mut self) -> Vec<Node> {
         let mut args = Vec::new();
-        
+
         if self.peek_token == Token::RightParen {
             self.next_token();
             return args;
         }
-        
+
         self.next_token();
         args.push(self.parse_expression(0).unwrap());
-        
+
         while self.peek_token == Token::Comma {
             self.next_token(); // Skip current
             self.next_token(); // Skip comma
             args.push(self.parse_expression(0).unwrap());
         }
-        
+
         if self.peek_token != Token::RightParen {
             let tok = self.peek_token.clone();
-            self.record_error(format!(
-                "Expected ')' after call arguments, found {}",
-                tok
-            ));
+            self.record_error(format!("Expected ')' after call arguments, found {}", tok));
         } else {
             self.next_token(); // Skip to ')'
         }
@@ -3634,8 +3963,11 @@ impl Parser {
         if self.current_token != Token::LeftBrace {
             let tok = self.current_token.clone();
             self.record_error(format!("Expected '{{' after struct name, found {}", tok));
-            return Node::StructDecl { name, fields: Vec::new(),
-            span: self.span_at_current() };
+            return Node::StructDecl {
+                name,
+                fields: Vec::new(),
+                span: self.span_at_current(),
+            };
         }
         self.next_token(); // skip '{'
 
@@ -3651,7 +3983,10 @@ impl Parser {
                 Token::Identifier(n) => n.clone(),
                 _ => {
                     let tok = self.current_token.clone();
-                    self.record_error(format!("Expected field name after type '{}', found {}", ty, tok));
+                    self.record_error(format!(
+                        "Expected field name after type '{}', found {}",
+                        ty, tok
+                    ));
                     break;
                 }
             };
@@ -3669,8 +4004,11 @@ impl Parser {
                 break;
             }
         }
-        Node::StructDecl { name, fields,
-            span: self.span_at_current() }
+        Node::StructDecl {
+            name,
+            fields,
+            span: self.span_at_current(),
+        }
     }
 
     /// Parse `new NAME { field: expr, ... }`. current_token is `new`
@@ -3689,16 +4027,22 @@ impl Parser {
         if self.current_token != Token::LeftBrace {
             let tok = self.current_token.clone();
             self.record_error(format!("Expected '{{' after struct name, found {}", tok));
-            return Node::StructLiteral { name, fields: Vec::new(),
-            span: self.span_at_current() };
+            return Node::StructLiteral {
+                name,
+                fields: Vec::new(),
+                span: self.span_at_current(),
+            };
         }
 
         let mut fields: Vec<(String, Node)> = Vec::new();
 
         if self.peek_token == Token::RightBrace {
             self.next_token(); // to '}'
-            return Node::StructLiteral { name, fields,
-            span: self.span_at_current() };
+            return Node::StructLiteral {
+                name,
+                fields,
+                span: self.span_at_current(),
+            };
         }
 
         self.next_token(); // skip '{'
@@ -3727,9 +4071,7 @@ impl Parser {
             // same name. The typechecker / interpreter stay
             // ignorant of the sugar; unknown-identifier diagnostics
             // surface naturally if the name isn't bound in scope.
-            if self.current_token == Token::Comma
-                || self.current_token == Token::RightBrace
-            {
+            if self.current_token == Token::Comma || self.current_token == Token::RightBrace {
                 let value = Node::Identifier {
                     name: fname.clone(),
                     span: fname_span,
@@ -3754,7 +4096,10 @@ impl Parser {
                 break;
             }
             self.next_token(); // skip ':'
-            let value = self.parse_expression(0).unwrap_or(Node::IntegerLiteral { value: 0, span: span::Span::default() });
+            let value = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+                value: 0,
+                span: span::Span::default(),
+            });
             fields.push((fname, value));
             // parse_expression leaves current on the last token of the
             // expression; advance to move past it.
@@ -3777,8 +4122,11 @@ impl Parser {
                 break;
             }
         }
-        Node::StructLiteral { name, fields,
-            span: self.span_at_current() }
+        Node::StructLiteral {
+            name,
+            fields,
+            span: self.span_at_current(),
+        }
     }
 
     /// Parse an anonymous `fn(params) -> TYPE? requires/ensures? { body }`.
@@ -3786,13 +4134,13 @@ impl Parser {
         self.next_token(); // skip 'fn'
         if self.current_token != Token::LeftParen {
             let tok = self.current_token.clone();
-            self.record_error(format!(
-                "Expected '(' after anonymous 'fn', found {}",
-                tok
-            ));
+            self.record_error(format!("Expected '(' after anonymous 'fn', found {}", tok));
             return Node::FunctionLiteral {
                 parameters: Vec::new(),
-                body: Box::new(Node::Block { stmts: Vec::new(), span: span::Span::default() }),
+                body: Box::new(Node::Block {
+                    stmts: Vec::new(),
+                    span: span::Span::default(),
+                }),
                 requires: Vec::new(),
                 ensures: Vec::new(),
                 return_type: None,
@@ -3805,13 +4153,13 @@ impl Parser {
         let (requires, ensures) = self.parse_function_contracts();
         if self.current_token != Token::LeftBrace {
             let tok = self.current_token.clone();
-            self.record_error(format!(
-                "Expected '{{' in anonymous fn, found {}",
-                tok
-            ));
+            self.record_error(format!("Expected '{{' in anonymous fn, found {}", tok));
             return Node::FunctionLiteral {
                 parameters,
-                body: Box::new(Node::Block { stmts: Vec::new(), span: span::Span::default() }),
+                body: Box::new(Node::Block {
+                    stmts: Vec::new(),
+                    span: span::Span::default(),
+                }),
                 requires,
                 ensures,
                 return_type,
@@ -3825,7 +4173,7 @@ impl Parser {
             requires,
             ensures,
             return_type,
-            span: self.span_at_current()
+            span: self.span_at_current(),
         }
     }
 
@@ -3833,16 +4181,22 @@ impl Parser {
     /// is `match` on entry; on exit it's `}`.
     fn parse_match_expression(&mut self) -> Node {
         self.next_token(); // skip 'match'
-        let scrutinee = self.parse_expression(0).unwrap_or(Node::BooleanLiteral { value: false, span: span::Span::default() });
+        let scrutinee = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+            value: false,
+            span: span::Span::default(),
+        });
         self.next_token(); // past last token of scrutinee
 
         if self.current_token != Token::LeftBrace {
             let tok = self.current_token.clone();
-            self.record_error(format!("Expected '{{' after match scrutinee, found {}", tok));
+            self.record_error(format!(
+                "Expected '{{' after match scrutinee, found {}",
+                tok
+            ));
             return Node::Match {
                 scrutinee: Box::new(scrutinee),
                 arms: Vec::new(),
-            span: self.span_at_current()
+                span: self.span_at_current(),
             };
         }
 
@@ -3852,7 +4206,7 @@ impl Parser {
             return Node::Match {
                 scrutinee: Box::new(scrutinee),
                 arms,
-            span: self.span_at_current()
+                span: self.span_at_current(),
             };
         }
 
@@ -3866,9 +4220,10 @@ impl Parser {
             // a `false` guard falls through to the next arm.
             let guard = if self.current_token == Token::If {
                 self.next_token(); // past `if`
-                let g = self.parse_expression(0).unwrap_or(
-                    Node::BooleanLiteral { value: true, span: span::Span::default() }
-                );
+                let g = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                    value: true,
+                    span: span::Span::default(),
+                });
                 self.next_token(); // past last token of guard
                 Some(g)
             } else {
@@ -3877,14 +4232,14 @@ impl Parser {
 
             if self.current_token != Token::FatArrow {
                 let tok = self.current_token.clone();
-                self.record_error(format!(
-                    "Expected '=>' after match pattern, found {}",
-                    tok
-                ));
+                self.record_error(format!("Expected '=>' after match pattern, found {}", tok));
                 break;
             }
             self.next_token(); // skip '=>'
-            let body = self.parse_expression(0).unwrap_or(Node::IntegerLiteral { value: 0, span: span::Span::default() });
+            let body = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+                value: 0,
+                span: span::Span::default(),
+            });
             arms.push((pattern, guard, body));
             self.next_token(); // past last token of body
             if self.current_token == Token::Comma {
@@ -3902,7 +4257,7 @@ impl Parser {
         Node::Match {
             scrutinee: Box::new(scrutinee),
             arms,
-            span: self.span_at_current()
+            span: self.span_at_current(),
         }
     }
 
@@ -3942,10 +4297,22 @@ impl Parser {
             // unexpected-token error since `Token::Default` isn't
             // accepted anywhere else in the grammar.
             Token::Default => Pattern::Wildcard,
-            Token::IntLiteral(n) => Pattern::Literal(Node::IntegerLiteral { value: *n, span: tok_span }),
-            Token::FloatLiteral(f) => Pattern::Literal(Node::FloatLiteral { value: *f, span: tok_span }),
-            Token::StringLiteral(s) => Pattern::Literal(Node::StringLiteral { value: s.clone(), span: tok_span }),
-            Token::BoolLiteral(b) => Pattern::Literal(Node::BooleanLiteral { value: *b, span: tok_span }),
+            Token::IntLiteral(n) => Pattern::Literal(Node::IntegerLiteral {
+                value: *n,
+                span: tok_span,
+            }),
+            Token::FloatLiteral(f) => Pattern::Literal(Node::FloatLiteral {
+                value: *f,
+                span: tok_span,
+            }),
+            Token::StringLiteral(s) => Pattern::Literal(Node::StringLiteral {
+                value: s.clone(),
+                span: tok_span,
+            }),
+            Token::BoolLiteral(b) => Pattern::Literal(Node::BooleanLiteral {
+                value: *b,
+                span: tok_span,
+            }),
             Token::Identifier(name) => {
                 let name = name.clone();
                 // RES-161a: `name @ inner` bind-subpattern.
@@ -3963,10 +4330,7 @@ impl Parser {
             }
             other => {
                 let tok = other.clone();
-                self.record_error(format!(
-                    "Unsupported match pattern starting with {:?}",
-                    tok
-                ));
+                self.record_error(format!("Unsupported match pattern starting with {:?}", tok));
                 Pattern::Wildcard
             }
         }
@@ -3977,6 +4341,25 @@ impl Parser {
         // RES-085: span covers the `.` at current_token on entry.
         let dot_span = self.span_at_current();
         self.next_token(); // skip '.'
+        // RES-127: `t.0`, `t.1`, … positional tuple access. If the
+        // token after `.` is a non-negative integer literal, emit a
+        // `TupleIndex` node instead of `FieldAccess`.
+        if let Token::IntLiteral(n) = &self.current_token {
+            if *n >= 0 {
+                let index = *n as usize;
+                return Some(Node::TupleIndex {
+                    tuple: Box::new(target),
+                    index,
+                    span: dot_span,
+                });
+            }
+            let tok = self.current_token.clone();
+            self.record_error(format!(
+                "Tuple index must be a non-negative integer, found {}",
+                tok
+            ));
+            return Some(target);
+        }
         let field = match &self.current_token {
             Token::Identifier(n) => n.clone(),
             _ => {
@@ -4000,7 +4383,10 @@ impl Parser {
         let mut items = Vec::new();
         if self.peek_token == Token::RightBracket {
             self.next_token(); // to ]
-            return Node::ArrayLiteral { items, span: bracket_span };
+            return Node::ArrayLiteral {
+                items,
+                span: bracket_span,
+            };
         }
         self.next_token(); // skip '['
         if let Some(first) = self.parse_expression(0) {
@@ -4033,7 +4419,10 @@ impl Parser {
         } else {
             self.next_token(); // to ]
         }
-        Node::ArrayLiteral { items, span: bracket_span }
+        Node::ArrayLiteral {
+            items,
+            span: bracket_span,
+        }
     }
 
     /// RES-156: desugar `[<expr> for <binding> in <iterable> (if
@@ -4054,11 +4443,7 @@ impl Parser {
     /// the closing `]` so `parse_expression`'s tail handling works
     /// unchanged. `first_expr` is the already-parsed result
     /// expression.
-    fn parse_array_comprehension(
-        &mut self,
-        first_expr: Node,
-        bracket_span: span::Span,
-    ) -> Node {
+    fn parse_array_comprehension(&mut self, first_expr: Node, bracket_span: span::Span) -> Node {
         // Advance from the end of <expr> to `for`.
         self.next_token(); // current_token == Token::For
         self.next_token(); // past `for` to the binding identifier
@@ -4089,12 +4474,10 @@ impl Parser {
             self.next_token(); // past `in`
         }
 
-        let iterable = self
-            .parse_expression(0)
-            .unwrap_or(Node::ArrayLiteral {
-                items: Vec::new(),
-                span: span::Span::default(),
-            });
+        let iterable = self.parse_expression(0).unwrap_or(Node::ArrayLiteral {
+            items: Vec::new(),
+            span: span::Span::default(),
+        });
 
         // Optional guard: `if <expr>`.
         let guard = if self.peek_token == Token::If {
@@ -4234,7 +4617,10 @@ impl Parser {
         // Empty map: `{}`.
         if self.peek_token == Token::RightBrace {
             self.next_token(); // to '}'
-            return Node::MapLiteral { entries, span: brace_span };
+            return Node::MapLiteral {
+                entries,
+                span: brace_span,
+            };
         }
         self.next_token(); // step past '{'
         // First entry.
@@ -4253,14 +4639,14 @@ impl Parser {
         }
         if self.peek_token != Token::RightBrace {
             let tok = self.peek_token.clone();
-            self.record_error(format!(
-                "Expected '}}' to close map literal, found {}",
-                tok
-            ));
+            self.record_error(format!("Expected '}}' to close map literal, found {}", tok));
         } else {
             self.next_token(); // to '}'
         }
-        Node::MapLiteral { entries, span: brace_span }
+        Node::MapLiteral {
+            entries,
+            span: brace_span,
+        }
     }
 
     /// RES-149: parse a set literal — `#{1, 2, 3}`. `current_token`
@@ -4273,7 +4659,10 @@ impl Parser {
         // Empty: `#{}`.
         if self.peek_token == Token::RightBrace {
             self.next_token(); // to `}`
-            return Node::SetLiteral { items, span: brace_span };
+            return Node::SetLiteral {
+                items,
+                span: brace_span,
+            };
         }
         self.next_token(); // step past `#{`
         // First item.
@@ -4292,14 +4681,14 @@ impl Parser {
         }
         if self.peek_token != Token::RightBrace {
             let tok = self.peek_token.clone();
-            self.record_error(format!(
-                "Expected '}}' to close set literal, found {}",
-                tok
-            ));
+            self.record_error(format!("Expected '}}' to close set literal, found {}", tok));
         } else {
             self.next_token(); // to `}`
         }
-        Node::SetLiteral { items, span: brace_span }
+        Node::SetLiteral {
+            items,
+            span: brace_span,
+        }
     }
 
     /// RES-148: parse a single `key -> value` pair. `current_token`
@@ -4367,7 +4756,7 @@ impl Parser {
             _ => 0,
         }
     }
-    
+
     fn peek_precedence(&self) -> u8 {
         match &self.peek_token {
             Token::Or => 1,
@@ -4419,6 +4808,10 @@ enum Value {
     /// RES-032: dynamic array. Mixed types allowed at runtime until a
     /// real type system (G7) can enforce a single element type.
     Array(Vec<Value>),
+    /// RES-127: fixed-arity product value — `(1, "hello")`. Elements
+    /// are accessed positionally via `.0`, `.1`, etc. VM/JIT lowering
+    /// is deferred; the interpreter works directly on the Vec.
+    Tuple(Vec<Value>),
     /// RES-038: user-defined record. Fields are stored in declaration
     /// order so Display is stable.
     Struct {
@@ -4569,6 +4962,7 @@ impl std::fmt::Debug for Value {
             }
             Value::Builtin { name, .. } => write!(f, "Builtin({})", name),
             Value::Array(items) => write!(f, "Array({} items)", items.len()),
+            Value::Tuple(items) => write!(f, "Tuple({} items)", items.len()),
             Value::Struct { name, fields } => {
                 write!(f, "Struct({}, {} fields)", name, fields.len())
             }
@@ -4615,6 +5009,19 @@ impl std::fmt::Display for Value {
                     write!(f, "{}", v)?;
                 }
                 write!(f, "]")
+            }
+            Value::Tuple(items) => {
+                write!(f, "(")?;
+                for (i, v) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", v)?;
+                }
+                if items.len() == 1 {
+                    write!(f, ",")?;
+                }
+                write!(f, ")")
             }
             Value::Struct { name, fields } => {
                 write!(f, "{} {{ ", name)?;
@@ -4833,11 +5240,15 @@ fn flatten_field_target(target: &Node, last_field: &str) -> (Option<String>, Vec
     let mut node = target;
     loop {
         match node {
-            Node::Identifier { name, .. } => return (Some(name.clone()), {
-                path.reverse();
-                path
-            }),
-            Node::FieldAccess { target: t, field, .. } => {
+            Node::Identifier { name, .. } => {
+                return (Some(name.clone()), {
+                    path.reverse();
+                    path
+                });
+            }
+            Node::FieldAccess {
+                target: t, field, ..
+            } => {
                 path.push(field.clone());
                 node = t;
             }
@@ -4857,9 +5268,10 @@ fn set_nested_field(root: Value, path: &[String], new_val: Value) -> RResult<Val
         Value::Struct { name, mut fields } => {
             let head = &path[0];
             let tail = &path[1..];
-            let idx = fields.iter().position(|(n, _)| n == head).ok_or_else(|| {
-                format!("Struct {} has no field '{}'", name, head)
-            })?;
+            let idx = fields
+                .iter()
+                .position(|(n, _)| n == head)
+                .ok_or_else(|| format!("Struct {} has no field '{}'", name, head))?;
             let old = std::mem::replace(&mut fields[idx].1, Value::Void);
             let updated = set_nested_field(old, tail, new_val)?;
             fields[idx].1 = updated;
@@ -4882,10 +5294,17 @@ fn format_contract_expr(node: &Node) -> String {
         Node::FloatLiteral { value, .. } => value.to_string(),
         Node::StringLiteral { value, .. } => format!("{:?}", value),
         Node::BooleanLiteral { value, .. } => value.to_string(),
-        Node::PrefixExpression { operator, right, .. } => {
+        Node::PrefixExpression {
+            operator, right, ..
+        } => {
             format!("{}{}", operator, format_contract_expr(right))
         }
-        Node::InfixExpression { left, operator, right, .. } => {
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => {
             format!(
                 "{} {} {}",
                 format_contract_expr(left),
@@ -4893,7 +5312,11 @@ fn format_contract_expr(node: &Node) -> String {
                 format_contract_expr(right)
             )
         }
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             let args: Vec<String> = arguments.iter().map(format_contract_expr).collect();
             format!("{}({})", format_contract_expr(function), args.join(", "))
         }
@@ -4932,13 +5355,7 @@ fn stringify_for_concat(v: &Value) -> Option<String> {
 // `&Environment`, but `&mut` is harmless and signals "we're populating".
 fn register_builtins(env: &mut Environment) {
     for (name, func) in BUILTINS {
-        env.set(
-            (*name).to_string(),
-            Value::Builtin {
-                name,
-                func: *func,
-            },
-        );
+        env.set((*name).to_string(), Value::Builtin { name, func: *func });
     }
 }
 
@@ -5099,17 +5516,12 @@ fn builtin_print(args: &[Value]) -> RResult<Value> {
 fn builtin_input(args: &[Value]) -> RResult<Value> {
     let prompt = match args {
         [Value::String(s)] => s.clone(),
-        [other] => {
-            return Err(format!(
-                "input: expected String prompt, got {}",
-                other
-            ))
-        }
+        [other] => return Err(format!("input: expected String prompt, got {}", other)),
         many => {
             return Err(format!(
                 "input: expected 1 argument (prompt), got {}",
                 many.len()
-            ))
+            ));
         }
     };
     let stdin = std::io::stdin();
@@ -5169,12 +5581,12 @@ fn builtin_pow(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Int(base), Value::Int(exp)] => {
             // Negative exponent isn't representable as Int.
-            let exp_u32: u32 = (*exp).try_into().map_err(|_| {
-                format!("pow: negative exponent {} undefined for int base", exp)
-            })?;
-            base.checked_pow(exp_u32).map(Value::Int).ok_or_else(|| {
-                format!("pow: integer overflow ({} ^ {})", base, exp)
-            })
+            let exp_u32: u32 = (*exp)
+                .try_into()
+                .map_err(|_| format!("pow: negative exponent {} undefined for int base", exp))?;
+            base.checked_pow(exp_u32)
+                .map(Value::Int)
+                .ok_or_else(|| format!("pow: integer overflow ({} ^ {})", base, exp))
         }
         [a, b] => {
             let to_f = |v: &Value| match v {
@@ -5183,7 +5595,10 @@ fn builtin_pow(args: &[Value]) -> RResult<Value> {
                 _ => None,
             };
             let (Some(base), Some(exp)) = (to_f(a), to_f(b)) else {
-                return Err(format!("pow: expected numeric args, got {:?} and {:?}", a, b));
+                return Err(format!(
+                    "pow: expected numeric args, got {:?} and {:?}",
+                    a, b
+                ));
             };
             Ok(Value::Float(base.powf(exp)))
         }
@@ -5271,10 +5686,7 @@ fn builtin_ln(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Float(f)] => {
             if *f <= 0.0 {
-                return Err(format!(
-                    "ln: argument must be > 0, got {}",
-                    f
-                ));
+                return Err(format!("ln: argument must be > 0, got {}", f));
             }
             Ok(Value::Float(f.ln()))
         }
@@ -5298,22 +5710,13 @@ fn builtin_log(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Float(base), Value::Float(x)] => {
             if *base <= 0.0 {
-                return Err(format!(
-                    "log: base must be > 0, got {}",
-                    base
-                ));
+                return Err(format!("log: base must be > 0, got {}", base));
             }
             if (*base - 1.0).abs() < f64::EPSILON {
-                return Err(
-                    "log: base must not be 1 (log_1(x) is undefined)"
-                        .to_string(),
-                );
+                return Err("log: base must not be 1 (log_1(x) is undefined)".to_string());
             }
             if *x <= 0.0 {
-                return Err(format!(
-                    "log: value must be > 0, got {}",
-                    x
-                ));
+                return Err(format!("log: value must be > 0, got {}", x));
             }
             Ok(Value::Float(x.log(*base)))
         }
@@ -5347,8 +5750,7 @@ fn builtin_exp(args: &[Value]) -> RResult<Value> {
 /// pay only the atomic-load cost plus an `Instant::now()` sample.
 /// The epoch is deliberately unspecified and unobservable except
 /// through `clock_ms()`: users get deltas, not absolute times.
-static CLOCK_EPOCH: std::sync::OnceLock<std::time::Instant> =
-    std::sync::OnceLock::new();
+static CLOCK_EPOCH: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
 
 /// RES-150: SplitMix64 — tiny, deterministic, dependency-free PRNG.
 ///
@@ -5384,9 +5786,7 @@ fn seed_rng(seed: u64) {
 /// so the user can pin it via `--seed <N>` on the next run.
 fn seed_rng_from_clock() -> u64 {
     let epoch = CLOCK_EPOCH.get_or_init(std::time::Instant::now);
-    let ns = std::time::Instant::now()
-        .duration_since(*epoch)
-        .as_nanos() as u64;
+    let ns = std::time::Instant::now().duration_since(*epoch).as_nanos() as u64;
     // XOR with a process-id and a fixed constant so two processes
     // launched at the "same" epoch still differ.
     let pid = std::process::id() as u64;
@@ -5426,10 +5826,7 @@ fn builtin_random_int(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Int(lo), Value::Int(hi)] => {
             if hi <= lo {
-                return Err(format!(
-                    "random_int: hi must be > lo ({} <= {})",
-                    hi, lo
-                ));
+                return Err(format!("random_int: hi must be > lo ({} <= {})", hi, lo));
             }
             let span = (*hi - *lo) as u64;
             let r = splitmix64_next() % span;
@@ -5539,9 +5936,7 @@ fn builtin_is_err(args: &[Value]) -> RResult<Value> {
 fn builtin_unwrap(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Result { ok: true, payload }] => Ok((**payload).clone()),
-        [Value::Result { ok: false, payload }] => {
-            Err(format!("unwrap called on Err({})", payload))
-        }
+        [Value::Result { ok: false, payload }] => Err(format!("unwrap called on Err({})", payload)),
         [other] => Err(format!("unwrap: expected Result, got {}", other)),
         _ => Err(format!("unwrap: expected 1 argument, got {}", args.len())),
     }
@@ -5570,7 +5965,9 @@ fn builtin_split(args: &[Value]) -> RResult<Value> {
             let parts: Vec<Value> = if sep.is_empty() {
                 s.chars().map(|c| Value::String(c.to_string())).collect()
             } else {
-                s.split(sep.as_str()).map(|p| Value::String(p.to_string())).collect()
+                s.split(sep.as_str())
+                    .map(|p| Value::String(p.to_string()))
+                    .collect()
             };
             Ok(Value::Array(parts))
         }
@@ -5599,7 +5996,10 @@ fn builtin_contains(args: &[Value]) -> RResult<Value> {
             "contains: expected (string, string), got ({:?}, {:?})",
             a, b
         )),
-        _ => Err(format!("contains: expected 2 arguments, got {}", args.len())),
+        _ => Err(format!(
+            "contains: expected 2 arguments, got {}",
+            args.len()
+        )),
     }
 }
 
@@ -5637,9 +6037,7 @@ fn builtin_replace(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::String(s), Value::String(from), Value::String(to)] => {
             if from.is_empty() {
-                return Err(
-                    "replace: `from` must be non-empty".to_string(),
-                );
+                return Err("replace: `from` must be non-empty".to_string());
             }
             Ok(Value::String(s.replace(from.as_str(), to)))
         }
@@ -5647,10 +6045,7 @@ fn builtin_replace(args: &[Value]) -> RResult<Value> {
             "replace: expected (string, string, string), got ({:?}, {:?}, {:?})",
             a, b, c
         )),
-        _ => Err(format!(
-            "replace: expected 3 arguments, got {}",
-            args.len()
-        )),
+        _ => Err(format!("replace: expected 3 arguments, got {}", args.len())),
     }
 }
 
@@ -5677,9 +6072,7 @@ fn builtin_starts_with(args: &[Value]) -> RResult<Value> {
 /// An empty suffix is always a match.
 fn builtin_ends_with(args: &[Value]) -> RResult<Value> {
     match args {
-        [Value::String(s), Value::String(suffix)] => {
-            Ok(Value::Bool(s.ends_with(suffix.as_str())))
-        }
+        [Value::String(s), Value::String(suffix)] => Ok(Value::Bool(s.ends_with(suffix.as_str()))),
         [a, b] => Err(format!(
             "ends_with: expected (string, string), got ({:?}, {:?})",
             a, b
@@ -5703,8 +6096,8 @@ fn builtin_repeat(args: &[Value]) -> RResult<Value> {
             }
             // `usize::try_from` guards against the (theoretical) case
             // where i64 > usize::MAX on exotic targets.
-            let count = usize::try_from(*n)
-                .map_err(|_| format!("repeat: count {} out of range", n))?;
+            let count =
+                usize::try_from(*n).map_err(|_| format!("repeat: count {} out of range", n))?;
             Ok(Value::String(s.repeat(count)))
         }
         [a, b] => Err(format!(
@@ -5735,13 +6128,13 @@ fn builtin_format(args: &[Value]) -> RResult<Value> {
             return Err(format!(
                 "format: expected (string, array), got ({:?}, {:?})",
                 a, b
-            ))
+            ));
         }
         many => {
             return Err(format!(
                 "format: expected 2 arguments (fmt, args), got {}",
                 many.len()
-            ))
+            ));
         }
     };
 
@@ -5888,17 +6281,8 @@ fn builtin_len(args: &[Value]) -> RResult<Value> {
 /// index targets the leaf cell that gets replaced. Bounds errors
 /// name the depth (1-indexed) where the out-of-range access occurred
 /// so users can tell `m[2][0]` (outer) from `m[0][5]` (inner).
-fn replace_at_path(
-    items: &mut [Value],
-    indices: &[i64],
-    value: Value,
-) -> RResult<()> {
-    fn recurse(
-        items: &mut [Value],
-        indices: &[i64],
-        value: Value,
-        depth: usize,
-    ) -> RResult<()> {
+fn replace_at_path(items: &mut [Value], indices: &[i64], value: Value) -> RResult<()> {
+    fn recurse(items: &mut [Value], indices: &[i64], value: Value, depth: usize) -> RResult<()> {
         let (i, rest) = match indices.split_first() {
             Some(pair) => pair,
             None => unreachable!("replace_at_path called with zero indices"),
@@ -5951,7 +6335,10 @@ fn builtin_min(args: &[Value]) -> RResult<Value> {
         [Value::Float(a), Value::Float(b)] => Ok(Value::Float(a.min(*b))),
         [Value::Int(a), Value::Float(b)] => Ok(Value::Float((*a as f64).min(*b))),
         [Value::Float(a), Value::Int(b)] => Ok(Value::Float(a.min(*b as f64))),
-        [a, b] => Err(format!("min: expected numeric args, got {:?} and {:?}", a, b)),
+        [a, b] => Err(format!(
+            "min: expected numeric args, got {:?} and {:?}",
+            a, b
+        )),
         _ => Err(format!("min: expected 2 arguments, got {}", args.len())),
     }
 }
@@ -5963,7 +6350,10 @@ fn builtin_max(args: &[Value]) -> RResult<Value> {
         [Value::Float(a), Value::Float(b)] => Ok(Value::Float(a.max(*b))),
         [Value::Int(a), Value::Float(b)] => Ok(Value::Float((*a as f64).max(*b))),
         [Value::Float(a), Value::Int(b)] => Ok(Value::Float(a.max(*b as f64))),
-        [a, b] => Err(format!("max: expected numeric args, got {:?} and {:?}", a, b)),
+        [a, b] => Err(format!(
+            "max: expected numeric args, got {:?} and {:?}",
+            a, b
+        )),
         _ => Err(format!("max: expected 2 arguments, got {}", args.len())),
     }
 }
@@ -5977,10 +6367,7 @@ fn builtin_to_float(args: &[Value]) -> RResult<Value> {
             "to_float: expected Int or Float argument, got {:?}",
             other
         )),
-        _ => Err(format!(
-            "to_float: expected 1 argument, got {}",
-            args.len()
-        )),
+        _ => Err(format!("to_float: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -6007,10 +6394,7 @@ fn builtin_to_int(args: &[Value]) -> RResult<Value> {
             // Rust — that silent saturation is exactly the invisible
             // bug we're trying to avoid, so reject it too.
             if *f < (i64::MIN as f64) || *f > (i64::MAX as f64) {
-                return Err(format!(
-                    "to_int: value {} is out of i64 range",
-                    f
-                ));
+                return Err(format!("to_int: value {} is out of i64 range", f));
             }
             Ok(Value::Int(*f as i64))
         }
@@ -6018,10 +6402,7 @@ fn builtin_to_int(args: &[Value]) -> RResult<Value> {
             "to_int: expected Int or Float argument, got {:?}",
             other
         )),
-        _ => Err(format!(
-            "to_int: expected 1 argument, got {}",
-            args.len()
-        )),
+        _ => Err(format!("to_int: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -6071,28 +6452,21 @@ fn builtin_file_read(args: &[Value]) -> RResult<Value> {
 /// the ticket's spirit that absence isn't a runtime error.
 fn builtin_env(args: &[Value]) -> RResult<Value> {
     match args {
-        [Value::String(key)] => {
-            match std::env::var(key) {
-                Ok(val) => Ok(Value::Result {
-                    ok: true,
-                    payload: Box::new(Value::String(val)),
-                }),
-                Err(std::env::VarError::NotPresent) => Ok(Value::Result {
-                    ok: false,
-                    payload: Box::new(Value::String("not set".to_string())),
-                }),
-                Err(std::env::VarError::NotUnicode(_)) => Ok(Value::Result {
-                    ok: false,
-                    payload: Box::new(Value::String(
-                        "invalid utf-8".to_string(),
-                    )),
-                }),
-            }
-        }
-        [other] => Err(format!(
-            "env: expected String argument, got {}",
-            other
-        )),
+        [Value::String(key)] => match std::env::var(key) {
+            Ok(val) => Ok(Value::Result {
+                ok: true,
+                payload: Box::new(Value::String(val)),
+            }),
+            Err(std::env::VarError::NotPresent) => Ok(Value::Result {
+                ok: false,
+                payload: Box::new(Value::String("not set".to_string())),
+            }),
+            Err(std::env::VarError::NotUnicode(_)) => Ok(Value::Result {
+                ok: false,
+                payload: Box::new(Value::String("invalid utf-8".to_string())),
+            }),
+        },
+        [other] => Err(format!("env: expected String argument, got {}", other)),
         _ => Err(format!(
             "env: expected 1 argument (key), got {}",
             args.len()
@@ -6125,10 +6499,7 @@ fn builtin_file_write(args: &[Value]) -> RResult<Value> {
 /// `map_new()` — produce an empty map.
 fn builtin_map_new(args: &[Value]) -> RResult<Value> {
     if !args.is_empty() {
-        return Err(format!(
-            "map_new: expected 0 arguments, got {}",
-            args.len()
-        ));
+        return Err(format!("map_new: expected 0 arguments, got {}", args.len()));
     }
     Ok(Value::Map(std::collections::HashMap::new()))
 }
@@ -6173,10 +6544,7 @@ fn builtin_map_get(args: &[Value]) -> RResult<Value> {
                 }),
             }
         }
-        [a, _] => Err(format!(
-            "map_get: first argument must be a Map, got {}",
-            a
-        )),
+        [a, _] => Err(format!("map_get: first argument must be a Map, got {}", a)),
         _ => Err(format!(
             "map_get: expected 2 arguments (map, key), got {}",
             args.len()
@@ -6226,14 +6594,8 @@ fn builtin_map_keys(args: &[Value]) -> RResult<Value> {
             let out: Vec<Value> = keys.iter().map(|k| k.to_value()).collect();
             Ok(Value::Array(out))
         }
-        [a] => Err(format!(
-            "map_keys: expected a Map, got {}",
-            a
-        )),
-        _ => Err(format!(
-            "map_keys: expected 1 argument, got {}",
-            args.len()
-        )),
+        [a] => Err(format!("map_keys: expected a Map, got {}", a)),
+        _ => Err(format!("map_keys: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -6241,14 +6603,8 @@ fn builtin_map_keys(args: &[Value]) -> RResult<Value> {
 fn builtin_map_len(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Map(m)] => Ok(Value::Int(m.len() as i64)),
-        [a] => Err(format!(
-            "map_len: expected a Map, got {}",
-            a
-        )),
-        _ => Err(format!(
-            "map_len: expected 1 argument, got {}",
-            args.len()
-        )),
+        [a] => Err(format!("map_len: expected a Map, got {}", a)),
+        _ => Err(format!("map_len: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -6265,10 +6621,7 @@ fn builtin_map_len(args: &[Value]) -> RResult<Value> {
 fn builtin_bytes_len(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Bytes(b)] => Ok(Value::Int(b.len() as i64)),
-        [other] => Err(format!(
-            "bytes_len: expected Bytes, got {}",
-            other
-        )),
+        [other] => Err(format!("bytes_len: expected Bytes, got {}", other)),
         _ => Err(format!(
             "bytes_len: expected 1 argument, got {}",
             args.len()
@@ -6350,10 +6703,7 @@ fn builtin_byte_at(args: &[Value]) -> RResult<Value> {
 /// `set_new()` — produce an empty set.
 fn builtin_set_new(args: &[Value]) -> RResult<Value> {
     if !args.is_empty() {
-        return Err(format!(
-            "set_new: expected 0 arguments, got {}",
-            args.len()
-        ));
+        return Err(format!("set_new: expected 0 arguments, got {}", args.len()));
     }
     Ok(Value::Set(std::collections::HashSet::new()))
 }
@@ -6364,9 +6714,7 @@ fn builtin_set_new(args: &[Value]) -> RResult<Value> {
 fn builtin_set_insert(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Set(s), x] => {
-            let k = MapKey::from_value(x).map_err(|e| {
-                e.replace("Map key", "Set element")
-            })?;
+            let k = MapKey::from_value(x).map_err(|e| e.replace("Map key", "Set element"))?;
             let mut out = s.clone();
             out.insert(k);
             Ok(Value::Set(out))
@@ -6387,9 +6735,7 @@ fn builtin_set_insert(args: &[Value]) -> RResult<Value> {
 fn builtin_set_remove(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Set(s), x] => {
-            let k = MapKey::from_value(x).map_err(|e| {
-                e.replace("Map key", "Set element")
-            })?;
+            let k = MapKey::from_value(x).map_err(|e| e.replace("Map key", "Set element"))?;
             let mut out = s.clone();
             out.remove(&k);
             Ok(Value::Set(out))
@@ -6409,15 +6755,10 @@ fn builtin_set_remove(args: &[Value]) -> RResult<Value> {
 fn builtin_set_has(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Set(s), x] => {
-            let k = MapKey::from_value(x).map_err(|e| {
-                e.replace("Map key", "Set element")
-            })?;
+            let k = MapKey::from_value(x).map_err(|e| e.replace("Map key", "Set element"))?;
             Ok(Value::Bool(s.contains(&k)))
         }
-        [a, _] => Err(format!(
-            "set_has: first argument must be a Set, got {}",
-            a
-        )),
+        [a, _] => Err(format!("set_has: first argument must be a Set, got {}", a)),
         _ => Err(format!(
             "set_has: expected 2 arguments (set, element), got {}",
             args.len()
@@ -6429,14 +6770,8 @@ fn builtin_set_has(args: &[Value]) -> RResult<Value> {
 fn builtin_set_len(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Set(s)] => Ok(Value::Int(s.len() as i64)),
-        [a] => Err(format!(
-            "set_len: expected a Set, got {}",
-            a
-        )),
-        _ => Err(format!(
-            "set_len: expected 1 argument, got {}",
-            args.len()
-        )),
+        [a] => Err(format!("set_len: expected a Set, got {}", a)),
+        _ => Err(format!("set_len: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -6460,10 +6795,7 @@ fn builtin_set_items(args: &[Value]) -> RResult<Value> {
             let out: Vec<Value> = items.iter().map(|k| k.to_value()).collect();
             Ok(Value::Array(out))
         }
-        [a] => Err(format!(
-            "set_items: expected a Set, got {}",
-            a
-        )),
+        [a] => Err(format!("set_items: expected a Set, got {}", a)),
         _ => Err(format!(
             "set_items: expected 1 argument, got {}",
             args.len()
@@ -6545,10 +6877,8 @@ impl Drop for LiveRetryGuard {
 // Cortex-M where only 32-bit atomics are native. 2^32 retries is
 // plenty of headroom for diagnostic runs.
 
-static LIVE_TOTAL_RETRIES: std::sync::atomic::AtomicU32 =
-    std::sync::atomic::AtomicU32::new(0);
-static LIVE_TOTAL_EXHAUSTIONS: std::sync::atomic::AtomicU32 =
-    std::sync::atomic::AtomicU32::new(0);
+static LIVE_TOTAL_RETRIES: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+static LIVE_TOTAL_EXHAUSTIONS: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
 /// RES-141: `live_total_retries() -> Int` — cumulative count of
 /// live-block retries since the process started.
@@ -6628,7 +6958,7 @@ impl Interpreter {
         self.proven_fns = Rc::new(proven);
         self
     }
-    
+
     fn eval(&mut self, node: &Node) -> RResult<Value> {
         match node {
             Node::Program(statements) => self.eval_program(statements),
@@ -6640,7 +6970,14 @@ impl Interpreter {
             // expand_uses. Stubs here so the interpreter is silent if
             // any slip through; real dispatch lands in Tasks 4-8.
             Node::Extern { .. } => Ok(Value::Void),
-            Node::Function { name, parameters, body, requires, ensures, .. } => {
+            Node::Function {
+                name,
+                parameters,
+                body,
+                requires,
+                ensures,
+                ..
+            } => {
                 // RES-068: if every observed call site for this fn was
                 // statically proven, the runtime requires check is
                 // provably redundant. Strip it.
@@ -6659,8 +6996,14 @@ impl Interpreter {
                 };
                 self.env.set(name.clone(), func);
                 Ok(Value::Void)
-            },
-            Node::LiveBlock { body, invariants, backoff, timeout, .. } => {
+            }
+            Node::LiveBlock {
+                body,
+                invariants,
+                backoff,
+                timeout,
+                ..
+            } => {
                 // RES-142: unpack the `within <duration>` clause
                 // (if any) into a flat `u64 ns` so the runtime loop
                 // doesn't re-match the boxed node every retry.
@@ -6680,9 +7023,15 @@ impl Interpreter {
                 "duration literals are only valid inside `live within ...` clauses (RES-142)"
                     .to_string(),
             ),
-            Node::Assert { condition, message, .. } => self.eval_assert(condition, message),
-            Node::Assume { condition, message, .. } => self.eval_assume(condition, message),
-            Node::Block { stmts: statements, .. } => self.eval_block_statement(statements),
+            Node::Assert {
+                condition, message, ..
+            } => self.eval_assert(condition, message),
+            Node::Assume {
+                condition, message, ..
+            } => self.eval_assume(condition, message),
+            Node::Block {
+                stmts: statements, ..
+            } => self.eval_block_statement(statements),
             Node::LetStatement { name, value, .. } => {
                 let val = self.eval(value)?;
                 // RES-041: if the RHS short-circuited (e.g. via `?`),
@@ -6692,7 +7041,7 @@ impl Interpreter {
                 }
                 self.env.set(name.clone(), val);
                 Ok(Value::Void)
-            },
+            }
             Node::LetDestructureStruct {
                 struct_name,
                 fields,
@@ -6720,8 +7069,7 @@ impl Interpreter {
                 }
                 // Bind each requested field into the environment.
                 for (field_name, local_name) in fields {
-                    let Some((_, field_val)) =
-                        obs_fields.iter().find(|(n, _)| n == field_name)
+                    let Some((_, field_val)) = obs_fields.iter().find(|(n, _)| n == field_name)
                     else {
                         return Err(format!(
                             "Struct {} has no field `{}`",
@@ -6741,7 +7089,7 @@ impl Interpreter {
                     self.statics.borrow_mut().insert(name.clone(), val);
                 }
                 Ok(Value::Void)
-            },
+            }
             Node::Assignment { name, value, .. } => {
                 let val = self.eval(value)?;
                 if matches!(val, Value::Return(_)) {
@@ -6755,22 +7103,24 @@ impl Interpreter {
                 } else {
                     Err(format!("Cannot assign to undeclared variable '{}'", name))
                 }
-            },
+            }
             Node::ReturnStatement { value, .. } => {
                 let val = match value {
                     Some(expr) => self.eval(expr)?,
                     None => Value::Void,
                 };
                 Ok(Value::Return(Box::new(val)))
-            },
-            Node::ForInStatement { name, iterable, body, .. } => {
+            }
+            Node::ForInStatement {
+                name,
+                iterable,
+                body,
+                ..
+            } => {
                 let iter_val = self.eval(iterable)?;
                 let items = match iter_val {
                     Value::Array(v) => v,
-                    other => return Err(format!(
-                        "`for` iterable must be an array, got {}",
-                        other
-                    )),
+                    other => return Err(format!("`for` iterable must be an array, got {}", other)),
                 };
                 for item in items {
                     self.env.set(name.clone(), item);
@@ -6780,8 +7130,10 @@ impl Interpreter {
                     }
                 }
                 Ok(Value::Void)
-            },
-            Node::WhileStatement { condition, body, .. } => {
+            }
+            Node::WhileStatement {
+                condition, body, ..
+            } => {
                 // Cap iterations as a safety net so a buggy loop can't
                 // freeze the interpreter. 1M is big enough for
                 // realistic work and small enough to catch runaways.
@@ -6804,8 +7156,13 @@ impl Interpreter {
                     }
                 }
                 Ok(Value::Void)
-            },
-            Node::IfStatement { condition, consequence, alternative, .. } => {
+            }
+            Node::IfStatement {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
                 let condition_value = self.eval(condition)?;
                 if self.is_truthy(&condition_value) {
                     self.eval(consequence)
@@ -6814,7 +7171,7 @@ impl Interpreter {
                 } else {
                     Ok(Value::Void)
                 }
-            },
+            }
             Node::ExpressionStatement { expr, .. } => self.eval(expr),
             Node::Identifier { name, .. } => {
                 if let Some(value) = self.env.get(name) {
@@ -6824,22 +7181,33 @@ impl Interpreter {
                 } else {
                     Err(format!("Identifier not found: {}", name))
                 }
-            },
+            }
             Node::IntegerLiteral { value, .. } => Ok(Value::Int(*value)),
             Node::FloatLiteral { value, .. } => Ok(Value::Float(*value)),
             Node::StringLiteral { value, .. } => Ok(Value::String(value.clone())),
             Node::BytesLiteral { value, .. } => Ok(Value::Bytes(value.clone())),
             Node::BooleanLiteral { value, .. } => Ok(Value::Bool(*value)),
-            Node::PrefixExpression { operator, right, .. } => {
+            Node::PrefixExpression {
+                operator, right, ..
+            } => {
                 let right_val = self.eval(right)?;
                 self.eval_prefix_expression(operator, right_val)
-            },
-            Node::InfixExpression { left, operator, right, .. } => {
+            }
+            Node::InfixExpression {
+                left,
+                operator,
+                right,
+                ..
+            } => {
                 let left_val = self.eval(left)?;
                 let right_val = self.eval(right)?;
                 self.eval_infix_expression(operator, left_val, right_val)
-            },
-            Node::CallExpression { function, arguments, .. } => {
+            }
+            Node::CallExpression {
+                function,
+                arguments,
+                ..
+            } => {
                 // RES-158: method call desugar.
                 //
                 // If the callee is `TARGET.NAME`, evaluate `TARGET`
@@ -6866,14 +7234,77 @@ impl Interpreter {
                 let func = self.eval(function)?;
                 let args = self.eval_expressions(arguments)?;
                 self.apply_function(func, args)
-            },
+            }
             Node::ArrayLiteral { items, .. } => {
                 let mut out = Vec::with_capacity(items.len());
                 for item in items {
                     out.push(self.eval(item)?);
                 }
                 Ok(Value::Array(out))
-            },
+            }
+            // RES-127: tuple literal — evaluate each element.
+            // A zero-element `TupleLiteral` (unit `()`) evaluates to `Void`.
+            Node::TupleLiteral { items, .. } => {
+                if items.is_empty() {
+                    return Ok(Value::Void);
+                }
+                let mut out = Vec::with_capacity(items.len());
+                for item in items {
+                    out.push(self.eval(item)?);
+                }
+                Ok(Value::Tuple(out))
+            }
+            // RES-127: `t.N` positional tuple access.
+            Node::TupleIndex { tuple, index, span } => {
+                let tval = self.eval(tuple)?;
+                match tval {
+                    Value::Tuple(items) => {
+                        if *index >= items.len() {
+                            return Err(format!(
+                                "{}:{}: tuple index {} out of bounds (tuple has {} elements)",
+                                span.start.line,
+                                span.start.column,
+                                index,
+                                items.len()
+                            ));
+                        }
+                        Ok(items[*index].clone())
+                    }
+                    other => Err(format!(
+                        "{}:{}: `.{}` requires a tuple value, got {}",
+                        span.start.line, span.start.column, index, other
+                    )),
+                }
+            }
+            // RES-127: `let (x, y) = expr;` tuple destructuring.
+            Node::LetDestructureTuple { names, value, span } => {
+                let val = self.eval(value)?;
+                if matches!(val, Value::Return(_)) {
+                    return Ok(val);
+                }
+                match val {
+                    Value::Tuple(items) => {
+                        if names.len() != items.len() {
+                            return Err(format!(
+                                "{}:{}: tuple destructure arity mismatch: \
+                                 pattern has {} names, value has {} elements",
+                                span.start.line,
+                                span.start.column,
+                                names.len(),
+                                items.len()
+                            ));
+                        }
+                        for (name, item) in names.iter().zip(items.into_iter()) {
+                            self.env.set(name.clone(), item);
+                        }
+                        Ok(Value::Void)
+                    }
+                    other => Err(format!(
+                        "{}:{}: tuple destructure requires a tuple value, got {}",
+                        span.start.line, span.start.column, other
+                    )),
+                }
+            }
             // RES-148: `{k -> v, ...}` — evaluate each key / value and
             // coerce keys to `MapKey` (errors if a key isn't one of
             // the hashable primitives). Later insertions on the same
@@ -6908,16 +7339,20 @@ impl Interpreter {
                 }
                 Ok(Value::Set(set))
             }
-            Node::FunctionLiteral { parameters, body, requires, ensures, .. } => {
-                Ok(Value::Function {
-                    parameters: parameters.clone(),
-                    body: body.clone(),
-                    env: self.env.clone(),
-                    requires: requires.clone(),
-                    ensures: ensures.clone(),
-                    name: "<anon>".to_string(),
-                })
-            },
+            Node::FunctionLiteral {
+                parameters,
+                body,
+                requires,
+                ensures,
+                ..
+            } => Ok(Value::Function {
+                parameters: parameters.clone(),
+                body: body.clone(),
+                env: self.env.clone(),
+                requires: requires.clone(),
+                ensures: ensures.clone(),
+                name: "<anon>".to_string(),
+            }),
             Node::TryExpression { expr: inner, .. } => {
                 let v = self.eval(inner)?;
                 match v {
@@ -6931,13 +7366,12 @@ impl Interpreter {
                             payload,
                         })))
                     }
-                    other => Err(format!(
-                        "? operator expects a Result, got {}",
-                        other
-                    )),
+                    other => Err(format!("? operator expects a Result, got {}", other)),
                 }
-            },
-            Node::Match { scrutinee, arms, .. } => {
+            }
+            Node::Match {
+                scrutinee, arms, ..
+            } => {
                 let sval = self.eval(scrutinee)?;
                 for (pattern, guard, body) in arms {
                     if let Some(bindings) = self.match_pattern(pattern, &sval)? {
@@ -6961,7 +7395,9 @@ impl Interpreter {
                                 match gv {
                                     Ok(v) => self.is_truthy(&v),
                                     Err(e) => {
-                                        if had_scope { self.env = saved.clone(); }
+                                        if had_scope {
+                                            self.env = saved.clone();
+                                        }
                                         return Err(e);
                                     }
                                 }
@@ -6969,24 +7405,28 @@ impl Interpreter {
                             None => true,
                         };
                         if !guard_pass {
-                            if had_scope { self.env = saved; }
+                            if had_scope {
+                                self.env = saved;
+                            }
                             continue; // try next arm
                         }
                         let result = self.eval(body);
-                        if had_scope { self.env = saved; }
+                        if had_scope {
+                            self.env = saved;
+                        }
                         return result;
                     }
                 }
                 // No arm matched → void.
                 Ok(Value::Void)
-            },
+            }
             Node::StructDecl { .. } => {
                 // Declarations are pure compile-time metadata today.
                 // The typechecker (G7) will register them in a struct
                 // table; for now they're a runtime no-op, and Value
                 // construction trusts the literal.
                 Ok(Value::Void)
-            },
+            }
             // RES-128: `type NAME = TARGET;` is purely a
             // typechecker / documentation concern. Runtime never
             // sees aliases — by the time `eval` runs, every use
@@ -6995,7 +7435,11 @@ impl Interpreter {
             // RES-158: `impl <Struct> { ... }` evaluates each method
             // as if it were a top-level `fn` decl. Methods are already
             // mangled to `<Struct>$<method>` by the parser.
-            Node::ImplBlock { methods, struct_name, .. } => {
+            Node::ImplBlock {
+                methods,
+                struct_name,
+                ..
+            } => {
                 for method in methods {
                     // Detect duplicate-method-across-blocks: if the
                     // mangled name already resolves to a user Function
@@ -7007,13 +7451,15 @@ impl Interpreter {
                         return Err(format!(
                             "duplicate method: `{}::{}` defined more than once across impl blocks",
                             struct_name,
-                            mangled.strip_prefix(&format!("{}$", struct_name)).unwrap_or(mangled),
+                            mangled
+                                .strip_prefix(&format!("{}$", struct_name))
+                                .unwrap_or(mangled),
                         ));
                     }
                     self.eval(method)?;
                 }
                 Ok(Value::Void)
-            },
+            }
             Node::StructLiteral { name, fields, .. } => {
                 let mut out = Vec::with_capacity(fields.len());
                 for (fname, fexpr) in fields {
@@ -7023,26 +7469,27 @@ impl Interpreter {
                     name: name.clone(),
                     fields: out,
                 })
-            },
+            }
             Node::FieldAccess { target, field, .. } => {
                 let tval = self.eval(target)?;
                 match tval {
-                    Value::Struct { name, fields } => {
-                        fields
-                            .into_iter()
-                            .find(|(n, _)| n == field)
-                            .map(|(_, v)| v)
-                            .ok_or_else(|| {
-                                format!("Struct {} has no field '{}'", name, field)
-                            })
-                    }
+                    Value::Struct { name, fields } => fields
+                        .into_iter()
+                        .find(|(n, _)| n == field)
+                        .map(|(_, v)| v)
+                        .ok_or_else(|| format!("Struct {} has no field '{}'", name, field)),
                     other => Err(format!(
                         "Cannot access field '{}' on non-struct {:?}",
                         field, other
                     )),
                 }
-            },
-            Node::FieldAssignment { target, field, value, .. } => {
+            }
+            Node::FieldAssignment {
+                target,
+                field,
+                value,
+                ..
+            } => {
                 // Only support `IDENT.field = v` and `IDENT.f1.f2 = v`
                 // for MVP. The target tree is a chain of Identifier and
                 // FieldAccess nodes; we walk it to find the root binding,
@@ -7050,10 +7497,7 @@ impl Interpreter {
                 let new_val = self.eval(value)?;
                 let (root_name, path) = flatten_field_target(target, field);
                 let Some(root_name) = root_name else {
-                    return Err(
-                        "Field assignment target must start with an identifier"
-                            .to_string(),
-                    );
+                    return Err("Field assignment target must start with an identifier".to_string());
                 };
                 let current = self
                     .env
@@ -7062,7 +7506,7 @@ impl Interpreter {
                 let updated = set_nested_field(current, &path, new_val)?;
                 let _ = self.env.reassign(&root_name, updated);
                 Ok(Value::Void)
-            },
+            }
             Node::IndexExpression { target, index, .. } => {
                 let target_val = self.eval(target)?;
                 let index_val = self.eval(index)?;
@@ -7078,14 +7522,18 @@ impl Interpreter {
                             Ok(items[i as usize].clone())
                         }
                     }
-                    (Value::Array(_), other) => Err(format!(
-                        "Array index must be int, got {}",
-                        other
-                    )),
+                    (Value::Array(_), other) => {
+                        Err(format!("Array index must be int, got {}", other))
+                    }
                     (other, _) => Err(format!("Cannot index {:?}", other)),
                 }
-            },
-            Node::IndexAssignment { target, index, value, .. } => {
+            }
+            Node::IndexAssignment {
+                target,
+                index,
+                value,
+                ..
+            } => {
                 // RES-034: walk the LHS chain to support a[i][j]...[k] = v.
                 // The parser builds nested IndexExpression nodes; descend
                 // through them collecting each index (root-to-leaf order)
@@ -7095,14 +7543,16 @@ impl Interpreter {
                 let root_name = loop {
                     match cursor {
                         Node::Identifier { name, .. } => break name.clone(),
-                        Node::IndexExpression { target: inner_t, index: inner_i, .. } => {
+                        Node::IndexExpression {
+                            target: inner_t,
+                            index: inner_i,
+                            ..
+                        } => {
                             indices_rev.push(inner_i);
                             cursor = inner_t;
                         }
                         _ => {
-                            return Err(
-                                "Index assignment target must be an identifier".to_string()
-                            );
+                            return Err("Index assignment target must be an identifier".to_string());
                         }
                     }
                 };
@@ -7141,10 +7591,10 @@ impl Interpreter {
                 replace_at_path(&mut items, &path_indices, new_val)?;
                 let _ = self.env.reassign(&root_name, Value::Array(items));
                 Ok(Value::Void)
-            },
+            }
         }
     }
-    
+
     fn eval_program(&mut self, statements: &[span::Spanned<Node>]) -> RResult<Value> {
         // RES-018 + RES-050: hoist top-level fn bindings so call sites
         // can forward-reference. ONE pass suffices now — captured envs
@@ -7177,7 +7627,8 @@ impl Interpreter {
             // source span so `execute_file` can reformat them as
             // `filename:line:col: Runtime error: <msg>` — matching the
             // VM's RES-091/092 output shape.
-            result = self.eval(&statement.node)
+            result = self
+                .eval(&statement.node)
                 .map_err(|e| decorate_runtime_error(e, &statement.span))?;
             if let Value::Return(value) = result {
                 return Ok(*value);
@@ -7186,21 +7637,21 @@ impl Interpreter {
 
         Ok(result)
     }
-    
+
     fn eval_block_statement(&mut self, statements: &[Node]) -> RResult<Value> {
         let mut result = Value::Void;
-        
+
         for statement in statements {
             result = self.eval(statement)?;
-            
+
             if let Value::Return(_) = result {
                 return Ok(result);
             }
         }
-        
+
         Ok(result)
     }
-    
+
     fn eval_live_block(
         &mut self,
         body: &Node,
@@ -7265,10 +7716,7 @@ impl Interpreter {
                     // being silently healed. Process exits 1 with
                     // a diagnostic pointing at the override flag.
                     if panic_on_fault_enabled() {
-                        eprintln!(
-                            "\x1B[31m[LIVE BLOCK] fault: {}\x1B[0m",
-                            error
-                        );
+                        eprintln!("\x1B[31m[LIVE BLOCK] fault: {}\x1B[0m", error);
                         eprintln!(
                             "[fault] --panic-on-fault: aborting (disable with --no-panic-on-fault)"
                         );
@@ -7287,8 +7735,7 @@ impl Interpreter {
                     // Relaxed is fine; counters are diagnostic-
                     // quality, not a synchronization primitive.
                     if retry_count < MAX_RETRIES {
-                        LIVE_TOTAL_RETRIES
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        LIVE_TOTAL_RETRIES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     }
 
                     eprintln!(
@@ -7319,16 +7766,12 @@ impl Interpreter {
                         } else {
                             "Maximum retry attempts reached"
                         };
-                        eprintln!(
-                            "\x1B[31m[LIVE BLOCK] {}, propagating error\x1B[0m",
-                            reason
-                        );
+                        eprintln!("\x1B[31m[LIVE BLOCK] {}, propagating error\x1B[0m", reason);
                         // RES-141: bump the exhaustion counter
                         // before returning — tracks how many
                         // times any live block gave up across the
                         // whole run. Timeout counts as exhaustion.
-                        LIVE_TOTAL_EXHAUSTIONS
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        LIVE_TOTAL_EXHAUSTIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         // RES-140: footer note recording the
                         // nesting depth at which exhaustion fired.
                         // `LIVE_RETRY_STACK.len()` at this point
@@ -7387,7 +7830,7 @@ impl Interpreter {
             }
         }
     }
-    
+
     fn eval_assert(&mut self, condition: &Node, message: &Option<Box<Node>>) -> RResult<Value> {
         let condition_value = self.eval(condition)?;
 
@@ -7445,18 +7888,20 @@ impl Interpreter {
     /// comparisons we re-evaluate the operands to show their values;
     /// for anything else we just show the final value.
     fn format_assert_detail(&mut self, condition: &Node, final_value: &Value) -> String {
-        if let Node::InfixExpression { left, operator, right, .. } = condition
+        if let Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } = condition
             && matches!(operator.as_str(), "==" | "!=" | "<" | ">" | "<=" | ">=")
             && let (Ok(lv), Ok(rv)) = (self.eval(left), self.eval(right))
         {
-            return format!(
-                "condition {} {} {} was {}",
-                lv, operator, rv, final_value
-            );
+            return format!("condition {} {} {} was {}", lv, operator, rv, final_value);
         }
         format!("Condition evaluated to: {}", final_value)
     }
-    
+
     fn eval_prefix_expression(&mut self, operator: &str, right: Value) -> RResult<Value> {
         match operator {
             "!" => self.eval_bang_operator_expression(right),
@@ -7464,7 +7909,7 @@ impl Interpreter {
             _ => Err(format!("Unknown operator: {}{}", operator, right)),
         }
     }
-    
+
     fn eval_bang_operator_expression(&mut self, right: Value) -> RResult<Value> {
         match right {
             Value::Bool(b) => Ok(Value::Bool(!b)),
@@ -7477,7 +7922,7 @@ impl Interpreter {
             _ => Ok(Value::Bool(false)),
         }
     }
-    
+
     fn eval_minus_prefix_operator_expression(&mut self, right: Value) -> RResult<Value> {
         match right {
             Value::Int(i) => Ok(Value::Int(-i)),
@@ -7485,18 +7930,21 @@ impl Interpreter {
             _ => Err(format!("Unknown operator: -{}", right)),
         }
     }
-    
-    fn eval_infix_expression(&mut self, operator: &str, left: Value, right: Value) -> RResult<Value> {
+
+    fn eval_infix_expression(
+        &mut self,
+        operator: &str,
+        left: Value,
+        right: Value,
+    ) -> RResult<Value> {
         // String + <primitive> coercion (RES-008): when `+` has a string on
         // either side and the other side is a primitive (int / float / bool),
         // coerce the primitive to its textual form and concatenate. This only
         // applies to `+` — other operators keep their strict behavior.
         if operator == "+"
             && (matches!(left, Value::String(_)) || matches!(right, Value::String(_)))
-            && let (Some(ls), Some(rs)) = (
-                stringify_for_concat(&left),
-                stringify_for_concat(&right),
-            )
+            && let (Some(ls), Some(rs)) =
+                (stringify_for_concat(&left), stringify_for_concat(&right))
         {
             return Ok(Value::String(format!("{ls}{rs}")));
         }
@@ -7517,19 +7965,24 @@ impl Interpreter {
             // program is typechecked; the runtime guard below
             // catches the same shape for programs bypassing
             // `--typecheck`.
-            (Value::Int(_), Value::Float(_)) | (Value::Float(_), Value::Int(_)) => {
-                Err(format!(
-                    "Cannot apply '{}' to int and float — Resilient does not implicitly coerce between numeric types. Use `to_float(x)` or `to_int(x)` explicitly.",
-                    operator
-                ))
+            (Value::Int(_), Value::Float(_)) | (Value::Float(_), Value::Int(_)) => Err(format!(
+                "Cannot apply '{}' to int and float — Resilient does not implicitly coerce between numeric types. Use `to_float(x)` or `to_int(x)` explicitly.",
+                operator
+            )),
+            (Value::String(l), Value::String(r)) => {
+                self.eval_string_infix_expression(operator, l, r)
             }
-            (Value::String(l), Value::String(r)) => self.eval_string_infix_expression(operator, l, r),
             (Value::Bool(l), Value::Bool(r)) => self.eval_boolean_infix_expression(operator, l, r),
             _ => Err(format!("Type mismatch: {} {} {}", left, operator, right)),
         }
     }
-    
-    fn eval_integer_infix_expression(&mut self, operator: &str, left: i64, right: i64) -> RResult<Value> {
+
+    fn eval_integer_infix_expression(
+        &mut self,
+        operator: &str,
+        left: i64,
+        right: i64,
+    ) -> RResult<Value> {
         match operator {
             "+" => Ok(Value::Int(left + right)),
             "-" => Ok(Value::Int(left - right)),
@@ -7540,14 +7993,14 @@ impl Interpreter {
                 } else {
                     Ok(Value::Int(left / right))
                 }
-            },
+            }
             "%" => {
                 if right == 0 {
                     Err("Modulo by zero".to_string())
                 } else {
                     Ok(Value::Int(left % right))
                 }
-            },
+            }
             "&" => Ok(Value::Int(left & right)),
             "|" => Ok(Value::Int(left | right)),
             "^" => Ok(Value::Int(left ^ right)),
@@ -7557,14 +8010,14 @@ impl Interpreter {
                 } else {
                     Ok(Value::Int(left << right))
                 }
-            },
+            }
             ">>" => {
                 if !(0..64).contains(&right) {
                     Err(format!("shift amount out of range: {}", right))
                 } else {
                     Ok(Value::Int(left >> right))
                 }
-            },
+            }
             "==" => Ok(Value::Bool(left == right)),
             "!=" => Ok(Value::Bool(left != right)),
             "<" => Ok(Value::Bool(left < right)),
@@ -7574,8 +8027,13 @@ impl Interpreter {
             _ => Err(format!("Unknown operator: {} {} {}", left, operator, right)),
         }
     }
-    
-    fn eval_float_infix_expression(&mut self, operator: &str, left: f64, right: f64) -> RResult<Value> {
+
+    fn eval_float_infix_expression(
+        &mut self,
+        operator: &str,
+        left: f64,
+        right: f64,
+    ) -> RResult<Value> {
         match operator {
             "+" => Ok(Value::Float(left + right)),
             "-" => Ok(Value::Float(left - right)),
@@ -7586,14 +8044,14 @@ impl Interpreter {
                 } else {
                     Ok(Value::Float(left / right))
                 }
-            },
+            }
             "%" => {
                 if right == 0.0 {
                     Err("Modulo by zero".to_string())
                 } else {
                     Ok(Value::Float(left % right))
                 }
-            },
+            }
             "==" => Ok(Value::Bool(left == right)),
             "!=" => Ok(Value::Bool(left != right)),
             "<" => Ok(Value::Bool(left < right)),
@@ -7603,8 +8061,13 @@ impl Interpreter {
             _ => Err(format!("Unknown operator: {} {} {}", left, operator, right)),
         }
     }
-    
-    fn eval_string_infix_expression(&mut self, operator: &str, left: String, right: String) -> RResult<Value> {
+
+    fn eval_string_infix_expression(
+        &mut self,
+        operator: &str,
+        left: String,
+        right: String,
+    ) -> RResult<Value> {
         // Lexicographic comparison for <, >, <=, >= matches the standard
         // behavior users expect from strings in most languages.
         match operator {
@@ -7618,8 +8081,13 @@ impl Interpreter {
             _ => Err(format!("Unknown operator: {} {} {}", left, operator, right)),
         }
     }
-    
-    fn eval_boolean_infix_expression(&mut self, operator: &str, left: bool, right: bool) -> RResult<Value> {
+
+    fn eval_boolean_infix_expression(
+        &mut self,
+        operator: &str,
+        left: bool,
+        right: bool,
+    ) -> RResult<Value> {
         match operator {
             "==" => Ok(Value::Bool(left == right)),
             "!=" => Ok(Value::Bool(left != right)),
@@ -7628,21 +8096,28 @@ impl Interpreter {
             _ => Err(format!("Unknown operator: {} {} {}", left, operator, right)),
         }
     }
-    
+
     fn eval_expressions(&mut self, expressions: &[Node]) -> RResult<Vec<Value>> {
         let mut result = Vec::new();
-        
+
         for expr in expressions {
             let value = self.eval(expr)?;
             result.push(value);
         }
-        
+
         Ok(result)
     }
-    
+
     fn apply_function(&mut self, func: Value, args: Vec<Value>) -> RResult<Value> {
         match func {
-            Value::Function { parameters, body, env, requires, ensures, name } => {
+            Value::Function {
+                parameters,
+                body,
+                env,
+                requires,
+                ensures,
+                name,
+            } => {
                 // RES-050: env.clone() is now an Rc bump, not a deep
                 // copy. The self-bind hack from c58c4b1 is gone — the
                 // captured env IS the same RefCell that gets the
@@ -7707,7 +8182,13 @@ impl Interpreter {
             }
             Value::Builtin { func, .. } => func(&args),
             #[cfg(feature = "ffi")]
-            Value::Foreign { name: _, symbol, requires, ensures, trusted } => {
+            Value::Foreign {
+                name: _,
+                symbol,
+                requires,
+                ensures,
+                trusted,
+            } => {
                 // Bind params positionally as `_0`, `_1`, ... for contract eval.
                 let contract_env = Environment::new_enclosed(self.env.clone());
                 for (i, v) in args.iter().enumerate() {
@@ -7726,7 +8207,7 @@ impl Interpreter {
                     };
                     if !ok {
                         return Err(
-                            "contract violation: `requires` failed entering foreign fn".to_string(),
+                            "contract violation: `requires` failed entering foreign fn".to_string()
                         );
                     }
                 }
@@ -7746,10 +8227,8 @@ impl Interpreter {
                             _ => false,
                         };
                         if !ok && !trusted {
-                            return Err(
-                                "contract violation: `ensures` failed leaving foreign fn"
-                                    .to_string(),
-                            );
+                            return Err("contract violation: `ensures` failed leaving foreign fn"
+                                .to_string());
                         }
                     }
                 }
@@ -7758,7 +8237,7 @@ impl Interpreter {
             _ => Err(format!("Not a function: {}", func)),
         }
     }
-    
+
     /// RES-039: test a pattern against a value. On match, returns
     /// `Some(binding)` where binding is `Some((name, value))` for an
     /// identifier pattern or `None` otherwise. On no match, returns `None`.
@@ -7826,13 +8305,13 @@ fn start_repl() -> RustylineResult<()> {
     let mut interpreter = Interpreter::new();
     let mut rl = DefaultEditor::new()?;
     let mut type_check_enabled = false;
-    
+
     // Load history if available
     let history_path = match env::var("HOME") {
         Ok(home) => Path::new(&home).join(".resilient_history"),
         Err(_) => Path::new(".resilient_history").to_path_buf(),
     };
-    
+
     if history_path.exists()
         && let Err(err) = rl.load_history(&history_path)
     {
@@ -7841,28 +8320,28 @@ fn start_repl() -> RustylineResult<()> {
 
     println!("Resilient Programming Language REPL (v0.1.0)");
     println!("Type 'exit' to quit, 'help' for command list");
-    
+
     loop {
         let prompt = if type_check_enabled {
             ">> [typecheck] "
         } else {
             ">> "
         };
-        
+
         let readline = rl.readline(prompt);
-        
+
         match readline {
             Ok(line) => {
                 let input = line.trim();
-                
+
                 // Skip empty lines
                 if input.is_empty() {
                     continue;
                 }
-                
+
                 // Add to history
                 rl.add_history_entry(input)?;
-                
+
                 // Handle special commands
                 match input {
                     "exit" | "quit" => break,
@@ -7872,53 +8351,65 @@ fn start_repl() -> RustylineResult<()> {
                         println!("  exit       - Exit the REPL");
                         println!("  clear      - Clear the screen");
                         println!("  examples   - Show example code snippets");
-                        println!("  typecheck  - Toggle type checking (currently {})", 
-                                 if type_check_enabled { "enabled" } else { "disabled" });
+                        println!(
+                            "  typecheck  - Toggle type checking (currently {})",
+                            if type_check_enabled {
+                                "enabled"
+                            } else {
+                                "disabled"
+                            }
+                        );
                         continue;
-                    },
+                    }
                     "clear" => {
                         print!("\x1B[2J\x1B[1;1H"); // ANSI escape code to clear screen
                         io::stdout().flush().unwrap();
                         continue;
-                    },
+                    }
                     "typecheck" => {
                         type_check_enabled = !type_check_enabled;
-                        println!("Type checking {}", 
-                                 if type_check_enabled { "enabled" } else { "disabled" });
+                        println!(
+                            "Type checking {}",
+                            if type_check_enabled {
+                                "enabled"
+                            } else {
+                                "disabled"
+                            }
+                        );
                         continue;
-                    },
+                    }
                     "examples" => {
                         println!("Example code snippets:");
                         println!("\n1. Basic variable and function:");
                         println!("let x = 42;");
                         println!("fn add(int a, int b) {{ return a + b; }}");
                         println!("add(x, 10);");
-                        
+
                         println!("\n2. Live block example:");
                         println!("live {{");
                         println!("  let result = 100 / 0; // This would normally crash");
                         println!("  println(\"Result: \" + result);");
                         println!("}}");
-                        
+
                         println!("\n3. Assertion example:");
                         println!("let age = 25;");
                         println!("assert(age >= 18, \"Must be an adult\");");
                         println!("println(\"Access granted\");");
                         continue;
-                    },
+                    }
                     _ => {}
                 }
-                
+
                 // Parse the input
                 let lexer = Lexer::new(input.to_string());
                 let mut parser = Parser::new(lexer);
                 let program = parser.parse_program();
-                
+
                 // Skip evaluation if any parser errors were recorded
                 if !parser.errors.is_empty() {
                     continue;
                 }
-                
+
                 // Run type checker if enabled
                 if type_check_enabled {
                     match typechecker::TypeChecker::new().check_program(&program) {
@@ -7929,39 +8420,39 @@ fn start_repl() -> RustylineResult<()> {
                         }
                     }
                 }
-                
+
                 // Evaluate the input
                 match interpreter.eval(&program) {
                     Ok(value) => {
                         if !matches!(value, Value::Void) {
                             println!("{}", value);
                         }
-                    },
+                    }
                     Err(error) => {
                         eprintln!("\x1B[31mError: {}\x1B[0m", error); // Red error text
                     }
                 }
-            },
+            }
             Err(ReadlineError::Interrupted) => {
                 println!("CTRL-C");
                 break;
-            },
+            }
             Err(ReadlineError::Eof) => {
                 println!("CTRL-D");
                 break;
-            },
+            }
             Err(err) => {
                 eprintln!("Error: {}", err);
                 break;
             }
         }
     }
-    
+
     // Save history
     if let Err(err) = rl.save_history(&history_path) {
         eprintln!("Error saving history: {}", err);
     }
-    
+
     Ok(())
 }
 
@@ -8022,7 +8513,11 @@ fn has_line_col_prefix(msg: &str) -> bool {
 /// the offending source position is visually underlined.
 fn format_interpreter_error(filename: &str, err: &str) -> String {
     if has_line_col_prefix(err) {
-        let header = format!("{}:{}", filename, err.replacen(": ", ": Runtime error: ", 1));
+        let header = format!(
+            "{}:{}",
+            filename,
+            err.replacen(": ", ": Runtime error: ", 1)
+        );
         header
     } else {
         format!("Runtime error: {}", err)
@@ -8057,7 +8552,10 @@ fn render_with_caret(src: &str, err: &str, level: &str) -> String {
     // Try the bare `<line>:<col>: <msg>` form first.
     let mut it = err.splitn(3, ':');
     if let (Some(line_s), Some(col_s), Some(rest)) = (it.next(), it.next(), it.next())
-        && let (Ok(line), Ok(col)) = (line_s.trim().parse::<usize>(), col_s.trim().parse::<usize>())
+        && let (Ok(line), Ok(col)) = (
+            line_s.trim().parse::<usize>(),
+            col_s.trim().parse::<usize>(),
+        )
     {
         return format!(
             "{}\n{}",
@@ -8103,16 +8601,18 @@ fn dump_tokens_to_stdout(src: &str) {
     loop {
         let (tok, span) = lex.next_token_with_span();
         let is_eof = matches!(tok, Token::Eof);
-        let lexeme: String = if span.end.offset > span.start.offset
-            && span.end.offset <= chars.len()
-        {
-            chars[span.start.offset..span.end.offset].iter().collect()
-        } else {
-            String::new()
-        };
+        let lexeme: String =
+            if span.end.offset > span.start.offset && span.end.offset <= chars.len() {
+                chars[span.start.offset..span.end.offset].iter().collect()
+            } else {
+                String::new()
+            };
         // Escape newlines / quotes in the lexeme so block comments
         // and multi-line string literals stay readable.
-        let lexeme = lexeme.replace('\\', "\\\\").replace('"', "\\\"").replace('\n', "\\n");
+        let lexeme = lexeme
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n");
         println!(
             "{}:{}  {:?}(\"{}\")",
             span.start.line, span.start.column, tok, lexeme
@@ -8248,12 +8748,28 @@ fn classify_lex_token(
 
     let (ty, modifiers) = match tok {
         // Keywords.
-        Token::Function | Token::Let | Token::Live | Token::Assert | Token::Assume
-        | Token::If | Token::Else | Token::Return | Token::Static
-        | Token::While | Token::For | Token::In
-        | Token::Requires | Token::Ensures | Token::Invariant
-        | Token::Struct | Token::New | Token::Match | Token::Use
-        | Token::Impl | Token::Type | Token::Default
+        Token::Function
+        | Token::Let
+        | Token::Live
+        | Token::Assert
+        | Token::Assume
+        | Token::If
+        | Token::Else
+        | Token::Return
+        | Token::Static
+        | Token::While
+        | Token::For
+        | Token::In
+        | Token::Requires
+        | Token::Ensures
+        | Token::Invariant
+        | Token::Struct
+        | Token::New
+        | Token::Match
+        | Token::Use
+        | Token::Impl
+        | Token::Type
+        | Token::Default
         | Token::BoolLiteral(_) => (sem_tok::KEYWORD, 0),
 
         // Numeric / string / bytes literals.
@@ -8263,13 +8779,9 @@ fn classify_lex_token(
         // Identifiers: context-dependent.
         Token::Identifier(_) => match prev_kw {
             Some(Token::Function) => (sem_tok::FUNCTION, sem_tok::MOD_DECLARATION),
-            Some(Token::Struct) | Some(Token::Type) => {
-                (sem_tok::TYPE, sem_tok::MOD_DECLARATION)
-            }
+            Some(Token::Struct) | Some(Token::Type) => (sem_tok::TYPE, sem_tok::MOD_DECLARATION),
             Some(Token::New) => (sem_tok::TYPE, 0),
-            Some(Token::Let) | Some(Token::Static) => {
-                (sem_tok::VARIABLE, sem_tok::MOD_DECLARATION)
-            }
+            Some(Token::Let) | Some(Token::Static) => (sem_tok::VARIABLE, sem_tok::MOD_DECLARATION),
             _ => (sem_tok::VARIABLE, 0),
         },
 
@@ -8278,12 +8790,29 @@ fn classify_lex_token(
         // forms. Brackets / braces / parens / semicolons /
         // commas are delimiters not highlighted as operators in
         // any standard LSP legend, so they get no token.
-        Token::Plus | Token::Minus | Token::Multiply | Token::Divide
-        | Token::Modulo | Token::Assign | Token::Equal | Token::NotEqual
-        | Token::And | Token::Or | Token::BitAnd | Token::BitOr
-        | Token::BitXor | Token::ShiftLeft | Token::ShiftRight
-        | Token::Greater | Token::Less | Token::GreaterEqual | Token::LessEqual
-        | Token::Bang | Token::Dot | Token::FatArrow | Token::Arrow
+        Token::Plus
+        | Token::Minus
+        | Token::Multiply
+        | Token::Divide
+        | Token::Modulo
+        | Token::Assign
+        | Token::Equal
+        | Token::NotEqual
+        | Token::And
+        | Token::Or
+        | Token::BitAnd
+        | Token::BitOr
+        | Token::BitXor
+        | Token::ShiftLeft
+        | Token::ShiftRight
+        | Token::Greater
+        | Token::Less
+        | Token::GreaterEqual
+        | Token::LessEqual
+        | Token::Bang
+        | Token::Dot
+        | Token::FatArrow
+        | Token::Arrow
         | Token::Question => (sem_tok::OPERATOR, 0),
 
         // Delimiters + internal tokens: no semantic highlight.
@@ -8294,7 +8823,13 @@ fn classify_lex_token(
     if length == 0 {
         return None;
     }
-    Some(AbsSemToken { line, col, length, ty, modifiers })
+    Some(AbsSemToken {
+        line,
+        col,
+        length,
+        ty,
+        modifiers,
+    })
 }
 
 /// RES-187: scan `src` for `// ... \n` line comments and
@@ -8450,21 +8985,25 @@ fn emit_certificates(
     sign_key_path: Option<&Path>,
 ) -> RResult<usize> {
     fs::create_dir_all(dir).map_err(|e| {
-        format!("could not create certificate directory {}: {}", dir.display(), e)
+        format!(
+            "could not create certificate directory {}: {}",
+            dir.display(),
+            e
+        )
     })?;
 
     // RES-195: optionally load the signing key once so the write
     // loop can compute per-obligation sigs as it goes.
-    let priv_b: Option<[u8; 32]> = if let Some(key_path) = sign_key_path {
-        let pem = fs::read_to_string(key_path).map_err(|e| {
-            format!("could not read signing key {}: {}", key_path.display(), e)
-        })?;
-        Some(cert_sign::parse_private_key_pem(&pem).map_err(|e| {
-            format!("could not parse signing key {}: {}", key_path.display(), e)
-        })?)
-    } else {
-        None
-    };
+    let priv_b: Option<[u8; 32]> =
+        if let Some(key_path) = sign_key_path {
+            let pem = fs::read_to_string(key_path)
+                .map_err(|e| format!("could not read signing key {}: {}", key_path.display(), e))?;
+            Some(cert_sign::parse_private_key_pem(&pem).map_err(|e| {
+                format!("could not parse signing key {}: {}", key_path.display(), e)
+            })?)
+        } else {
+            None
+        };
 
     // Walk the certificates, write each one, and build the
     // manifest as we go.
@@ -8472,9 +9011,16 @@ fn emit_certificates(
         Vec::with_capacity(certificates.len());
     for cert in certificates {
         // Sanitize fn_name: only [A-Za-z0-9_] survives, others become '_'.
-        let safe: String = cert.fn_name
+        let safe: String = cert
+            .fn_name
             .chars()
-            .map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' })
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
             .collect();
         let filename = format!("{}__{}__{}.smt2", safe, cert.kind, cert.idx);
         let path = dir.join(&filename);
@@ -8536,8 +9082,8 @@ fn execute_file(
     verifier_timeout_ms: u32,
     warn_unverified: bool,
 ) -> RResult<()> {
-    let contents = fs::read_to_string(filename)
-        .map_err(|e| format!("Error reading file: {}", e))?;
+    let contents =
+        fs::read_to_string(filename).map_err(|e| format!("Error reading file: {}", e))?;
 
     let lexer = Lexer::new(contents.clone());
     let mut parser = Parser::new(lexer);
@@ -8555,7 +9101,10 @@ fn execute_file(
         for e in &parser.errors {
             eprintln!("{}", render_with_caret(&contents, e, "Parser error"));
         }
-        return Err(format!("Failed to parse program: {} parser error(s)", parser.errors.len()));
+        return Err(format!(
+            "Failed to parse program: {} parser error(s)",
+            parser.errors.len()
+        ));
     }
 
     // RES-073: resolve `use` imports before typecheck / interpret.
@@ -8636,18 +9185,15 @@ fn execute_file(
         // a panic or opaque message.
         #[cfg(feature = "jit")]
         {
-            let result = jit_backend::run(&program)
-                .map_err(|e| format!("{}: {}", filename, e))?;
+            let result = jit_backend::run(&program).map_err(|e| format!("{}: {}", filename, e))?;
             println!("{}", result);
             return Ok(());
         }
         #[cfg(not(feature = "jit"))]
         {
-            return Err(
-                "--jit requires the `jit` feature. Rebuild with:\n  \
+            return Err("--jit requires the `jit` feature. Rebuild with:\n  \
                  cargo build --features jit"
-                    .to_string(),
-            );
+                .to_string());
         }
     }
 
@@ -8656,8 +9202,7 @@ fn execute_file(
         // a Program (main chunk + function table), run it, print the
         // resulting value (mirroring the tree walker's behavior for
         // non-Void results).
-        let prog = compiler::compile(&program)
-            .map_err(|e| format!("VM compile error: {}", e))?;
+        let prog = compiler::compile(&program).map_err(|e| format!("VM compile error: {}", e))?;
         let result = vm::run(&prog).map_err(|e| {
             // RES-095: mirror the typechecker's `<file>:<line>:` shape
             // so VM runtime errors are editor-clickable when the
@@ -8707,7 +9252,8 @@ fn execute_file(
                             // SAFETY: intentional one-time-per-extern-decl leak to obtain a &'static str
                             // for Value::Foreign.name. The leaked memory is bounded by the number of
                             // extern decls in the program and is reclaimed when the process exits.
-                            let name: &'static str = Box::leak(d.resilient_name.clone().into_boxed_str());
+                            let name: &'static str =
+                                Box::leak(d.resilient_name.clone().into_boxed_str());
                             interpreter.env.set(
                                 d.resilient_name.clone(),
                                 Value::Foreign {
@@ -8751,8 +9297,7 @@ fn execute_file(
 /// typecheck. Tells the user exactly what the static verifier
 /// discharged vs deferred to runtime.
 fn print_verification_audit(stats: &typechecker::VerificationStats) {
-    let total_callsite =
-        stats.requires_discharged_at_compile + stats.requires_left_for_runtime;
+    let total_callsite = stats.requires_discharged_at_compile + stats.requires_left_for_runtime;
     println!();
     println!("\x1B[36m--- Verification Audit ---\x1B[0m");
     println!(
@@ -8788,7 +9333,10 @@ fn print_verification_audit(stats: &typechecker::VerificationStats) {
     );
     if total_callsite > 0 {
         let pct = (stats.requires_discharged_at_compile as f64 / total_callsite as f64) * 100.0;
-        println!("  static coverage:                          \x1B[36m{:.0}%\x1B[0m", pct);
+        println!(
+            "  static coverage:                          \x1B[36m{:.0}%\x1B[0m",
+            pct
+        );
     }
 
     // RES-192: per-fn inferred effect set. Sorted so the output
@@ -8867,10 +9415,7 @@ fn dispatch_pkg_subcommand(args: &[String]) -> Option<i32> {
                     // preserves the RES-205 invocation shape.
                     name = Some(a.clone());
                 } else {
-                    eprintln!(
-                        "Error: unexpected extra argument `{}` to `pkg init`",
-                        a
-                    );
+                    eprintln!("Error: unexpected extra argument `{}` to `pkg init`", a);
                     return Some(2);
                 }
                 i += 1;
@@ -9018,9 +9563,7 @@ fn dispatch_verify_cert_subcommand(args: &[String]) -> Option<i32> {
     }
 
     let Some(dir) = dir_path else {
-        eprintln!(
-            "Error: `resilient verify-cert <dir> [--pubkey <path>]` requires a directory"
-        );
+        eprintln!("Error: `resilient verify-cert <dir> [--pubkey <path>]` requires a directory");
         return Some(2);
     };
 
@@ -9042,7 +9585,10 @@ fn dispatch_verify_cert_subcommand(args: &[String]) -> Option<i32> {
         None => match cert_sign::parse_public_key_pem(cert_sign::EMBEDDED_PUBLIC_KEY_PEM) {
             Ok(b) => b,
             Err(e) => {
-                eprintln!("Error: embedded public key failed to parse: {} (this is a bug)", e);
+                eprintln!(
+                    "Error: embedded public key failed to parse: {} (this is a bug)",
+                    e
+                );
                 return Some(1);
             }
         },
@@ -9075,7 +9621,10 @@ fn dispatch_verify_cert_subcommand(args: &[String]) -> Option<i32> {
     };
     match cert_sign::verify_payload(&pub_b, &payload, &sig) {
         Ok(true) => {
-            println!("\x1B[32mcert: signature verified\x1B[0m for {}", dir.display());
+            println!(
+                "\x1B[32mcert: signature verified\x1B[0m for {}",
+                dir.display()
+            );
             Some(0)
         }
         Ok(false) => {
@@ -9232,14 +9781,19 @@ fn dispatch_verify_all_subcommand(args: &[String]) -> Option<i32> {
         // Step 2: signature (if present).
         let sig_ok = match (&o.sig, pub_b) {
             (Some(sig_hex), Some(pk)) => match cert_sign::parse_signature_hex(sig_hex) {
-                Ok(sig) => cert_sign::verify_payload(&pk, &cert_bytes, &sig)
-                    .unwrap_or(false),
+                Ok(sig) => cert_sign::verify_payload(&pk, &cert_bytes, &sig).unwrap_or(false),
                 Err(_) => false,
             },
             (Some(_), None) => false, // signed manifest but no key we could load
             (None, _) => true,        // no sig → vacuously passes
         };
-        let sig_label = if o.sig.is_none() { "-" } else if sig_ok { "ok" } else { "FAIL" };
+        let sig_label = if o.sig.is_none() {
+            "-"
+        } else if sig_ok {
+            "ok"
+        } else {
+            "FAIL"
+        };
 
         // Step 3: Z3.
         let z3_label = if !z3_ok {
@@ -9283,7 +9837,9 @@ fn short_label(fn_name: &str, kind: &str, idx: usize) -> String {
 /// Check whether `z3` is on PATH without shelling out at this
 /// point. Uses `which`-equivalent by walking `PATH`.
 fn which_z3() -> bool {
-    let Some(path_env) = env::var_os("PATH") else { return false };
+    let Some(path_env) = env::var_os("PATH") else {
+        return false;
+    };
     for p in env::split_paths(&path_env) {
         let candidate = p.join("z3");
         if candidate.is_file() {
@@ -9683,9 +10239,7 @@ fn main() {
                 // Only meaningful when paired with --emit-certificate.
                 i += 1;
                 if i >= args.len() {
-                    eprintln!(
-                        "Error: --sign-cert requires a path to the Ed25519 private key PEM"
-                    );
+                    eprintln!("Error: --sign-cert requires a path to the Ed25519 private key PEM");
                     std::process::exit(2);
                 }
                 sign_cert_key = Some(PathBuf::from(&args[i]));
@@ -9739,10 +10293,7 @@ fn main() {
                 });
             } else if let Some(val) = arg.strip_prefix("--verifier-timeout-ms=") {
                 verifier_timeout_ms = val.parse().unwrap_or_else(|_| {
-                    eprintln!(
-                        "Error: --verifier-timeout-ms expects a u32, got {:?}",
-                        val
-                    );
+                    eprintln!("Error: --verifier-timeout-ms expects a u32, got {:?}", val);
                     std::process::exit(2);
                 });
             } else if arg == "--warn-unverified" {
@@ -9765,18 +10316,12 @@ fn main() {
                     std::process::exit(2);
                 }
                 seed_override = Some(args[i].parse().unwrap_or_else(|_| {
-                    eprintln!(
-                        "Error: --seed expects a u64, got {:?}",
-                        args[i]
-                    );
+                    eprintln!("Error: --seed expects a u64, got {:?}", args[i]);
                     std::process::exit(2);
                 }));
             } else if let Some(val) = arg.strip_prefix("--seed=") {
                 seed_override = Some(val.parse().unwrap_or_else(|_| {
-                    eprintln!(
-                        "Error: --seed expects a u64, got {:?}",
-                        val
-                    );
+                    eprintln!("Error: --seed expects a u64, got {:?}", val);
                     std::process::exit(2);
                 }));
             } else if arg == "--panic-on-fault" {
@@ -9940,16 +10485,11 @@ fn main() {
             #[cfg(feature = "jit")]
             if jit_cache_stats {
                 let (h, m, c) = jit_backend::cache_stats();
-                eprintln!(
-                    "jit-cache: hits={} misses={} compiles={}",
-                    h, m, c
-                );
+                eprintln!("jit-cache: hits={} misses={} compiles={}", h, m, c);
             }
             #[cfg(not(feature = "jit"))]
             if jit_cache_stats {
-                eprintln!(
-                    "jit-cache: unavailable (built without `--features jit`)"
-                );
+                eprintln!("jit-cache: unavailable (built without `--features jit`)");
             }
             match run_result {
                 Ok(_) => {
@@ -10175,7 +10715,11 @@ mod tests {
     fn lex_bench_100kloc() {
         use std::time::Instant;
 
-        fn time_runs<F: FnMut() -> usize>(mut f: F, warmup: usize, runs: usize) -> (u128, u128, u128, usize) {
+        fn time_runs<F: FnMut() -> usize>(
+            mut f: F,
+            warmup: usize,
+            runs: usize,
+        ) -> (u128, u128, u128, usize) {
             for _ in 0..warmup {
                 let _ = f();
             }
@@ -10195,7 +10739,11 @@ mod tests {
 
         let input = build_100kloc_input();
         let line_count = input.lines().count();
-        println!("RES-109: lex-bench input = {} lines, {} bytes", line_count, input.len());
+        println!(
+            "RES-109: lex-bench input = {} lines, {} bytes",
+            line_count,
+            input.len()
+        );
 
         // Warm up 2, time 10 — the legacy lexer is char-by-char
         // over a large Vec<char>, on the order of ~10 s per pass
@@ -10219,12 +10767,8 @@ mod tests {
         let ratio_p50 = legacy_p50 as f64 / logos_p50.max(1) as f64;
         let ratio_mean = legacy_mean as f64 / logos_mean.max(1) as f64;
 
-        println!(
-            "| lexer   | p50 (us) | p99 (us) | mean (us) | tokens |"
-        );
-        println!(
-            "|---------|----------|----------|-----------|--------|"
-        );
+        println!("| lexer   | p50 (us) | p99 (us) | mean (us) | tokens |");
+        println!("|---------|----------|----------|-----------|--------|");
         println!(
             "| legacy  | {:>8} | {:>8} | {:>9} | {:>6} |",
             legacy_p50, legacy_p99, legacy_mean, legacy_n,
@@ -10233,14 +10777,8 @@ mod tests {
             "| logos   | {:>8} | {:>8} | {:>9} | {:>6} |",
             logos_p50, logos_p99, logos_mean, logos_n,
         );
-        println!(
-            "ratio p50:  legacy / logos = {:.2}×",
-            ratio_p50
-        );
-        println!(
-            "ratio mean: legacy / logos = {:.2}×",
-            ratio_mean
-        );
+        println!("ratio p50:  legacy / logos = {:.2}×", ratio_p50);
+        println!("ratio mean: legacy / logos = {:.2}×", ratio_mean);
     }
 
     #[cfg(feature = "logos-lexer")]
@@ -10490,7 +11028,11 @@ mod tests {
         let has_string = tokens
             .iter()
             .any(|t| matches!(t, Token::StringLiteral(s) if s == "hi\n"));
-        assert!(has_string, "expected StringLiteral(\"hi\\n\") in {:?}", tokens);
+        assert!(
+            has_string,
+            "expected StringLiteral(\"hi\\n\") in {:?}",
+            tokens
+        );
     }
 
     // ---------- Parser ----------
@@ -10531,9 +11073,15 @@ mod tests {
         assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
         match program {
             Node::Program(stmts) => match &stmts[0].node {
-                Node::Function { name, parameters, .. } => {
+                Node::Function {
+                    name, parameters, ..
+                } => {
                     assert_eq!(name, "main");
-                    assert!(parameters.is_empty(), "expected no params, got {:?}", parameters);
+                    assert!(
+                        parameters.is_empty(),
+                        "expected no params, got {:?}",
+                        parameters
+                    );
                 }
                 other => panic!("expected Function, got {:?}", other),
             },
@@ -10547,7 +11095,9 @@ mod tests {
         assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
         match program {
             Node::Program(stmts) => match &stmts[0].node {
-                Node::Function { name, parameters, .. } => {
+                Node::Function {
+                    name, parameters, ..
+                } => {
                     assert_eq!(name, "add");
                     assert_eq!(
                         parameters,
@@ -10667,7 +11217,10 @@ mod tests {
         // `Token::Default` isn't a prefix operator / atom.
         let src = "fn f() { return default; } f();";
         let (_program, errs) = parse(src);
-        assert!(!errs.is_empty(), "expected parse errors for `default` as expr, got none");
+        assert!(
+            !errs.is_empty(),
+            "expected parse errors for `default` as expr, got none"
+        );
     }
 
     #[test]
@@ -11131,11 +11684,7 @@ mod tests {
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let mut tc = typechecker::TypeChecker::new();
         let err = tc.check_program(&program).unwrap_err();
-        assert!(
-            err.contains("Non-exhaustive match"),
-            "err was: {}",
-            err
-        );
+        assert!(err.contains("Non-exhaustive match"), "err was: {}", err);
     }
 
     #[test]
@@ -11157,11 +11706,7 @@ mod tests {
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let mut tc = typechecker::TypeChecker::new();
         let err = tc.check_program(&program).unwrap_err();
-        assert!(
-            err.contains("missing `true`"),
-            "err was: {}",
-            err
-        );
+        assert!(err.contains("missing `true`"), "err was: {}", err);
     }
 
     #[test]
@@ -11204,11 +11749,7 @@ mod tests {
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let mut tc = typechecker::TypeChecker::new();
         let err = tc.check_program(&program).unwrap_err();
-        assert!(
-            err.contains("guard must be a boolean"),
-            "err was: {}",
-            err
-        );
+        assert!(err.contains("guard must be a boolean"), "err was: {}", err);
     }
 
     // --- RES-156: array comprehensions ---
@@ -11585,9 +12126,11 @@ mod tests {
                 Node::Function { body, .. } => walk(body),
                 Node::Block { stmts, .. } => stmts.iter().find_map(walk),
                 Node::LetStatement { value, .. } => walk(value),
-                Node::IfStatement { consequence, alternative, .. } => {
-                    walk(consequence).or_else(|| alternative.as_ref().and_then(|a| walk(a)))
-                }
+                Node::IfStatement {
+                    consequence,
+                    alternative,
+                    ..
+                } => walk(consequence).or_else(|| alternative.as_ref().and_then(|a| walk(a))),
                 _ => None,
             }
         }
@@ -11679,9 +12222,7 @@ mod tests {
             fields[0].1
         );
         // Second is shorthand Identifier(y)
-        assert!(
-            matches!(&fields[1].1, Node::Identifier { name, .. } if name == "y")
-        );
+        assert!(matches!(&fields[1].1, Node::Identifier { name, .. } if name == "y"));
     }
 
     #[test]
@@ -11807,15 +12348,11 @@ mod tests {
     #[test]
     fn bytes_slice_rejects_out_of_range() {
         let b = Value::Bytes(vec![1, 2, 3]);
-        let err = builtin_bytes_slice(&[b.clone(), Value::Int(0), Value::Int(10)])
-            .unwrap_err();
+        let err = builtin_bytes_slice(&[b.clone(), Value::Int(0), Value::Int(10)]).unwrap_err();
         assert!(err.contains("out of range"), "err was: {}", err);
-        let err =
-            builtin_bytes_slice(&[b.clone(), Value::Int(-1), Value::Int(1)])
-                .unwrap_err();
+        let err = builtin_bytes_slice(&[b.clone(), Value::Int(-1), Value::Int(1)]).unwrap_err();
         assert!(err.contains("negative index"), "err was: {}", err);
-        let err = builtin_bytes_slice(&[b, Value::Int(2), Value::Int(1)])
-            .unwrap_err();
+        let err = builtin_bytes_slice(&[b, Value::Int(2), Value::Int(1)]).unwrap_err();
         assert!(err.contains("start must be <= end"), "err was: {}", err);
     }
 
@@ -11846,11 +12383,7 @@ mod tests {
     #[test]
     fn byte_at_rejects_non_bytes_first_arg() {
         let err = builtin_byte_at(&[Value::Int(1), Value::Int(0)]).unwrap_err();
-        assert!(
-            err.contains("expected (Bytes, Int)"),
-            "err was: {}",
-            err
-        );
+        assert!(err.contains("expected (Bytes, Int)"), "err was: {}", err);
     }
 
     #[test]
@@ -11892,7 +12425,9 @@ mod tests {
         // and the key is unique per call via `env_name`, so
         // the race window this API guards against doesn't
         // exist here.
-        unsafe { std::env::set_var(&key, "hello"); }
+        unsafe {
+            std::env::set_var(&key, "hello");
+        }
         let got = builtin_env(&[Value::String(key.clone())]).unwrap();
         match got {
             Value::Result { ok: true, payload } => match *payload {
@@ -11903,7 +12438,9 @@ mod tests {
         }
         // SAFETY: same rationale as the set_var above —
         // serialized by ENV_TEST_LOCK, unique key.
-        unsafe { std::env::remove_var(&key); }
+        unsafe {
+            std::env::remove_var(&key);
+        }
     }
 
     #[test]
@@ -11915,7 +12452,9 @@ mod tests {
         // still have collisions.
         // SAFETY: same rationale as the set_var above — serialized
         // by ENV_TEST_LOCK, unique key.
-        unsafe { std::env::remove_var(&key); }
+        unsafe {
+            std::env::remove_var(&key);
+        }
         let got = builtin_env(&[Value::String(key)]).unwrap();
         match got {
             Value::Result { ok: false, payload } => match *payload {
@@ -11936,11 +12475,7 @@ mod tests {
     fn env_rejects_wrong_arity() {
         let err = builtin_env(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
-        let err = builtin_env(&[
-            Value::String("A".into()),
-            Value::String("B".into()),
-        ])
-        .unwrap_err();
+        let err = builtin_env(&[Value::String("A".into()), Value::String("B".into())]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 
@@ -11992,25 +12527,21 @@ mod tests {
         let _g = RNG_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_rng(42);
         let a: Vec<i64> = (0..10)
-            .map(|_| {
-                match builtin_random_int(&[Value::Int(0), Value::Int(1_000_000)])
-                    .unwrap()
-                {
+            .map(
+                |_| match builtin_random_int(&[Value::Int(0), Value::Int(1_000_000)]).unwrap() {
                     Value::Int(n) => n,
                     other => panic!("expected Int, got {:?}", other),
-                }
-            })
+                },
+            )
             .collect();
         reset_rng(42);
         let b: Vec<i64> = (0..10)
-            .map(|_| {
-                match builtin_random_int(&[Value::Int(0), Value::Int(1_000_000)])
-                    .unwrap()
-                {
+            .map(
+                |_| match builtin_random_int(&[Value::Int(0), Value::Int(1_000_000)]).unwrap() {
                     Value::Int(n) => n,
                     other => panic!("expected Int, got {:?}", other),
-                }
-            })
+                },
+            )
             .collect();
         assert_eq!(a, b, "same seed must produce same sequence");
     }
@@ -12022,11 +12553,7 @@ mod tests {
             let v = builtin_random_int(&[Value::Int(10), Value::Int(20)]).unwrap();
             match v {
                 Value::Int(n) => {
-                    assert!(
-                        (10..20).contains(&n),
-                        "value {} outside [10, 20)",
-                        n
-                    );
+                    assert!((10..20).contains(&n), "value {} outside [10, 20)", n);
                 }
                 other => panic!("expected Int, got {:?}", other),
             }
@@ -12035,18 +12562,15 @@ mod tests {
 
     #[test]
     fn random_int_rejects_reversed_bounds() {
-        let err =
-            builtin_random_int(&[Value::Int(5), Value::Int(5)]).unwrap_err();
+        let err = builtin_random_int(&[Value::Int(5), Value::Int(5)]).unwrap_err();
         assert!(err.contains("hi must be > lo"), "err was: {}", err);
-        let err =
-            builtin_random_int(&[Value::Int(10), Value::Int(5)]).unwrap_err();
+        let err = builtin_random_int(&[Value::Int(10), Value::Int(5)]).unwrap_err();
         assert!(err.contains("hi must be > lo"), "err was: {}", err);
     }
 
     #[test]
     fn random_int_rejects_non_int_args() {
-        let err =
-            builtin_random_int(&[Value::Float(1.0), Value::Int(5)]).unwrap_err();
+        let err = builtin_random_int(&[Value::Float(1.0), Value::Int(5)]).unwrap_err();
         assert!(err.contains("expected (Int, Int)"), "err was: {}", err);
     }
 
@@ -12063,11 +12587,7 @@ mod tests {
             let v = builtin_random_float(&[]).unwrap();
             match v {
                 Value::Float(f) => {
-                    assert!(
-                        (0.0..1.0).contains(&f),
-                        "value {} outside [0.0, 1.0)",
-                        f
-                    );
+                    assert!((0.0..1.0).contains(&f), "value {} outside [0.0, 1.0)", f);
                 }
                 other => panic!("expected Float, got {:?}", other),
             }
@@ -12138,11 +12658,7 @@ mod tests {
     fn set_insert_rejects_non_hashable_element() {
         let s = builtin_set_new(&[]).unwrap();
         let err = builtin_set_insert(&[s, Value::Float(1.5)]).unwrap_err();
-        assert!(
-            err.contains("Set element must be"),
-            "err was: {}",
-            err
-        );
+        assert!(err.contains("Set element must be"), "err was: {}", err);
     }
 
     #[test]
@@ -12170,7 +12686,11 @@ mod tests {
     #[test]
     fn set_has_rejects_non_set_first_arg() {
         let err = builtin_set_has(&[Value::Int(1), Value::Int(2)]).unwrap_err();
-        assert!(err.contains("first argument must be a Set"), "err was: {}", err);
+        assert!(
+            err.contains("first argument must be a Set"),
+            "err was: {}",
+            err
+        );
     }
 
     #[test]
@@ -12269,11 +12789,7 @@ mod tests {
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let mut interp = Interpreter::new();
         let err = interp.eval(&program).unwrap_err();
-        assert!(
-            err.contains("Set element must be"),
-            "err was: {}",
-            err
-        );
+        assert!(err.contains("Set element must be"), "err was: {}", err);
     }
 
     // --- RES-147: clock_ms() monotonic builtin ---
@@ -12317,12 +12833,7 @@ mod tests {
         let mut prev = as_int(builtin_clock_ms(&[]).unwrap());
         for _ in 0..10 {
             let cur = as_int(builtin_clock_ms(&[]).unwrap());
-            assert!(
-                cur >= prev,
-                "clock_ms regressed: {} -> {}",
-                prev,
-                cur
-            );
+            assert!(cur >= prev, "clock_ms regressed: {} -> {}", prev, cur);
             prev = cur;
         }
     }
@@ -12362,9 +12873,21 @@ mod tests {
 
     #[test]
     fn sin_cos_tan_zero() {
-        close(as_float(builtin_sin(&[Value::Float(0.0)]).unwrap()), 0.0, "sin(0)");
-        close(as_float(builtin_cos(&[Value::Float(0.0)]).unwrap()), 1.0, "cos(0)");
-        close(as_float(builtin_tan(&[Value::Float(0.0)]).unwrap()), 0.0, "tan(0)");
+        close(
+            as_float(builtin_sin(&[Value::Float(0.0)]).unwrap()),
+            0.0,
+            "sin(0)",
+        );
+        close(
+            as_float(builtin_cos(&[Value::Float(0.0)]).unwrap()),
+            1.0,
+            "cos(0)",
+        );
+        close(
+            as_float(builtin_tan(&[Value::Float(0.0)]).unwrap()),
+            0.0,
+            "tan(0)",
+        );
     }
 
     #[test]
@@ -12372,22 +12895,42 @@ mod tests {
         // sin(π/2) = 1, cos(π/2) ≈ 0 (the f64 rep of π/2 has a
         // tiny residual so cos is ~6e-17; well within 1e-9).
         let pi_2 = std::f64::consts::FRAC_PI_2;
-        close(as_float(builtin_sin(&[Value::Float(pi_2)]).unwrap()), 1.0, "sin(π/2)");
-        close(as_float(builtin_cos(&[Value::Float(pi_2)]).unwrap()), 0.0, "cos(π/2)");
+        close(
+            as_float(builtin_sin(&[Value::Float(pi_2)]).unwrap()),
+            1.0,
+            "sin(π/2)",
+        );
+        close(
+            as_float(builtin_cos(&[Value::Float(pi_2)]).unwrap()),
+            0.0,
+            "cos(π/2)",
+        );
     }
 
     #[test]
     fn tan_pi_over_4() {
         // tan(π/4) = 1.
         let pi_4 = std::f64::consts::FRAC_PI_4;
-        close(as_float(builtin_tan(&[Value::Float(pi_4)]).unwrap()), 1.0, "tan(π/4)");
+        close(
+            as_float(builtin_tan(&[Value::Float(pi_4)]).unwrap()),
+            1.0,
+            "tan(π/4)",
+        );
     }
 
     #[test]
     fn ln_of_e_and_one() {
         let e = std::f64::consts::E;
-        close(as_float(builtin_ln(&[Value::Float(e)]).unwrap()), 1.0, "ln(e)");
-        close(as_float(builtin_ln(&[Value::Float(1.0)]).unwrap()), 0.0, "ln(1)");
+        close(
+            as_float(builtin_ln(&[Value::Float(e)]).unwrap()),
+            1.0,
+            "ln(e)",
+        );
+        close(
+            as_float(builtin_ln(&[Value::Float(1.0)]).unwrap()),
+            0.0,
+            "ln(1)",
+        );
     }
 
     #[test]
@@ -12401,11 +12944,7 @@ mod tests {
     #[test]
     fn ln_rejects_int_per_res130() {
         let err = builtin_ln(&[Value::Int(10)]).unwrap_err();
-        assert!(
-            err.contains("expected Float"),
-            "err was: {}",
-            err
-        );
+        assert!(err.contains("expected Float"), "err was: {}", err);
         assert!(
             err.contains("to_float"),
             "diagnostic must hint at `to_float` bridge: {}",
@@ -12426,26 +12965,31 @@ mod tests {
 
     #[test]
     fn log_rejects_base_one() {
-        let err =
-            builtin_log(&[Value::Float(1.0), Value::Float(10.0)]).unwrap_err();
+        let err = builtin_log(&[Value::Float(1.0), Value::Float(10.0)]).unwrap_err();
         assert!(err.contains("base must not be 1"), "err was: {}", err);
     }
 
     #[test]
     fn log_rejects_non_positive_base_and_value() {
-        let err =
-            builtin_log(&[Value::Float(-2.0), Value::Float(8.0)]).unwrap_err();
+        let err = builtin_log(&[Value::Float(-2.0), Value::Float(8.0)]).unwrap_err();
         assert!(err.contains("base must be > 0"), "err was: {}", err);
-        let err =
-            builtin_log(&[Value::Float(2.0), Value::Float(0.0)]).unwrap_err();
+        let err = builtin_log(&[Value::Float(2.0), Value::Float(0.0)]).unwrap_err();
         assert!(err.contains("value must be > 0"), "err was: {}", err);
     }
 
     #[test]
     fn exp_zero_one_and_ln_roundtrip() {
-        close(as_float(builtin_exp(&[Value::Float(0.0)]).unwrap()), 1.0, "exp(0)");
+        close(
+            as_float(builtin_exp(&[Value::Float(0.0)]).unwrap()),
+            1.0,
+            "exp(0)",
+        );
         let e = std::f64::consts::E;
-        close(as_float(builtin_exp(&[Value::Float(1.0)]).unwrap()), e, "exp(1)");
+        close(
+            as_float(builtin_exp(&[Value::Float(1.0)]).unwrap()),
+            e,
+            "exp(1)",
+        );
         // ln(exp(x)) ≈ x for a mid-range value
         let x = 2.5;
         let round = builtin_ln(&[builtin_exp(&[Value::Float(x)]).unwrap()]).unwrap();
@@ -12467,12 +13011,16 @@ mod tests {
     #[test]
     fn trig_log_exp_arity_errors() {
         assert!(builtin_sin(&[]).unwrap_err().contains("expected 1"));
-        assert!(builtin_cos(&[Value::Float(0.0), Value::Float(0.0)])
-            .unwrap_err()
-            .contains("expected 1"));
-        assert!(builtin_log(&[Value::Float(2.0)])
-            .unwrap_err()
-            .contains("expected 2"));
+        assert!(
+            builtin_cos(&[Value::Float(0.0), Value::Float(0.0)])
+                .unwrap_err()
+                .contains("expected 1")
+        );
+        assert!(
+            builtin_log(&[Value::Float(2.0)])
+                .unwrap_err()
+                .contains("expected 2")
+        );
     }
 
     // --- RES-145: string builtins — replace / to_upper / to_lower / format ---
@@ -12546,10 +13094,7 @@ mod tests {
     fn format_interpolates_placeholders_in_order() {
         let v = builtin_format(&[
             Value::String("hello {}, you are {} years old".into()),
-            Value::Array(vec![
-                Value::String("alice".into()),
-                Value::Int(30),
-            ]),
+            Value::Array(vec![Value::String("alice".into()), Value::Int(30)]),
         ])
         .unwrap();
         assert_eq!(s145(v), "hello alice, you are 30 years old");
@@ -12574,11 +13119,7 @@ mod tests {
             Value::Array(vec![Value::Int(1)]),
         ])
         .unwrap_err();
-        assert!(
-            err.contains("not enough arguments"),
-            "err was: {}",
-            err
-        );
+        assert!(err.contains("not enough arguments"), "err was: {}", err);
     }
 
     #[test]
@@ -12593,11 +13134,8 @@ mod tests {
 
     #[test]
     fn format_errors_on_unmatched_close_brace() {
-        let err = builtin_format(&[
-            Value::String("close }here".into()),
-            Value::Array(vec![]),
-        ])
-        .unwrap_err();
+        let err = builtin_format(&[Value::String("close }here".into()), Value::Array(vec![])])
+            .unwrap_err();
         assert!(err.contains("unmatched `}`"), "err was: {}", err);
     }
 
@@ -12614,11 +13152,7 @@ mod tests {
 
     #[test]
     fn format_rejects_non_array_second_arg() {
-        let err = builtin_format(&[
-            Value::String("{}".into()),
-            Value::Int(42),
-        ])
-        .unwrap_err();
+        let err = builtin_format(&[Value::String("{}".into()), Value::Int(42)]).unwrap_err();
         assert!(err.contains("expected (string, array)"), "err was: {}", err);
     }
 
@@ -12687,22 +13221,15 @@ mod tests {
     #[test]
     fn builtin_input_rejects_non_string_prompt() {
         let err = builtin_input(&[Value::Int(42)]).unwrap_err();
-        assert!(
-            err.contains("expected String prompt"),
-            "err was: {}",
-            err
-        );
+        assert!(err.contains("expected String prompt"), "err was: {}", err);
     }
 
     #[test]
     fn builtin_input_rejects_wrong_arity() {
         let err = builtin_input(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
-        let err = builtin_input(&[
-            Value::String("a".into()),
-            Value::String("b".into()),
-        ])
-        .unwrap_err();
+        let err =
+            builtin_input(&[Value::String("a".into()), Value::String("b".into())]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 
@@ -12715,12 +13242,7 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        std::env::temp_dir().join(format!(
-            "res_143_{}_{}_{}.tmp",
-            tag,
-            std::process::id(),
-            n
-        ))
+        std::env::temp_dir().join(format!("res_143_{}_{}_{}.tmp", tag, std::process::id(), n))
     }
 
     #[test]
@@ -12749,8 +13271,8 @@ mod tests {
         let path = tmp_path("missing");
         // Ensure it doesn't exist.
         let _ = std::fs::remove_file(&path);
-        let err = builtin_file_read(&[Value::String(path.to_string_lossy().to_string())])
-            .unwrap_err();
+        let err =
+            builtin_file_read(&[Value::String(path.to_string_lossy().to_string())]).unwrap_err();
         assert!(
             err.starts_with("file_read:"),
             "expected `file_read:` prefix, got: {}",
@@ -12763,8 +13285,8 @@ mod tests {
         let path = tmp_path("nonutf8");
         // 0xFF is never a valid UTF-8 start byte.
         std::fs::write(&path, [0xFFu8, 0xFE, 0xFD]).expect("write bytes");
-        let err = builtin_file_read(&[Value::String(path.to_string_lossy().to_string())])
-            .unwrap_err();
+        let err =
+            builtin_file_read(&[Value::String(path.to_string_lossy().to_string())]).unwrap_err();
         assert!(
             err.contains("not valid UTF-8"),
             "expected UTF-8 error, got: {}",
@@ -12803,12 +13325,7 @@ mod tests {
     #[test]
     fn map_insert_then_get_round_trip() {
         let m = builtin_map_new(&[]).unwrap();
-        let m = builtin_map_insert(&[
-            m,
-            Value::String("a".into()),
-            Value::Int(1),
-        ])
-        .unwrap();
+        let m = builtin_map_insert(&[m, Value::String("a".into()), Value::Int(1)]).unwrap();
         let r = builtin_map_get(&[m, Value::String("a".into())]).unwrap();
         match r {
             Value::Result { ok: true, payload } => match *payload {
@@ -12859,7 +13376,10 @@ mod tests {
                         other => panic!("non-string key, got {:?}", other),
                     })
                     .collect();
-                assert_eq!(strs, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+                assert_eq!(
+                    strs,
+                    vec!["a".to_string(), "b".to_string(), "c".to_string()]
+                );
             }
             other => panic!("expected Array, got {:?}", other),
         }
@@ -12915,8 +13435,14 @@ mod tests {
         match interp.env.get("m").unwrap() {
             Value::Map(m) => {
                 assert_eq!(m.len(), 2);
-                assert!(matches!(m.get(&MapKey::Str("a".into())), Some(Value::Int(1))));
-                assert!(matches!(m.get(&MapKey::Str("b".into())), Some(Value::Int(2))));
+                assert!(matches!(
+                    m.get(&MapKey::Str("a".into())),
+                    Some(Value::Int(1))
+                ));
+                assert!(matches!(
+                    m.get(&MapKey::Str("b".into())),
+                    Some(Value::Int(2))
+                ));
             }
             other => panic!("expected Map, got {:?}", other),
         }
@@ -12990,18 +13516,28 @@ mod tests {
             panic!("expected Line struct, got {:?}", l);
         };
         let a = fields.iter().find(|(n, _)| n == "a").map(|(_, v)| v);
-        let Some(Value::Struct { fields: a_fields, .. }) = a else {
+        let Some(Value::Struct {
+            fields: a_fields, ..
+        }) = a
+        else {
             panic!("expected Point struct for a, got {:?}", a);
         };
         let x = a_fields.iter().find(|(n, _)| n == "x").map(|(_, v)| v);
         assert!(matches!(x, Some(Value::Int(99))), "got x = {:?}", x);
         // b is unchanged.
         let b = fields.iter().find(|(n, _)| n == "b").map(|(_, v)| v);
-        let Some(Value::Struct { fields: b_fields, .. }) = b else {
+        let Some(Value::Struct {
+            fields: b_fields, ..
+        }) = b
+        else {
             panic!("expected Point struct for b, got {:?}", b);
         };
         let bx = b_fields.iter().find(|(n, _)| n == "x").map(|(_, v)| v);
-        assert!(matches!(bx, Some(Value::Int(3))), "b.x should be unchanged, got {:?}", bx);
+        assert!(
+            matches!(bx, Some(Value::Int(3))),
+            "b.x should be unchanged, got {:?}",
+            bx
+        );
     }
 
     // --- RES-158: impl blocks + method calls ---
@@ -13176,7 +13712,9 @@ mod tests {
         let tokens = tokenize(". 1.5");
         assert_eq!(tokens[0], Token::Dot);
         assert!(
-            tokens.iter().any(|t| matches!(t, Token::FloatLiteral(f) if *f == 1.5)),
+            tokens
+                .iter()
+                .any(|t| matches!(t, Token::FloatLiteral(f) if *f == 1.5)),
             "expected FloatLiteral(1.5) to follow, got {:?}",
             tokens
         );
@@ -13249,13 +13787,15 @@ mod tests {
 
     #[test]
     fn audit_counts_discharged_and_runtime() {
-        let (program, _e) = parse(r#"
+        let (program, _e) = parse(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             let r1 = pos(5);
             let n = 7;
             let r2 = pos(n);
             let dyn_val = pos(r1);  // r1's type is Any → not foldable
-        "#);
+        "#,
+        );
         let mut tc = typechecker::TypeChecker::new();
         tc.check_program(&program).unwrap();
         assert!(
@@ -13272,43 +13812,53 @@ mod tests {
     fn caller_requires_chains_to_callee() {
         // pos requires x > 0; caller requires n == 5; pos(n) holds
         // because 5 > 0 is statically true.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             fn caller(int n) requires n == 5 {
                 let r = pos(n);
             }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn caller_requires_violates_callee_caught() {
         // caller asserts n == 0; calls pos(n); pos requires x > 0;
         // 0 > 0 is false → reject.
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             fn caller(int n) requires n == 0 {
                 let r = pos(n);
             }
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(err.contains("Contract violation"), "got: {}", err);
     }
 
     #[test]
     fn caller_without_requires_still_works() {
         // No assumptions to propagate; call still folds normally.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             fn caller(int n) {
                 let r = pos(5);
             }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn caller_requires_does_not_leak_across_functions() {
         // The assumption is restored at end of body, so a later fn
         // sees an unconstrained n.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             fn first(int n) requires n == 5 {
                 let a = pos(n);
@@ -13318,7 +13868,9 @@ mod tests {
                 // not be rejected by stale assumptions.
                 let b = pos(n);
             }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     // ---------- Flow-sensitive if-branch assumptions (RES-064) ----------
@@ -13327,28 +13879,34 @@ mod tests {
     fn if_branch_assumption_satisfies_contract() {
         // We assume `x == 5` inside the consequence; pos requires x > 0;
         // 5 > 0 is true, so discharged.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             fn caller(int x) {
                 if x == 5 {
                     let r = pos(x);
                 }
             }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn if_branch_assumption_rejects_violating_call() {
         // We assume `x == 0` inside the consequence; pos requires x > 0;
         // 0 > 0 is false → reject.
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             fn caller(int x) {
                 if x == 0 {
                     let r = pos(x);
                 }
             }
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(err.contains("Contract violation"), "got: {}", err);
     }
 
@@ -13356,7 +13914,8 @@ mod tests {
     fn if_branch_assumption_does_not_leak_outside() {
         // After the if, x's value is unknown again.
         // pos(x) outside the if → not rejected (left for runtime)
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             fn caller(int x) {
                 if x == 0 {
@@ -13364,20 +13923,25 @@ mod tests {
                 }
                 let r2 = pos(x);  // x's assumption is gone now
             }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn if_literal_eq_ident_form_works_too() {
         // `5 == x` form, not just `x == 5`.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             fn caller(int x) {
                 if 5 == x {
                     let r = pos(x);
                 }
             }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     // ---------- Elide proven runtime checks (RES-068) ----------
@@ -13406,8 +13970,10 @@ mod tests {
         interp.eval(&program).unwrap();
         match interp.env.get("pos").unwrap() {
             Value::Function { requires, .. } => {
-                assert!(requires.is_empty(),
-                    "expected requires to be elided after proof");
+                assert!(
+                    requires.is_empty(),
+                    "expected requires to be elided after proof"
+                );
             }
             other => panic!("expected Function, got {:?}", other),
         }
@@ -13428,15 +13994,20 @@ mod tests {
         let mut tc = typechecker::TypeChecker::new();
         tc.check_program(&program).unwrap();
         let proven = tc.stats.fully_provable_fns();
-        assert!(!proven.contains("pos"),
-            "pos has an unproven call site, should NOT be fully proven");
+        assert!(
+            !proven.contains("pos"),
+            "pos has an unproven call site, should NOT be fully proven"
+        );
 
         let mut interp = Interpreter::new().with_proven_fns(proven);
         interp.eval(&program).unwrap();
         match interp.env.get("pos").unwrap() {
             Value::Function { requires, .. } => {
-                assert_eq!(requires.len(), 1,
-                    "expected requires to be retained for runtime check");
+                assert_eq!(
+                    requires.len(),
+                    1,
+                    "expected requires to be retained for runtime check"
+                );
             }
             other => panic!("expected Function, got {:?}", other),
         }
@@ -13446,32 +14017,41 @@ mod tests {
 
     #[test]
     fn const_let_satisfies_contract() {
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             let n = 5;
             let r = pos(n);
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn const_let_violates_contract() {
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             let bad = 0;
             let r = pos(bad);
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(err.contains("Contract violation"), "got: {}", err);
     }
 
     #[test]
     fn const_chain_through_arithmetic() {
         // n is 5, then m is 2*5 = 10 (foldable), then call.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             let n = 5;
             let m = n * 2;
             let r = pos(m);
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -13480,40 +14060,52 @@ mod tests {
         // even if we then assign 0, the verifier conservatively gives
         // up rather than risk being unsound. So pos(n) should NOT be
         // rejected, just left for runtime.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             let n = 5;
             n = 7;          // killed; verifier gives up
             let r = pos(n); // not rejected, runtime check
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn shadowing_with_non_const_kills_tracking() {
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             let n = 5;
             let n = 10 / 2;  // foldable, still a constant
             let r = pos(n);
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     // ---------- Call-site contract fold (RES-061) ----------
 
     #[test]
     fn callsite_constant_args_satisfy_requires() {
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn divide(int a, int b) requires b != 0 { return a / b; }
             let r = divide(10, 5);
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn callsite_constant_args_violate_requires() {
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             fn divide(int a, int b) requires b != 0 { return a / b; }
             let r = divide(10, 0);
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(
             err.contains("Contract violation") && err.contains("divide"),
             "unexpected: {}",
@@ -13524,38 +14116,50 @@ mod tests {
     #[test]
     fn callsite_with_inequality_constraints() {
         // `requires x > 0`. Caller passes -3 → reject.
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             let bad = pos(0 - 3);
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(err.contains("Contract violation"), "unexpected: {}", err);
         // Caller passes 5 → accept.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             let good = pos(5);
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn callsite_free_variable_argument_left_for_runtime() {
         // The argument is a variable, not a literal — folder gives up
         // and the call type-checks fine.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn pos(int x) requires x > 0 { return x; }
             let v = 5;
             let r = pos(v);
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn callsite_multiple_clauses_one_violated() {
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             fn ranged(int n)
                 requires n >= 0
                 requires n <= 100
             { return n; }
             let bad = ranged(150);
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(err.contains("Contract violation"), "unexpected: {}", err);
     }
 
@@ -13564,16 +14168,22 @@ mod tests {
     #[test]
     fn contract_tautology_passes_typecheck() {
         // `5 != 0` is provably true — the typechecker folds it.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn f() requires 5 != 0 { return 1; }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn contract_contradiction_rejected_at_compile_time() {
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             fn f() requires 0 != 0 { return 1; }
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(
             err.contains("contract can never hold"),
             "unexpected: {}",
@@ -13583,9 +14193,12 @@ mod tests {
 
     #[test]
     fn contract_literal_false_rejected() {
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             fn f() requires false { return 1; }
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(
             err.contains("contract can never hold"),
             "unexpected: {}",
@@ -13597,21 +14210,30 @@ mod tests {
     fn contract_with_free_variable_not_folded() {
         // `x > 0` can't be proven at compile time; typecheck should
         // accept it and leave the check for runtime.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn f(int x) requires x > 0 { return x; }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn contract_complex_arithmetic_folds() {
         // 2 + 3 == 5 → tautology.
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             fn f() requires 2 + 3 == 5 { return 1; }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
         // 2 + 3 == 4 → contradiction.
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             fn g() requires 2 + 3 == 4 { return 1; }
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(err.contains("never hold"), "unexpected: {}", err);
     }
 
@@ -13620,7 +14242,9 @@ mod tests {
     fn typecheck_src(src: &str) -> Result<(), String> {
         let (program, errors) = parse(src);
         assert!(errors.is_empty(), "parse errors: {:?}", errors);
-        typechecker::TypeChecker::new().check_program(&program).map(|_| ())
+        typechecker::TypeChecker::new()
+            .check_program(&program)
+            .map(|_| ())
     }
 
     #[test]
@@ -13648,11 +14272,7 @@ mod tests {
     #[test]
     fn typecheck_rejects_fn_return_type_mismatch() {
         let err = typecheck_src(r#"fn f() -> int { return "hi"; }"#).unwrap_err();
-        assert!(
-            err.contains("return type mismatch"),
-            "unexpected: {}",
-            err
-        );
+        assert!(err.contains("return type mismatch"), "unexpected: {}", err);
     }
 
     #[test]
@@ -13716,9 +14336,9 @@ mod tests {
         let src = r#"extern "libfoo" { @pure fn f() -> Int; }"#;
         let (_, parse_errs) = parse(src);
         assert!(
-            parse_errs.iter().any(|e| {
-                e.contains("attribute") || e.contains("@pure") || e.contains("pure")
-            }),
+            parse_errs
+                .iter()
+                .any(|e| { e.contains("attribute") || e.contains("@pure") || e.contains("pure") }),
             "expected parse error about @pure attribute, got {:?}",
             parse_errs
         );
@@ -13732,7 +14352,12 @@ mod tests {
         assert!(errors.is_empty(), "{:?}", errors);
         match p {
             Node::Program(stmts) => match &stmts[0].node {
-                Node::LetStatement { name, value, type_annot, .. } => {
+                Node::LetStatement {
+                    name,
+                    value,
+                    type_annot,
+                    ..
+                } => {
                     assert_eq!(name, "x");
                     assert_eq!(type_annot.as_deref(), Some("int"));
                     assert!(matches!(**value, Node::IntegerLiteral { value: 42, .. }));
@@ -13765,7 +14390,9 @@ mod tests {
         assert!(errors.is_empty(), "{:?}", errors);
         match p {
             Node::Program(stmts) => match &stmts[0].node {
-                Node::LetStatement { name, type_annot, .. } => {
+                Node::LetStatement {
+                    name, type_annot, ..
+                } => {
                     assert_eq!(name, "a");
                     assert_eq!(type_annot.as_deref(), Some("[Int; 3]"));
                 }
@@ -13866,7 +14493,9 @@ mod tests {
         // not panic, and must keep advancing.
         let (_p, errors) = parse("let a: [Int 3] = [1, 2, 3];");
         assert!(
-            errors.iter().any(|e| e.contains("';'") || e.contains("semicolon")),
+            errors
+                .iter()
+                .any(|e| e.contains("';'") || e.contains("semicolon")),
             "expected a ';' error, got {:?}",
             errors
         );
@@ -13878,7 +14507,9 @@ mod tests {
         // (const-generics are deferred per the ticket notes).
         let (_p, errors) = parse("let a: [Int; x] = [1, 2, 3];");
         assert!(
-            errors.iter().any(|e| e.contains("integer") || e.contains("length")),
+            errors
+                .iter()
+                .any(|e| e.contains("integer") || e.contains("length")),
             "expected an integer-length error, got {:?}",
             errors
         );
@@ -13914,7 +14545,9 @@ mod tests {
         // Find the Function node to check its return_type.
         match p {
             Node::Program(stmts) => match &stmts[0].node {
-                Node::Function { name, return_type, .. } => {
+                Node::Function {
+                    name, return_type, ..
+                } => {
                     assert_eq!(name, "add");
                     assert_eq!(return_type.as_deref(), Some("int"));
                 }
@@ -14047,18 +14680,23 @@ mod tests {
 
     #[test]
     fn result_ok_and_err_construct() {
-        let (p, _e) = parse(r#"
+        let (p, _e) = parse(
+            r#"
             let good = Ok(42);
             let bad = Err("boom");
             let g_ok = is_ok(good);
             let b_ok = is_ok(bad);
             let g = unwrap(good);
             let b = unwrap_err(bad);
-        "#);
+        "#,
+        );
         let mut interp = Interpreter::new();
         interp.eval(&p).unwrap();
         assert!(matches!(interp.env.get("g_ok").unwrap(), Value::Bool(true)));
-        assert!(matches!(interp.env.get("b_ok").unwrap(), Value::Bool(false)));
+        assert!(matches!(
+            interp.env.get("b_ok").unwrap(),
+            Value::Bool(false)
+        ));
         assert!(matches!(interp.env.get("g").unwrap(), Value::Int(42)));
         assert!(matches!(interp.env.get("b").unwrap(), Value::String(s) if s == "boom"));
     }
@@ -14089,7 +14727,10 @@ mod tests {
         assert!(errors.is_empty(), "{:?}", errors);
         let mut interp = Interpreter::new();
         interp.eval(&p).unwrap();
-        assert!(matches!(interp.env.get("was_err").unwrap(), Value::Bool(true)));
+        assert!(matches!(
+            interp.env.get("was_err").unwrap(),
+            Value::Bool(true)
+        ));
         assert!(matches!(interp.env.get("msg").unwrap(), Value::String(s) if s == "not a number"));
     }
 
@@ -14122,13 +14763,15 @@ mod tests {
 
     #[test]
     fn string_builtins_basic() {
-        let (p, _e) = parse(r#"
+        let (p, _e) = parse(
+            r#"
             let parts = split("a,b,c", ",");
             let t = trim("   hi   ");
             let hasH = contains("hello", "ell");
             let up = to_upper("Foo");
             let lo = to_lower("BAR");
-        "#);
+        "#,
+        );
         let mut interp = Interpreter::new();
         interp.eval(&p).unwrap();
         match interp.env.get("parts").unwrap() {
@@ -14159,43 +14802,28 @@ mod tests {
 
     #[test]
     fn starts_with_happy_path_and_empty_prefix() {
-        let v = builtin_starts_with(&[
-            Value::String("hello".into()),
-            Value::String("hel".into()),
-        ])
-        .unwrap();
+        let v = builtin_starts_with(&[Value::String("hello".into()), Value::String("hel".into())])
+            .unwrap();
         assert!(matches!(v, Value::Bool(true)));
 
-        let v = builtin_starts_with(&[
-            Value::String("hello".into()),
-            Value::String("".into()),
-        ])
-        .unwrap();
+        let v = builtin_starts_with(&[Value::String("hello".into()), Value::String("".into())])
+            .unwrap();
         assert!(matches!(v, Value::Bool(true)));
 
-        let v = builtin_starts_with(&[
-            Value::String("hello".into()),
-            Value::String("world".into()),
-        ])
-        .unwrap();
+        let v =
+            builtin_starts_with(&[Value::String("hello".into()), Value::String("world".into())])
+                .unwrap();
         assert!(matches!(v, Value::Bool(false)));
 
         // Empty haystack + non-empty prefix → false (no match).
-        let v = builtin_starts_with(&[
-            Value::String("".into()),
-            Value::String("x".into()),
-        ])
-        .unwrap();
+        let v =
+            builtin_starts_with(&[Value::String("".into()), Value::String("x".into())]).unwrap();
         assert!(matches!(v, Value::Bool(false)));
     }
 
     #[test]
     fn starts_with_rejects_non_string_args() {
-        let err = builtin_starts_with(&[
-            Value::String("hello".into()),
-            Value::Int(1),
-        ])
-        .unwrap_err();
+        let err = builtin_starts_with(&[Value::String("hello".into()), Value::Int(1)]).unwrap_err();
         assert!(
             err.contains("starts_with: expected (string, string)"),
             "err was: {}",
@@ -14205,32 +14833,22 @@ mod tests {
 
     #[test]
     fn ends_with_happy_path_and_empty_suffix() {
-        let v = builtin_ends_with(&[
-            Value::String("hello".into()),
-            Value::String("lo".into()),
-        ])
-        .unwrap();
+        let v = builtin_ends_with(&[Value::String("hello".into()), Value::String("lo".into())])
+            .unwrap();
         assert!(matches!(v, Value::Bool(true)));
 
-        let v = builtin_ends_with(&[
-            Value::String("hello".into()),
-            Value::String("".into()),
-        ])
-        .unwrap();
+        let v =
+            builtin_ends_with(&[Value::String("hello".into()), Value::String("".into())]).unwrap();
         assert!(matches!(v, Value::Bool(true)));
 
-        let v = builtin_ends_with(&[
-            Value::String("hello".into()),
-            Value::String("hi".into()),
-        ])
-        .unwrap();
+        let v = builtin_ends_with(&[Value::String("hello".into()), Value::String("hi".into())])
+            .unwrap();
         assert!(matches!(v, Value::Bool(false)));
     }
 
     #[test]
     fn ends_with_rejects_non_string_args() {
-        let err = builtin_ends_with(&[Value::Int(7), Value::String("x".into())])
-            .unwrap_err();
+        let err = builtin_ends_with(&[Value::Int(7), Value::String("x".into())]).unwrap_err();
         assert!(
             err.contains("ends_with: expected (string, string)"),
             "err was: {}",
@@ -14240,22 +14858,19 @@ mod tests {
 
     #[test]
     fn repeat_happy_path_and_zero() {
-        let v = builtin_repeat(&[Value::String("ab".into()), Value::Int(3)])
-            .unwrap();
+        let v = builtin_repeat(&[Value::String("ab".into()), Value::Int(3)]).unwrap();
         match v {
             Value::String(s) => assert_eq!(s, "ababab"),
             other => panic!("expected String, got {:?}", other),
         }
 
-        let v = builtin_repeat(&[Value::String("ab".into()), Value::Int(0)])
-            .unwrap();
+        let v = builtin_repeat(&[Value::String("ab".into()), Value::Int(0)]).unwrap();
         match v {
             Value::String(s) => assert_eq!(s, ""),
             other => panic!("expected String, got {:?}", other),
         }
 
-        let v = builtin_repeat(&[Value::String("".into()), Value::Int(5)])
-            .unwrap();
+        let v = builtin_repeat(&[Value::String("".into()), Value::Int(5)]).unwrap();
         match v {
             Value::String(s) => assert_eq!(s, ""),
             other => panic!("expected String, got {:?}", other),
@@ -14264,18 +14879,13 @@ mod tests {
 
     #[test]
     fn repeat_negative_count_errors() {
-        let err = builtin_repeat(&[Value::String("ab".into()), Value::Int(-1)])
-            .unwrap_err();
+        let err = builtin_repeat(&[Value::String("ab".into()), Value::Int(-1)]).unwrap_err();
         assert!(err.contains("count must be >= 0"), "err was: {}", err);
     }
 
     #[test]
     fn repeat_rejects_non_int_count() {
-        let err = builtin_repeat(&[
-            Value::String("ab".into()),
-            Value::Float(3.0),
-        ])
-        .unwrap_err();
+        let err = builtin_repeat(&[Value::String("ab".into()), Value::Float(3.0)]).unwrap_err();
         assert!(
             err.contains("repeat: expected (string, int)"),
             "err was: {}",
@@ -14324,45 +14934,60 @@ mod tests {
 
     #[test]
     fn typecheck_rejects_non_exhaustive_bool_match() {
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             let b = true;
             let r = match b { true => 1, };
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(err.contains("Non-exhaustive match on bool"), "got: {}", err);
         assert!(err.contains("missing `false`"), "got: {}", err);
     }
 
     #[test]
     fn typecheck_accepts_exhaustive_bool_match() {
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             let b = true;
             let r = match b { true => 1, false => 0, };
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn typecheck_accepts_bool_match_with_wildcard() {
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             let b = true;
             let r = match b { true => 1, _ => 0, };
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]
     fn typecheck_rejects_int_match_without_default() {
-        let err = typecheck_src(r#"
+        let err = typecheck_src(
+            r#"
             let n = 5;
             let r = match n { 0 => "zero", 1 => "one", };
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(err.contains("Non-exhaustive match on int"), "got: {}", err);
     }
 
     #[test]
     fn typecheck_accepts_int_match_with_identifier_default() {
-        typecheck_src(r#"
+        typecheck_src(
+            r#"
             let n = 5;
             let r = match n { 0 => "zero", x => "other", };
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
     }
 
     // ---------- match (RES-039) ----------
@@ -14864,13 +15489,15 @@ mod tests {
 
     #[test]
     fn bitwise_operators() {
-        let (p, _e) = parse(r#"
+        let (p, _e) = parse(
+            r#"
             let a = 0xF0 & 0x33;
             let b = 0x01 | 0x02;
             let c = 0xFF ^ 0x0F;
             let d = 1 << 4;
             let e = 256 >> 3;
-        "#);
+        "#,
+        );
         let mut interp = Interpreter::new();
         interp.eval(&p).unwrap();
         assert!(matches!(interp.env.get("a").unwrap(), Value::Int(0x30)));
@@ -14899,7 +15526,11 @@ mod tests {
         let (p, _e) = parse(src);
         let mut interp = Interpreter::new();
         let err = interp.eval(&p).unwrap_err();
-        assert!(err.contains("Fuel must be non-negative"), "msg lost: {}", err);
+        assert!(
+            err.contains("Fuel must be non-negative"),
+            "msg lost: {}",
+            err
+        );
         assert!(
             err.contains("-5 >= 0") || err.contains("condition -5 >= 0"),
             "expected both operands in error, got: {}",
@@ -14923,7 +15554,11 @@ mod tests {
         let (p, _e) = parse(src);
         let mut interp = Interpreter::new();
         let err = interp.eval(&p).unwrap_err();
-        assert!(err.contains("ASSUME VIOLATED"), "expected ASSUME VIOLATED, got: {}", err);
+        assert!(
+            err.contains("ASSUME VIOLATED"),
+            "expected ASSUME VIOLATED, got: {}",
+            err
+        );
     }
 
     #[test]
@@ -14952,7 +15587,10 @@ mod tests {
         interp.eval(&p).unwrap();
         assert!(matches!(interp.env.get("a").unwrap(), Value::Int(255)));
         assert!(matches!(interp.env.get("b").unwrap(), Value::Int(10)));
-        assert!(matches!(interp.env.get("c").unwrap(), Value::Int(0xDEADBEEF)));
+        assert!(matches!(
+            interp.env.get("c").unwrap(),
+            Value::Int(0xDEADBEEF)
+        ));
     }
 
     #[test]
@@ -15038,7 +15676,11 @@ mod tests {
         let w = find_while(&p).expect("expected a WhileStatement");
         match w {
             Node::WhileStatement { invariants, .. } => {
-                assert!(invariants.is_empty(), "expected no invariants, got {:?}", invariants);
+                assert!(
+                    invariants.is_empty(),
+                    "expected no invariants, got {:?}",
+                    invariants
+                );
             }
             _ => unreachable!(),
         }
@@ -15051,7 +15693,11 @@ mod tests {
         let f = find_for_in(&p).expect("expected a ForInStatement");
         match f {
             Node::ForInStatement { invariants, .. } => {
-                assert!(invariants.is_empty(), "expected no invariants, got {:?}", invariants);
+                assert!(
+                    invariants.is_empty(),
+                    "expected no invariants, got {:?}",
+                    invariants
+                );
             }
             _ => unreachable!(),
         }
@@ -15203,12 +15849,14 @@ mod tests {
 
     #[test]
     fn string_comparisons() {
-        let (p, _e) = parse(r#"
+        let (p, _e) = parse(
+            r#"
             let a = "apple" < "banana";
             let b = "abc" == "abc";
             let c = "xy" >= "xz";
             let d = len("héllo");
-        "#);
+        "#,
+        );
         let mut interp = Interpreter::new();
         interp.eval(&p).unwrap();
         let g = |n: &str| interp.env.get(n).unwrap();
@@ -15221,12 +15869,14 @@ mod tests {
 
     #[test]
     fn logical_and_or_evaluate() {
-        let (p, _e) = parse(r#"
+        let (p, _e) = parse(
+            r#"
             let a = true && false;
             let b = true || false;
             let c = false || (1 < 2);
             let d = (5 > 0) && (5 < 10);
-        "#);
+        "#,
+        );
         let mut interp = Interpreter::new();
         interp.eval(&p).unwrap();
         let g = |n: &str| match interp.env.get(n).unwrap() {
@@ -15580,9 +16230,12 @@ mod tests {
     #[test]
     fn pow_int_overflow_is_clean_error() {
         // 2^63 overflows i64.
-        let err = builtin_pow(&[Value::Int(2), Value::Int(63)])
-            .expect_err("must overflow");
-        assert!(err.contains("overflow"), "error should mention overflow: {}", err);
+        let err = builtin_pow(&[Value::Int(2), Value::Int(63)]).expect_err("must overflow");
+        assert!(
+            err.contains("overflow"),
+            "error should mention overflow: {}",
+            err
+        );
     }
 
     #[test]
@@ -15640,8 +16293,12 @@ mod tests {
 
     /// Read `m[i][j]` and assert it is `Value::Int(expected)`.
     fn nested_int(m: &Value, i: usize, j: usize) -> i64 {
-        let Value::Array(rows) = m else { panic!("expected outer Array, got {:?}", m); };
-        let Value::Array(row) = &rows[i] else { panic!("expected inner Array at row {}, got {:?}", i, rows[i]); };
+        let Value::Array(rows) = m else {
+            panic!("expected outer Array, got {:?}", m);
+        };
+        let Value::Array(row) = &rows[i] else {
+            panic!("expected inner Array at row {}, got {:?}", i, rows[i]);
+        };
         match &row[j] {
             Value::Int(v) => *v,
             other => panic!("expected Int at [{}][{}], got {:?}", i, j, other),
@@ -15701,9 +16358,15 @@ mod tests {
         let mut interp = Interpreter::new();
         interp.eval(&p).unwrap();
         let m = interp.env.get("m").unwrap();
-        let Value::Array(outer) = &m else { panic!("outer"); };
-        let Value::Array(mid) = &outer[1] else { panic!("mid"); };
-        let Value::Array(leaf) = &mid[0] else { panic!("leaf"); };
+        let Value::Array(outer) = &m else {
+            panic!("outer");
+        };
+        let Value::Array(mid) = &outer[1] else {
+            panic!("mid");
+        };
+        let Value::Array(leaf) = &mid[0] else {
+            panic!("leaf");
+        };
         assert!(matches!(leaf[0], Value::Int(99)));
     }
 
@@ -15759,7 +16422,9 @@ mod tests {
         let src = "fn one() { return 1; }\nfn two() { return 2; }";
         let (program, errors) = parse(src);
         assert!(errors.is_empty(), "parse errors: {:?}", errors);
-        let Node::Program(stmts) = &program else { panic!() };
+        let Node::Program(stmts) = &program else {
+            panic!()
+        };
         let Node::Function { span: s0, .. } = &stmts[0].node else {
             panic!("expected Function for stmt 0");
         };
@@ -15771,7 +16436,8 @@ mod tests {
         assert!(
             s1.start.line > s0.start.line,
             "expected fn 2 line ({}) > fn 1 line ({})",
-            s1.start.line, s0.start.line
+            s1.start.line,
+            s0.start.line
         );
     }
 
@@ -15781,9 +16447,17 @@ mod tests {
         // now. Parse a fn body + confirm both have populated spans.
         let (program, errors) = parse("fn f() { let x = 1; let y = 2; }");
         assert!(errors.is_empty());
-        let Node::Program(stmts) = &program else { panic!() };
-        let Node::Function { body, .. } = &stmts[0].node else { panic!() };
-        let Node::Block { stmts: inner, span: block_span } = body.as_ref() else {
+        let Node::Program(stmts) = &program else {
+            panic!()
+        };
+        let Node::Function { body, .. } = &stmts[0].node else {
+            panic!()
+        };
+        let Node::Block {
+            stmts: inner,
+            span: block_span,
+        } = body.as_ref()
+        else {
             panic!("expected Block");
         };
         assert_eq!(inner.len(), 2);
@@ -15791,7 +16465,9 @@ mod tests {
 
         // ExpressionStatement: `1 + 2;` at top level
         let (program, _) = parse("1 + 2;");
-        let Node::Program(stmts) = &program else { panic!() };
+        let Node::Program(stmts) = &program else {
+            panic!()
+        };
         let Node::ExpressionStatement { expr: _, span } = &stmts[0].node else {
             panic!("expected ExpressionStatement");
         };
@@ -15804,8 +16480,12 @@ mod tests {
         // now. Confirm both parse sites populate their spans.
         let (program, errors) = parse("[1, 2, 3];");
         assert!(errors.is_empty());
-        let Node::Program(stmts) = &program else { panic!() };
-        let Node::ExpressionStatement { expr, .. } = &stmts[0].node else { panic!() };
+        let Node::Program(stmts) = &program else {
+            panic!()
+        };
+        let Node::ExpressionStatement { expr, .. } = &stmts[0].node else {
+            panic!()
+        };
         let Node::ArrayLiteral { items, span } = expr.as_ref() else {
             panic!("expected ArrayLiteral, got {:?}", expr);
         };
@@ -15815,10 +16495,18 @@ mod tests {
         // TryExpression: `ok(1)?`
         let (program, _) = parse("fn f() { let x = ok(1)?; return x; }");
         // Walk into the fn body to find the `?` expression.
-        let Node::Program(stmts) = &program else { panic!() };
-        let Node::Function { body, .. } = &stmts[0].node else { panic!() };
-        let Node::Block { stmts: inner, .. } = body.as_ref() else { panic!() };
-        let Node::LetStatement { value, .. } = &inner[0] else { panic!() };
+        let Node::Program(stmts) = &program else {
+            panic!()
+        };
+        let Node::Function { body, .. } = &stmts[0].node else {
+            panic!()
+        };
+        let Node::Block { stmts: inner, .. } = body.as_ref() else {
+            panic!()
+        };
+        let Node::LetStatement { value, .. } = &inner[0] else {
+            panic!()
+        };
         let Node::TryExpression { span, .. } = value.as_ref() else {
             panic!("expected TryExpression, got {:?}", value);
         };
@@ -15833,15 +16521,21 @@ mod tests {
         // real source.
         let (program, errors) = parse("let a = [1, 2]; a[0]; let b = a; b.len;");
         assert!(errors.is_empty(), "parse errors: {:?}", errors);
-        let Node::Program(stmts) = &program else { panic!() };
+        let Node::Program(stmts) = &program else {
+            panic!()
+        };
         // stmt 1: `a[0];` expression statement wrapping IndexExpression
-        let Node::ExpressionStatement { expr, .. } = &stmts[1].node else { panic!() };
+        let Node::ExpressionStatement { expr, .. } = &stmts[1].node else {
+            panic!()
+        };
         let Node::IndexExpression { span, .. } = expr.as_ref() else {
             panic!("expected IndexExpression");
         };
         assert!(span.start.line >= 1, "index span: {:?}", span);
         // stmt 3: `b.len;` expression statement wrapping FieldAccess
-        let Node::ExpressionStatement { expr, .. } = &stmts[3].node else { panic!() };
+        let Node::ExpressionStatement { expr, .. } = &stmts[3].node else {
+            panic!()
+        };
         let Node::FieldAccess { span, .. } = expr.as_ref() else {
             panic!("expected FieldAccess");
         };
@@ -15855,7 +16549,9 @@ mod tests {
         // source so start.line should be >= 1.
         let (program, errors) = parse("1 + 2;");
         assert!(errors.is_empty());
-        let Node::Program(stmts) = &program else { panic!() };
+        let Node::Program(stmts) = &program else {
+            panic!()
+        };
         let Node::ExpressionStatement { expr, .. } = &stmts[0].node else {
             panic!("expected ExpressionStatement, got {:?}", stmts[0].node);
         };
@@ -15871,15 +16567,25 @@ mod tests {
         // RES-084: prefix `!x` and call `f()` both record their
         // operator/parenthesis location.
         let (program, _) = parse("fn f() { return 1; }\n!true;\nf();");
-        let Node::Program(stmts) = &program else { panic!() };
+        let Node::Program(stmts) = &program else {
+            panic!()
+        };
         // stmt 0 is the fn decl; stmt 1 is the !true expression
-        let Node::ExpressionStatement { expr, .. } = &stmts[1].node else { panic!() };
-        let Node::PrefixExpression { operator, span, .. } = expr.as_ref() else { panic!() };
+        let Node::ExpressionStatement { expr, .. } = &stmts[1].node else {
+            panic!()
+        };
+        let Node::PrefixExpression { operator, span, .. } = expr.as_ref() else {
+            panic!()
+        };
         assert_eq!(operator, "!");
         assert!(span.start.line >= 1);
         // stmt 2 is the call f()
-        let Node::ExpressionStatement { expr, .. } = &stmts[2].node else { panic!() };
-        let Node::CallExpression { span, .. } = expr.as_ref() else { panic!() };
+        let Node::ExpressionStatement { expr, .. } = &stmts[2].node else {
+            panic!()
+        };
+        let Node::CallExpression { span, .. } = expr.as_ref() else {
+            panic!()
+        };
         assert!(span.start.line >= 1);
     }
 
@@ -15891,9 +16597,15 @@ mod tests {
         let src = "let x = 1;\nlet y = 2;";
         let (program, errors) = parse(src);
         assert!(errors.is_empty());
-        let Node::Program(stmts) = &program else { panic!("expected Program"); };
-        let Node::LetStatement { span: s0, .. } = &stmts[0].node else { panic!(); };
-        let Node::LetStatement { span: s1, .. } = &stmts[1].node else { panic!(); };
+        let Node::Program(stmts) = &program else {
+            panic!("expected Program");
+        };
+        let Node::LetStatement { span: s0, .. } = &stmts[0].node else {
+            panic!();
+        };
+        let Node::LetStatement { span: s1, .. } = &stmts[1].node else {
+            panic!();
+        };
         assert!(s0.start.line >= 1, "s0 line: {}", s0.start.line);
         assert!(s1.start.line >= 2, "s1 line: {}", s1.start.line);
         assert!(s1.start.line > s0.start.line);
@@ -15917,7 +16629,11 @@ mod tests {
             panic!("expected IntegerLiteral");
         };
         assert_eq!(*lit, 42);
-        assert!(span.start.line >= 1, "int literal span.start.line = {}", span.start.line);
+        assert!(
+            span.start.line >= 1,
+            "int literal span.start.line = {}",
+            span.start.line
+        );
     }
 
     #[test]
@@ -15926,7 +16642,9 @@ mod tests {
         // the Identifier's span should surface in the error message.
         let (program, _) = parse("let x = undefined_thing;");
         let mut tc = typechecker::TypeChecker::new();
-        let err = tc.check_program(&program).expect_err("must reject undefined");
+        let err = tc
+            .check_program(&program)
+            .expect_err("must reject undefined");
         // check_program goes through the statement-level prefix
         // (RES-080) too, so the error has two file:line:col segments.
         // We just need the identifier-level `at N:M` part to appear.
@@ -15959,7 +16677,8 @@ mod tests {
         assert!(
             s1.span.start.line > s0.span.start.line,
             "expected line order, got s0={:?} s1={:?}",
-            s0.span, s1.span
+            s0.span,
+            s1.span
         );
         // The inner node still has its existing shape.
         assert!(matches!(s0.node, Node::LetStatement { .. }));
@@ -16203,9 +16922,8 @@ mod tests {
         let src = "struct Point { int x, int y, } let p = new Point { x: 1 y: 2 };";
         let (_program, errs) = parse(src);
         assert!(
-            errs.iter().any(|e| e.contains("expected one of")
-                && e.contains("`,`")
-                && e.contains("`}`")),
+            errs.iter()
+                .any(|e| e.contains("expected one of") && e.contains("`,`") && e.contains("`}`")),
             "expected multi-alternative diagnostic, got: {:?}",
             errs
         );
@@ -16224,10 +16942,7 @@ mod tests {
     #[test]
     fn expected_hint_caps_long_lists_with_ellipsis() {
         // Slices longer than 5 entries truncate with `…`.
-        let s = format_expected(
-            &["`a`", "`b`", "`c`", "`d`", "`e`", "`f`", "`g`"],
-            "`x`",
-        );
+        let s = format_expected(&["`a`", "`b`", "`c`", "`d`", "`e`", "`f`", "`g`"], "`x`");
         assert!(
             s.starts_with("expected one of `a`, `b`, `c`, `d`, `e`, …"),
             "unexpected shape: {}",
@@ -16244,17 +16959,9 @@ mod tests {
     fn live_total_retries_zero_arity() {
         // Zero-arg contract.
         let err = builtin_live_total_retries(&[Value::Int(0)]).unwrap_err();
-        assert!(
-            err.contains("expected 0 arguments"),
-            "got: {}",
-            err
-        );
+        assert!(err.contains("expected 0 arguments"), "got: {}", err);
         let err = builtin_live_total_exhaustions(&[Value::Int(0)]).unwrap_err();
-        assert!(
-            err.contains("expected 0 arguments"),
-            "got: {}",
-            err
-        );
+        assert!(err.contains("expected 0 arguments"), "got: {}", err);
     }
 
     #[test]
@@ -16351,11 +17058,28 @@ mod tests {
             .eval(&program)
             .expect_err("outer live block should eventually exhaust");
         // Error shape: `Live block failed after 3 attempts (retry depth: 1): Live block failed after 3 attempts (retry depth: 2): ...`
-        assert!(err.contains("Live block failed after 3 attempts"), "got: {}", err);
-        assert!(err.contains("retry depth: 1"), "outer level note missing: {}", err);
-        assert!(err.contains("retry depth: 2"), "inner level note missing: {}", err);
+        assert!(
+            err.contains("Live block failed after 3 attempts"),
+            "got: {}",
+            err
+        );
+        assert!(
+            err.contains("retry depth: 1"),
+            "outer level note missing: {}",
+            err
+        );
+        assert!(
+            err.contains("retry depth: 2"),
+            "inner level note missing: {}",
+            err
+        );
         // 3 outer * 3 inner = 9 inner invocations.
-        match interp.statics.borrow().get("inner_calls").expect("static counter") {
+        match interp
+            .statics
+            .borrow()
+            .get("inner_calls")
+            .expect("static counter")
+        {
             Value::Int(n) => assert_eq!(*n, 9, "expected 9 inner invocations, got {}", n),
             other => panic!("expected Int, got {:?}", other),
         }
@@ -16411,11 +17135,15 @@ mod tests {
 
     #[test]
     fn backoff_delay_ms_caps_at_max() {
-        let cfg = BackoffConfig { base_ms: 1, factor: 2, max_ms: 100 };
-        assert_eq!(cfg.delay_ms(0), 1);    // 1 * 2^0 = 1
-        assert_eq!(cfg.delay_ms(1), 2);    // 1 * 2^1 = 2
-        assert_eq!(cfg.delay_ms(5), 32);   // 1 * 2^5 = 32
-        assert_eq!(cfg.delay_ms(7), 100);  // 1 * 2^7 = 128, capped at 100
+        let cfg = BackoffConfig {
+            base_ms: 1,
+            factor: 2,
+            max_ms: 100,
+        };
+        assert_eq!(cfg.delay_ms(0), 1); // 1 * 2^0 = 1
+        assert_eq!(cfg.delay_ms(1), 2); // 1 * 2^1 = 2
+        assert_eq!(cfg.delay_ms(5), 32); // 1 * 2^5 = 32
+        assert_eq!(cfg.delay_ms(7), 100); // 1 * 2^7 = 128, capped at 100
         assert_eq!(cfg.delay_ms(30), 100); // huge growth still capped
     }
 
@@ -16424,7 +17152,11 @@ mod tests {
         // `saturating_pow` / `saturating_mul` guard against `u64`
         // wrap on intentionally aggressive values; the cap still
         // holds.
-        let cfg = BackoffConfig { base_ms: 1_000_000, factor: 10, max_ms: 50 };
+        let cfg = BackoffConfig {
+            base_ms: 1_000_000,
+            factor: 10,
+            max_ms: 50,
+        };
         assert_eq!(cfg.delay_ms(63), 50);
     }
 
@@ -16525,9 +17257,11 @@ mod tests {
                 Node::Program(stmts) => stmts.iter().find_map(|s| walk(&s.node)),
                 Node::Function { body, .. } => walk(body),
                 Node::Block { stmts, .. } => stmts.iter().find_map(walk),
-                Node::IfStatement { consequence, alternative, .. } => walk(consequence).or_else(|| {
-                    alternative.as_ref().and_then(|a| walk(a))
-                }),
+                Node::IfStatement {
+                    consequence,
+                    alternative,
+                    ..
+                } => walk(consequence).or_else(|| alternative.as_ref().and_then(|a| walk(a))),
                 _ => None,
             }
         }
@@ -16542,16 +17276,20 @@ mod tests {
     fn find_first_live_timeout_ns(program: &Node) -> Option<u64> {
         fn walk(n: &Node) -> Option<u64> {
             match n {
-                Node::LiveBlock { timeout, .. } => timeout.as_ref().and_then(|t| match t.as_ref() {
-                    Node::DurationLiteral { nanos, .. } => Some(*nanos),
-                    _ => None,
-                }),
+                Node::LiveBlock { timeout, .. } => {
+                    timeout.as_ref().and_then(|t| match t.as_ref() {
+                        Node::DurationLiteral { nanos, .. } => Some(*nanos),
+                        _ => None,
+                    })
+                }
                 Node::Program(stmts) => stmts.iter().find_map(|s| walk(&s.node)),
                 Node::Function { body, .. } => walk(body),
                 Node::Block { stmts, .. } => stmts.iter().find_map(walk),
-                Node::IfStatement { consequence, alternative, .. } => walk(consequence).or_else(|| {
-                    alternative.as_ref().and_then(|a| walk(a))
-                }),
+                Node::IfStatement {
+                    consequence,
+                    alternative,
+                    ..
+                } => walk(consequence).or_else(|| alternative.as_ref().and_then(|a| walk(a))),
                 _ => None,
             }
         }
@@ -16581,7 +17319,12 @@ mod tests {
                 src_unit
             );
             let (program, errs) = parse(&src);
-            assert!(errs.is_empty(), "parse errors for `{}`: {:?}", src_unit, errs);
+            assert!(
+                errs.is_empty(),
+                "parse errors for `{}`: {:?}",
+                src_unit,
+                errs
+            );
             assert_eq!(
                 find_first_live_timeout_ns(&program),
                 Some(expected_ns),
@@ -16596,7 +17339,8 @@ mod tests {
         let src = "fn main(int _d) { live within 10min { let x = 1; } } main(0);";
         let (_program, errs) = parse(src);
         assert!(
-            errs.iter().any(|e| e.contains("Unknown duration unit `min`")),
+            errs.iter()
+                .any(|e| e.contains("Unknown duration unit `min`")),
             "expected unknown-unit diagnostic, got: {:?}",
             errs
         );
@@ -16607,7 +17351,8 @@ mod tests {
         let src = "fn main(int _d) { live within -5ms { let x = 1; } } main(0);";
         let (_program, errs) = parse(src);
         assert!(
-            errs.iter().any(|e| e.contains("non-negative integer literal after `within`")),
+            errs.iter()
+                .any(|e| e.contains("non-negative integer literal after `within`")),
             "expected integer-literal diagnostic, got: {:?}",
             errs
         );
@@ -16726,7 +17471,10 @@ mod tests {
         // test), fail with the dedicated diagnostic rather than
         // silently coercing.
         use span::Span;
-        let dl = Node::DurationLiteral { nanos: 1_000_000, span: Span::default() };
+        let dl = Node::DurationLiteral {
+            nanos: 1_000_000,
+            span: Span::default(),
+        };
         let mut interp = Interpreter::new();
         let err = interp.eval(&dl).unwrap_err();
         assert!(
@@ -16855,15 +17603,25 @@ mod tests {
     }
 
     #[test]
-    fn no_coercion_plus()  { assert_coercion_error("let a = 1 + 2.0;"); }
+    fn no_coercion_plus() {
+        assert_coercion_error("let a = 1 + 2.0;");
+    }
     #[test]
-    fn no_coercion_minus() { assert_coercion_error("let a = 1 - 2.0;"); }
+    fn no_coercion_minus() {
+        assert_coercion_error("let a = 1 - 2.0;");
+    }
     #[test]
-    fn no_coercion_mul()   { assert_coercion_error("let a = 1 * 2.0;"); }
+    fn no_coercion_mul() {
+        assert_coercion_error("let a = 1 * 2.0;");
+    }
     #[test]
-    fn no_coercion_div()   { assert_coercion_error("let a = 1 / 2.0;"); }
+    fn no_coercion_div() {
+        assert_coercion_error("let a = 1 / 2.0;");
+    }
     #[test]
-    fn no_coercion_mod()   { assert_coercion_error("let a = 1 % 2.0;"); }
+    fn no_coercion_mod() {
+        assert_coercion_error("let a = 1 % 2.0;");
+    }
 
     #[test]
     fn no_coercion_float_int_reversed() {
@@ -16893,11 +17651,7 @@ mod tests {
         // is caught by the interpreter's divide-by-zero guard
         // BEFORE IEEE-754 semantics kick in).
         let err = builtin_to_int(&[Value::Float(f64::NAN)]).unwrap_err();
-        assert!(
-            err.contains("NaN"),
-            "expected NaN diagnostic, got: {}",
-            err
-        );
+        assert!(err.contains("NaN"), "expected NaN diagnostic, got: {}", err);
     }
 
     #[test]
@@ -17063,7 +17817,11 @@ mod tests {
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let mut tc = typechecker::TypeChecker::new();
         let res = tc.check_program(&program);
-        assert!(res.is_ok(), "same-named struct assignment should pass: {:?}", res);
+        assert!(
+            res.is_ok(),
+            "same-named struct assignment should pass: {:?}",
+            res
+        );
     }
 
     #[test]
@@ -17158,7 +17916,9 @@ mod tests {
             _ => panic!("expected Program"),
         };
         for sp in stmts {
-            if let Node::Function { name, type_params, .. } = &sp.node
+            if let Node::Function {
+                name, type_params, ..
+            } = &sp.node
                 && name == fn_name
             {
                 return type_params.clone();
@@ -17166,7 +17926,9 @@ mod tests {
             // impl-block methods are wrapped; walk inside.
             if let Node::ImplBlock { methods, .. } = &sp.node {
                 for m in methods {
-                    if let Node::Function { name, type_params, .. } = m
+                    if let Node::Function {
+                        name, type_params, ..
+                    } = m
                         && name == fn_name
                     {
                         return type_params.clone();
@@ -17213,10 +17975,7 @@ mod tests {
             { return x; }\n";
         let (program, errs) = parse(src);
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
-        assert_eq!(
-            type_params_of(&program, "identity"),
-            vec!["T".to_string()]
-        );
+        assert_eq!(type_params_of(&program, "identity"), vec!["T".to_string()]);
     }
 
     #[test]
@@ -17232,7 +17991,12 @@ mod tests {
         let f = stmts
             .iter()
             .find_map(|s| {
-                if let Node::Function { name, pure, type_params, .. } = &s.node
+                if let Node::Function {
+                    name,
+                    pure,
+                    type_params,
+                    ..
+                } = &s.node
                     && name == "id"
                 {
                     return Some((*pure, type_params.clone()));
@@ -17283,15 +18047,29 @@ mod tests {
     #[test]
     fn encode_semantic_tokens_delta_encodes_same_line() {
         let tokens = vec![
-            AbsSemToken { line: 0, col: 0, length: 3, ty: sem_tok::KEYWORD, modifiers: 0 },
-            AbsSemToken { line: 0, col: 4, length: 3, ty: sem_tok::FUNCTION,
-                          modifiers: sem_tok::MOD_DECLARATION },
+            AbsSemToken {
+                line: 0,
+                col: 0,
+                length: 3,
+                ty: sem_tok::KEYWORD,
+                modifiers: 0,
+            },
+            AbsSemToken {
+                line: 0,
+                col: 4,
+                length: 3,
+                ty: sem_tok::FUNCTION,
+                modifiers: sem_tok::MOD_DECLARATION,
+            },
         ];
         let wire = encode_semantic_tokens(&tokens);
         // First token: dLine=0, dStart=0, len=3, type=0, mods=0
         assert_eq!(&wire[0..5], &[0, 0, 3, sem_tok::KEYWORD, 0]);
         // Second: same line → dLine=0, dStart=4
-        assert_eq!(&wire[5..10], &[0, 4, 3, sem_tok::FUNCTION, sem_tok::MOD_DECLARATION]);
+        assert_eq!(
+            &wire[5..10],
+            &[0, 4, 3, sem_tok::FUNCTION, sem_tok::MOD_DECLARATION]
+        );
     }
 
     /// Tokens on later lines encode an absolute deltaStart (the
@@ -17299,8 +18077,20 @@ mod tests {
     #[test]
     fn encode_semantic_tokens_delta_encodes_across_lines() {
         let tokens = vec![
-            AbsSemToken { line: 0, col: 0, length: 3, ty: sem_tok::KEYWORD, modifiers: 0 },
-            AbsSemToken { line: 2, col: 4, length: 5, ty: sem_tok::VARIABLE, modifiers: 0 },
+            AbsSemToken {
+                line: 0,
+                col: 0,
+                length: 3,
+                ty: sem_tok::KEYWORD,
+                modifiers: 0,
+            },
+            AbsSemToken {
+                line: 2,
+                col: 4,
+                length: 5,
+                ty: sem_tok::VARIABLE,
+                modifiers: 0,
+            },
         ];
         let wire = encode_semantic_tokens(&tokens);
         // First: line 0 col 0.
@@ -17319,8 +18109,20 @@ mod tests {
         let tokens = vec![
             // Out-of-order: comment on line 2 first, then a
             // line-0 keyword.
-            AbsSemToken { line: 2, col: 0, length: 4, ty: sem_tok::COMMENT, modifiers: 0 },
-            AbsSemToken { line: 0, col: 0, length: 2, ty: sem_tok::KEYWORD, modifiers: 0 },
+            AbsSemToken {
+                line: 2,
+                col: 0,
+                length: 4,
+                ty: sem_tok::COMMENT,
+                modifiers: 0,
+            },
+            AbsSemToken {
+                line: 0,
+                col: 0,
+                length: 2,
+                ty: sem_tok::KEYWORD,
+                modifiers: 0,
+            },
         ];
         let wire = encode_semantic_tokens(&tokens);
         // After sort: keyword first.
@@ -17342,9 +18144,7 @@ mod tests {
         let tokens = collect_semantic_tokens(src);
         // Expect tokens: fn (KEYWORD), alpha (FUNCTION+DECLARATION),
         // return (KEYWORD), 0 (NUMBER).
-        let by_kind: Vec<(u32, u32)> = tokens.iter()
-            .map(|t| (t.ty, t.modifiers))
-            .collect();
+        let by_kind: Vec<(u32, u32)> = tokens.iter().map(|t| (t.ty, t.modifiers)).collect();
         assert!(
             by_kind.contains(&(sem_tok::FUNCTION, sem_tok::MOD_DECLARATION)),
             "expected FUNCTION+DECLARATION for `alpha`, got: {:?}",
@@ -17358,11 +18158,10 @@ mod tests {
     /// not a define).
     #[test]
     fn classify_lex_token_struct_type_new_all_tag_type() {
-        let src = "struct Point { int x }\ntype Meters = int;\nfn f() { let p = new Point(); return 0; }";
+        let src =
+            "struct Point { int x }\ntype Meters = int;\nfn f() { let p = new Point(); return 0; }";
         let tokens = collect_semantic_tokens(src);
-        let by_kind: Vec<(u32, u32)> = tokens.iter()
-            .map(|t| (t.ty, t.modifiers))
-            .collect();
+        let by_kind: Vec<(u32, u32)> = tokens.iter().map(|t| (t.ty, t.modifiers)).collect();
         // `Point` appears twice — once as a struct declaration,
         // once via `new`. At least one of each variant should
         // show up.
@@ -17387,7 +18186,11 @@ mod tests {
         let src = "// hi\nlet s = \"abc\";\nlet n = 42;";
         let tokens = collect_semantic_tokens(src);
         let tys: Vec<u32> = tokens.iter().map(|t| t.ty).collect();
-        assert!(tys.contains(&sem_tok::COMMENT), "missing COMMENT: {:?}", tys);
+        assert!(
+            tys.contains(&sem_tok::COMMENT),
+            "missing COMMENT: {:?}",
+            tys
+        );
         assert!(tys.contains(&sem_tok::STRING), "missing STRING: {:?}", tys);
         assert!(tys.contains(&sem_tok::NUMBER), "missing NUMBER: {:?}", tys);
     }
@@ -17438,22 +18241,28 @@ mod tests {
             }\n\
         ";
         let tokens = collect_semantic_tokens(src);
-        let types_seen: std::collections::HashSet<u32> =
-            tokens.iter().map(|t| t.ty).collect();
+        let types_seen: std::collections::HashSet<u32> = tokens.iter().map(|t| t.ty).collect();
         for want in [
-            sem_tok::KEYWORD, sem_tok::FUNCTION, sem_tok::VARIABLE,
-            sem_tok::TYPE, sem_tok::STRING, sem_tok::NUMBER,
-            sem_tok::COMMENT, sem_tok::OPERATOR,
+            sem_tok::KEYWORD,
+            sem_tok::FUNCTION,
+            sem_tok::VARIABLE,
+            sem_tok::TYPE,
+            sem_tok::STRING,
+            sem_tok::NUMBER,
+            sem_tok::COMMENT,
+            sem_tok::OPERATOR,
         ] {
             assert!(
                 types_seen.contains(&want),
                 "expected token type {} in output, got types {:?}",
-                want, types_seen
+                want,
+                types_seen
             );
         }
         // At least one DECLARATION modifier should appear (on
         // `greet` and `Point`).
-        let any_decl = tokens.iter()
+        let any_decl = tokens
+            .iter()
             .any(|t| t.modifiers & sem_tok::MOD_DECLARATION != 0);
         assert!(any_decl, "expected a DECLARATION modifier somewhere");
     }
@@ -17468,13 +18277,98 @@ mod tests {
         let wire = compute_semantic_tokens(src);
         assert!(!wire.is_empty(), "expected tokens for non-empty program");
         assert_eq!(
-            wire.len() % 5, 0,
+            wire.len() % 5,
+            0,
             "wire format must be 5-tuples, got len {}",
             wire.len()
         );
         // First token starts at column 0 of line 0.
         assert_eq!(wire[0], 0, "first dLine should be 0");
         assert_eq!(wire[1], 0, "first dStart should be 0");
+    }
+
+    // ── RES-127: tuple types + destructuring let ───────────────────────────
+
+    /// `(1, 2).0` → 1
+    #[test]
+    fn tuple_index_first() {
+        let result = eval_to_int("let t = (1, 2); t.0");
+        assert_eq!(result, 1);
+    }
+
+    /// `(1, 2).1` → 2
+    #[test]
+    fn tuple_index_second() {
+        let result = eval_to_int("let t = (1, 2); t.1");
+        assert_eq!(result, 2);
+    }
+
+    /// Mixed-type tuple: `.1` returns the string element.
+    #[test]
+    fn tuple_mixed_index() {
+        let src = r#"let t = (1, "hello"); t.1"#;
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::String(s) => assert_eq!(s, "hello"),
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    /// `let (x, y) = (10, 20); x + y` → 30
+    #[test]
+    fn tuple_destructure_let() {
+        let result = eval_to_int("let (x, y) = (10, 20); x + y");
+        assert_eq!(result, 30);
+    }
+
+    /// Single-element tuple `(42,)` round-trips as a tuple.
+    #[test]
+    fn tuple_singleton() {
+        let src = "let t = (42,); t.0";
+        let result = eval_to_int(src);
+        assert_eq!(result, 42);
+    }
+
+    /// Function returning a tuple; caller destructures it.
+    #[test]
+    fn tuple_from_function() {
+        let result = eval_to_int(
+            "fn pair(int a, int b) { return (a, b); } \
+             let (x, y) = pair(3, 4); x + y",
+        );
+        assert_eq!(result, 7);
+    }
+
+    /// Arity mismatch in destructure is a runtime error.
+    #[test]
+    fn tuple_destructure_arity_mismatch_runtime_error() {
+        let src = "let (a, b, c) = (1, 2); a";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        let err = interp.eval(&program).unwrap_err();
+        assert!(
+            err.contains("arity mismatch"),
+            "expected arity mismatch error, got: {}",
+            err
+        );
+    }
+
+    /// Typechecker catches arity mismatch statically.
+    #[test]
+    fn tuple_type_arity_mismatch_typecheck_error() {
+        // `(Int, Bool)` vs `(Int, Int, Int)` is incompatible.
+        let src = "let x: (int, bool) = (1, 2, 3);";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut tc = typechecker::TypeChecker::new();
+        let result = tc.check_program(&program);
+        assert!(
+            result.is_err(),
+            "expected type error for arity mismatch, got Ok"
+        );
     }
 }
 
@@ -17504,7 +18398,8 @@ mod ffi_integration_tests {
                             // SAFETY: intentional one-time-per-extern-decl leak to obtain a &'static str
                             // for Value::Foreign.name. The leaked memory is bounded by the number of
                             // extern decls in the program and is reclaimed when the process exits.
-                            let name: &'static str = Box::leak(d.resilient_name.clone().into_boxed_str());
+                            let name: &'static str =
+                                Box::leak(d.resilient_name.clone().into_boxed_str());
                             interpreter.env.set(
                                 d.resilient_name.clone(),
                                 Value::Foreign {
@@ -17536,11 +18431,7 @@ mod ffi_integration_tests {
         let src = "extern \"libm.so.6\" { fn my_cos(x: Float) -> Float = \"cos\"; }; fn main(int _d) { return my_cos(0.0); } main(0);";
         let result = run_with_ffi(src).expect("cos(0.0) should work");
         match result {
-            Value::Float(v) => assert!(
-                (v - 1.0_f64).abs() < 1e-10,
-                "cos(0.0) ≈ 1.0, got {}",
-                v
-            ),
+            Value::Float(v) => assert!((v - 1.0_f64).abs() < 1e-10, "cos(0.0) ≈ 1.0, got {}", v),
             other => panic!("expected Float, got {:?}", other),
         }
     }
@@ -17624,10 +18515,6 @@ mod ffi_integration_tests {
         assert!(parse_errs.is_empty(), "parse errors: {:?}", parse_errs);
         let mut tc = typechecker::TypeChecker::new();
         let result = tc.check_program(&program);
-        assert!(
-            result.is_ok(),
-            "typecheck/verifier failed: {:?}",
-            result
-        );
+        assert!(result.is_ok(), "typecheck/verifier failed: {:?}", result);
     }
 }

--- a/resilient/src/peephole.rs
+++ b/resilient/src/peephole.rs
@@ -36,8 +36,8 @@
 //! even if it forgoes some optimization opportunities. A future
 //! iterative pass could relax this at the cost of analysis.
 
-use crate::bytecode::{Chunk, Op};
 use crate::Value;
+use crate::bytecode::{Chunk, Op};
 
 /// Top-level entry. Applies all peephole rules in one linear scan.
 /// Idempotent for the rules shipped today (no rule creates a new
@@ -195,15 +195,13 @@ fn is_jump_op(op: Op) -> bool {
 
 /// Rule 1: drop `Const(k); Add` when constants[k] is Int(0).
 /// Skips if PC i+1 is a jump target.
-pub(crate) fn rule_add_zero_identity(
-    chunk: &Chunk,
-    i: usize,
-    targets: &[bool],
-) -> bool {
+pub(crate) fn rule_add_zero_identity(chunk: &Chunk, i: usize, targets: &[bool]) -> bool {
     if i + 1 >= chunk.code.len() {
         return false;
     }
-    let Op::Const(k) = chunk.code[i] else { return false; };
+    let Op::Const(k) = chunk.code[i] else {
+        return false;
+    };
     if !matches!(chunk.code[i + 1], Op::Add) {
         return false;
     }
@@ -220,20 +218,22 @@ pub(crate) fn rule_add_zero_identity(
 
 /// Rule 2: fold `LoadLocal x; Const(k==1); Add; StoreLocal x` →
 /// `IncLocal(x)`. Returns `Some(x)` on a match.
-pub(crate) fn rule_inc_local(
-    chunk: &Chunk,
-    i: usize,
-    targets: &[bool],
-) -> Option<u16> {
+pub(crate) fn rule_inc_local(chunk: &Chunk, i: usize, targets: &[bool]) -> Option<u16> {
     if i + 3 >= chunk.code.len() {
         return None;
     }
-    let Op::LoadLocal(x1) = chunk.code[i] else { return None; };
-    let Op::Const(k) = chunk.code[i + 1] else { return None; };
+    let Op::LoadLocal(x1) = chunk.code[i] else {
+        return None;
+    };
+    let Op::Const(k) = chunk.code[i + 1] else {
+        return None;
+    };
     if !matches!(chunk.code[i + 2], Op::Add) {
         return None;
     }
-    let Op::StoreLocal(x2) = chunk.code[i + 3] else { return None; };
+    let Op::StoreLocal(x2) = chunk.code[i + 3] else {
+        return None;
+    };
     if x1 != x2 {
         return None;
     }
@@ -257,11 +257,7 @@ pub(crate) fn rule_dead_jump(chunk: &Chunk, i: usize) -> bool {
 
 /// Rule 4: fold `Not; JumpIfFalse(off)` → `JumpIfTrue(off)`.
 /// Returns `Some(off)` on a match.
-pub(crate) fn rule_not_jif_to_jit(
-    chunk: &Chunk,
-    i: usize,
-    targets: &[bool],
-) -> Option<i16> {
+pub(crate) fn rule_not_jif_to_jit(chunk: &Chunk, i: usize, targets: &[bool]) -> Option<i16> {
     if i + 1 >= chunk.code.len() {
         return None;
     }
@@ -294,31 +290,19 @@ mod tests {
 
     #[test]
     fn rule1_fires_on_const_zero_plus_add() {
-        let chunk = mk_chunk(
-            &[Op::Const(0), Op::Add],
-            vec![Value::Int(0)],
-            &[1, 1],
-        );
+        let chunk = mk_chunk(&[Op::Const(0), Op::Add], vec![Value::Int(0)], &[1, 1]);
         assert!(rule_add_zero_identity(&chunk, 0, &[false; 3]));
     }
 
     #[test]
     fn rule1_skips_when_const_is_nonzero() {
-        let chunk = mk_chunk(
-            &[Op::Const(0), Op::Add],
-            vec![Value::Int(5)],
-            &[1, 1],
-        );
+        let chunk = mk_chunk(&[Op::Const(0), Op::Add], vec![Value::Int(5)], &[1, 1]);
         assert!(!rule_add_zero_identity(&chunk, 0, &[false; 3]));
     }
 
     #[test]
     fn rule1_skips_when_add_is_jump_target() {
-        let chunk = mk_chunk(
-            &[Op::Const(0), Op::Add],
-            vec![Value::Int(0)],
-            &[1, 1],
-        );
+        let chunk = mk_chunk(&[Op::Const(0), Op::Add], vec![Value::Int(0)], &[1, 1]);
         let mut targets = vec![false; 3];
         targets[1] = true;
         assert!(!rule_add_zero_identity(&chunk, 0, &targets));
@@ -374,7 +358,13 @@ mod tests {
     #[test]
     fn rule2_folds_in_full_pass() {
         let mut chunk = mk_chunk(
-            &[Op::LoadLocal(2), Op::Const(0), Op::Add, Op::StoreLocal(2), Op::Return],
+            &[
+                Op::LoadLocal(2),
+                Op::Const(0),
+                Op::Add,
+                Op::StoreLocal(2),
+                Op::Return,
+            ],
             vec![Value::Int(1)],
             &[7, 7, 7, 7, 8],
         );
@@ -414,11 +404,7 @@ mod tests {
 
     #[test]
     fn rule4_fires_on_not_jif() {
-        let chunk = mk_chunk(
-            &[Op::Not, Op::JumpIfFalse(5)],
-            vec![],
-            &[1, 1],
-        );
+        let chunk = mk_chunk(&[Op::Not, Op::JumpIfFalse(5)], vec![], &[1, 1]);
         assert_eq!(rule_not_jif_to_jit(&chunk, 0, &[false; 3]), Some(5));
     }
 
@@ -506,10 +492,9 @@ mod tests {
         assert!(matches!(chunk.code[0], Op::LoadLocal(0)));
         assert!(matches!(chunk.code[2], Op::Return));
         match chunk.code[1] {
-            Op::JumpIfFalse(o) => assert_eq!(
-                o, 0,
-                "jump must still land on the Return at new PC 2"
-            ),
+            Op::JumpIfFalse(o) => {
+                assert_eq!(o, 0, "jump must still land on the Return at new PC 2")
+            }
             other => panic!("expected JumpIfFalse, got {:?}", other),
         }
     }

--- a/resilient/src/pkg_init.rs
+++ b/resilient/src/pkg_init.rs
@@ -333,12 +333,8 @@ mod tests {
     fn tmp_parent(tag: &str) -> PathBuf {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let p = std::env::temp_dir().join(format!(
-            "res_pkg_init_{}_{}_{}",
-            tag,
-            std::process::id(),
-            n
-        ));
+        let p =
+            std::env::temp_dir().join(format!("res_pkg_init_{}_{}_{}", tag, std::process::id(), n));
         fs::create_dir_all(&p).expect("mkdir tmp parent");
         p
     }
@@ -361,12 +357,11 @@ mod tests {
     fn manifest_contents_match_template() {
         let parent = tmp_parent("manifest");
         scaffold_in(&parent, "cool_proj").expect("scaffold");
-        let got = fs::read_to_string(parent.join("cool_proj/resilient.toml"))
-            .expect("read manifest");
+        let got =
+            fs::read_to_string(parent.join("cool_proj/resilient.toml")).expect("read manifest");
         let expected = format!(
             "[package]\nname = \"cool_proj\"\nversion = \"0.1.0\"\nauthor = \"{}\"\nedition = \"{}\"\n\n[dependencies]\n",
-            DEFAULT_AUTHOR,
-            DEFAULT_EDITION,
+            DEFAULT_AUTHOR, DEFAULT_EDITION,
         );
         assert_eq!(got, expected);
         let _ = fs::remove_dir_all(&parent);
@@ -378,8 +373,8 @@ mod tests {
         // `[dependencies]` fails loudly rather than silently.
         let parent = tmp_parent("deps");
         scaffold_in(&parent, "projdeps").expect("scaffold");
-        let got = fs::read_to_string(parent.join("projdeps/resilient.toml"))
-            .expect("read manifest");
+        let got =
+            fs::read_to_string(parent.join("projdeps/resilient.toml")).expect("read manifest");
         assert!(
             got.contains("[dependencies]"),
             "missing [dependencies] table in: {got}"
@@ -392,8 +387,7 @@ mod tests {
     fn hello_world_main_runs_via_template() {
         let parent = tmp_parent("hello");
         scaffold_in(&parent, "greetings").expect("scaffold");
-        let got = fs::read_to_string(parent.join("greetings/src/main.res"))
-            .expect("read main.res");
+        let got = fs::read_to_string(parent.join("greetings/src/main.res")).expect("read main.res");
         assert!(got.contains("fn main"), "expected fn main in: {got}");
         assert!(got.contains("Hello, world!"), "expected greeting in: {got}");
         let _ = fs::remove_dir_all(&parent);
@@ -403,8 +397,7 @@ mod tests {
     fn gitignore_ignores_target_and_cert() {
         let parent = tmp_parent("gitignore");
         scaffold_in(&parent, "proj").expect("scaffold");
-        let got = fs::read_to_string(parent.join("proj/.gitignore"))
-            .expect("read gitignore");
+        let got = fs::read_to_string(parent.join("proj/.gitignore")).expect("read gitignore");
         assert!(got.contains("target/"));
         assert!(got.contains("cert/"));
         let _ = fs::remove_dir_all(&parent);
@@ -417,11 +410,11 @@ mod tests {
         fs::create_dir(&target).unwrap();
         fs::write(target.join("stray.txt"), "preexisting content").unwrap();
 
-        let err = scaffold_in(&parent, "existing")
-            .expect_err("scaffold should refuse");
+        let err = scaffold_in(&parent, "existing").expect_err("scaffold should refuse");
         assert!(
             matches!(err, PkgInitError::DirectoryNotEmpty(_)),
-            "unexpected error: {:?}", err
+            "unexpected error: {:?}",
+            err
         );
         // Guarantee: the stray file survived unchanged.
         assert_eq!(
@@ -448,11 +441,11 @@ mod tests {
         )
         .unwrap();
 
-        let err = scaffold_in(&parent, "already")
-            .expect_err("scaffold should refuse");
+        let err = scaffold_in(&parent, "already").expect_err("scaffold should refuse");
         assert!(
             matches!(err, PkgInitError::ManifestExists(_)),
-            "unexpected error: {:?}", err
+            "unexpected error: {:?}",
+            err
         );
         let _ = fs::remove_dir_all(&parent);
     }
@@ -518,9 +511,8 @@ mod tests {
     fn read_package_name_picks_up_field() {
         let parent = tmp_parent("readname");
         scaffold_in(&parent, "pkg_read_ok").expect("scaffold");
-        let name =
-            read_package_name(&parent.join("pkg_read_ok/resilient.toml"))
-                .expect("should find name");
+        let name = read_package_name(&parent.join("pkg_read_ok/resilient.toml"))
+            .expect("should find name");
         assert_eq!(name, "pkg_read_ok");
         let _ = fs::remove_dir_all(&parent);
     }
@@ -537,10 +529,7 @@ mod tests {
             "[dependencies]\nname = \"not-the-package\"\n\n[package]\nname = \"real\"\n",
         )
         .unwrap();
-        assert_eq!(
-            read_package_name(&manifest).as_deref(),
-            Some("real"),
-        );
+        assert_eq!(read_package_name(&manifest).as_deref(), Some("real"),);
         let _ = fs::remove_dir_all(&parent);
     }
 
@@ -558,8 +547,7 @@ mod tests {
         let proj = parent.join("proj");
         let nested = proj.join("src/nested");
         fs::create_dir_all(&nested).unwrap();
-        fs::write(proj.join("resilient.toml"), "[package]\nname = \"p\"\n")
-            .unwrap();
+        fs::write(proj.join("resilient.toml"), "[package]\nname = \"p\"\n").unwrap();
         let found = find_manifest_upwards(&nested).expect("should find");
         assert_eq!(found, proj.join("resilient.toml"));
         let _ = fs::remove_dir_all(&parent);

--- a/resilient/src/repl.rs
+++ b/resilient/src/repl.rs
@@ -1,12 +1,12 @@
 // Enhanced REPL for Resilient language
-use crate::{Lexer, Parser, Value};
 use crate::typechecker;
+use crate::{Lexer, Parser, Value};
 use rustyline::error::ReadlineError;
 use rustyline::{DefaultEditor, Result as RustylineResult};
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 
 // ANSI color codes for syntax highlighting
 const RESET: &str = "\x1B[0m";
@@ -63,10 +63,14 @@ impl EnhancedREPL {
             eprintln!("Error loading history: {}", err);
         }
 
-        println!("{}Resilient Programming Language REPL (v0.1.0){}",
-                 CYAN, RESET);
-        println!("Type '{}help{}' for command list, '{}exit{}' to quit",
-                 GREEN, RESET, RED, RESET);
+        println!(
+            "{}Resilient Programming Language REPL (v0.1.0){}",
+            CYAN, RESET
+        );
+        println!(
+            "Type '{}help{}' for command list, '{}exit{}' to quit",
+            GREEN, RESET, RED, RESET
+        );
 
         loop {
             // Create prompt with type checking indicator
@@ -93,15 +97,15 @@ impl EnhancedREPL {
 
                     // Process the input
                     self.process_input(input);
-                },
+                }
                 Err(ReadlineError::Interrupted) => {
                     println!("CTRL-C");
                     break;
-                },
+                }
                 Err(ReadlineError::Eof) => {
                     println!("CTRL-D");
                     break;
-                },
+                }
                 Err(err) => {
                     eprintln!("Error: {}", err);
                     break;
@@ -123,30 +127,32 @@ impl EnhancedREPL {
             "exit" | "quit" => {
                 println!("Exiting Resilient REPL");
                 std::process::exit(0);
-            },
+            }
             "help" => {
                 self.show_help();
                 return;
-            },
+            }
             "clear" => {
                 print!("\x1B[2J\x1B[1;1H"); // ANSI escape code to clear screen
                 io::stdout().flush().unwrap();
                 return;
-            },
+            }
             "typecheck" => {
                 self.type_check_enabled = !self.type_check_enabled;
-                println!("Type checking {}",
-                         if self.type_check_enabled {
-                             format!("{}enabled{}", GREEN, RESET)
-                         } else {
-                             format!("{}disabled{}", YELLOW, RESET)
-                         });
+                println!(
+                    "Type checking {}",
+                    if self.type_check_enabled {
+                        format!("{}enabled{}", GREEN, RESET)
+                    } else {
+                        format!("{}disabled{}", YELLOW, RESET)
+                    }
+                );
                 return;
-            },
+            }
             "examples" => {
                 self.show_examples();
                 return;
-            },
+            }
             _ => {}
         }
 
@@ -188,7 +194,7 @@ impl EnhancedREPL {
                 if !matches!(value, Value::Void) {
                     println!("{}{}{}", CYAN, value, RESET);
                 }
-            },
+            }
             Err(error) => {
                 eprintln!("{}Error: {}{}", RED, error, RESET);
             }
@@ -210,21 +216,39 @@ impl EnhancedREPL {
                 GREEN, RESET
             );
         } else {
-            println!("  {}examples{}   - Show example code snippets", GREEN, RESET);
+            println!(
+                "  {}examples{}   - Show example code snippets",
+                GREEN, RESET
+            );
         }
-        println!("  {}typecheck{}  - Toggle type checking (currently {})",
-                 GREEN, RESET,
-                 if self.type_check_enabled {
-                     format!("{}enabled{}", GREEN, RESET)
-                 } else {
-                     format!("{}disabled{}", YELLOW, RESET)
-                 });
+        println!(
+            "  {}typecheck{}  - Toggle type checking (currently {})",
+            GREEN,
+            RESET,
+            if self.type_check_enabled {
+                format!("{}enabled{}", GREEN, RESET)
+            } else {
+                format!("{}disabled{}", YELLOW, RESET)
+            }
+        );
 
         println!("\n{}Resilient Language Syntax:{}", CYAN, RESET);
-        println!("  {}fn name(type param) {{ ... }}{}  - Define a function", YELLOW, RESET);
-        println!("  {}let name = value;{}       - Declare a variable", YELLOW, RESET);
-        println!("  {}live {{ ... }}{}             - Define a live block", YELLOW, RESET);
-        println!("  {}assert(condition, \"msg\");{}  - Add an assertion", YELLOW, RESET);
+        println!(
+            "  {}fn name(type param) {{ ... }}{}  - Define a function",
+            YELLOW, RESET
+        );
+        println!(
+            "  {}let name = value;{}       - Declare a variable",
+            YELLOW, RESET
+        );
+        println!(
+            "  {}live {{ ... }}{}             - Define a live block",
+            YELLOW, RESET
+        );
+        println!(
+            "  {}assert(condition, \"msg\");{}  - Add an assertion",
+            YELLOW, RESET
+        );
     }
 
     fn show_examples(&self) {
@@ -297,7 +321,10 @@ impl EnhancedREPL {
             Err(_) => {
                 eprintln!(
                     "{}examples: no such file '{}' in {}{}",
-                    RED, name, dir.display(), RESET
+                    RED,
+                    name,
+                    dir.display(),
+                    RESET
                 );
             }
         }
@@ -307,16 +334,12 @@ impl EnhancedREPL {
     /// so unit tests can assert on it without fighting stdout capture.
     /// Sorted alphabetically; one basename per line.
     pub(crate) fn list_examples_in(dir: &Path) -> Result<String, String> {
-        let entries = fs::read_dir(dir)
-            .map_err(|e| format!("could not read {}: {}", dir.display(), e))?;
+        let entries =
+            fs::read_dir(dir).map_err(|e| format!("could not read {}: {}", dir.display(), e))?;
         let mut names: Vec<String> = entries
             .flatten()
-            .filter(|e| {
-                e.path().extension().and_then(|s| s.to_str()) == Some("res")
-            })
-            .filter_map(|e| {
-                e.file_name().into_string().ok()
-            })
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("res"))
+            .filter_map(|e| e.file_name().into_string().ok())
             .collect();
         names.sort();
         let mut out = String::new();
@@ -334,11 +357,7 @@ mod tests {
     use super::*;
 
     fn make_tmp(label: &str) -> PathBuf {
-        let p = std::env::temp_dir().join(format!(
-            "res_026_{}_{}",
-            label,
-            std::process::id()
-        ));
+        let p = std::env::temp_dir().join(format!("res_026_{}_{}", label, std::process::id()));
         // Wipe any leftover from a prior run so each test starts clean.
         let _ = fs::remove_dir_all(&p);
         fs::create_dir_all(&p).expect("create tmp dir");
@@ -358,11 +377,7 @@ mod tests {
             "missing alpha.res:\n{}",
             listing
         );
-        assert!(
-            listing.contains("foo.res"),
-            "missing foo.res:\n{}",
-            listing
-        );
+        assert!(listing.contains("foo.res"), "missing foo.res:\n{}", listing);
         assert!(
             !listing.contains("ignored.txt"),
             "non-.res file should be filtered:\n{}",
@@ -380,8 +395,7 @@ mod tests {
     fn list_examples_in_errors_cleanly_on_missing_dir() {
         let bogus = std::env::temp_dir().join("res_026_definitely_not_here");
         let _ = fs::remove_dir_all(&bogus);
-        let err = EnhancedREPL::list_examples_in(&bogus)
-            .expect_err("missing dir must error");
+        let err = EnhancedREPL::list_examples_in(&bogus).expect_err("missing dir must error");
         assert!(err.contains("could not read"), "got: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1,7 +1,7 @@
 // Type checker module for Resilient language
-use std::collections::HashMap;
-use crate::{Node, Pattern};
 use crate::span::Span;
+use crate::{Node, Pattern};
+use std::collections::HashMap;
 
 /// RES-189: one entry in the typechecker's post-walk inlay-hint
 /// cache. Produced for every unannotated `let` binding (i.e.
@@ -56,6 +56,11 @@ pub enum Type {
     /// variant; the `dead_code` allow goes away when RES-120 lands.
     #[allow(dead_code)]
     Var(u32),
+    /// RES-127: fixed-arity product type — `(Int, String)`. Elements
+    /// are positionally indexed (`.0`, `.1`, …). `()` is an alias for
+    /// `Type::Void`; `(T,)` is a one-element tuple. The arity is
+    /// fixed at the construction site — no variadic tuples.
+    Tuple(Vec<Type>),
 }
 
 impl std::fmt::Display for Type {
@@ -66,7 +71,10 @@ impl std::fmt::Display for Type {
             Type::String => write!(f, "string"),
             Type::Bool => write!(f, "bool"),
             Type::Bytes => write!(f, "bytes"),
-            Type::Function { params, return_type } => {
+            Type::Function {
+                params,
+                return_type,
+            } => {
                 write!(f, "fn(")?;
                 for (i, param) in params.iter().enumerate() {
                     if i > 0 {
@@ -75,21 +83,43 @@ impl std::fmt::Display for Type {
                     write!(f, "{}", param)?;
                 }
                 write!(f, ") -> {}", return_type)
-            },
+            }
             Type::Array => write!(f, "array"),
             Type::Result => write!(f, "Result"),
             Type::Struct(n) => write!(f, "{}", n),
             Type::Void => write!(f, "void"),
             Type::Any => write!(f, "any"),
             Type::Var(id) => write!(f, "?t{}", id),
+            Type::Tuple(elems) => {
+                write!(f, "(")?;
+                for (i, e) in elems.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", e)?;
+                }
+                if elems.len() == 1 {
+                    write!(f, ",")?;
+                }
+                write!(f, ")")
+            }
         }
     }
 }
 
 /// RES-053: Two types are compatible if they're equal or if either is
 /// Any. Used everywhere we need "same type, or we don't know yet."
+///
+/// RES-127: two `Tuple` types are compatible when they have the same
+/// arity AND every element pair is compatible.
 fn compatible(a: &Type, b: &Type) -> bool {
-    a == b || matches!(a, Type::Any) || matches!(b, Type::Any)
+    if matches!(a, Type::Any) || matches!(b, Type::Any) {
+        return true;
+    }
+    if let (Type::Tuple(as_), Type::Tuple(bs)) = (a, b) {
+        return as_.len() == bs.len() && as_.iter().zip(bs.iter()).all(|(x, y)| compatible(x, y));
+    }
+    a == b
 }
 
 /// RES-160: collect the binding names a pattern introduces, in
@@ -104,10 +134,7 @@ fn pattern_bindings(p: &Pattern) -> Vec<String> {
             // introduces the same names — pick the first branch's
             // list. Callers use this helper AFTER the consistency
             // check.
-            branches
-                .first()
-                .map(pattern_bindings)
-                .unwrap_or_default()
+            branches.first().map(pattern_bindings).unwrap_or_default()
         }
         // RES-161a: outer name + whatever the inner pattern binds.
         Pattern::Bind(outer, inner) => {
@@ -117,8 +144,6 @@ fn pattern_bindings(p: &Pattern) -> Vec<String> {
         }
     }
 }
-
-
 
 /// RES-160: does the pattern match every value (i.e. a
 /// wildcard / identifier, or an or-pattern with at least one
@@ -153,11 +178,7 @@ fn pattern_covers_bool(p: &Pattern, want: bool) -> bool {
 /// Returns the result type on success or a type-error diagnostic
 /// pointing users at the explicit `to_float(x)` / `to_int(x)`
 /// conversions when they mixed the two.
-fn check_numeric_same_type(
-    op: &str,
-    left: &Type,
-    right: &Type,
-) -> Result<Type, String> {
+fn check_numeric_same_type(op: &str, left: &Type, right: &Type) -> Result<Type, String> {
     match (left, right) {
         (Type::Int, Type::Int) => Ok(Type::Int),
         (Type::Float, Type::Float) => Ok(Type::Float),
@@ -170,10 +191,7 @@ fn check_numeric_same_type(
             "Cannot apply '{}' to int and float — Resilient does not implicitly coerce between numeric types. Use `to_float(x)` or `to_int(x)` explicitly.",
             op
         )),
-        _ => Err(format!(
-            "Cannot apply '{}' to {} and {}",
-            op, left, right
-        )),
+        _ => Err(format!("Cannot apply '{}' to {} and {}", op, left, right)),
     }
 }
 
@@ -192,43 +210,46 @@ fn check_numeric_same_type(
 fn fold_const_bool(n: &Node, bindings: &HashMap<String, i64>) -> Option<bool> {
     match n {
         Node::BooleanLiteral { value: b, .. } => Some(*b),
-        Node::PrefixExpression { operator, right, .. } if operator == "!" => {
-            fold_const_bool(right, bindings).map(|b| !b)
-        }
-        Node::InfixExpression { left, operator, right, .. } => {
-            match operator.as_str() {
-                "&&" => match (
-                    fold_const_bool(left, bindings),
-                    fold_const_bool(right, bindings),
-                ) {
-                    (Some(a), Some(b)) => Some(a && b),
-                    (Some(false), _) | (_, Some(false)) => Some(false),
-                    _ => None,
-                },
-                "||" => match (
-                    fold_const_bool(left, bindings),
-                    fold_const_bool(right, bindings),
-                ) {
-                    (Some(a), Some(b)) => Some(a || b),
-                    (Some(true), _) | (_, Some(true)) => Some(true),
-                    _ => None,
-                },
-                "==" | "!=" | "<" | ">" | "<=" | ">=" => {
-                    let l = fold_const_i64(left, bindings)?;
-                    let r = fold_const_i64(right, bindings)?;
-                    Some(match operator.as_str() {
-                        "==" => l == r,
-                        "!=" => l != r,
-                        "<" => l < r,
-                        ">" => l > r,
-                        "<=" => l <= r,
-                        ">=" => l >= r,
-                        _ => unreachable!(),
-                    })
-                }
+        Node::PrefixExpression {
+            operator, right, ..
+        } if operator == "!" => fold_const_bool(right, bindings).map(|b| !b),
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => match operator.as_str() {
+            "&&" => match (
+                fold_const_bool(left, bindings),
+                fold_const_bool(right, bindings),
+            ) {
+                (Some(a), Some(b)) => Some(a && b),
+                (Some(false), _) | (_, Some(false)) => Some(false),
                 _ => None,
+            },
+            "||" => match (
+                fold_const_bool(left, bindings),
+                fold_const_bool(right, bindings),
+            ) {
+                (Some(a), Some(b)) => Some(a || b),
+                (Some(true), _) | (_, Some(true)) => Some(true),
+                _ => None,
+            },
+            "==" | "!=" | "<" | ">" | "<=" | ">=" => {
+                let l = fold_const_i64(left, bindings)?;
+                let r = fold_const_i64(right, bindings)?;
+                Some(match operator.as_str() {
+                    "==" => l == r,
+                    "!=" => l != r,
+                    "<" => l < r,
+                    ">" => l > r,
+                    "<=" => l <= r,
+                    ">=" => l >= r,
+                    _ => unreachable!(),
+                })
             }
-        }
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -241,7 +262,12 @@ fn fold_const_bool(n: &Node, bindings: &HashMap<String, i64>) -> Option<bool> {
 /// Future tickets will extend to inequality bounds, ranges, and the
 /// negative branch (else).
 fn extract_eq_assumption(cond: &Node) -> Option<(String, i64)> {
-    if let Node::InfixExpression { left, operator, right, .. } = cond
+    if let Node::InfixExpression {
+        left,
+        operator,
+        right,
+        ..
+    } = cond
         && operator == "=="
     {
         let no_b: HashMap<String, i64> = HashMap::new();
@@ -264,10 +290,15 @@ fn fold_const_i64(n: &Node, bindings: &HashMap<String, i64>) -> Option<i64> {
     match n {
         Node::IntegerLiteral { value: v, .. } => Some(*v),
         Node::Identifier { name, .. } => bindings.get(name).copied(),
-        Node::PrefixExpression { operator, right, .. } if operator == "-" => {
-            fold_const_i64(right, bindings).map(|v| -v)
-        }
-        Node::InfixExpression { left, operator, right, .. } => {
+        Node::PrefixExpression {
+            operator, right, ..
+        } if operator == "-" => fold_const_i64(right, bindings).map(|v| -v),
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => {
             let l = fold_const_i64(left, bindings)?;
             let r = fold_const_i64(right, bindings)?;
             match operator.as_str() {
@@ -297,14 +328,14 @@ impl TypeEnvironment {
             outer: None,
         }
     }
-    
+
     pub fn new_enclosed(outer: TypeEnvironment) -> Self {
         TypeEnvironment {
             store: HashMap::new(),
             outer: Some(Box::new(outer)),
         }
     }
-    
+
     pub fn get(&self, name: &str) -> Option<Type> {
         match self.store.get(name) {
             Some(typ) => Some(typ.clone()),
@@ -317,7 +348,7 @@ impl TypeEnvironment {
             }
         }
     }
-    
+
     pub fn set(&mut self, name: String, typ: Type) {
         self.store.insert(name, typ);
     }
@@ -614,26 +645,38 @@ impl TypeChecker {
         env.set("tan".to_string(), fn_float_to_float());
         env.set("ln".to_string(), fn_float_to_float());
         env.set("exp".to_string(), fn_float_to_float());
-        env.set("log".to_string(), Type::Function {
-            params: vec![Type::Float, Type::Float],
-            return_type: Box::new(Type::Float),
-        });
+        env.set(
+            "log".to_string(),
+            Type::Function {
+                params: vec![Type::Float, Type::Float],
+                return_type: Box::new(Type::Float),
+            },
+        );
 
         // RES-147: monotonic ms-clock builtin. std-only.
-        env.set("clock_ms".to_string(), Type::Function {
-            params: vec![],
-            return_type: Box::new(Type::Int),
-        });
+        env.set(
+            "clock_ms".to_string(),
+            Type::Function {
+                params: vec![],
+                return_type: Box::new(Type::Int),
+            },
+        );
 
         // RES-150: seedable random builtins. std-only.
-        env.set("random_int".to_string(), Type::Function {
-            params: vec![Type::Int, Type::Int],
-            return_type: Box::new(Type::Int),
-        });
-        env.set("random_float".to_string(), Type::Function {
-            params: vec![],
-            return_type: Box::new(Type::Float),
-        });
+        env.set(
+            "random_int".to_string(),
+            Type::Function {
+                params: vec![Type::Int, Type::Int],
+                return_type: Box::new(Type::Int),
+            },
+        );
+        env.set(
+            "random_float".to_string(),
+            Type::Function {
+                params: vec![],
+                return_type: Box::new(Type::Float),
+            },
+        );
 
         // len: any -> int
         env.set(
@@ -645,190 +688,301 @@ impl TypeChecker {
         );
 
         // Array builtins: any -> array / (array,int,int) -> array
-        env.set("push".to_string(), Type::Function {
-            params: vec![Type::Array, Type::Any],
-            return_type: Box::new(Type::Array),
-        });
-        env.set("pop".to_string(), Type::Function {
-            params: vec![Type::Array],
-            return_type: Box::new(Type::Array),
-        });
-        env.set("slice".to_string(), Type::Function {
-            params: vec![Type::Array, Type::Int, Type::Int],
-            return_type: Box::new(Type::Array),
-        });
+        env.set(
+            "push".to_string(),
+            Type::Function {
+                params: vec![Type::Array, Type::Any],
+                return_type: Box::new(Type::Array),
+            },
+        );
+        env.set(
+            "pop".to_string(),
+            Type::Function {
+                params: vec![Type::Array],
+                return_type: Box::new(Type::Array),
+            },
+        );
+        env.set(
+            "slice".to_string(),
+            Type::Function {
+                params: vec![Type::Array, Type::Int, Type::Int],
+                return_type: Box::new(Type::Array),
+            },
+        );
 
         // String builtins
-        env.set("split".to_string(), Type::Function {
-            params: vec![Type::String, Type::String],
-            return_type: Box::new(Type::Array),
-        });
-        env.set("trim".to_string(), Type::Function {
-            params: vec![Type::String],
-            return_type: Box::new(Type::String),
-        });
-        env.set("contains".to_string(), Type::Function {
-            params: vec![Type::String, Type::String],
-            return_type: Box::new(Type::Bool),
-        });
-        env.set("to_upper".to_string(), Type::Function {
-            params: vec![Type::String],
-            return_type: Box::new(Type::String),
-        });
-        env.set("to_lower".to_string(), Type::Function {
-            params: vec![Type::String],
-            return_type: Box::new(Type::String),
-        });
+        env.set(
+            "split".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Array),
+            },
+        );
+        env.set(
+            "trim".to_string(),
+            Type::Function {
+                params: vec![Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
+        env.set(
+            "contains".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Bool),
+            },
+        );
+        env.set(
+            "to_upper".to_string(),
+            Type::Function {
+                params: vec![Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
+        env.set(
+            "to_lower".to_string(),
+            Type::Function {
+                params: vec![Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
         // RES-145: replace + format.
-        env.set("replace".to_string(), Type::Function {
-            params: vec![Type::String, Type::String, Type::String],
-            return_type: Box::new(Type::String),
-        });
+        env.set(
+            "replace".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String, Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
         // `format`'s second argument is `Array<?>` — the prelude
         // `Type::Array` is untyped (no element-type parameter yet),
         // which fits the ticket's `Array<?>` signature.
-        env.set("format".to_string(), Type::Function {
-            params: vec![Type::String, Type::Array],
-            return_type: Box::new(Type::String),
-        });
+        env.set(
+            "format".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::Array],
+                return_type: Box::new(Type::String),
+            },
+        );
         // RES-213: prefix/suffix tests + string repetition.
-        env.set("starts_with".to_string(), Type::Function {
-            params: vec![Type::String, Type::String],
-            return_type: Box::new(Type::Bool),
-        });
-        env.set("ends_with".to_string(), Type::Function {
-            params: vec![Type::String, Type::String],
-            return_type: Box::new(Type::Bool),
-        });
-        env.set("repeat".to_string(), Type::Function {
-            params: vec![Type::String, Type::Int],
-            return_type: Box::new(Type::String),
-        });
+        env.set(
+            "starts_with".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Bool),
+            },
+        );
+        env.set(
+            "ends_with".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Bool),
+            },
+        );
+        env.set(
+            "repeat".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::Int],
+                return_type: Box::new(Type::String),
+            },
+        );
 
         // RES-130: explicit int ↔ float conversions. These are the
         // only supported bridge between the two numeric types —
         // arithmetic and literal-match pattern equality both reject
         // implicit coercion (see `check_numeric_same_type`).
-        env.set("to_float".to_string(), Type::Function {
-            params: vec![Type::Any],
-            return_type: Box::new(Type::Float),
-        });
-        env.set("to_int".to_string(), Type::Function {
-            params: vec![Type::Any],
-            return_type: Box::new(Type::Int),
-        });
+        env.set(
+            "to_float".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Float),
+            },
+        );
+        env.set(
+            "to_int".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Int),
+            },
+        );
 
         // RES-138: current retry counter of the enclosing live block.
-        env.set("live_retries".to_string(), Type::Function {
-            params: vec![],
-            return_type: Box::new(Type::Int),
-        });
+        env.set(
+            "live_retries".to_string(),
+            Type::Function {
+                params: vec![],
+                return_type: Box::new(Type::Int),
+            },
+        );
 
         // RES-141: process-wide live-block telemetry.
-        env.set("live_total_retries".to_string(), Type::Function {
-            params: vec![],
-            return_type: Box::new(Type::Int),
-        });
-        env.set("live_total_exhaustions".to_string(), Type::Function {
-            params: vec![],
-            return_type: Box::new(Type::Int),
-        });
+        env.set(
+            "live_total_retries".to_string(),
+            Type::Function {
+                params: vec![],
+                return_type: Box::new(Type::Int),
+            },
+        );
+        env.set(
+            "live_total_exhaustions".to_string(),
+            Type::Function {
+                params: vec![],
+                return_type: Box::new(Type::Int),
+            },
+        );
 
         // RES-144: one-line stdin reader (std-only).
-        env.set("input".to_string(), Type::Function {
-            params: vec![Type::String],
-            return_type: Box::new(Type::String),
-        });
+        env.set(
+            "input".to_string(),
+            Type::Function {
+                params: vec![Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
 
         // RES-143: file I/O builtins (std-only; the resilient-runtime
         // sibling crate has no builtins table so its no_std posture is
         // unaffected).
-        env.set("file_read".to_string(), Type::Function {
-            params: vec![Type::String],
-            return_type: Box::new(Type::String),
-        });
-        env.set("file_write".to_string(), Type::Function {
-            params: vec![Type::String, Type::String],
-            return_type: Box::new(Type::Void),
-        });
+        env.set(
+            "file_read".to_string(),
+            Type::Function {
+                params: vec![Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
+        env.set(
+            "file_write".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Void),
+            },
+        );
 
         // RES-151: read-only env-var accessor. `Result<String, String>`
         // — absence is a first-class outcome, not a runtime halt.
-        env.set("env".to_string(), Type::Function {
-            params: vec![Type::String],
-            return_type: Box::new(Type::Result),
-        });
+        env.set(
+            "env".to_string(),
+            Type::Function {
+                params: vec![Type::String],
+                return_type: Box::new(Type::Result),
+            },
+        );
 
         // RES-148: Map builtins. The typechecker doesn't (yet) carry
         // a dedicated `Type::Map<K, V>` constructor — following the
         // same permissive-Any convention as the Array / Result
         // builtins until G7 inference lands.
-        env.set("map_new".to_string(), Type::Function {
-            params: vec![],
-            return_type: Box::new(Type::Any),
-        });
-        env.set("map_insert".to_string(), Type::Function {
-            params: vec![Type::Any, Type::Any, Type::Any],
-            return_type: Box::new(Type::Any),
-        });
-        env.set("map_get".to_string(), Type::Function {
-            params: vec![Type::Any, Type::Any],
-            return_type: Box::new(Type::Result),
-        });
-        env.set("map_remove".to_string(), Type::Function {
-            params: vec![Type::Any, Type::Any],
-            return_type: Box::new(Type::Any),
-        });
-        env.set("map_keys".to_string(), Type::Function {
-            params: vec![Type::Any],
-            return_type: Box::new(Type::Array),
-        });
-        env.set("map_len".to_string(), Type::Function {
-            params: vec![Type::Any],
-            return_type: Box::new(Type::Int),
-        });
+        env.set(
+            "map_new".to_string(),
+            Type::Function {
+                params: vec![],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "map_insert".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "map_get".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Result),
+            },
+        );
+        env.set(
+            "map_remove".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "map_keys".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Array),
+            },
+        );
+        env.set(
+            "map_len".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Int),
+            },
+        );
 
         // RES-149: Set builtins. Same permissive-Any convention as
         // Map — no dedicated `Type::Set<T>` until inference lands.
-        env.set("set_new".to_string(), Type::Function {
-            params: vec![],
-            return_type: Box::new(Type::Any),
-        });
-        env.set("set_insert".to_string(), Type::Function {
-            params: vec![Type::Any, Type::Any],
-            return_type: Box::new(Type::Any),
-        });
-        env.set("set_remove".to_string(), Type::Function {
-            params: vec![Type::Any, Type::Any],
-            return_type: Box::new(Type::Any),
-        });
-        env.set("set_has".to_string(), Type::Function {
-            params: vec![Type::Any, Type::Any],
-            return_type: Box::new(Type::Bool),
-        });
-        env.set("set_len".to_string(), Type::Function {
-            params: vec![Type::Any],
-            return_type: Box::new(Type::Int),
-        });
-        env.set("set_items".to_string(), Type::Function {
-            params: vec![Type::Any],
-            return_type: Box::new(Type::Array),
-        });
+        env.set(
+            "set_new".to_string(),
+            Type::Function {
+                params: vec![],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "set_insert".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "set_remove".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "set_has".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Bool),
+            },
+        );
+        env.set(
+            "set_len".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Int),
+            },
+        );
+        env.set(
+            "set_items".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Array),
+            },
+        );
 
         // RES-152: Bytes builtins. `bytes_slice` returns new Bytes;
         // `byte_at` returns Int — the language has no `u8` yet.
-        env.set("bytes_len".to_string(), Type::Function {
-            params: vec![Type::Bytes],
-            return_type: Box::new(Type::Int),
-        });
-        env.set("bytes_slice".to_string(), Type::Function {
-            params: vec![Type::Bytes, Type::Int, Type::Int],
-            return_type: Box::new(Type::Bytes),
-        });
-        env.set("byte_at".to_string(), Type::Function {
-            params: vec![Type::Bytes, Type::Int],
-            return_type: Box::new(Type::Int),
-        });
+        env.set(
+            "bytes_len".to_string(),
+            Type::Function {
+                params: vec![Type::Bytes],
+                return_type: Box::new(Type::Int),
+            },
+        );
+        env.set(
+            "bytes_slice".to_string(),
+            Type::Function {
+                params: vec![Type::Bytes, Type::Int, Type::Int],
+                return_type: Box::new(Type::Bytes),
+            },
+        );
+        env.set(
+            "byte_at".to_string(),
+            Type::Function {
+                params: vec![Type::Bytes, Type::Int],
+                return_type: Box::new(Type::Int),
+            },
+        );
 
         // Result builtins
         env.set("Ok".to_string(), fn_any_to_result());
@@ -948,10 +1102,7 @@ impl TypeChecker {
                         } else {
                             format!(
                                 "{}:{}:{}: {}",
-                                source_path,
-                                stmt.span.start.line,
-                                stmt.span.start.column,
-                                e
+                                source_path, stmt.span.start.line, stmt.span.start.column, e
                             )
                         }
                     })?;
@@ -979,7 +1130,7 @@ impl TypeChecker {
             _ => Err("Expected program node".to_string()),
         }
     }
-    
+
     pub fn check_node(&mut self, node: &Node) -> Result<Type, String> {
         match node {
             Node::Program(_statements) => self.check_program(node),
@@ -995,21 +1146,32 @@ impl TypeChecker {
                         if !PARAM_PRIMS.contains(&ty.as_str()) {
                             return Err(format!(
                                 "FFI: extern parameter `{}` has type `{}`; extern fn supports only {} in v1",
-                                name, ty, PARAM_PRIMS.join(", ")
+                                name,
+                                ty,
+                                PARAM_PRIMS.join(", ")
                             ));
                         }
                     }
                     if !RET_PRIMS.contains(&d.return_type.as_str()) {
                         return Err(format!(
                             "FFI: extern return type `{}` not supported in v1 (allowed: {})",
-                            d.return_type, RET_PRIMS.join(", ")
+                            d.return_type,
+                            RET_PRIMS.join(", ")
                         ));
                     }
                 }
                 Ok(Type::Void)
             }
-            
-            Node::Function { name, parameters, body, requires, ensures, return_type: declared_rt, .. } => {
+
+            Node::Function {
+                name,
+                parameters,
+                body,
+                requires,
+                ensures,
+                return_type: declared_rt,
+                ..
+            } => {
                 let mut param_types = Vec::new();
 
                 // Create a new enclosed environment for function body
@@ -1118,8 +1280,12 @@ impl TypeChecker {
                 // Restore const_bindings to its pre-body state.
                 for (aname, prev) in pushed_assumptions.into_iter().rev() {
                     match prev {
-                        Some(v) => { self.const_bindings.insert(aname, v); }
-                        None => { self.const_bindings.remove(&aname); }
+                        Some(v) => {
+                            self.const_bindings.insert(aname, v);
+                        }
+                        None => {
+                            self.const_bindings.remove(&aname);
+                        }
                     }
                 }
 
@@ -1149,12 +1315,12 @@ impl TypeChecker {
                 self.env.set(name.clone(), func_type);
 
                 Ok(effective_rt)
-            },
-            
+            }
+
             Node::LiveBlock { body, .. } => {
                 // Live blocks preserve the type of their body
                 self.check_node(body)
-            },
+            }
 
             // RES-142: duration literals are a parser-internal node
             // that only appear inside a `live ... within <duration>`
@@ -1164,12 +1330,17 @@ impl TypeChecker {
             // (nanosecond count) — defensive; should never fire in
             // well-formed programs.
             Node::DurationLiteral { .. } => Ok(Type::Int),
-            
-            Node::Assert { condition, message, .. } => {
+
+            Node::Assert {
+                condition, message, ..
+            } => {
                 // Condition must be a boolean expression
                 let condition_type = self.check_node(condition)?;
                 if condition_type != Type::Bool && condition_type != Type::Any {
-                    return Err(format!("Assert condition must be a boolean, got {}", condition_type));
+                    return Err(format!(
+                        "Assert condition must be a boolean, got {}",
+                        condition_type
+                    ));
                 }
 
                 // Message, if present, should be a string
@@ -1181,13 +1352,18 @@ impl TypeChecker {
                 }
 
                 Ok(Type::Void)
-            },
+            }
 
             // RES-133a: assume has the same type rules as assert
-            Node::Assume { condition, message, .. } => {
+            Node::Assume {
+                condition, message, ..
+            } => {
                 let condition_type = self.check_node(condition)?;
                 if condition_type != Type::Bool && condition_type != Type::Any {
-                    return Err(format!("Assume condition must be a boolean, got {}", condition_type));
+                    return Err(format!(
+                        "Assume condition must be a boolean, got {}",
+                        condition_type
+                    ));
                 }
                 if let Some(msg) = message {
                     let msg_type = self.check_node(msg)?;
@@ -1196,26 +1372,33 @@ impl TypeChecker {
                     }
                 }
                 Ok(Type::Void)
-            },
-            
-            Node::Block { stmts: statements, .. } => {
+            }
+
+            Node::Block {
+                stmts: statements, ..
+            } => {
                 let mut result_type = Type::Void;
-                
+
                 // Create a new enclosed environment for block
                 let mut block_env = TypeEnvironment::new_enclosed(self.env.clone());
                 std::mem::swap(&mut self.env, &mut block_env);
-                
+
                 for stmt in statements {
                     result_type = self.check_node(stmt)?;
                 }
-                
+
                 // Restore original environment
                 std::mem::swap(&mut self.env, &mut block_env);
-                
+
                 Ok(result_type)
-            },
-            
-            Node::LetStatement { name, value, type_annot, span } => {
+            }
+
+            Node::LetStatement {
+                name,
+                value,
+                type_annot,
+                span,
+            } => {
                 let value_type = self.check_node(value)?;
                 // RES-053: enforce `let x: T = value` — reject if value's
                 // type isn't compatible with the declared annotation.
@@ -1236,10 +1419,7 @@ impl TypeChecker {
                     // (shouldn't happen for a let, but guard
                     // against it) or `Var` (inference artifact
                     // that shouldn't leak to users).
-                    if !matches!(
-                        value_type,
-                        Type::Any | Type::Void | Type::Var(_)
-                    ) {
+                    if !matches!(value_type, Type::Any | Type::Void | Type::Var(_)) {
                         self.let_type_hints.push(LetTypeHint {
                             span: *span,
                             name_len_chars: name.chars().count(),
@@ -1262,7 +1442,7 @@ impl TypeChecker {
                     self.const_bindings.remove(name);
                 }
                 Ok(Type::Void)
-            },
+            }
 
             // RES-155: `let <StructName> { field1, field2: local, .. } = expr;`.
             // Exhaustiveness: without `..`, every struct field must
@@ -1290,19 +1470,14 @@ impl TypeChecker {
                     // would otherwise generate.
                     for (pf, _) in fields {
                         if !declared_fields.iter().any(|(fname, _)| fname == pf) {
-                            return Err(format!(
-                                "Struct {} has no field `{}`",
-                                struct_name, pf
-                            ));
+                            return Err(format!("Struct {} has no field `{}`", struct_name, pf));
                         }
                     }
                     // Exhaustiveness check when `..` is not used.
                     if !has_rest {
                         let mut missing: Vec<&str> = declared_fields
                             .iter()
-                            .filter(|(fname, _)| {
-                                !fields.iter().any(|(pf, _)| pf == fname)
-                            })
+                            .filter(|(fname, _)| !fields.iter().any(|(pf, _)| pf == fname))
                             .map(|(fname, _)| fname.as_str())
                             .collect();
                         if !missing.is_empty() {
@@ -1322,7 +1497,9 @@ impl TypeChecker {
                     let ty = declared
                         .as_ref()
                         .and_then(|dfs| {
-                            dfs.iter().find(|(fn_, _)| fn_ == field_name).map(|(_, t)| t.clone())
+                            dfs.iter()
+                                .find(|(fn_, _)| fn_ == field_name)
+                                .map(|(_, t)| t.clone())
                         })
                         .unwrap_or(Type::Any);
                     self.env.set(local_name.clone(), ty);
@@ -1336,7 +1513,74 @@ impl TypeChecker {
                     let _ = self.check_node(item)?;
                 }
                 Ok(Type::Array)
-            },
+            }
+
+            // RES-127: `(a, b)` tuple literal. Walk each element;
+            // return `Type::Tuple` of the inferred element types.
+            Node::TupleLiteral { items, .. } => {
+                let mut elem_types = Vec::with_capacity(items.len());
+                for item in items {
+                    elem_types.push(self.check_node(item)?);
+                }
+                Ok(Type::Tuple(elem_types))
+            }
+
+            // RES-127: `t.0`, `t.1`, … tuple positional access.
+            // Returns the declared element type when the target is a
+            // known `Tuple`; falls back to `Any` for unknown targets.
+            Node::TupleIndex { tuple, index, span } => {
+                let tup_ty = self.check_node(tuple)?;
+                match &tup_ty {
+                    Type::Tuple(elems) => {
+                        if *index >= elems.len() {
+                            return Err(format!(
+                                "{}:{}: tuple index {} out of bounds for {}-element tuple",
+                                span.start.line,
+                                span.start.column,
+                                index,
+                                elems.len()
+                            ));
+                        }
+                        Ok(elems[*index].clone())
+                    }
+                    Type::Any => Ok(Type::Any),
+                    other => Err(format!(
+                        "{}:{}: `.{}` requires a tuple, got {}",
+                        span.start.line, span.start.column, index, other
+                    )),
+                }
+            }
+
+            // RES-127: `let (x, y) = expr;` tuple destructuring.
+            Node::LetDestructureTuple { names, value, .. } => {
+                let val_ty = self.check_node(value)?;
+                match val_ty {
+                    Type::Tuple(elems) => {
+                        if names.len() != elems.len() {
+                            return Err(format!(
+                                "tuple destructure arity mismatch: pattern has {} names, value has {} elements",
+                                names.len(),
+                                elems.len()
+                            ));
+                        }
+                        for (name, ty) in names.iter().zip(elems.iter()) {
+                            self.env.set(name.clone(), ty.clone());
+                            self.const_bindings.remove(name);
+                        }
+                    }
+                    Type::Any => {
+                        // Unknown tuple type — bind all names as Any.
+                        for name in names {
+                            self.env.set(name.clone(), Type::Any);
+                            self.const_bindings.remove(name);
+                        }
+                    }
+                    other => {
+                        return Err(format!("tuple destructure requires a tuple, got {}", other));
+                    }
+                }
+                Ok(Type::Void)
+            }
 
             // RES-148: map literal — walk every key and value to
             // surface nested type errors, but fall back to `Type::Any`
@@ -1348,7 +1592,7 @@ impl TypeChecker {
                     let _ = self.check_node(v)?;
                 }
                 Ok(Type::Any)
-            },
+            }
 
             // RES-149: set literal. Walk each item to catch nested
             // type errors; return `Type::Any` for now — same posture
@@ -1358,22 +1602,21 @@ impl TypeChecker {
                     let _ = self.check_node(item)?;
                 }
                 Ok(Type::Any)
-            },
+            }
 
             Node::TryExpression { expr: inner, .. } => {
                 let inner_type = self.check_node(inner)?;
                 // `?` expects a Result and unwraps to Any at MVP (we
                 // don't track Ok's payload type yet).
                 if !compatible(&inner_type, &Type::Result) {
-                    return Err(format!(
-                        "? operator expects a Result, got {}",
-                        inner_type
-                    ));
+                    return Err(format!("? operator expects a Result, got {}", inner_type));
                 }
                 Ok(Type::Any)
-            },
+            }
 
-            Node::FunctionLiteral { parameters, body, .. } => {
+            Node::FunctionLiteral {
+                parameters, body, ..
+            } => {
                 // Evaluate the body's type in a child env with params
                 // bound, just like named Function.
                 let mut param_types = Vec::new();
@@ -1390,9 +1633,11 @@ impl TypeChecker {
                     params: param_types,
                     return_type: Box::new(body_type),
                 })
-            },
+            }
 
-            Node::Match { scrutinee, arms, .. } => {
+            Node::Match {
+                scrutinee, arms, ..
+            } => {
                 let scrutinee_type = self.check_node(scrutinee)?;
                 for (pattern, guard, body) in arms {
                     // RES-160: or-pattern binding consistency —
@@ -1438,13 +1683,12 @@ impl TypeChecker {
                             for (n, prev) in &rollback_bindings {
                                 match prev {
                                     Some(t) => self.env.set(n.clone(), t.clone()),
-                                    None => { self.env.remove(n); }
+                                    None => {
+                                        self.env.remove(n);
+                                    }
                                 }
                             }
-                            return Err(format!(
-                                "Match arm guard must be a boolean, got {}",
-                                gt
-                            ));
+                            return Err(format!("Match arm guard must be a boolean, got {}", gt));
                         }
                     }
                     let body_res = self.check_node(body);
@@ -1452,7 +1696,9 @@ impl TypeChecker {
                     for (n, prev) in rollback_bindings {
                         match prev {
                             Some(t) => self.env.set(n, t),
-                            None => { self.env.remove(&n); }
+                            None => {
+                                self.env.remove(&n);
+                            }
                         }
                     }
                     let _ = body_res?;
@@ -1463,9 +1709,9 @@ impl TypeChecker {
                 // pattern contains at least one wildcard / identifier
                 // branch — `pattern_is_default` recurses through
                 // or-patterns so `_ | x` and `0 | _` both count.
-                let has_default = arms.iter().any(|(p, guard, _)| {
-                    guard.is_none() && pattern_is_default(p)
-                });
+                let has_default = arms
+                    .iter()
+                    .any(|(p, guard, _)| guard.is_none() && pattern_is_default(p));
 
                 if !has_default {
                     match scrutinee_type {
@@ -1510,7 +1756,7 @@ impl TypeChecker {
                 }
 
                 Ok(Type::Any)
-            },
+            }
 
             // RES-158: walk each method as if it were a top-level fn.
             // The parser has already mangled the name and injected
@@ -1558,7 +1804,7 @@ impl TypeChecker {
                     let _ = self.check_node(e)?;
                 }
                 Ok(Type::Struct(name.clone()))
-            },
+            }
 
             Node::FieldAccess { target, field, .. } => {
                 let tgt_ty = self.check_node(target)?;
@@ -1573,9 +1819,14 @@ impl TypeChecker {
                     return Ok(ty.clone());
                 }
                 Ok(Type::Any)
-            },
+            }
 
-            Node::FieldAssignment { target, field, value, .. } => {
+            Node::FieldAssignment {
+                target,
+                field,
+                value,
+                ..
+            } => {
                 let tgt_ty = self.check_node(target)?;
                 let _ = self.check_node(value)?;
                 // RES-153: reject writes to non-existent fields
@@ -1586,8 +1837,7 @@ impl TypeChecker {
                     && let Some(declared) = self.struct_fields.get(sname)
                     && !declared.iter().any(|(n, _)| n == field)
                 {
-                    let avail: Vec<&str> =
-                        declared.iter().map(|(n, _)| n.as_str()).collect();
+                    let avail: Vec<&str> = declared.iter().map(|(n, _)| n.as_str()).collect();
                     return Err(format!(
                         "struct `{}` has no field `{}`; available fields: {}",
                         sname,
@@ -1596,33 +1846,40 @@ impl TypeChecker {
                     ));
                 }
                 Ok(Type::Void)
-            },
+            }
 
             Node::IndexExpression { target, index, .. } => {
                 let _ = self.check_node(target)?;
                 let _ = self.check_node(index)?;
                 // Element type not tracked at MVP.
                 Ok(Type::Any)
-            },
+            }
 
-            Node::IndexAssignment { target, index, value, .. } => {
+            Node::IndexAssignment {
+                target,
+                index,
+                value,
+                ..
+            } => {
                 let _ = self.check_node(target)?;
                 let _ = self.check_node(index)?;
                 let _ = self.check_node(value)?;
                 Ok(Type::Void)
-            },
+            }
 
             Node::ForInStatement { iterable, body, .. } => {
                 let _ = self.check_node(iterable)?;
                 let _ = self.check_node(body)?;
                 Ok(Type::Void)
-            },
+            }
 
-            Node::WhileStatement { condition, body, .. } => {
+            Node::WhileStatement {
+                condition, body, ..
+            } => {
                 let _ = self.check_node(condition)?;
                 let _ = self.check_node(body)?;
                 Ok(Type::Void)
-            },
+            }
 
             Node::StaticLet { name, value, .. } => {
                 let value_type = self.check_node(value)?;
@@ -1632,7 +1889,7 @@ impl TypeChecker {
                 // for verification.
                 self.const_bindings.remove(name);
                 Ok(Type::Void)
-            },
+            }
 
             Node::Assignment { name, value, .. } => {
                 let _ = self.check_node(value)?;
@@ -1642,8 +1899,8 @@ impl TypeChecker {
                 // choice keeps the verifier sound.
                 self.const_bindings.remove(name);
                 Ok(Type::Void)
-            },
-            
+            }
+
             Node::ReturnStatement { value, .. } => {
                 // Bare `return;` has type Void; otherwise pass through
                 // the type of the returned value.
@@ -1651,12 +1908,20 @@ impl TypeChecker {
                     Some(expr) => self.check_node(expr),
                     None => Ok(Type::Void),
                 }
-            },
-            
-            Node::IfStatement { condition, consequence, alternative, .. } => {
+            }
+
+            Node::IfStatement {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
                 let condition_type = self.check_node(condition)?;
                 if condition_type != Type::Bool && condition_type != Type::Any {
-                    return Err(format!("If condition must be a boolean, got {}", condition_type));
+                    return Err(format!(
+                        "If condition must be a boolean, got {}",
+                        condition_type
+                    ));
                 }
 
                 // RES-064: if the condition is `IDENT == LITERAL` (or
@@ -1677,8 +1942,12 @@ impl TypeChecker {
                 // Restore.
                 if let Some((name, prev)) = saved {
                     match prev {
-                        Some(v) => { self.const_bindings.insert(name, v); }
-                        None => { self.const_bindings.remove(&name); }
+                        Some(v) => {
+                            self.const_bindings.insert(name, v);
+                        }
+                        None => {
+                            self.const_bindings.remove(&name);
+                        }
                     }
                 }
 
@@ -1686,21 +1955,22 @@ impl TypeChecker {
                     let alternative_type = self.check_node(alt)?;
 
                     // Both branches should have compatible types
-                    if consequence_type != alternative_type &&
-                       consequence_type != Type::Any &&
-                       alternative_type != Type::Any {
-                        return Err(format!("If branches have incompatible types: {} and {}",
-                                          consequence_type, alternative_type));
+                    if consequence_type != alternative_type
+                        && consequence_type != Type::Any
+                        && alternative_type != Type::Any
+                    {
+                        return Err(format!(
+                            "If branches have incompatible types: {} and {}",
+                            consequence_type, alternative_type
+                        ));
                     }
                 }
 
                 Ok(consequence_type)
-            },
-            
-            Node::ExpressionStatement { expr, .. } => {
-                self.check_node(expr)
-            },
-            
+            }
+
+            Node::ExpressionStatement { expr, .. } => self.check_node(expr),
+
             Node::Identifier { name, span } => {
                 // RES-078: identifier span lets us tell users where
                 // exactly the undefined reference lives. Skip the
@@ -1718,35 +1988,45 @@ impl TypeChecker {
                         }
                     }
                 }
-            },
-            
+            }
+
             Node::IntegerLiteral { .. } => Ok(Type::Int),
             Node::FloatLiteral { .. } => Ok(Type::Float),
             Node::StringLiteral { .. } => Ok(Type::String),
             Node::BytesLiteral { .. } => Ok(Type::Bytes),
             Node::BooleanLiteral { .. } => Ok(Type::Bool),
-            
-            Node::PrefixExpression { operator, right, .. } => {
+
+            Node::PrefixExpression {
+                operator, right, ..
+            } => {
                 let right_type = self.check_node(right)?;
-                
+
                 match operator.as_str() {
                     "!" => {
                         if right_type != Type::Bool && right_type != Type::Any {
                             return Err(format!("Cannot apply '!' to {}", right_type));
                         }
                         Ok(Type::Bool)
-                    },
+                    }
                     "-" => {
-                        if right_type != Type::Int && right_type != Type::Float && right_type != Type::Any {
+                        if right_type != Type::Int
+                            && right_type != Type::Float
+                            && right_type != Type::Any
+                        {
                             return Err(format!("Cannot apply '-' to {}", right_type));
                         }
                         Ok(right_type)
-                    },
+                    }
                     _ => Err(format!("Unknown prefix operator: {}", operator)),
                 }
-            },
-            
-            Node::InfixExpression { left, operator, right, .. } => {
+            }
+
+            Node::InfixExpression {
+                left,
+                operator,
+                right,
+                ..
+            } => {
                 let left_type = self.check_node(left)?;
                 let right_type = self.check_node(right)?;
 
@@ -1783,8 +2063,7 @@ impl TypeChecker {
                     }
                     "&" | "|" | "^" | "<<" | ">>" => {
                         // Bitwise operators are int-only.
-                        if compatible(&left_type, &Type::Int)
-                            && compatible(&right_type, &Type::Int)
+                        if compatible(&left_type, &Type::Int) && compatible(&right_type, &Type::Int)
                         {
                             Ok(Type::Int)
                         } else {
@@ -1808,17 +2087,18 @@ impl TypeChecker {
                         if compatible(&left_type, &right_type) {
                             Ok(Type::Bool)
                         } else {
-                            Err(format!(
-                                "Cannot compare {} and {}",
-                                left_type, right_type
-                            ))
+                            Err(format!("Cannot compare {} and {}", left_type, right_type))
                         }
                     }
                     _ => Err(format!("Unknown infix operator: {}", operator)),
                 }
-            },
-            
-            Node::CallExpression { function, arguments, .. } => {
+            }
+
+            Node::CallExpression {
+                function,
+                arguments,
+                ..
+            } => {
                 let func_type = self.check_node(function)?;
 
                 // RES-061 + RES-063: if the callee is a known top-level
@@ -1826,7 +2106,9 @@ impl TypeChecker {
                 // call's arguments substituted for parameters. Arguments
                 // can be literal expressions OR identifiers that resolve
                 // to a constant via const_bindings.
-                if let Node::Identifier { name: callee_name, .. } = function.as_ref()
+                if let Node::Identifier {
+                    name: callee_name, ..
+                } = function.as_ref()
                     && let Some(info) = self.contract_table.get(callee_name).cloned()
                 {
                     if !info.requires.is_empty() {
@@ -1870,9 +2152,7 @@ impl TypeChecker {
                             // position; suppressed on
                             // `--no-warn-unverified`.
                             if verdict.is_none() && self.warn_unverified {
-                                emit_partial_proof_warning(
-                                    &self.source_path, clause,
-                                );
+                                emit_partial_proof_warning(&self.source_path, clause);
                             }
                             if matches!(verdict, Some(true))
                                 && let Some(smt2) = cert
@@ -1901,46 +2181,65 @@ impl TypeChecker {
                             }
                             Some(true) => {
                                 self.stats.requires_discharged_at_compile += 1;
-                                *self.stats.per_fn_discharged
-                                    .entry(callee_name.clone()).or_insert(0) += 1;
+                                *self
+                                    .stats
+                                    .per_fn_discharged
+                                    .entry(callee_name.clone())
+                                    .or_insert(0) += 1;
                             }
                             None => {
                                 self.stats.requires_left_for_runtime += 1;
-                                *self.stats.per_fn_runtime
-                                    .entry(callee_name.clone()).or_insert(0) += 1;
+                                *self
+                                    .stats
+                                    .per_fn_runtime
+                                    .entry(callee_name.clone())
+                                    .or_insert(0) += 1;
                             }
                         }
                     }
                 }
 
                 match func_type {
-                    Type::Function { params, return_type } => {
+                    Type::Function {
+                        params,
+                        return_type,
+                    } => {
                         // Check argument count
                         if arguments.len() != params.len() {
-                            return Err(format!("Expected {} arguments, got {}",
-                                              params.len(), arguments.len()));
+                            return Err(format!(
+                                "Expected {} arguments, got {}",
+                                params.len(),
+                                arguments.len()
+                            ));
                         }
 
                         // Check each argument type
-                        for (i, (arg, param_type)) in arguments.iter().zip(params.iter()).enumerate() {
+                        for (i, (arg, param_type)) in
+                            arguments.iter().zip(params.iter()).enumerate()
+                        {
                             let arg_type = self.check_node(arg)?;
-                            if arg_type != *param_type && *param_type != Type::Any && arg_type != Type::Any {
-                                return Err(format!("Type mismatch in argument {}: expected {}, got {}",
-                                                  i + 1, param_type, arg_type));
+                            if arg_type != *param_type
+                                && *param_type != Type::Any
+                                && arg_type != Type::Any
+                            {
+                                return Err(format!(
+                                    "Type mismatch in argument {}: expected {}, got {}",
+                                    i + 1,
+                                    param_type,
+                                    arg_type
+                                ));
                             }
                         }
 
                         Ok(*return_type)
-                    },
-                    Type::Any => {
-                        Ok(Type::Any)
-                    },
+                    }
+                    Type::Any => Ok(Type::Any),
                     _ => Err(format!("Cannot call non-function type: {}", func_type)),
                 }
-            },
+            }
         }
     }
-    
+
     fn parse_type_name(&self, name: &str) -> Result<Type, String> {
         self.parse_type_name_inner(name, &mut Vec::new())
     }
@@ -1952,6 +2251,27 @@ impl TypeChecker {
     /// as a diagnostic instead of looping forever or stack-
     /// overflowing.
     fn parse_type_name_inner(&self, name: &str, seen: &mut Vec<String>) -> Result<Type, String> {
+        // RES-127: `(T1, T2, ...)` tuple type — serialised by the parser
+        // as the string `"(T1, T2)"`. Recognise the leading `(`, split
+        // the inner list, and recurse for each element type.
+        if name.starts_with('(') && name.ends_with(')') {
+            let inner = &name[1..name.len() - 1];
+            // Unit tuple `()` → Void.
+            if inner.trim().is_empty() {
+                return Ok(Type::Void);
+            }
+            // Split on top-level commas only (no nested parens yet — a
+            // limitation fine for the core slice; generics/nested tuples
+            // extend this in a follow-up).
+            let parts = split_tuple_type_parts(inner);
+            let elems: Result<Vec<Type>, String> = parts
+                .iter()
+                .map(|s| self.parse_type_name_inner(s.trim(), seen))
+                .collect();
+            let elems = elems?;
+            return Ok(Type::Tuple(elems));
+        }
+
         match name {
             "int" => Ok(Type::Int),
             "float" => Ok(Type::Float),
@@ -1968,10 +2288,7 @@ impl TypeChecker {
                     // how they got into it.
                     let mut chain = seen.clone();
                     chain.push(other.to_string());
-                    return Err(format!(
-                        "type alias cycle: {}",
-                        chain.join(" -> ")
-                    ));
+                    return Err(format!("type alias cycle: {}", chain.join(" -> ")));
                 }
                 seen.push(other.to_string());
                 let target = self.type_aliases[other].clone();
@@ -1983,6 +2300,32 @@ impl TypeChecker {
             other => Ok(Type::Struct(other.to_string())),
         }
     }
+}
+
+/// RES-127: split a comma-separated type list at the top level (respecting
+/// nested parentheses). Used to parse `T1, T2` out of `(T1, T2)` without
+/// being confused by a nested tuple like `(Int, (Bool, Float))`.
+fn split_tuple_type_parts(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    // Trailing segment (possibly empty after a trailing comma like `(T,)`).
+    let tail = s[start..].trim();
+    if !tail.is_empty() {
+        parts.push(&s[start..]);
+    }
+    parts
 }
 
 // ============================================================
@@ -2022,20 +2365,26 @@ impl TypeChecker {
 /// new I/O / clock / env builtin there means adding it here.
 const IMPURE_BUILTINS: &[&str] = &[
     // RES-004 / RES-144: stdio.
-    "println", "print", "input",
+    "println",
+    "print",
+    "input",
     // RES-147: monotonic clock.
     "clock_ms",
     // RES-150: seedable PRNG — nondeterministic from the caller's
     // point of view even though the seed pins it globally.
-    "random_int", "random_float",
+    "random_int",
+    "random_float",
     // RES-143: disk I/O.
-    "file_read", "file_write",
+    "file_read",
+    "file_write",
     // RES-151: env-var reads depend on process state outside
     // the fn.
     "env",
     // RES-138 / RES-141: retry-counter readers — observe runtime
     // state that isn't the fn's parameters.
-    "live_retries", "live_total_retries", "live_total_exhaustions",
+    "live_retries",
+    "live_total_retries",
+    "live_total_exhaustions",
 ];
 
 /// RES-191: top-level entry for the purity pass. Walks the
@@ -2053,17 +2402,24 @@ fn check_program_purity(
     // Optimistic assumption: every `@pure` fn is pure until proven
     // otherwise. Populate the set so mutual-recursion checks
     // succeed.
-    let mut pure_fns: std::collections::HashSet<String> =
-        std::collections::HashSet::new();
+    let mut pure_fns: std::collections::HashSet<String> = std::collections::HashSet::new();
     for stmt in statements {
-        if let Node::Function { name, pure: true, .. } = &stmt.node {
+        if let Node::Function {
+            name, pure: true, ..
+        } = &stmt.node
+        {
             pure_fns.insert(name.clone());
         }
     }
 
     // Second pass: check each pure fn's body.
     for stmt in statements {
-        if let Node::Function { name, body, pure: true, .. } = &stmt.node
+        if let Node::Function {
+            name,
+            body,
+            pure: true,
+            ..
+        } = &stmt.node
             && let Err(reason) = check_body_purity(body, name, &pure_fns)
         {
             let (line, col) = (stmt.span.start.line, stmt.span.start.column);
@@ -2108,18 +2464,27 @@ fn check_body_purity(
         Node::LetStatement { value, .. } | Node::StaticLet { value, .. } => {
             check_body_purity(value, fn_name, pure_fns)?;
         }
-        Node::ReturnStatement { value: Some(value), .. } => {
+        Node::ReturnStatement {
+            value: Some(value), ..
+        } => {
             check_body_purity(value, fn_name, pure_fns)?;
         }
         Node::ReturnStatement { value: None, .. } => {}
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             check_body_purity(condition, fn_name, pure_fns)?;
             check_body_purity(consequence, fn_name, pure_fns)?;
             if let Some(a) = alternative {
                 check_body_purity(a, fn_name, pure_fns)?;
             }
         }
-        Node::WhileStatement { condition, body, .. } => {
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
             check_body_purity(condition, fn_name, pure_fns)?;
             check_body_purity(body, fn_name, pure_fns)?;
         }
@@ -2137,7 +2502,8 @@ fn check_body_purity(
             // live-blocks retry on failure — that's observable,
             // non-pure behaviour by construction.
             return Err("contains a `live` block (retries are \
-                        observable side effects)".to_string());
+                        observable side effects)"
+                .to_string());
         }
         Node::InfixExpression { left, right, .. } => {
             check_body_purity(left, fn_name, pure_fns)?;
@@ -2146,7 +2512,11 @@ fn check_body_purity(
         Node::PrefixExpression { right, .. } => {
             check_body_purity(right, fn_name, pure_fns)?;
         }
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             // Recurse into args first (nested calls get checked too).
             for a in arguments {
                 check_body_purity(a, fn_name, pure_fns)?;
@@ -2158,9 +2528,7 @@ fn check_body_purity(
             // conservative "unknown callee — reject" treatment.
             if let Node::Identifier { name: callee, .. } = function.as_ref() {
                 if IMPURE_BUILTINS.contains(&callee.as_str()) {
-                    return Err(format!(
-                        "calls impure builtin `{}`", callee
-                    ));
+                    return Err(format!("calls impure builtin `{}`", callee));
                 }
                 // Pure-to-pure is fine.
                 if pure_fns.contains(callee) {
@@ -2176,18 +2544,14 @@ fn check_body_purity(
                 if is_known_pure_builtin(callee) {
                     return Ok(());
                 }
-                return Err(format!(
-                    "calls unannotated fn `{}`", callee
-                ));
+                return Err(format!("calls unannotated fn `{}`", callee));
             }
             // Indirect / method callee — can't resolve statically.
             // Conservatively reject so @pure is meaningful.
             check_body_purity(function, fn_name, pure_fns)?;
-            return Err(
-                "calls a non-identifier callee (method or computed); \
+            return Err("calls a non-identifier callee (method or computed); \
                  only bare-identifier calls to pure fns are allowed"
-                    .to_string()
-            );
+                .to_string());
         }
         Node::FieldAccess { target, .. } => {
             check_body_purity(target, fn_name, pure_fns)?;
@@ -2196,9 +2560,7 @@ fn check_body_purity(
             check_body_purity(target, fn_name, pure_fns)?;
             check_body_purity(value, fn_name, pure_fns)?;
             // Mutating a field is observable — disallow.
-            return Err(
-                "mutates a struct field (field assignment is a side effect)".to_string()
-            );
+            return Err("mutates a struct field (field assignment is a side effect)".to_string());
         }
         Node::Assignment { value, .. } => {
             check_body_purity(value, fn_name, pure_fns)?;
@@ -2207,12 +2569,17 @@ fn check_body_purity(
             check_body_purity(target, fn_name, pure_fns)?;
             check_body_purity(index, fn_name, pure_fns)?;
         }
-        Node::IndexAssignment { target, index, value, .. } => {
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
             check_body_purity(target, fn_name, pure_fns)?;
             check_body_purity(index, fn_name, pure_fns)?;
             check_body_purity(value, fn_name, pure_fns)?;
             return Err(
-                "mutates an array/map element (index assignment is a side effect)".to_string()
+                "mutates an array/map element (index assignment is a side effect)".to_string(),
             );
         }
         Node::ArrayLiteral { items, .. } => {
@@ -2225,7 +2592,9 @@ fn check_body_purity(
                 check_body_purity(v, fn_name, pure_fns)?;
             }
         }
-        Node::Match { scrutinee, arms, .. } => {
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
             check_body_purity(scrutinee, fn_name, pure_fns)?;
             // Each arm is `(pattern, guard?, body)`. Recurse into
             // the optional guard and the body.
@@ -2277,21 +2646,59 @@ fn is_known_pure_builtin(name: &str) -> bool {
     // minus the names in `IMPURE_BUILTINS`.
     const PURE_BUILTINS: &[&str] = &[
         // Math.
-        "abs", "min", "max", "sqrt", "pow", "floor", "ceil",
-        "to_float", "to_int",
-        "sin", "cos", "tan", "ln", "log", "exp",
+        "abs",
+        "min",
+        "max",
+        "sqrt",
+        "pow",
+        "floor",
+        "ceil",
+        "to_float",
+        "to_int",
+        "sin",
+        "cos",
+        "tan",
+        "ln",
+        "log",
+        "exp",
         // String/collection.
-        "len", "push", "pop", "slice", "split", "trim", "contains",
-        "to_upper", "to_lower", "replace", "format",
-        "starts_with", "ends_with", "repeat",
+        "len",
+        "push",
+        "pop",
+        "slice",
+        "split",
+        "trim",
+        "contains",
+        "to_upper",
+        "to_lower",
+        "replace",
+        "format",
+        "starts_with",
+        "ends_with",
+        "repeat",
         // Result helpers.
-        "Ok", "Err", "is_ok", "is_err", "unwrap", "unwrap_err",
+        "Ok",
+        "Err",
+        "is_ok",
+        "is_err",
+        "unwrap",
+        "unwrap_err",
         // Map/Set/Bytes.
-        "map_new", "map_insert", "map_get", "map_remove",
-        "map_keys", "map_len",
-        "set_new", "set_insert", "set_remove", "set_has",
-        "set_len", "set_items",
-        "bytes_len", "bytes_slice", "byte_at",
+        "map_new",
+        "map_insert",
+        "map_get",
+        "map_remove",
+        "map_keys",
+        "map_len",
+        "set_new",
+        "set_insert",
+        "set_remove",
+        "set_has",
+        "set_len",
+        "set_items",
+        "bytes_len",
+        "bytes_slice",
+        "byte_at",
     ];
     PURE_BUILTINS.contains(&name)
 }
@@ -2324,8 +2731,7 @@ pub fn infer_fn_effects(
     statements: &[crate::span::Spanned<Node>],
 ) -> std::collections::HashMap<String, bool> {
     // Step 1: collect user-fn names + their body references.
-    let mut fn_bodies: std::collections::HashMap<String, &Node> =
-        std::collections::HashMap::new();
+    let mut fn_bodies: std::collections::HashMap<String, &Node> = std::collections::HashMap::new();
     for stmt in statements {
         if let Node::Function { name, body, .. } = &stmt.node {
             fn_bodies.insert(name.clone(), body.as_ref());
@@ -2361,10 +2767,7 @@ pub fn infer_fn_effects(
 /// current `effects` snapshot. Used inside the fixpoint loop —
 /// each iteration treats `effects` as a frozen best-estimate and
 /// asks "does this body reach anything marked IO today?".
-fn body_reaches_io(
-    node: &Node,
-    effects: &std::collections::HashMap<String, bool>,
-) -> bool {
+fn body_reaches_io(node: &Node, effects: &std::collections::HashMap<String, bool>) -> bool {
     match node {
         Node::Block { stmts, .. } => stmts.iter().any(|s| body_reaches_io(s, effects)),
         Node::LetStatement { value, .. } | Node::StaticLet { value, .. } => {
@@ -2372,22 +2775,29 @@ fn body_reaches_io(
         }
         Node::ReturnStatement { value: Some(v), .. } => body_reaches_io(v, effects),
         Node::ReturnStatement { value: None, .. } => false,
-        Node::IfStatement { condition, consequence, alternative, .. } => {
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
             body_reaches_io(condition, effects)
                 || body_reaches_io(consequence, effects)
                 || alternative
                     .as_ref()
                     .is_some_and(|a| body_reaches_io(a, effects))
         }
-        Node::WhileStatement { condition, body, .. } => {
-            body_reaches_io(condition, effects) || body_reaches_io(body, effects)
-        }
+        Node::WhileStatement {
+            condition, body, ..
+        } => body_reaches_io(condition, effects) || body_reaches_io(body, effects),
         Node::ForInStatement { iterable, body, .. } => {
             body_reaches_io(iterable, effects) || body_reaches_io(body, effects)
         }
         Node::Assert { condition, .. } => body_reaches_io(condition, effects),
         Node::Assume { condition, .. } => body_reaches_io(condition, effects),
-        Node::LiveBlock { body, invariants, .. } => {
+        Node::LiveBlock {
+            body, invariants, ..
+        } => {
             // A `live` block is NOT intrinsically IO (retries on
             // failure observe error state, but not IO per the
             // ticket's definition). If the body reaches IO, the
@@ -2399,7 +2809,11 @@ fn body_reaches_io(
             body_reaches_io(left, effects) || body_reaches_io(right, effects)
         }
         Node::PrefixExpression { right, .. } => body_reaches_io(right, effects),
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             // Any arg side-effecting → IO.
             if arguments.iter().any(|a| body_reaches_io(a, effects)) {
                 return true;
@@ -2437,18 +2851,23 @@ fn body_reaches_io(
         Node::IndexExpression { target, index, .. } => {
             body_reaches_io(target, effects) || body_reaches_io(index, effects)
         }
-        Node::IndexAssignment { target, index, value, .. } => {
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
             body_reaches_io(target, effects)
                 || body_reaches_io(index, effects)
                 || body_reaches_io(value, effects)
         }
-        Node::ArrayLiteral { items, .. } => {
-            items.iter().any(|i| body_reaches_io(i, effects))
-        }
+        Node::ArrayLiteral { items, .. } => items.iter().any(|i| body_reaches_io(i, effects)),
         Node::StructLiteral { fields, .. } => {
             fields.iter().any(|(_, v)| body_reaches_io(v, effects))
         }
-        Node::Match { scrutinee, arms, .. } => {
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
             if body_reaches_io(scrutinee, effects) {
                 return true;
             }
@@ -2545,8 +2964,7 @@ mod purity_tests {
             fn helper(int x) { return x + 1; }\n\
             @pure fn f(int x) { return helper(x); }\n";
         let s = stmts(src);
-        let err = check_program_purity(&s, "<t>")
-            .expect_err("unannotated user fn is rejected");
+        let err = check_program_purity(&s, "<t>").expect_err("unannotated user fn is rejected");
         assert!(
             err.contains("calls unannotated fn `helper`"),
             "unexpected error: {err}"
@@ -2567,8 +2985,7 @@ mod purity_tests {
         // purity pass itself correctly handles mutual recursion
         // because the optimistic first pass populates `pure_fns`
         // with both names.
-        check_program_purity(&s, "<t>")
-            .expect("mutual recursion between two @pure fns is fine");
+        check_program_purity(&s, "<t>").expect("mutual recursion between two @pure fns is fine");
     }
 
     #[test]
@@ -2576,8 +2993,7 @@ mod purity_tests {
         // `live` blocks retry on failure — observable from outside.
         let src = "@pure fn f(int x) { live { return x; } return 0; }\n";
         let s = stmts(src);
-        let err = check_program_purity(&s, "<t>")
-            .expect_err("live blocks are impure");
+        let err = check_program_purity(&s, "<t>").expect_err("live blocks are impure");
         assert!(err.contains("live"), "unexpected error: {err}");
     }
 
@@ -2587,8 +3003,7 @@ mod purity_tests {
         // leave them alone even if they'd violate purity.
         let src = "fn noisy() { println(\"hi\"); return 0; }\n";
         let s = stmts(src);
-        check_program_purity(&s, "<t>")
-            .expect("non-@pure fns bypass the purity checker");
+        check_program_purity(&s, "<t>").expect("non-@pure fns bypass the purity checker");
     }
 
     // ---------- error message shape ----------
@@ -2599,7 +3014,10 @@ mod purity_tests {
         let s = stmts(src);
         let err = check_program_purity(&s, "<t>").unwrap_err();
         assert!(err.contains("noisy"), "expected fn name in error: {err}");
-        assert!(err.contains("println"), "expected callee name in error: {err}");
+        assert!(
+            err.contains("println"),
+            "expected callee name in error: {err}"
+        );
     }
 
     #[test]

--- a/resilient/src/unify.rs
+++ b/resilient/src/unify.rs
@@ -72,7 +72,9 @@ pub struct Substitution {
 impl Substitution {
     /// A fresh (identity) substitution.
     pub fn new() -> Self {
-        Self { inner: HashMap::new() }
+        Self {
+            inner: HashMap::new(),
+        }
     }
 
     /// The underlying map — exposed as `&` so tests can assert on
@@ -111,10 +113,15 @@ impl Substitution {
                     }
                 }
             }
-            Type::Function { params, return_type } => Type::Function {
+            Type::Function {
+                params,
+                return_type,
+            } => Type::Function {
                 params: params.iter().map(|p| self.apply(p)).collect(),
                 return_type: Box::new(self.apply(return_type)),
             },
+            // RES-127: apply substitution element-wise through tuples.
+            Type::Tuple(elems) => Type::Tuple(elems.iter().map(|e| self.apply(e)).collect()),
             // Primitive and opaque variants have no sub-types.
             Type::Int
             | Type::Float
@@ -157,8 +164,14 @@ impl Substitution {
             (other, Type::Var(v)) => self.bind(v, other),
             // Function: unify arities and then per-component.
             (
-                Type::Function { params: p1, return_type: r1 },
-                Type::Function { params: p2, return_type: r2 },
+                Type::Function {
+                    params: p1,
+                    return_type: r1,
+                },
+                Type::Function {
+                    params: p2,
+                    return_type: r2,
+                },
             ) => {
                 if p1.len() != p2.len() {
                     return Err(UnifyError::ArityMismatch(p1.len(), p2.len()));
@@ -167,6 +180,18 @@ impl Substitution {
                     self.unify(l, r)?;
                 }
                 self.unify(&r1, &r2)
+            }
+            // RES-127: tuples unify element-wise; arity mismatch is an
+            // error. Reuse `ArityMismatch` (it carries two lengths) for
+            // a consistent diagnostic shape.
+            (Type::Tuple(es1), Type::Tuple(es2)) => {
+                if es1.len() != es2.len() {
+                    return Err(UnifyError::ArityMismatch(es1.len(), es2.len()));
+                }
+                for (l, r) in es1.iter().zip(es2.iter()) {
+                    self.unify(l, r)?;
+                }
+                Ok(())
             }
             (a, b) => Err(UnifyError::Mismatch(a, b)),
         }
@@ -226,9 +251,12 @@ impl Substitution {
                 }
                 false
             }
-            Type::Function { params, return_type } => {
-                params.iter().any(|p| self.occurs(v, p)) || self.occurs(v, return_type)
-            }
+            Type::Function {
+                params,
+                return_type,
+            } => params.iter().any(|p| self.occurs(v, p)) || self.occurs(v, return_type),
+            // RES-127: tuples carry sub-types; check each element.
+            Type::Tuple(elems) => elems.iter().any(|e| self.occurs(v, e)),
             _ => false,
         }
     }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -336,10 +336,15 @@ fn translate_bool<'c>(
 ) -> Option<Bool<'c>> {
     match node {
         Node::BooleanLiteral { value: b, .. } => Some(Bool::from_bool(ctx, *b)),
-        Node::PrefixExpression { operator, right, .. } if operator == "!" => {
-            translate_bool(ctx, right, bindings).map(|b| b.not())
-        }
-        Node::InfixExpression { left, operator, right, .. } => match operator.as_str() {
+        Node::PrefixExpression {
+            operator, right, ..
+        } if operator == "!" => translate_bool(ctx, right, bindings).map(|b| b.not()),
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => match operator.as_str() {
             "&&" => {
                 let l = translate_bool(ctx, left, bindings)?;
                 let r = translate_bool(ctx, right, bindings)?;
@@ -384,10 +389,15 @@ fn translate_int<'c>(
             Some(v) => Some(Int::from_i64(ctx, *v)),
             None => Some(Int::new_const(ctx, name.as_str())),
         },
-        Node::PrefixExpression { operator, right, .. } if operator == "-" => {
-            translate_int(ctx, right, bindings).map(|v| v.unary_minus())
-        }
-        Node::InfixExpression { left, operator, right, .. } => {
+        Node::PrefixExpression {
+            operator, right, ..
+        } if operator == "-" => translate_int(ctx, right, bindings).map(|v| v.unary_minus()),
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => {
             let l = translate_int(ctx, left, bindings)?;
             let r = translate_int(ctx, right, bindings)?;
             Some(match operator.as_str() {
@@ -408,9 +418,11 @@ fn translate_int<'c>(
         // injected by `collect_len_args` + the `prove_with_timeout`
         // caller, not here; this fn stays side-effect-free on the
         // solver.
-        Node::CallExpression { function, arguments, .. }
-            if is_len_call(function, arguments) =>
-        {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } if is_len_call(function, arguments) => {
             if let Node::Identifier { name, .. } = &arguments[0] {
                 Some(Int::new_const(ctx, format!("len_{}", name)))
             } else {
@@ -441,9 +453,11 @@ fn is_len_call(function: &Node, arguments: &[Node]) -> bool {
 /// format the axiom / certificate consistently.
 fn collect_len_args(node: &Node, out: &mut BTreeSet<String>) {
     match node {
-        Node::CallExpression { function, arguments, .. }
-            if is_len_call(function, arguments) =>
-        {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } if is_len_call(function, arguments) => {
             if let Node::Identifier { name, .. } = &arguments[0] {
                 out.insert(name.clone());
             }
@@ -455,7 +469,11 @@ fn collect_len_args(node: &Node, out: &mut BTreeSet<String>) {
             collect_len_args(left, out);
             collect_len_args(right, out);
         }
-        Node::CallExpression { function, arguments, .. } => {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
             collect_len_args(function, out);
             for arg in arguments {
                 collect_len_args(arg, out);
@@ -474,9 +492,15 @@ mod tests {
         let no_b = HashMap::new();
         // `5 != 0` — provably true, no free variables.
         let expr = Node::InfixExpression {
-            left: Box::new(Node::IntegerLiteral { value: 5, span: crate::span::Span::default() }),
+            left: Box::new(Node::IntegerLiteral {
+                value: 5,
+                span: crate::span::Span::default(),
+            }),
             operator: "!=".to_string(),
-            right: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
+            right: Box::new(Node::IntegerLiteral {
+                value: 0,
+                span: crate::span::Span::default(),
+            }),
             span: crate::span::Span::default(),
         };
         assert_eq!(prove(&expr, &no_b), Some(true));
@@ -487,9 +511,15 @@ mod tests {
         let no_b = HashMap::new();
         // `0 != 0` — provably false.
         let expr = Node::InfixExpression {
-            left: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
+            left: Box::new(Node::IntegerLiteral {
+                value: 0,
+                span: crate::span::Span::default(),
+            }),
             operator: "!=".to_string(),
-            right: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
+            right: Box::new(Node::IntegerLiteral {
+                value: 0,
+                span: crate::span::Span::default(),
+            }),
             span: crate::span::Span::default(),
         };
         assert_eq!(prove(&expr, &no_b), Some(false));
@@ -502,13 +532,22 @@ mod tests {
         let no_b = HashMap::new();
         let expr = Node::InfixExpression {
             left: Box::new(Node::InfixExpression {
-                left: Box::new(Node::Identifier { name: "x".to_string(), span: crate::span::Span::default() }),
+                left: Box::new(Node::Identifier {
+                    name: "x".to_string(),
+                    span: crate::span::Span::default(),
+                }),
                 operator: "+".to_string(),
-                right: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
-            span: crate::span::Span::default(),
+                right: Box::new(Node::IntegerLiteral {
+                    value: 0,
+                    span: crate::span::Span::default(),
+                }),
+                span: crate::span::Span::default(),
             }),
             operator: "==".to_string(),
-            right: Box::new(Node::Identifier { name: "x".to_string(), span: crate::span::Span::default() }),
+            right: Box::new(Node::Identifier {
+                name: "x".to_string(),
+                span: crate::span::Span::default(),
+            }),
             span: crate::span::Span::default(),
         };
         assert_eq!(prove(&expr, &no_b), Some(true));
@@ -527,17 +566,29 @@ mod tests {
         let no_b = HashMap::new();
         let expr = Node::InfixExpression {
             left: Box::new(Node::InfixExpression {
-                left: Box::new(Node::Identifier { name: "x".to_string(), span: crate::span::Span::default() }),
+                left: Box::new(Node::Identifier {
+                    name: "x".to_string(),
+                    span: crate::span::Span::default(),
+                }),
                 operator: ">".to_string(),
-                right: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
-            span: crate::span::Span::default(),
+                right: Box::new(Node::IntegerLiteral {
+                    value: 0,
+                    span: crate::span::Span::default(),
+                }),
+                span: crate::span::Span::default(),
             }),
             operator: "||".to_string(),
             right: Box::new(Node::InfixExpression {
-                left: Box::new(Node::Identifier { name: "x".to_string(), span: crate::span::Span::default() }),
+                left: Box::new(Node::Identifier {
+                    name: "x".to_string(),
+                    span: crate::span::Span::default(),
+                }),
                 operator: "<=".to_string(),
-                right: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
-            span: crate::span::Span::default(),
+                right: Box::new(Node::IntegerLiteral {
+                    value: 0,
+                    span: crate::span::Span::default(),
+                }),
+                span: crate::span::Span::default(),
             }),
             span: crate::span::Span::default(),
         };
@@ -552,22 +603,47 @@ mod tests {
         let no_b = HashMap::new();
         let expr = Node::InfixExpression {
             left: Box::new(Node::InfixExpression {
-                left: Box::new(Node::Identifier { name: "x".to_string(), span: crate::span::Span::default() }),
+                left: Box::new(Node::Identifier {
+                    name: "x".to_string(),
+                    span: crate::span::Span::default(),
+                }),
                 operator: "+".to_string(),
-                right: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
-            span: crate::span::Span::default(),
+                right: Box::new(Node::IntegerLiteral {
+                    value: 0,
+                    span: crate::span::Span::default(),
+                }),
+                span: crate::span::Span::default(),
             }),
             operator: "==".to_string(),
-            right: Box::new(Node::Identifier { name: "x".to_string(), span: crate::span::Span::default() }),
+            right: Box::new(Node::Identifier {
+                name: "x".to_string(),
+                span: crate::span::Span::default(),
+            }),
             span: crate::span::Span::default(),
         };
         let (verdict, cert) = prove_with_certificate(&expr, &no_b);
         assert_eq!(verdict, Some(true));
         let cert = cert.expect("tautology must yield a certificate");
-        assert!(cert.smt2.contains("(declare-const x Int)"), "missing decl in:\n{}", cert.smt2);
-        assert!(cert.smt2.contains("(check-sat)"), "missing check-sat in:\n{}", cert.smt2);
-        assert!(cert.smt2.contains("(set-logic"), "missing set-logic in:\n{}", cert.smt2);
-        assert!(cert.smt2.contains("(assert "), "missing negated assertion in:\n{}", cert.smt2);
+        assert!(
+            cert.smt2.contains("(declare-const x Int)"),
+            "missing decl in:\n{}",
+            cert.smt2
+        );
+        assert!(
+            cert.smt2.contains("(check-sat)"),
+            "missing check-sat in:\n{}",
+            cert.smt2
+        );
+        assert!(
+            cert.smt2.contains("(set-logic"),
+            "missing set-logic in:\n{}",
+            cert.smt2
+        );
+        assert!(
+            cert.smt2.contains("(assert "),
+            "missing negated assertion in:\n{}",
+            cert.smt2
+        );
     }
 
     #[test]
@@ -578,16 +654,26 @@ mod tests {
         let mut bindings = HashMap::new();
         bindings.insert("n".to_string(), 5);
         let expr = Node::InfixExpression {
-            left: Box::new(Node::Identifier { name: "n".to_string(), span: crate::span::Span::default() }),
+            left: Box::new(Node::Identifier {
+                name: "n".to_string(),
+                span: crate::span::Span::default(),
+            }),
             operator: ">".to_string(),
-            right: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
+            right: Box::new(Node::IntegerLiteral {
+                value: 0,
+                span: crate::span::Span::default(),
+            }),
             span: crate::span::Span::default(),
         };
         let (verdict, cert) = prove_with_certificate(&expr, &bindings);
         assert_eq!(verdict, Some(true));
         let cert = cert.expect("bound tautology must yield a certificate");
         assert!(cert.smt2.contains("(declare-const n Int)"));
-        assert!(cert.smt2.contains("(assert (= n 5))"), "missing binding pin:\n{}", cert.smt2);
+        assert!(
+            cert.smt2.contains("(assert (= n 5))"),
+            "missing binding pin:\n{}",
+            cert.smt2
+        );
     }
 
     #[test]
@@ -595,9 +681,15 @@ mod tests {
         // RES-071: don't emit a certificate when there's no proof.
         let no_b = HashMap::new();
         let expr = Node::InfixExpression {
-            left: Box::new(Node::Identifier { name: "x".to_string(), span: crate::span::Span::default() }),
+            left: Box::new(Node::Identifier {
+                name: "x".to_string(),
+                span: crate::span::Span::default(),
+            }),
             operator: ">".to_string(),
-            right: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
+            right: Box::new(Node::IntegerLiteral {
+                value: 0,
+                span: crate::span::Span::default(),
+            }),
             span: crate::span::Span::default(),
         };
         let (_, cert) = prove_with_certificate(&expr, &no_b);
@@ -610,9 +702,15 @@ mod tests {
         // sat for both forms, so prove() returns None.
         let no_b = HashMap::new();
         let expr = Node::InfixExpression {
-            left: Box::new(Node::Identifier { name: "x".to_string(), span: crate::span::Span::default() }),
+            left: Box::new(Node::Identifier {
+                name: "x".to_string(),
+                span: crate::span::Span::default(),
+            }),
             operator: ">".to_string(),
-            right: Box::new(Node::IntegerLiteral { value: 0, span: crate::span::Span::default() }),
+            right: Box::new(Node::IntegerLiteral {
+                value: 0,
+                span: crate::span::Span::default(),
+            }),
             span: crate::span::Span::default(),
         };
         assert_eq!(prove(&expr, &no_b), None);
@@ -622,12 +720,18 @@ mod tests {
 
     /// Build `Node::Identifier { name }` with a default span.
     fn ident(name: &str) -> Node {
-        Node::Identifier { name: name.to_string(), span: crate::span::Span::default() }
+        Node::Identifier {
+            name: name.to_string(),
+            span: crate::span::Span::default(),
+        }
     }
 
     /// Build `Node::IntegerLiteral { value }` with a default span.
     fn int(value: i64) -> Node {
-        Node::IntegerLiteral { value, span: crate::span::Span::default() }
+        Node::IntegerLiteral {
+            value,
+            span: crate::span::Span::default(),
+        }
     }
 
     /// Build `left OP right` with a default span.
@@ -654,7 +758,11 @@ mod tests {
         let (verdict, _cert, cx) = prove_with_certificate_and_counterexample(&expr, &no_b);
         assert_eq!(verdict, Some(false));
         let cx = cx.expect("contradiction must surface a counterexample");
-        assert!(cx.contains("x ="), "counterexample should name `x`; got: {:?}", cx);
+        assert!(
+            cx.contains("x ="),
+            "counterexample should name `x`; got: {:?}",
+            cx
+        );
     }
 
     #[test]
@@ -667,7 +775,11 @@ mod tests {
         let (verdict, _cert, cx) = prove_with_certificate_and_counterexample(&expr, &no_b);
         assert_eq!(verdict, None);
         let cx = cx.expect("undecidable clause must surface a counterexample");
-        assert!(cx.contains("x ="), "counterexample should name `x`; got: {:?}", cx);
+        assert!(
+            cx.contains("x ="),
+            "counterexample should name `x`; got: {:?}",
+            cx
+        );
     }
 
     #[test]
@@ -677,7 +789,11 @@ mod tests {
         let expr = infix(infix(ident("x"), "+", int(0)), "==", ident("x"));
         let (verdict, _cert, cx) = prove_with_certificate_and_counterexample(&expr, &no_b);
         assert_eq!(verdict, Some(true));
-        assert!(cx.is_none(), "tautology should have no counterexample, got: {:?}", cx);
+        assert!(
+            cx.is_none(),
+            "tautology should have no counterexample, got: {:?}",
+            cx
+        );
     }
 
     #[test]
@@ -750,8 +866,7 @@ mod tests {
                 int(3),
             ),
         );
-        let (_verdict, _cert, _cx, timed_out) =
-            prove_with_timeout(&expr, &no_b, 1);
+        let (_verdict, _cert, _cx, timed_out) = prove_with_timeout(&expr, &no_b, 1);
         assert!(
             timed_out,
             "expected the 1ms budget to trigger Z3's Unknown return"
@@ -767,10 +882,7 @@ mod tests {
         let expr = infix(infix(ident("x"), "+", int(0)), "==", ident("x"));
         let (verdict, _cert, _cx, timed_out) = prove_with_timeout(&expr, &no_b, 0);
         assert_eq!(verdict, Some(true));
-        assert!(
-            !timed_out,
-            "unlimited timeout should not report timed_out"
-        );
+        assert!(!timed_out, "unlimited timeout should not report timed_out");
     }
 
     // ---------- RES-131 (RES-131a): len(<ident>) SMT encoding ----------
@@ -790,7 +902,10 @@ mod tests {
     }
 
     fn int_lit(v: i64) -> Node {
-        Node::IntegerLiteral { value: v, span: crate::span::Span::default() }
+        Node::IntegerLiteral {
+            value: v,
+            span: crate::span::Span::default(),
+        }
     }
 
     #[test]
@@ -901,11 +1016,7 @@ mod tests {
 
     #[test]
     fn collect_len_args_finds_all_references() {
-        let expr = infix(
-            infix(len_call("xs"), "+", len_call("ys")),
-            ">",
-            int_lit(0),
-        );
+        let expr = infix(infix(len_call("xs"), "+", len_call("ys")), ">", int_lit(0));
         let mut out = BTreeSet::new();
         collect_len_args(&expr, &mut out);
         assert_eq!(
@@ -946,8 +1057,7 @@ mod tests {
         let no_b = HashMap::new();
         let goal = infix(ident("r"), ">=", int(0));
         let axiom = infix(ident("r"), ">=", int(0));
-        let (verdict, _cert, _cx, _t) =
-            prove_with_axioms_and_timeout(&goal, &no_b, &[axiom], 0);
+        let (verdict, _cert, _cx, _t) = prove_with_axioms_and_timeout(&goal, &no_b, &[axiom], 0);
         assert_eq!(verdict, Some(true));
     }
 
@@ -991,8 +1101,7 @@ mod tests {
         let goal = infix(ident("b"), ">", int(0));
         let ax1 = infix(ident("a"), ">", int(0));
         let ax2 = infix(ident("b"), ">", ident("a"));
-        let (verdict, _cert, _cx, _t) =
-            prove_with_axioms_and_timeout(&goal, &no_b, &[ax1, ax2], 0);
+        let (verdict, _cert, _cx, _t) = prove_with_axioms_and_timeout(&goal, &no_b, &[ax1, ax2], 0);
         assert_eq!(verdict, Some(true));
     }
 }

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -12,8 +12,8 @@
 
 #![allow(dead_code)]
 
-use crate::bytecode::{Chunk, Op, Program};
 use crate::Value;
+use crate::bytecode::{Chunk, Op, Program};
 
 /// Errors the VM can surface at runtime. Like `CompileError`, the
 /// `&'static str` payloads describe the offending op without
@@ -51,7 +51,10 @@ pub enum VmError {
     /// RES-171a: array indexing ran past the array's length (or
     /// got a negative index). Carries the offending index and the
     /// array's length so the Display message is diagnostic-ready.
-    ArrayIndexOutOfBounds { index: i64, len: usize },
+    ArrayIndexOutOfBounds {
+        index: i64,
+        len: usize,
+    },
 }
 
 impl VmError {
@@ -102,7 +105,10 @@ fn err_at(line_info: &[u32], pc: usize, e: VmError) -> VmError {
     // line.
     let op_pc = pc.saturating_sub(1);
     match line_info.get(op_pc) {
-        Some(&line) if line > 0 => VmError::AtLine { line, kind: Box::new(e) },
+        Some(&line) if line > 0 => VmError::AtLine {
+            line,
+            kind: Box::new(e),
+        },
         _ => e,
     }
 }
@@ -161,10 +167,7 @@ pub fn run(program: &Program) -> Result<Value, VmError> {
 /// wrap any returned error with source-line info. `last_pc` is
 /// updated at the top of every iteration so the outer wrapper knows
 /// which instruction was about to execute when the failure fired.
-fn run_inner(
-    program: &Program,
-    last_pc: &mut (usize, usize),
-) -> Result<Value, VmError> {
+fn run_inner(program: &Program, last_pc: &mut (usize, usize)) -> Result<Value, VmError> {
     let mut stack: Vec<Value> = Vec::with_capacity(64);
     let mut locals: Vec<Value> = Vec::new();
     let mut frames: Vec<CallFrame> = Vec::with_capacity(16);
@@ -361,9 +364,7 @@ fn run_inner(
             Op::IncLocal(idx) => {
                 let base = frames[frame_idx].locals_base;
                 let abs = base + idx as usize;
-                let v = locals
-                    .get(abs)
-                    .ok_or(VmError::LocalOutOfBounds(idx))?;
+                let v = locals.get(abs).ok_or(VmError::LocalOutOfBounds(idx))?;
                 let Value::Int(n) = *v else {
                     return Err(VmError::TypeMismatch("IncLocal"));
                 };
@@ -498,7 +499,10 @@ mod tests {
             main.code.push(*op);
             main.line_info.push(1);
         }
-        Program { main, functions: Vec::new() }
+        Program {
+            main,
+            functions: Vec::new(),
+        }
     }
 
     fn compile_run(src: &str) -> Result<Value, VmError> {
@@ -547,7 +551,11 @@ mod tests {
         let src = "fn unsafe_div(int n) {\n    let r = 100 / n;\n    return r;\n}\nunsafe_div(0);";
         let err = compile_run(src).unwrap_err();
         let display = err.to_string();
-        assert!(display.contains("divide by zero"), "missing kind: {}", display);
+        assert!(
+            display.contains("divide by zero"),
+            "missing kind: {}",
+            display
+        );
         assert!(
             display.contains("line 2"),
             "expected `line 2` (the body's divide line); got: {}",
@@ -656,7 +664,10 @@ mod tests {
         main.code.push(Op::Return);
         main.line_info.push(1);
         main.line_info.push(1);
-        let p = Program { main, functions: vec![runaway] };
+        let p = Program {
+            main,
+            functions: vec![runaway],
+        };
         let err = run(&p).unwrap_err();
         assert_eq!(err.kind(), &VmError::CallStackOverflow);
     }
@@ -690,7 +701,8 @@ mod tests {
     #[test]
     fn recursive_fib_ten_is_fifty_five() {
         // The payoff test — recursion + branching together.
-        let src = "fn fib(int n) { if n <= 1 { return n; } return fib(n - 1) + fib(n - 2); } fib(10);";
+        let src =
+            "fn fib(int n) { if n <= 1 { return n; } return fib(n - 1) + fib(n - 2); } fib(10);";
         assert_int(compile_run(src).unwrap(), 55);
     }
 
@@ -806,7 +818,10 @@ mod tests {
         // cleanly via `VmError::Unsupported("MakeClosure")`.
         let p = const_program(
             &[],
-            &[Op::MakeClosure { fn_idx: 0, upvalue_count: 0 }],
+            &[Op::MakeClosure {
+                fn_idx: 0,
+                upvalue_count: 0,
+            }],
         );
         let err = run(&p).unwrap_err();
         match err.kind() {
@@ -912,7 +927,12 @@ mod tests {
     fn res171a_load_index_reads_element() {
         // [10, 20, 30][1] == 20
         let p = const_program(
-            &[Value::Int(10), Value::Int(20), Value::Int(30), Value::Int(1)],
+            &[
+                Value::Int(10),
+                Value::Int(20),
+                Value::Int(30),
+                Value::Int(1),
+            ],
             &[
                 Op::Const(0),
                 Op::Const(1),
@@ -963,7 +983,10 @@ mod tests {
             ],
         );
         let err = run(&p).unwrap_err();
-        assert!(matches!(err.kind(), VmError::ArrayIndexOutOfBounds { index: -1, len: 2 }));
+        assert!(matches!(
+            err.kind(),
+            VmError::ArrayIndexOutOfBounds { index: -1, len: 2 }
+        ));
     }
 
     #[test]
@@ -1023,13 +1046,19 @@ mod tests {
             ],
         );
         let err = run(&p).unwrap_err();
-        assert!(matches!(err.kind(), VmError::ArrayIndexOutOfBounds { index: 5, len: 2 }));
+        assert!(matches!(
+            err.kind(),
+            VmError::ArrayIndexOutOfBounds { index: 5, len: 2 }
+        ));
     }
 
     #[test]
     fn res171a_store_index_display_is_descriptive() {
         let e = VmError::ArrayIndexOutOfBounds { index: 7, len: 3 };
-        assert_eq!(e.to_string(), "vm: array index 7 out of bounds for length 3");
+        assert_eq!(
+            e.to_string(),
+            "vm: array index 7 out of bounds for length 3"
+        );
     }
 
     // ---- RES-171a: compile + run roundtrips (integration) ----
@@ -1058,9 +1087,7 @@ mod tests {
     #[test]
     fn res171a_compile_rejects_nested_index_assignment() {
         // a[i][j] = v is RES-171c — today we emit a clean error.
-        let (program, _) = crate::parse(
-            "let a = [[1,2],[3,4]]; a[0][1] = 99; return 0;",
-        );
+        let (program, _) = crate::parse("let a = [[1,2],[3,4]]; a[0][1] = 99; return 0;");
         let err = crate::compiler::compile(&program).unwrap_err();
         match err {
             crate::bytecode::CompileError::Unsupported(msg) => {

--- a/resilient/tests/diagnostics_snapshots.rs
+++ b/resilient/tests/diagnostics_snapshots.rs
@@ -41,12 +41,7 @@ fn bin() -> &'static str {
 fn scratch_path(tag: &str) -> PathBuf {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
-        "res_snap_{}_{}_{}.rs",
-        tag,
-        std::process::id(),
-        n
-    ))
+    std::env::temp_dir().join(format!("res_snap_{}_{}_{}.rs", tag, std::process::id(), n))
 }
 
 /// Strip ANSI color escapes (CSI `ESC [ ... m`) from `s`. The
@@ -179,7 +174,11 @@ fn parser_let_missing_identifier() {
 #[test]
 fn typecheck_let_int_assigned_string() {
     let src = "fn main(int _d) {\n    let bad: int = \"hi\";\n    return 0;\n}\n";
-    check_diagnostic("typecheck_let_int_assigned_string", &["-t", "--seed", "0"], src);
+    check_diagnostic(
+        "typecheck_let_int_assigned_string",
+        &["-t", "--seed", "0"],
+        src,
+    );
 }
 
 #[test]
@@ -197,13 +196,21 @@ fn typecheck_call_arity_mismatch() {
 #[test]
 fn typecheck_if_condition_nonbool() {
     let src = "fn main(int _d) {\n    if 1 { return 0; }\n    return 0;\n}\nmain(0);\n";
-    check_diagnostic("typecheck_if_condition_nonbool", &["-t", "--seed", "0"], src);
+    check_diagnostic(
+        "typecheck_if_condition_nonbool",
+        &["-t", "--seed", "0"],
+        src,
+    );
 }
 
 #[test]
 fn typecheck_binop_array_plus_int() {
     let src = "fn main(int _d) {\n    let xs = [1, 2, 3];\n    return xs + 1;\n}\nmain(0);\n";
-    check_diagnostic("typecheck_binop_array_plus_int", &["-t", "--seed", "0"], src);
+    check_diagnostic(
+        "typecheck_binop_array_plus_int",
+        &["-t", "--seed", "0"],
+        src,
+    );
 }
 
 // ---------- runtime canaries (default run) ----------

--- a/resilient/tests/dump_chunks_smoke.rs
+++ b/resilient/tests/dump_chunks_smoke.rs
@@ -18,12 +18,8 @@ fn write_temp(contents: &str, tag: &str) -> std::path::PathBuf {
     use std::sync::atomic::{AtomicUsize, Ordering};
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!(
-        "res_173_{}_{}_{}.rs",
-        tag,
-        std::process::id(),
-        n
-    ));
+    let path =
+        std::env::temp_dir().join(format!("res_173_{}_{}_{}.rs", tag, std::process::id(), n));
     let mut f = std::fs::File::create(&path).expect("create temp");
     f.write_all(contents.as_bytes()).expect("write temp");
     path

--- a/resilient/tests/examples_golden.rs
+++ b/resilient/tests/examples_golden.rs
@@ -48,7 +48,9 @@ fn expected_path(example: &Path) -> PathBuf {
 /// missing-expected-file audit also treats them as intentional.
 fn is_interactive(example: &Path) -> bool {
     let stem = example.file_stem().and_then(|s| s.to_str()).unwrap();
-    example.with_file_name(format!("{stem}.interactive")).exists()
+    example
+        .with_file_name(format!("{stem}.interactive"))
+        .exists()
 }
 
 fn run(example: &Path) -> String {

--- a/resilient/tests/examples_smoke.rs
+++ b/resilient/tests/examples_smoke.rs
@@ -182,10 +182,7 @@ fn bytecode_jit_runs_arithmetic_program() {
     // which the JIT lowers to native code and executes. Driver
     // prints the i64 result then exits 0.
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_096_smoke_{}.rs",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_096_smoke_{}.rs", std::process::id()));
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp");
         writeln!(f, "return 7 + 14;").unwrap();
@@ -216,10 +213,7 @@ fn bytecode_jit_runs_division() {
     // `return 100 / 4;` exercises sdiv end-to-end (parse →
     // lower → cranelift → native code → driver prints).
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_099_smoke_{}.rs",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_099_smoke_{}.rs", std::process::id()));
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp");
         writeln!(f, "return 100 / 4;").unwrap();
@@ -251,10 +245,7 @@ fn bytecode_jit_runs_comparison() {
     // back as i64. Joins the existing arith + division smokes in
     // covering the end-to-end JIT path for a third op family.
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_100_smoke_{}.rs",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_100_smoke_{}.rs", std::process::id()));
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp");
         writeln!(f, "return 7 == 7;").unwrap();
@@ -287,10 +278,7 @@ fn bytecode_jit_runs_if_else() {
     // brif → then_block → return_, plus the dead else_block →
     // return_ that the verifier still requires.
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_102_smoke_{}.rs",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_102_smoke_{}.rs", std::process::id()));
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp");
         writeln!(f, "if (3 < 7) {{ return 42; }} else {{ return 0; }}").unwrap();
@@ -322,10 +310,7 @@ fn bytecode_jit_runs_if_with_fallthrough() {
     // exercises the merge mechanic: condition false → bare-if
     // semantics via no-op else → fallthrough → trailing return.
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_103_smoke_{}.rs",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_103_smoke_{}.rs", std::process::id()));
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp");
         writeln!(f, "if (5 < 3) {{ return 7; }} return 9;").unwrap();
@@ -357,10 +342,7 @@ fn bytecode_jit_runs_let_bindings() {
     // local variables flowing into a RES-099 sdiv. Driver gets
     // 25 back as i64.
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_104_smoke_{}.rs",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_104_smoke_{}.rs", std::process::id()));
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp");
         writeln!(f, "let x = 100; let y = 4; return x / y;").unwrap();
@@ -393,17 +375,10 @@ fn bytecode_jit_runs_function_call() {
     // declare double as a FuncId in Pass 1, compile its body in
     // Pass 2, lower the call site as `call(local_func_ref, &args)`.
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_105_smoke_{}.rs",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_105_smoke_{}.rs", std::process::id()));
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp");
-        writeln!(
-            f,
-            "fn double(int x) {{ return x + x; }} return double(21);"
-        )
-        .unwrap();
+        writeln!(f, "fn double(int x) {{ return x + x; }} return double(21);").unwrap();
     }
     let output = Command::new(bin())
         .arg("--jit")
@@ -430,10 +405,7 @@ fn vm_runtime_error_includes_source_filename() {
     // <file>:<line>: so editors auto-link the location, matching
     // the typechecker's RES-080 format.
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_095_smoke_{}.rs",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_095_smoke_{}.rs", std::process::id()));
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp");
         // Line 1: fn opener; line 2: divide-by-zero; line 3: return; etc.
@@ -523,7 +495,11 @@ fn bytecode_vm_rejects_unsupported_construct_cleanly() {
         .output()
         .expect("spawn resilient");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_ne!(output.status.code(), Some(0), "unsupported VM input must fail");
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "unsupported VM input must fail"
+    );
     assert!(
         stderr.contains("VM compile error") || stderr.contains("unsupported"),
         "expected VM compile-error diagnostic; got:\n{stderr}"
@@ -560,7 +536,11 @@ fn typecheck_error_prefixes_path_and_line() {
         stderr.contains(path_str.as_ref()),
         "expected source path '{path_str}' in stderr; got:\n{stderr}"
     );
-    assert_ne!(output.status.code(), Some(0), "type-check failure must exit non-zero");
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "type-check failure must exit non-zero"
+    );
     let _ = std::fs::remove_file(&tmp);
 }
 
@@ -594,8 +574,11 @@ fn imports_missing_file_errors_cleanly() {
     let tmp = std::env::temp_dir().join("res_073_missing_use.rs");
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp file");
-        writeln!(f, "use \"definitely-not-here.rs\";\nfn main() {{}}\nmain();")
-            .expect("write tmp");
+        writeln!(
+            f,
+            "use \"definitely-not-here.rs\";\nfn main() {{}}\nmain();"
+        )
+        .expect("write tmp");
     }
     let output = Command::new(bin())
         .arg(&tmp)
@@ -621,10 +604,7 @@ fn bytecode_jit_runs_while_loop() {
     // confirming the header/body/exit block dance compiles and
     // runs end-to-end.
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_107_smoke_{}.rs",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_107_smoke_{}.rs", std::process::id()));
     {
         let mut f = std::fs::File::create(&tmp).expect("create tmp");
         writeln!(
@@ -660,11 +640,7 @@ fn bytecode_jit_runs_while_loop() {
 #[cfg(feature = "z3")]
 fn write_partial_proof_program(tag: &str) -> std::path::PathBuf {
     use std::io::Write;
-    let tmp = std::env::temp_dir().join(format!(
-        "res_217_{}_{}.rs",
-        tag,
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("res_217_{}_{}.rs", tag, std::process::id()));
     let src = "\
 fn check(int a, int b)
     requires a * a * a + b * b * b != 9 * a * b * b + 3

--- a/resilient/tests/ffi_integration.rs
+++ b/resilient/tests/ffi_integration.rs
@@ -128,7 +128,10 @@ main(0);"#,
     let combined = format!("{stdout}{stderr}");
     // Should fail gracefully, not panic — exit code != 0 and message mentions
     // either `symbol` (from FfiError::SymbolNotFound) or `FFI`.
-    assert!(code != 0, "expected non-zero exit, got stdout={stdout} stderr={stderr}");
+    assert!(
+        code != 0,
+        "expected non-zero exit, got stdout={stdout} stderr={stderr}"
+    );
     assert!(
         combined.contains("symbol") || combined.contains("FFI"),
         "expected FFI/symbol error, got stdout={stdout} stderr={stderr}"

--- a/resilient/tests/lint_smoke.rs
+++ b/resilient/tests/lint_smoke.rs
@@ -17,12 +17,8 @@ fn bin() -> &'static str {
 fn tmp_file(tag: &str, body: &str) -> PathBuf {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!(
-        "res_198_{}_{}_{}.rs",
-        tag,
-        std::process::id(),
-        n
-    ));
+    let path =
+        std::env::temp_dir().join(format!("res_198_{}_{}_{}.rs", tag, std::process::id(), n));
     std::fs::write(&path, body).expect("write scratch");
     path
 }
@@ -126,10 +122,7 @@ fn lint_rejects_unknown_deny_code() {
         .expect("spawn lint");
     assert_eq!(out.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        stderr.contains("unknown lint code"),
-        "stderr: {stderr}"
-    );
+    assert!(stderr.contains("unknown lint code"), "stderr: {stderr}");
     let _ = std::fs::remove_file(&src);
 }
 

--- a/resilient/tests/lsp_completion_smoke.rs
+++ b/resilient/tests/lsp_completion_smoke.rs
@@ -38,8 +38,8 @@ fn read_one_message<R: Read>(r: &mut R, deadline: Instant) -> Result<String, Str
         }
         header.push(buf[0]);
         if header.ends_with(b"\r\n\r\n") {
-            let header_str = std::str::from_utf8(&header)
-                .map_err(|e| format!("bad header utf8: {}", e))?;
+            let header_str =
+                std::str::from_utf8(&header).map_err(|e| format!("bad header utf8: {}", e))?;
             for line in header_str.split("\r\n") {
                 let line = line.trim();
                 if let Some(rest) = line.strip_prefix("Content-Length:") {
@@ -53,7 +53,10 @@ fn read_one_message<R: Read>(r: &mut R, deadline: Instant) -> Result<String, Str
             if content_length.is_some() {
                 break;
             }
-            return Err(format!("LSP header missing Content-Length: {:?}", header_str));
+            return Err(format!(
+                "LSP header missing Content-Length: {:?}",
+                header_str
+            ));
         }
     }
     let len = content_length.unwrap();

--- a/resilient/tests/lsp_goto_def_smoke.rs
+++ b/resilient/tests/lsp_goto_def_smoke.rs
@@ -37,8 +37,8 @@ fn read_one_message<R: Read>(r: &mut R, deadline: Instant) -> Result<String, Str
         }
         header.push(buf[0]);
         if header.ends_with(b"\r\n\r\n") {
-            let header_str = std::str::from_utf8(&header)
-                .map_err(|e| format!("bad header utf8: {}", e))?;
+            let header_str =
+                std::str::from_utf8(&header).map_err(|e| format!("bad header utf8: {}", e))?;
             for line in header_str.split("\r\n") {
                 let line = line.trim();
                 if let Some(rest) = line.strip_prefix("Content-Length:") {
@@ -52,7 +52,10 @@ fn read_one_message<R: Read>(r: &mut R, deadline: Instant) -> Result<String, Str
             if content_length.is_some() {
                 break;
             }
-            return Err(format!("LSP header missing Content-Length: {:?}", header_str));
+            return Err(format!(
+                "LSP header missing Content-Length: {:?}",
+                header_str
+            ));
         }
     }
     let len = content_length.unwrap();

--- a/resilient/tests/lsp_hover_smoke.rs
+++ b/resilient/tests/lsp_hover_smoke.rs
@@ -40,8 +40,8 @@ fn read_one_message<R: Read>(r: &mut R, deadline: Instant) -> Result<String, Str
         }
         header.push(buf[0]);
         if header.ends_with(b"\r\n\r\n") {
-            let header_str = std::str::from_utf8(&header)
-                .map_err(|e| format!("bad header utf8: {}", e))?;
+            let header_str =
+                std::str::from_utf8(&header).map_err(|e| format!("bad header utf8: {}", e))?;
             for line in header_str.split("\r\n") {
                 let line = line.trim();
                 if let Some(rest) = line.strip_prefix("Content-Length:") {
@@ -55,7 +55,10 @@ fn read_one_message<R: Read>(r: &mut R, deadline: Instant) -> Result<String, Str
             if content_length.is_some() {
                 break;
             }
-            return Err(format!("LSP header missing Content-Length: {:?}", header_str));
+            return Err(format!(
+                "LSP header missing Content-Length: {:?}",
+                header_str
+            ));
         }
     }
     let len = content_length.unwrap();
@@ -178,7 +181,7 @@ fn lsp_hover_returns_type_name_for_literal_positions() {
     // zero-indexed. Each request uses a distinct id so we can
     // match replies.
     let cases: &[(u64, u64, u64, &str)] = &[
-        (2, 0, 9, "Int"),    // `4` of 42
+        (2, 0, 9, "Int"),     // `4` of 42
         (3, 1, 10, "String"), // `h` inside "hi"
         (4, 2, 10, "Bool"),   // `u` of true
         (5, 3, 10, "Float"),  // `.` of 3.14

--- a/resilient/tests/lsp_smoke.rs
+++ b/resilient/tests/lsp_smoke.rs
@@ -46,8 +46,8 @@ fn read_one_message<R: Read>(r: &mut R, deadline: Instant) -> Result<String, Str
         header.push(buf[0]);
         // Look for `\r\n\r\n` terminator.
         if header.ends_with(b"\r\n\r\n") {
-            let header_str = std::str::from_utf8(&header)
-                .map_err(|e| format!("bad header utf8: {}", e))?;
+            let header_str =
+                std::str::from_utf8(&header).map_err(|e| format!("bad header utf8: {}", e))?;
             for line in header_str.split("\r\n") {
                 let line = line.trim();
                 if let Some(rest) = line.strip_prefix("Content-Length:") {
@@ -61,7 +61,10 @@ fn read_one_message<R: Read>(r: &mut R, deadline: Instant) -> Result<String, Str
             if content_length.is_some() {
                 break;
             }
-            return Err(format!("LSP header missing Content-Length: {:?}", header_str));
+            return Err(format!(
+                "LSP header missing Content-Length: {:?}",
+                header_str
+            ));
         }
     }
 
@@ -100,7 +103,8 @@ fn lsp_initialize_round_trip() {
     let mut stdout = child.stdout.take().expect("piped stdout");
 
     // Step 1: initialize request. Minimal valid params.
-    let init_body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#;
+    let init_body =
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#;
     stdin
         .write_all(frame(init_body).as_bytes())
         .expect("write initialize");
@@ -193,7 +197,9 @@ fn lsp_did_open_publishes_diagnostics() {
 
     // Step 1: initialize handshake.
     let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#;
-    stdin.write_all(frame(init).as_bytes()).expect("write initialize");
+    stdin
+        .write_all(frame(init).as_bytes())
+        .expect("write initialize");
     stdin.flush().ok();
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -202,13 +208,17 @@ fn lsp_did_open_publishes_diagnostics() {
 
     // Step 2: initialized notification.
     let initialized = r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#;
-    stdin.write_all(frame(initialized).as_bytes()).expect("write initialized");
+    stdin
+        .write_all(frame(initialized).as_bytes())
+        .expect("write initialized");
 
     // Step 3: didOpen with a 3-line program where line 3 is a known
     // type error. The typechecker rejects `let bad: int = "hi";`
     // (RES-053), and RES-080 prefixes the message with `<uri>:3:5:`.
     let did_open = r#"{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///tmp/lsp_test.rs","languageId":"resilient","version":1,"text":"let a = 1;\nlet b = 2;\nlet bad: int = \"hi\";"}}}"#;
-    stdin.write_all(frame(did_open).as_bytes()).expect("write didOpen");
+    stdin
+        .write_all(frame(did_open).as_bytes())
+        .expect("write didOpen");
     stdin.flush().ok();
 
     // Step 4: read until publishDiagnostics arrives. Skip log
@@ -227,8 +237,7 @@ fn lsp_did_open_publishes_diagnostics() {
     );
     // Source line 3 → 0-indexed LSP line 2. Allow `"line":2` or
     // `"line": 2` (whitespace tolerance).
-    let has_line_2 = diag_body.contains(r#""line":2"#)
-        || diag_body.contains(r#""line": 2"#);
+    let has_line_2 = diag_body.contains(r#""line":2"#) || diag_body.contains(r#""line": 2"#);
     assert!(
         has_line_2,
         "expected `\"line\":2` (source line 3, 0-indexed) in: {diag_body}"
@@ -286,8 +295,7 @@ fn lsp_document_symbol_lists_outline() {
     stdin.write_all(frame(init).as_bytes()).unwrap();
     stdin.flush().ok();
     let init_deadline = Instant::now() + Duration::from_secs(5);
-    let init_resp = read_one_message(&mut stdout, init_deadline)
-        .expect("read initialize response");
+    let init_resp = read_one_message(&mut stdout, init_deadline).expect("read initialize response");
     // Capability smoke-check — the server should advertise
     // documentSymbolProvider.
     assert!(
@@ -387,17 +395,16 @@ fn lsp_workspace_symbol_searches_multiple_files() {
     use std::sync::atomic::{AtomicUsize, Ordering};
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let root = std::env::temp_dir()
-        .join(format!("res_186_smoke_{}_{}", std::process::id(), n));
+    let root = std::env::temp_dir().join(format!("res_186_smoke_{}_{}", std::process::id(), n));
     std::fs::create_dir_all(&root).expect("mkdir scratch");
-    std::fs::write(root.join("mod_a.rs"), "fn a_fn() { return 0; }\nstruct A_Struct { int x }\n")
-        .unwrap();
+    std::fs::write(
+        root.join("mod_a.rs"),
+        "fn a_fn() { return 0; }\nstruct A_Struct { int x }\n",
+    )
+    .unwrap();
     std::fs::write(root.join("mod_b.rs"), "fn b_fn() { return 0; }\n").unwrap();
     // URI of the scratch dir as a file:// URL.
-    let root_uri = format!(
-        "file://{}",
-        root.to_string_lossy().replace("\\", "/")
-    );
+    let root_uri = format!("file://{}", root.to_string_lossy().replace("\\", "/"));
 
     let mut child = Command::new(bin())
         .arg("--lsp")
@@ -417,8 +424,7 @@ fn lsp_workspace_symbol_searches_multiple_files() {
     stdin.write_all(frame(&init).as_bytes()).unwrap();
     stdin.flush().ok();
     let init_deadline = Instant::now() + Duration::from_secs(5);
-    let init_resp = read_one_message(&mut stdout, init_deadline)
-        .expect("read initialize response");
+    let init_resp = read_one_message(&mut stdout, init_deadline).expect("read initialize response");
     assert!(
         init_resp.contains(r#""workspaceSymbolProvider":true"#),
         "expected workspaceSymbolProvider:true in capabilities, got:\n{}",
@@ -460,7 +466,8 @@ fn lsp_workspace_symbol_searches_multiple_files() {
     );
 
     // Now a filtered query — "struct" should match only A_Struct.
-    let req2 = r#"{"jsonrpc":"2.0","id":3,"method":"workspace/symbol","params":{"query":"struct"}}"#;
+    let req2 =
+        r#"{"jsonrpc":"2.0","id":3,"method":"workspace/symbol","params":{"query":"struct"}}"#;
     stdin.write_all(frame(req2).as_bytes()).unwrap();
     stdin.flush().ok();
     let filtered = read_until(
@@ -525,8 +532,7 @@ fn lsp_semantic_tokens_full() {
     stdin.write_all(frame(init).as_bytes()).unwrap();
     stdin.flush().ok();
     let init_deadline = Instant::now() + Duration::from_secs(5);
-    let init_resp = read_one_message(&mut stdout, init_deadline)
-        .expect("read initialize response");
+    let init_resp = read_one_message(&mut stdout, init_deadline).expect("read initialize response");
     // Capability advertised — presence of the `legend` key is
     // enough to confirm the server registered semantic tokens.
     assert!(
@@ -590,13 +596,15 @@ fn lsp_semantic_tokens_full() {
     //    the first line at column 0 — the `//` comment).
     let data_start = response.find(r#""data":["#).expect("find data array");
     let after_bracket = data_start + r#""data":["#.len();
-    let bracket_end = after_bracket + response[after_bracket..].find(']')
-        .expect("find closing ]");
+    let bracket_end = after_bracket + response[after_bracket..].find(']').expect("find closing ]");
     let nums: Vec<u32> = response[after_bracket..bracket_end]
         .split(',')
         .filter_map(|s| s.trim().parse::<u32>().ok())
         .collect();
-    assert!(!nums.is_empty(), "data array should be non-empty, got response:\n{response}");
+    assert!(
+        !nums.is_empty(),
+        "data array should be non-empty, got response:\n{response}"
+    );
     assert_eq!(
         nums.len() % 5,
         0,
@@ -652,8 +660,7 @@ fn lsp_inlay_hint_types_for_unannotated_lets() {
     stdin.write_all(frame(init).as_bytes()).unwrap();
     stdin.flush().ok();
     let init_deadline = Instant::now() + Duration::from_secs(5);
-    let init_resp = read_one_message(&mut stdout, init_deadline)
-        .expect("read initialize response");
+    let init_resp = read_one_message(&mut stdout, init_deadline).expect("read initialize response");
     assert!(
         init_resp.contains(r#""inlayHintProvider""#),
         "expected inlayHintProvider in capabilities, got:\n{}",
@@ -874,9 +881,12 @@ fn lsp_did_change_republishes_diagnostics() {
     let is_diag = |body: &str| body.contains(r#""method":"textDocument/publishDiagnostics""#);
 
     // Step 1: clean program → empty diagnostics
-    let body =
-        read_until(&mut stdout, is_diag, Instant::now() + Duration::from_secs(5))
-            .expect("read clean publishDiagnostics");
+    let body = read_until(
+        &mut stdout,
+        is_diag,
+        Instant::now() + Duration::from_secs(5),
+    )
+    .expect("read clean publishDiagnostics");
     assert!(
         body.contains(r#""diagnostics":[]"#),
         "expected EMPTY diagnostics for clean program; got:\n{body}"
@@ -886,12 +896,17 @@ fn lsp_did_change_republishes_diagnostics() {
     let did_change_buggy = format!(
         r#"{{"jsonrpc":"2.0","method":"textDocument/didChange","params":{{"textDocument":{{"uri":"{uri}","version":2}},"contentChanges":[{{"text":"let bad: int = \"hi\";"}}]}}}}"#
     );
-    stdin.write_all(frame(&did_change_buggy).as_bytes()).unwrap();
+    stdin
+        .write_all(frame(&did_change_buggy).as_bytes())
+        .unwrap();
     stdin.flush().ok();
 
-    let body =
-        read_until(&mut stdout, is_diag, Instant::now() + Duration::from_secs(5))
-            .expect("read buggy publishDiagnostics");
+    let body = read_until(
+        &mut stdout,
+        is_diag,
+        Instant::now() + Duration::from_secs(5),
+    )
+    .expect("read buggy publishDiagnostics");
     assert!(
         !body.contains(r#""diagnostics":[]"#),
         "expected NON-empty diagnostics for buggy program; got:\n{body}"
@@ -905,12 +920,17 @@ fn lsp_did_change_republishes_diagnostics() {
     let did_change_clean = format!(
         r#"{{"jsonrpc":"2.0","method":"textDocument/didChange","params":{{"textDocument":{{"uri":"{uri}","version":3}},"contentChanges":[{{"text":"let x = 1;"}}]}}}}"#
     );
-    stdin.write_all(frame(&did_change_clean).as_bytes()).unwrap();
+    stdin
+        .write_all(frame(&did_change_clean).as_bytes())
+        .unwrap();
     stdin.flush().ok();
 
-    let body =
-        read_until(&mut stdout, is_diag, Instant::now() + Duration::from_secs(5))
-            .expect("read fixed publishDiagnostics");
+    let body = read_until(
+        &mut stdout,
+        is_diag,
+        Instant::now() + Duration::from_secs(5),
+    )
+    .expect("read fixed publishDiagnostics");
     assert!(
         body.contains(r#""diagnostics":[]"#),
         "expected EMPTY diagnostics after revert; got:\n{body}"

--- a/resilient/tests/panic_on_fault_smoke.rs
+++ b/resilient/tests/panic_on_fault_smoke.rs
@@ -26,11 +26,7 @@ fn bin() -> &'static str {
 fn write_fault_program() -> PathBuf {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!(
-        "res_211_fault_{}_{}.rs",
-        std::process::id(),
-        n
-    ));
+    let path = std::env::temp_dir().join(format!("res_211_fault_{}_{}.rs", std::process::id(), n));
     let src = "\
 fn main(int _d) {\n\
     live {\n\

--- a/resilient/tests/pkg_init_smoke.rs
+++ b/resilient/tests/pkg_init_smoke.rs
@@ -55,9 +55,11 @@ fn pkg_init_creates_project_skeleton() {
 
     // Manifest content — pin [package] + name + [dependencies] to
     // catch template drift.
-    let manifest = std::fs::read_to_string(root.join("resilient.toml"))
-        .expect("read manifest");
-    assert!(manifest.contains("[package]"), "missing [package]: {manifest}");
+    let manifest = std::fs::read_to_string(root.join("resilient.toml")).expect("read manifest");
+    assert!(
+        manifest.contains("[package]"),
+        "missing [package]: {manifest}"
+    );
     assert!(
         manifest.contains(r#"name = "hello_res""#),
         "missing name in: {manifest}"
@@ -80,16 +82,14 @@ fn pkg_init_creates_project_skeleton() {
     );
 
     // Entry point has the hello-world greeting.
-    let main_src = std::fs::read_to_string(root.join("src/main.res"))
-        .expect("read main.res");
+    let main_src = std::fs::read_to_string(root.join("src/main.res")).expect("read main.res");
     assert!(
         main_src.contains("Hello, world!"),
         "missing greeting in: {main_src}"
     );
 
     // Gitignore ignores target/ and cert/.
-    let gi = std::fs::read_to_string(root.join(".gitignore"))
-        .expect("read gitignore");
+    let gi = std::fs::read_to_string(root.join(".gitignore")).expect("read gitignore");
     assert!(gi.contains("target/"), "missing target/ in: {gi}");
     assert!(gi.contains("cert/"), "missing cert/ in: {gi}");
 
@@ -115,8 +115,7 @@ fn pkg_init_accepts_name_flag() {
         String::from_utf8_lossy(&output.stderr),
     );
     let root = parent.join("via_flag");
-    let manifest = std::fs::read_to_string(root.join("resilient.toml"))
-        .expect("read manifest");
+    let manifest = std::fs::read_to_string(root.join("resilient.toml")).expect("read manifest");
     assert!(
         manifest.contains(r#"name = "via_flag""#),
         "missing name in: {manifest}"
@@ -133,8 +132,11 @@ fn pkg_init_name_flag_equals_form() {
         .current_dir(&parent)
         .output()
         .expect("spawn resilient pkg init --name=");
-    assert!(output.status.success(), "stderr: {}",
-        String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     assert!(parent.join("via_equals/resilient.toml").exists());
     let _ = std::fs::remove_dir_all(&parent);
 }
@@ -234,8 +236,7 @@ fn pkg_init_missing_name_errors() {
     assert!(!output.status.success(), "expected non-zero exit");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("requires a project name")
-            || stderr.contains("<name>"),
+        stderr.contains("requires a project name") || stderr.contains("<name>"),
         "expected usage hint, got: {stderr}"
     );
     let _ = std::fs::remove_dir_all(&parent);

--- a/resilient/tests/verify_all_smoke.rs
+++ b/resilient/tests/verify_all_smoke.rs
@@ -29,12 +29,7 @@ fn bin() -> &'static str {
 fn tmp_dir(tag: &str) -> PathBuf {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let p = std::env::temp_dir().join(format!(
-        "res_195_{}_{}_{}",
-        tag,
-        std::process::id(),
-        n
-    ));
+    let p = std::env::temp_dir().join(format!("res_195_{}_{}_{}", tag, std::process::id(), n));
     std::fs::create_dir_all(&p).expect("mkdir tmp");
     p
 }

--- a/resilient/tests/verify_cert_smoke.rs
+++ b/resilient/tests/verify_cert_smoke.rs
@@ -29,12 +29,7 @@ fn bin() -> &'static str {
 fn tmp_dir(tag: &str) -> PathBuf {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let p = std::env::temp_dir().join(format!(
-        "res_194_{}_{}_{}",
-        tag,
-        std::process::id(),
-        n
-    ));
+    let p = std::env::temp_dir().join(format!("res_194_{}_{}_{}", tag, std::process::id(), n));
     std::fs::create_dir_all(&p).expect("mkdir tmp");
     p
 }
@@ -104,12 +99,7 @@ fn sign_cert_and_verify_round_trip() {
 
     // --emit-certificate + --sign-cert
     let emit = Command::new(bin())
-        .args([
-            "-t",
-            "--seed",
-            "0",
-            "--emit-certificate",
-        ])
+        .args(["-t", "--seed", "0", "--emit-certificate"])
         .arg(&cert_dir)
         .arg("--sign-cert")
         .arg(&priv_pem)
@@ -177,8 +167,7 @@ fn verify_cert_fails_against_mismatched_key() {
     );
     let stderr = String::from_utf8_lossy(&mismatch.stderr);
     assert!(
-        stderr.to_uppercase().contains("MISMATCH")
-            || stderr.to_lowercase().contains("tampered"),
+        stderr.to_uppercase().contains("MISMATCH") || stderr.to_lowercase().contains("tampered"),
         "unexpected stderr: {stderr}"
     );
 
@@ -204,8 +193,7 @@ fn verify_cert_detects_payload_tamper() {
 
     // Append a fake .smt2 file to the cert dir — the payload
     // changes, so the signature should no longer verify.
-    std::fs::write(cert_dir.join("tamper__fake__99.smt2"), b"(assert wrong)\n")
-        .unwrap();
+    std::fs::write(cert_dir.join("tamper__fake__99.smt2"), b"(assert wrong)\n").unwrap();
 
     let verify = Command::new(bin())
         .args(["verify-cert"])
@@ -214,10 +202,7 @@ fn verify_cert_detects_payload_tamper() {
         .arg(&pub_pem)
         .output()
         .expect("spawn verify");
-    assert!(
-        !verify.status.success(),
-        "tamper must fail verification"
-    );
+    assert!(!verify.status.success(), "tamper must fail verification");
 
     let _ = std::fs::remove_dir_all(&scratch);
 }


### PR DESCRIPTION
## Summary

- Parser: `(a, b)` tuple literals, `(Int, String)` type annotations, `t.0`/`t.1` positional indexing, `let (x, y) = expr` destructuring
- AST: `Node::TupleLiteral`, `Node::TupleIndex`, `Node::LetDestructureTuple`; `Value::Tuple(Vec<Value>)`
- Typechecker: `Type::Tuple(Vec<Type>)` variant with element-wise arity-mismatch diagnostics
- HM unification (`unify.rs`): element-wise unification, `ArityMismatch` on differing arity
- Inference (`infer.rs`): FTV collection and substitution application through tuple elements
- All companion passes updated: `compiler.rs`, `formatter.rs`, `free_vars.rs`
- 8 new unit tests: literal construction, indexing, destructuring, singleton, function return, arity-mismatch runtime error, arity-mismatch typecheck error
- VM opcodes and JIT lowering deferred to follow-up ticket

## Test changes

Pre-existing test files were reformatted by `cargo fmt --all` — whitespace and line-length only. No test logic, assertions, or expected outputs were modified.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml` — 705 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] 8 new tuple-specific tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)