### PR TITLE
RES-384: VM tail-call optimisation

### DIFF
--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -107,6 +107,13 @@ pub enum Op {
     /// wire the actual slab; today the dispatch arm returns
     /// `VmError::Unsupported`.
     LoadUpvalue(u16),
+    /// RES-384: self-tail-call in tail position. Reuses the current
+    /// `CallFrame` instead of pushing a new one, keeping call-stack
+    /// depth O(1) for tail-recursive functions. The callee MUST be
+    /// the same function (self-recursive — cross-function TCO is out
+    /// of scope). Arity is the function's declared param count; the
+    /// VM pops that many arguments and overwrites locals 0..arity.
+    TailCall(u16),
     /// RES-171a: pop `len` values off the operand stack (rightmost
     /// first so the source-order `[a, b, c]` literal ends with `a`
     /// deepest), wrap them in a `Value::Array(Vec<Value>)`, and

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -135,6 +135,16 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
                 )?;
             }
             chunk.emit(Op::ReturnFromCall, 0);
+            // RES-384: replace self-tail-calls with TailCall. Scan
+            // for every `Call(own_idx); ReturnFromCall` pair and
+            // fold it into a single `TailCall(own_idx)`. This
+            // handles tail calls in all positions — explicit
+            // `return f(args);` statements and implicit tail
+            // returns from if-branches. Must run before the
+            // peephole pass so peephole sees the final opcode
+            // sequence.
+            let own_fn_idx = functions.len() as u16;
+            rewrite_tail_calls(&mut chunk, own_fn_idx);
             // RES-172: run the peephole optimizer over the
             // just-emitted chunk. Idempotent and linear-scan —
             // no effect on chunks that don't contain any of the
@@ -790,6 +800,58 @@ fn node_kind(n: &Node) -> &'static str {
         Node::IndexExpression { .. } => "IndexExpression",
         Node::IndexAssignment { .. } => "IndexAssignment",
         _ => "<other>",
+    }
+}
+
+// ============================================================
+// RES-384: tail-call rewriting pass
+// ============================================================
+
+/// Scan `chunk.code` for every adjacent `Call(fn_idx); ReturnFromCall`
+/// pair where `fn_idx == own_fn_idx` and replace the pair with a
+/// single `TailCall(fn_idx)`. The removed `ReturnFromCall` leaves a
+/// hole; rather than shifting the Vec (which would invalidate all
+/// existing jump targets), we overwrite the second slot of each pair
+/// with a `Jump(0)` sentinel pointing one step back so the dead op
+/// can never be reached:
+///
+/// ```text
+/// before:  [..., Call(i), ReturnFromCall, ...]
+/// after:   [..., TailCall(i), (dead/unreachable), ...]
+/// ```
+///
+/// Because `TailCall` does not fall through (it loops back to pc=0),
+/// the instruction following it is dead. We leave it as a `Return`
+/// no-op rather than a `Jump` to avoid confusing the disassembler;
+/// the VM will never execute it.
+///
+/// Jump targets are NOT shifted — this transform only touches pairs
+/// where the second op is `ReturnFromCall`, which nothing ever jumps
+/// TO (no other op emits a forward-jump into `ReturnFromCall`; all
+/// branch targets land on the instruction AFTER a block, not ON a
+/// return). This invariant holds for the patterns the compiler emits.
+fn rewrite_tail_calls(chunk: &mut crate::bytecode::Chunk, own_fn_idx: u16) {
+    let len = chunk.code.len();
+    if len < 2 {
+        return;
+    }
+    // We need indices so we can write back; collect positions first.
+    let mut positions: Vec<usize> = Vec::new();
+    for i in 0..len - 1 {
+        if chunk.code[i] == Op::Call(own_fn_idx) && chunk.code[i + 1] == Op::ReturnFromCall {
+            positions.push(i);
+        }
+    }
+    for pos in positions {
+        // Replace the Call with TailCall; mark the ReturnFromCall
+        // dead by overwriting with a no-op Return. The VM never
+        // reaches it because TailCall resets pc, but leaving a
+        // valid opcode keeps the chunk well-formed for the
+        // disassembler and any future static analyses.
+        chunk.code[pos] = Op::TailCall(own_fn_idx);
+        chunk.code[pos + 1] = Op::Return; // unreachable tombstone
+        // Preserve line info alignment by keeping the two slots;
+        // no shift needed.
     }
 }
 

--- a/resilient/src/disasm.rs
+++ b/resilient/src/disasm.rs
@@ -137,6 +137,13 @@ fn write_op(
             }
         }
         Op::ReturnFromCall => write!(out, "ReturnFromCall")?,
+        // RES-384: TailCall reuses the current frame (TCO).
+        Op::TailCall(idx) => {
+            write!(out, "TailCall {}", idx)?;
+            if let Some(name) = fn_names.get(idx as usize) {
+                write!(out, "       ; -> {} (tail)", name)?;
+            }
+        }
         Op::Jump(offset) => {
             let target = (pc as isize + 1) + offset as isize;
             write!(out, "Jump         -> {:04x}", target.max(0) as usize)?;
@@ -326,6 +333,40 @@ mod tests {
         disassemble(&program, &mut out).unwrap();
         assert!(out.contains("(empty)"));
         assert!(out.contains("constants: (none)"));
+    }
+
+    // ---------- RES-384: TailCall disasm ----------
+
+    #[test]
+    fn res384_tail_call_renders_with_fn_name() {
+        let program = Program {
+            main: mk_chunk(vec![Op::Return], vec![], vec![1]),
+            functions: vec![Function {
+                name: "loop_fn".to_string(),
+                arity: 1,
+                chunk: mk_chunk(
+                    vec![
+                        Op::TailCall(0),
+                        Op::Return, // unreachable tombstone
+                    ],
+                    vec![],
+                    vec![1, 1],
+                ),
+                local_count: 1,
+            }],
+        };
+        let mut out = String::new();
+        disassemble(&program, &mut out).unwrap();
+        assert!(
+            out.contains("TailCall 0") && out.contains("loop_fn"),
+            "expected `TailCall 0 ... loop_fn` in disasm, got:\n{}",
+            out
+        );
+        assert!(
+            out.contains("(tail)"),
+            "expected `(tail)` annotation in disasm, got:\n{}",
+            out
+        );
     }
 
     // ---------- RES-169a: skeleton closure-opcode disasm ----------

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -321,6 +321,42 @@ fn run_inner(program: &Program, last_pc: &mut (usize, usize)) -> Result<Value, V
                 locals.truncate(popped.locals_base);
                 stack.push(ret);
             }
+            // RES-384: self-tail-call. Reuse the current frame
+            // instead of pushing a new one — O(1) call-stack depth
+            // for tail-recursive functions. Steps:
+            //   1. Look up the callee (must be the same function).
+            //   2. Pop `arity` args off the operand stack.
+            //   3. Overwrite locals[locals_base..locals_base+arity]
+            //      with the new args (in source order).
+            //   4. Reset frame.pc to 0 so the next iteration
+            //      starts the function from the top.
+            // We do NOT push a new CallFrame — the existing frame is
+            // reused with its locals slab base unchanged.
+            Op::TailCall(idx) => {
+                let func = program
+                    .functions
+                    .get(idx as usize)
+                    .ok_or(VmError::FunctionOutOfBounds(idx))?;
+                let arity = func.arity as usize;
+                if stack.len() < arity {
+                    return Err(VmError::EmptyStack);
+                }
+                // The locals slab for this frame may be larger than
+                // arity (body has let-bindings beyond params). We
+                // only reset the parameter slots; body-locals are
+                // re-initialized by StoreLocal on the next pass.
+                let base = frames[frame_idx].locals_base;
+                // Pop args in reverse order (rightmost first) and
+                // write into locals[base+0..base+arity] in source
+                // order, matching the Call path.
+                for i in (0..arity).rev() {
+                    let v = stack.pop().ok_or(VmError::EmptyStack)?;
+                    locals[base + i] = v;
+                }
+                // Reset pc: the next loop iteration picks up at
+                // instruction 0 of this frame's chunk.
+                frames[frame_idx].pc = 0;
+            }
             Op::Jump(offset) => {
                 let new_pc = (frames[frame_idx].pc as isize) + offset as isize;
                 if new_pc < 0 || (new_pc as usize) > chunk.code.len() {
@@ -836,6 +872,94 @@ mod tests {
             panic!("expected Program");
         };
         interp.eval(&stmts[0].node).expect("eval")
+    }
+
+    // ---------- RES-384: tail-call optimisation ----------
+
+    #[test]
+    fn res384_tail_recursive_sum_does_not_overflow() {
+        // Without TCO this would exceed MAX_CALL_DEPTH (1024) at n=100_000.
+        // With TCO the call stack stays at depth 1.
+        // sum(0, 100) = 1+2+...+100 = 5050
+        let src = "fn sum(int acc, int n) { if n == 0 { return acc; } return sum(acc + n, n - 1); } sum(0, 100);";
+        assert_int(compile_run(src).unwrap(), 5050);
+    }
+
+    #[test]
+    fn res384_tail_recursive_sum_large_does_not_overflow() {
+        // 100_000 iterations — would blow the 1024-frame cap without TCO.
+        let src = r#"
+            fn sum(int acc, int n) {
+                if n == 0 { return acc; }
+                return sum(acc + n, n - 1);
+            }
+            sum(0, 100000);
+        "#;
+        // sum(0, 100_000) = 100_000 * 100_001 / 2 = 5_000_050_000
+        let result = compile_run(src).unwrap();
+        assert_int(result, 5_000_050_000i64);
+    }
+
+    #[test]
+    fn res384_tail_call_opcode_is_emitted_for_self_tail_call() {
+        // After compilation the function body should contain TailCall,
+        // not a plain Call followed by ReturnFromCall.
+        let src = "fn count(int n) { if n == 0 { return 0; } return count(n - 1); } count(5);";
+        let (ast, _) = crate::parse(src);
+        let prog = crate::compiler::compile(&ast).unwrap();
+        let f = &prog.functions[0];
+        let has_tail_call = f
+            .chunk
+            .code
+            .iter()
+            .any(|op| matches!(op, crate::bytecode::Op::TailCall(0)));
+        assert!(
+            has_tail_call,
+            "expected TailCall(0) in fn body: {:?}",
+            f.chunk.code
+        );
+    }
+
+    #[test]
+    fn res384_non_self_call_still_uses_regular_call() {
+        // A call to a *different* function must not be promoted to TailCall.
+        let src =
+            "fn double(int n) { return n + n; } fn wrap(int n) { return double(n); } wrap(3);";
+        let (ast, _) = crate::parse(src);
+        let prog = crate::compiler::compile(&ast).unwrap();
+        // fn wrap (index 1) calls fn double (index 0) — must remain Call(0)
+        let wrap = &prog.functions[1];
+        let has_regular_call = wrap
+            .chunk
+            .code
+            .iter()
+            .any(|op| matches!(op, crate::bytecode::Op::Call(0)));
+        assert!(
+            has_regular_call,
+            "cross-function call should remain Call, not TailCall: {:?}",
+            wrap.chunk.code
+        );
+    }
+
+    #[test]
+    fn res384_mutual_recursion_still_works_via_call() {
+        // Mutual recursion (is_even/is_odd) cannot use TailCall (different
+        // functions) — must still run correctly via regular Call.
+        let src = r#"
+            fn is_even(int n) { if n == 0 { return 1; } return is_odd(n - 1); }
+            fn is_odd(int n) { if n == 0 { return 0; } return is_even(n - 1); }
+            is_even(10);
+        "#;
+        assert_int(compile_run(src).unwrap(), 1); // 10 is even → 1
+    }
+
+    #[test]
+    fn res384_non_tail_recursive_still_works() {
+        // A non-tail-recursive function (fib) must still produce correct
+        // results — the rewriting pass must only touch self-tail-calls.
+        let src =
+            "fn fib(int n) { if n <= 1 { return n; } return fib(n - 1) + fib(n - 2); } fib(10);";
+        assert_int(compile_run(src).unwrap(), 55);
     }
 
     // ---------- RES-169a: skeleton closure-opcode dispatch ----------


### PR DESCRIPTION
Closes #176

## Summary

- New `Op::TailCall(u16)` opcode in `bytecode.rs` — documented with the same detail level as other opcodes
- Post-compile rewriting pass in `compiler.rs` (`rewrite_tail_calls`) scans each compiled function for `Call(own_idx); ReturnFromCall` pairs and folds them into `TailCall(own_idx)` — handles explicit `return f(args);`, implicit tail expressions, and tail calls inside if-branches uniformly
- VM dispatch in `vm.rs` handles `Op::TailCall` by overwriting the current frame's params and resetting `pc = 0` — O(1) call-stack depth for tail-recursive functions
- Disassembler in `disasm.rs` renders `TailCall N ; -> fn_name (tail)`
- 7 new tests: stack-overflow guard at 100 iterations, stack-overflow guard at 100_000 iterations, opcode emission verification, non-self-call safety (cross-fn calls stay as `Call`), mutual recursion correctness, non-tail-recursive fib still correct

## Limitations

Only self-recursive tail calls are promoted to `TailCall`. Cross-function mutual tail-call TCO (trampoline-style) is out of scope for this ticket. Detection is done via a bytecode-level scan rather than AST analysis, which means it covers all code paths (explicit return, implicit tail position, branches) without needing to thread context through every compiler helper.

## Test changes

None — no existing tests were modified. All 7 added tests are new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)