### PR TITLE
RES-254 RES-258: fmt preserves extern blocks + LSP identifier hover

### DIFF
--- a/.board/tickets/DONE/RES-254-formatter-extern-block-support.md
+++ b/.board/tickets/DONE/RES-254-formatter-extern-block-support.md
@@ -1,11 +1,12 @@
 ---
 id: RES-254
 title: "`resilient fmt` silently drops `extern` blocks"
-state: OPEN
+state: DONE
 priority: P2
 goalpost: tooling
 created: 2026-04-20
 owner: executor
+Claimed-by: Claude Sonnet 4.6
 ---
 
 ## Summary

--- a/.board/tickets/DONE/RES-258-lsp-identifier-hover.md
+++ b/.board/tickets/DONE/RES-258-lsp-identifier-hover.md
@@ -1,11 +1,12 @@
 ---
 id: RES-258
 title: "LSP: identifier hover (RES-181b) — show fn signature / type on cursor"
-state: OPEN
+state: DONE
 priority: P2
 goalpost: G17
 created: 2026-04-20
 owner: executor
+Claimed-by: Claude Sonnet 4.6
 ---
 
 ## Summary

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -29,9 +29,9 @@
 //   This is a known deficiency documented in `docs/tooling.md` and
 //   is the top follow-up for the next formatter ticket.
 
+use crate::BackoffConfig;
 use crate::Node;
 use crate::Pattern;
-use crate::BackoffConfig;
 
 /// Canonical indent width, in spaces.
 const INDENT: &str = "    ";
@@ -46,7 +46,11 @@ pub struct Formatter {
 
 impl Formatter {
     pub fn new() -> Self {
-        Self { out: String::new(), depth: 0, at_line_start: true }
+        Self {
+            out: String::new(),
+            depth: 0,
+            at_line_start: true,
+        }
     }
 
     /// Entry point. Formats a `Node::Program` (or any top-level
@@ -140,7 +144,13 @@ impl Formatter {
                 self.newline();
             }
             Node::Function {
-                name, parameters, body, requires, ensures, return_type, ..
+                name,
+                parameters,
+                body,
+                requires,
+                ensures,
+                return_type,
+                ..
             } => {
                 self.fmt_function(
                     Some(name),
@@ -163,7 +173,11 @@ impl Formatter {
                 self.write("}");
                 self.newline();
             }
-            Node::ImplBlock { struct_name, methods, .. } => {
+            Node::ImplBlock {
+                struct_name,
+                methods,
+                ..
+            } => {
                 self.write(&format!("impl {} {{", struct_name));
                 self.newline();
                 self.indent();
@@ -181,7 +195,12 @@ impl Formatter {
                 self.write(&format!("type {} = {};", name, target));
                 self.newline();
             }
-            Node::LetStatement { name, value, type_annot, .. } => {
+            Node::LetStatement {
+                name,
+                value,
+                type_annot,
+                ..
+            } => {
                 let ann = match type_annot {
                     Some(t) => format!(": {}", t),
                     None => String::new(),
@@ -198,7 +217,11 @@ impl Formatter {
                 self.newline();
             }
             Node::LetDestructureStruct {
-                struct_name, fields, has_rest, value, ..
+                struct_name,
+                fields,
+                has_rest,
+                value,
+                ..
             } => {
                 self.write(&format!("let {} {{ ", struct_name));
                 let mut parts: Vec<String> = Vec::new();
@@ -236,7 +259,12 @@ impl Formatter {
                     self.newline();
                 }
             },
-            Node::IfStatement { condition, consequence, alternative, .. } => {
+            Node::IfStatement {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
                 self.write("if ");
                 self.fmt_expr(condition);
                 self.write(" ");
@@ -253,7 +281,12 @@ impl Formatter {
                     self.newline();
                 }
             }
-            Node::WhileStatement { condition, body, invariants, .. } => {
+            Node::WhileStatement {
+                condition,
+                body,
+                invariants,
+                ..
+            } => {
                 self.write("while ");
                 self.fmt_expr(condition);
                 if !invariants.is_empty() {
@@ -274,7 +307,13 @@ impl Formatter {
                     self.newline();
                 }
             }
-            Node::ForInStatement { name, iterable, body, invariants, .. } => {
+            Node::ForInStatement {
+                name,
+                iterable,
+                body,
+                invariants,
+                ..
+            } => {
                 self.write(&format!("for {} in ", name));
                 self.fmt_expr(iterable);
                 if !invariants.is_empty() {
@@ -295,7 +334,13 @@ impl Formatter {
                     self.newline();
                 }
             }
-            Node::LiveBlock { body, invariants, backoff, timeout, .. } => {
+            Node::LiveBlock {
+                body,
+                invariants,
+                backoff,
+                timeout,
+                ..
+            } => {
                 self.write("live");
                 if let Some(bo) = backoff {
                     self.write(&format!(
@@ -318,7 +363,9 @@ impl Formatter {
                     self.newline();
                 }
             }
-            Node::Assert { condition, message, .. } => {
+            Node::Assert {
+                condition, message, ..
+            } => {
                 self.write("assert(");
                 self.fmt_expr(condition);
                 if let Some(m) = message {
@@ -328,7 +375,9 @@ impl Formatter {
                 self.write(");");
                 self.newline();
             }
-            Node::Assume { condition, message, .. } => {
+            Node::Assume {
+                condition, message, ..
+            } => {
                 self.write("assume(");
                 self.fmt_expr(condition);
                 if let Some(m) = message {
@@ -354,8 +403,47 @@ impl Formatter {
                 self.write(";");
                 self.newline();
             }
-            // FFI v1: extern blocks not yet formatted (Tasks 4-8).
-            Node::Extern { .. } => {}
+            Node::Extern { library, decls, .. } => {
+                self.write(&format!("extern \"{}\" {{", library));
+                self.newline();
+                self.indent();
+                for decl in decls {
+                    if decl.trusted {
+                        self.write("@trusted ");
+                    }
+                    self.write("fn ");
+                    self.write(&decl.resilient_name);
+                    self.write("(");
+                    // ExternDecl parameters are stored as (type, name) — same
+                    // convention as Node::Function — but extern syntax is `name: Type`.
+                    let params: Vec<String> = decl
+                        .parameters
+                        .iter()
+                        .map(|(ty, name)| format!("{}: {}", name, ty))
+                        .collect();
+                    self.write(&params.join(", "));
+                    self.write(")");
+                    if decl.return_type != "Void" {
+                        self.write(&format!(" -> {}", decl.return_type));
+                    }
+                    if decl.resilient_name != decl.c_name {
+                        self.write(&format!(" = \"{}\"", decl.c_name));
+                    }
+                    for req in &decl.requires {
+                        self.write(" requires ");
+                        self.fmt_expr(req);
+                    }
+                    for ens in &decl.ensures {
+                        self.write(" ensures ");
+                        self.fmt_expr(ens);
+                    }
+                    self.write(";");
+                    self.newline();
+                }
+                self.dedent();
+                self.write("}");
+                self.newline();
+            }
             // Anything else was an expression; dispatch to fmt_expr
             // and terminate with a semicolon so a bare expression
             // statement at top level still looks like a statement.
@@ -490,16 +578,27 @@ impl Formatter {
                 }
                 self.write("\"");
             }
-            Node::PrefixExpression { operator, right, .. } => {
+            Node::PrefixExpression {
+                operator, right, ..
+            } => {
                 self.write(operator);
                 self.fmt_expr(right);
             }
-            Node::InfixExpression { left, operator, right, .. } => {
+            Node::InfixExpression {
+                left,
+                operator,
+                right,
+                ..
+            } => {
                 self.fmt_expr(left);
                 self.write(&format!(" {} ", operator));
                 self.fmt_expr(right);
             }
-            Node::CallExpression { function, arguments, .. } => {
+            Node::CallExpression {
+                function,
+                arguments,
+                ..
+            } => {
                 self.fmt_expr(function);
                 self.write("(");
                 for (i, a) in arguments.iter().enumerate() {
@@ -518,7 +617,12 @@ impl Formatter {
                 self.fmt_expr(target);
                 self.write(&format!(".{}", field));
             }
-            Node::FieldAssignment { target, field, value, .. } => {
+            Node::FieldAssignment {
+                target,
+                field,
+                value,
+                ..
+            } => {
                 self.fmt_expr(target);
                 self.write(&format!(".{} = ", field));
                 self.fmt_expr(value);
@@ -529,7 +633,12 @@ impl Formatter {
                 self.fmt_expr(index);
                 self.write("]");
             }
-            Node::IndexAssignment { target, index, value, .. } => {
+            Node::IndexAssignment {
+                target,
+                index,
+                value,
+                ..
+            } => {
                 self.fmt_expr(target);
                 self.write("[");
                 self.fmt_expr(index);
@@ -588,7 +697,12 @@ impl Formatter {
                 self.write("}");
             }
             Node::FunctionLiteral {
-                parameters, body, requires, ensures, return_type, ..
+                parameters,
+                body,
+                requires,
+                ensures,
+                return_type,
+                ..
             } => {
                 // Anonymous fn inside an expression context: reuse the
                 // shared function-renderer with `name = None`.
@@ -601,7 +715,9 @@ impl Formatter {
                     body,
                 );
             }
-            Node::Match { scrutinee, arms, .. } => {
+            Node::Match {
+                scrutinee, arms, ..
+            } => {
                 self.write("match ");
                 self.fmt_expr(scrutinee);
                 self.write(" {");
@@ -744,8 +860,7 @@ fn f(int x) -> int {
     /// Golden: function contracts land indented under the signature.
     #[test]
     fn fmt_function_contracts() {
-        let src =
-            "fn safe_div(int a, int b) -> int requires b != 0 ensures result * b == a { return a / b; }";
+        let src = "fn safe_div(int a, int b) -> int requires b != 0 ensures result * b == a { return a / b; }";
         let (program, errs) = parse(src);
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let out = Formatter::format(&program);
@@ -783,8 +898,53 @@ struct Point {
         let (program, errs) = parse(src);
         assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let out = Formatter::format(&program);
-        assert!(out.contains("live {"), "expected brace on same line: {}", out);
-        assert!(out.contains("    live {"), "expected indented live block: {}", out);
+        assert!(
+            out.contains("live {"),
+            "expected brace on same line: {}",
+            out
+        );
+        assert!(
+            out.contains("    live {"),
+            "expected indented live block: {}",
+            out
+        );
+    }
+
+    /// Golden: extern block round-trips without data loss.
+    #[test]
+    fn fmt_extern_block_roundtrip() {
+        let src = r#"extern "libm.so.6" {
+    fn sqrt(x: Float) -> Float requires x >= 0.0 ensures result >= 0.0;
+}
+"#;
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let out = Formatter::format(&program);
+        // Re-parse the formatted output and check no extern decls were lost.
+        let (program2, errs2) = parse(&out);
+        assert!(
+            errs2.is_empty(),
+            "re-parse errors: {:?}\nsource was:\n{}",
+            errs2,
+            out
+        );
+        // The round-tripped program still contains exactly one extern block.
+        if let crate::Node::Program(stmts) = &program2 {
+            let extern_count = stmts
+                .iter()
+                .filter(|s| matches!(&s.node, crate::Node::Extern { .. }))
+                .count();
+            assert_eq!(
+                extern_count, 1,
+                "expected 1 extern block after round-trip, got {}",
+                extern_count
+            );
+        } else {
+            panic!("expected Program node");
+        }
+        // Idempotent: formatting the round-tripped output yields the same string.
+        let out2 = Formatter::format(&program2);
+        assert_eq!(out, out2, "formatter is not idempotent for extern blocks");
     }
 
     /// Property: formatting is idempotent — formatting twice yields
@@ -796,7 +956,12 @@ struct Point {
         assert!(errs.is_empty());
         let once = Formatter::format(&p1);
         let (p2, errs2) = parse(&once);
-        assert!(errs2.is_empty(), "re-parse failed: {:?}\nsource was:\n{}", errs2, once);
+        assert!(
+            errs2.is_empty(),
+            "re-parse failed: {:?}\nsource was:\n{}",
+            errs2,
+            once
+        );
         let twice = Formatter::format(&p2);
         assert_eq!(once, twice, "formatter is not idempotent");
     }

--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -5,9 +5,12 @@
 //! and publish diagnostics with source ranges derived from
 //! RES-077's per-statement `Spanned<Node>` wrappers.
 //!
-//! Nothing else yet — no hover, no completion, no go-to-definition.
-//! Those are dedicated follow-up tickets. This ticket is the
-//! scaffolding that makes an editor light up with red squiggles.
+//! Subsequent tickets added: hover (literal types RES-181a, fn signatures
+//! RES-258), document symbols (RES-185), workspace symbols (RES-186),
+//! semantic tokens (RES-187), inlay hints (RES-189), go-to-definition
+//! (RES-182a), find-references (RES-183), rename (RES-184), and
+//! completion (RES-188a). This file is the scaffolding that makes an
+//! editor light up with red squiggles and IDE features.
 //!
 //! The `mod lsp_server;` declaration in `main.rs` is already
 //! gated on `cfg(feature = "lsp")`, so this file is only compiled
@@ -622,6 +625,47 @@ fn walk_call_sites(node: &Node, target: &str, out: &mut Vec<Range>) {
         // TypeAlias, StructDecl, LetDestructureStruct, AssumeStatement, etc.
         _ => {}
     }
+}
+
+/// RES-258: build a human-readable fn signature string from a
+/// `Node::Function` node, e.g. `fn add(int a, int b) -> int`.
+/// Returns `None` when `node` is not a `Node::Function`.
+pub(crate) fn fn_signature_string(node: &Node) -> Option<String> {
+    let (name, parameters, return_type) = match node {
+        Node::Function {
+            name,
+            parameters,
+            return_type,
+            ..
+        } => (name.as_str(), parameters.as_slice(), return_type.as_deref()),
+        _ => return None,
+    };
+    let params: Vec<String> = parameters
+        .iter()
+        .map(|(ty, pname)| format!("{} {}", ty, pname))
+        .collect();
+    let ret = match return_type {
+        Some(rt) => format!(" -> {}", rt),
+        None => String::new(),
+    };
+    Some(format!("fn {}({}){}", name, params.join(", "), ret))
+}
+
+/// RES-258: find the `Node::Function` with the given name in the program.
+/// Returns a reference to the `Node` if found, `None` otherwise.
+pub(crate) fn find_fn_node<'a>(program: &'a Node, name: &str) -> Option<&'a Node> {
+    let stmts = match program {
+        Node::Program(s) => s,
+        _ => return None,
+    };
+    for spanned in stmts {
+        if let Node::Function { name: fn_name, .. } = &spanned.node
+            && fn_name == name
+        {
+            return Some(&spanned.node);
+        }
+    }
+    None
 }
 
 /// RES-188a: hard cap on the completion list. Large lists hurt
@@ -1464,24 +1508,22 @@ impl LanguageServer for Backend {
         Ok(Some(DocumentSymbolResponse::Nested(symbols)))
     }
 
-    /// RES-181a: respond to `textDocument/hover` — today, only
-    /// literal positions yield a result. A literal under the
-    /// cursor returns its Resilient-surface type name (`Int`,
-    /// `Float`, `String`, `Bool`, `Bytes`); any other position
-    /// returns `Ok(None)` so the client renders nothing.
+    /// RES-181a + RES-258: respond to `textDocument/hover`.
     ///
-    /// Implementation drives the lexer directly against the
-    /// cached source text (not the AST), because the parser's
-    /// per-leaf spans record `last_token_*` AFTER the lexer
-    /// advances — unreliable for literal positions. See the
-    /// module-level comment on `hover_literal_at` for the
-    /// rationale.
+    /// Priority order:
+    /// 1. Literal token (Int / Float / String / Bool / Bytes) → return
+    ///    the Resilient type name (`Int`, `Float`, etc.) — RES-181a.
+    /// 2. Identifier token that names a top-level `fn` in the cached
+    ///    AST → return the fn's signature as a Markdown code block —
+    ///    RES-258 (identifier hover).
+    /// 3. Identifier token that does NOT resolve to a known top-level fn
+    ///    → return `"unknown"` so the client shows something rather than
+    ///    nothing. Panics and internal errors are not surfaced.
+    /// 4. Anything else (keyword, operator, out-of-range) → `Ok(None)`.
     ///
-    /// RES-181b will extend this to identifier positions once
-    /// RES-120 exposes a per-position inferred-type table. The
-    /// plumbing here (document lookup, capability advertisement,
-    /// Hover response shape) is the shared scaffolding that
-    /// ticket will build on.
+    /// Implementation drives the lexer directly against the cached source
+    /// text (not the AST) for token-position accuracy; see `hover_literal_at`
+    /// for the rationale.
     async fn hover(&self, params: HoverParams) -> JsonResult<Option<Hover>> {
         let uri = params.text_document_position_params.text_document.uri;
         let pos = params.text_document_position_params.position;
@@ -1492,15 +1534,44 @@ impl LanguageServer for Backend {
         let Some(text) = text else {
             return Ok(None);
         };
-        let Some((type_name, range)) = hover_literal_at(&text, pos) else {
+
+        // Priority 1: literal hover (RES-181a) — unchanged behaviour.
+        if let Some((type_name, range)) = hover_literal_at(&text, pos) {
+            return Ok(Some(Hover {
+                contents: HoverContents::Scalar(MarkedString::String(type_name.to_string())),
+                range: Some(range),
+            }));
+        }
+
+        // Priority 2 & 3: identifier hover (RES-258).
+        let Some((name, range)) = identifier_at(&text, pos) else {
+            // Non-identifier token (keyword, operator, etc.) → no hover.
             return Ok(None);
         };
-        // `MarkedString::String` keeps the bubble universal —
-        // both markdown-rendering and plain-text clients display
-        // it identically. Type name alone is the body; no extra
-        // prose.
+
+        // Look up the identifier in the cached AST.
+        let program = match self.documents.lock() {
+            Ok(map) => map.get(&uri).cloned(),
+            Err(_) => None,
+        };
+        let Some(program) = program else {
+            return Ok(None);
+        };
+
+        let content = if let Some(fn_node) = find_fn_node(&program, &name) {
+            // Known top-level fn: format the signature.
+            match fn_signature_string(fn_node) {
+                Some(sig) => sig,
+                None => "unknown".to_string(),
+            }
+        } else {
+            // Identifier does not resolve to a known fn — return "unknown"
+            // rather than nothing so the user knows we tried.
+            "unknown".to_string()
+        };
+
         Ok(Some(Hover {
-            contents: HoverContents::Scalar(MarkedString::String(type_name.to_string())),
+            contents: HoverContents::Scalar(MarkedString::String(content)),
             range: Some(range),
         }))
     }
@@ -2665,6 +2736,72 @@ mod tests {
         let sp = Span::new(Pos::new(2, 1, 0), Pos::new(2, 5, 4));
         assert!(!lex_span_contains_lsp_position(sp, Position::new(0, 1)));
         assert!(!lex_span_contains_lsp_position(sp, Position::new(5, 1)));
+    }
+
+    // ============================================================
+    // RES-258: identifier hover helpers
+    // ============================================================
+
+    #[test]
+    fn hover_on_fn_name_returns_signature() {
+        // `fn add(int a, int b) -> int` — cursor on `add` at col 3 (LSP).
+        let src = "fn add(int a, int b) -> int { return a + b; }";
+        let prog = {
+            let (p, _) = parse(src);
+            p
+        };
+        // `add` starts at col 4 (1-indexed) = LSP col 3.
+        let sig = fn_signature_string(find_fn_node(&prog, "add").expect("fn add not found"));
+        assert_eq!(sig, Some("fn add(int a, int b) -> int".to_string()));
+    }
+
+    #[test]
+    fn hover_on_fn_name_no_return_type() {
+        // Function without explicit return type: no `-> <ret>` in output.
+        let src = "fn hello() { return 0; }";
+        let (prog, _) = parse(src);
+        let sig = fn_signature_string(find_fn_node(&prog, "hello").expect("fn hello not found"));
+        assert_eq!(sig, Some("fn hello()".to_string()));
+    }
+
+    #[test]
+    fn hover_on_multi_param_fn_signature_format() {
+        // Multi-param fn: each param is `type name`, joined with `, `.
+        let src = "fn f(int x, bool flag, string msg) -> string { return msg; }";
+        let (prog, _) = parse(src);
+        let sig = fn_signature_string(find_fn_node(&prog, "f").expect("fn f not found"));
+        assert_eq!(
+            sig,
+            Some("fn f(int x, bool flag, string msg) -> string".to_string())
+        );
+    }
+
+    #[test]
+    fn hover_on_unknown_identifier_returns_unknown_string() {
+        // Identifier not in the program's top-level defs → find_fn_node returns None.
+        let src = "fn foo() { return 1; }";
+        let (prog, _) = parse(src);
+        assert!(find_fn_node(&prog, "bar").is_none());
+    }
+
+    #[test]
+    fn hover_fn_signature_string_on_non_fn_node_returns_none() {
+        // Non-Function node passed to fn_signature_string → None.
+        let node = Node::IntegerLiteral {
+            value: 42,
+            span: crate::span::Span::default(),
+        };
+        assert!(fn_signature_string(&node).is_none());
+    }
+
+    #[test]
+    fn hover_identifier_at_returns_none_for_keyword() {
+        // `fn` keyword is not an identifier token → None.
+        let r = identifier_at("fn foo() { return 0; }", Position::new(0, 0));
+        assert!(
+            r.is_none(),
+            "fn keyword should not be returned by identifier_at"
+        );
     }
 
     // ============================================================


### PR DESCRIPTION
## Summary

- **RES-254**: `resilient fmt` was silently dropping `extern` blocks (the `Node::Extern` arm in `formatter.rs` emitted nothing). Now emits full canonical form: `extern "lib" { fn f(x: T) -> R requires ..; }`. Adds a round-trip + idempotency test for extern blocks.
- **RES-258**: LSP `textDocument/hover` now handles identifier tokens in addition to literal tokens. Hovering over a function name returns its signature (e.g. `fn add(int a, int b) -> int`). Unknown identifiers return `"unknown"`. Adds `fn_signature_string` and `find_fn_node` helpers plus 6 unit tests.

## Test plan

- [ ] `cargo test --manifest-path resilient/Cargo.toml` — all pass (confirmed: 813+ tests, only 2 pre-existing `.rs`-extension failures in `walk_resilient_files` and `workspace_index` unrelated to this PR)
- [ ] `cargo test --manifest-path resilient/Cargo.toml --features lsp` — 813 passing, 2 pre-existing failures
- [ ] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets --features lsp -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] New test `fmt_extern_block_roundtrip` verifies extern block survives parse → format → re-parse → re-format cycle
- [ ] New tests `hover_on_fn_name_returns_signature`, `hover_on_multi_param_fn_signature_format`, `hover_on_unknown_identifier_returns_unknown_string`, `hover_fn_signature_string_on_non_fn_node_returns_none`, `hover_on_fn_name_no_return_type`, `hover_identifier_at_returns_none_for_keyword`

🤖 Generated with [Claude Code](https://claude.com/claude-code)