### PR TITLE
RES-371: live block retry NDJSON telemetry

### DIFF
--- a/resilient-runtime/src/lib.rs
+++ b/resilient-runtime/src/lib.rs
@@ -53,6 +53,7 @@ extern crate alloc;
 
 // RES-180: `Sink` abstraction + global `print` / `println`
 // helpers that route through a user-installed sink.
+pub mod live_telemetry;
 pub mod sink;
 
 #[cfg(feature = "ffi-static")]
@@ -237,7 +238,10 @@ mod tests {
         assert_eq!(a.clone().add(b.clone()).unwrap(), Value::Float(4.0));
         assert_eq!(a.clone().sub(b.clone()).unwrap(), Value::Float(1.0));
         assert_eq!(a.clone().mul(b.clone()).unwrap(), Value::Float(3.75));
-        assert_eq!(Value::Float(10.0).div(Value::Float(4.0)).unwrap(), Value::Float(2.5));
+        assert_eq!(
+            Value::Float(10.0).div(Value::Float(4.0)).unwrap(),
+            Value::Float(2.5)
+        );
     }
 
     #[test]
@@ -282,11 +286,15 @@ mod tests {
     #[test]
     fn string_eq() {
         assert_eq!(
-            Value::String(String::from("x")).eq(Value::String(String::from("x"))).unwrap(),
+            Value::String(String::from("x"))
+                .eq(Value::String(String::from("x")))
+                .unwrap(),
             Value::Bool(true)
         );
         assert_eq!(
-            Value::String(String::from("x")).eq(Value::String(String::from("y"))).unwrap(),
+            Value::String(String::from("x"))
+                .eq(Value::String(String::from("y")))
+                .unwrap(),
             Value::Bool(false)
         );
     }
@@ -294,7 +302,9 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn string_does_not_subtract() {
-        let err = Value::String(String::from("a")).sub(Value::String(String::from("b"))).unwrap_err();
+        let err = Value::String(String::from("a"))
+            .sub(Value::String(String::from("b")))
+            .unwrap_err();
         assert_eq!(err, RuntimeError::TypeMismatch("sub"));
     }
 

--- a/resilient-runtime/src/live_telemetry.rs
+++ b/resilient-runtime/src/live_telemetry.rs
@@ -1,0 +1,105 @@
+//! RES-371: optional hook for live-block retry telemetry on `#![no_std]` hosts.
+//!
+//! The full `resilient` CLI writes NDJSON when `--emit-live-log <file>` is set.
+//! Embedded builds that execute live blocks without the driver install a
+//! [`LiveTelemetryBackend`] once at startup; [`emit_live_retry`] becomes a
+//! no-op when nothing is registered.
+
+use core::cell::UnsafeCell;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Embedder-implemented sink for live-block retry events.
+pub trait LiveTelemetryBackend {
+    fn on_live_retry(&mut self, block: &str, retry: usize, reason: &str, ts_ns: u64);
+}
+
+struct BackendCell(UnsafeCell<Option<*mut (dyn LiveTelemetryBackend + 'static)>>);
+
+unsafe impl Sync for BackendCell {}
+
+static BACKEND: BackendCell = BackendCell(UnsafeCell::new(None));
+static BACKEND_PRESENT: AtomicBool = AtomicBool::new(false);
+
+/// True when a backend was installed and not yet cleared.
+pub fn has_live_telemetry_backend() -> bool {
+    BACKEND_PRESENT.load(Ordering::Relaxed)
+}
+
+/// Install `backend` as the global live-telemetry target.
+///
+/// # Safety
+///
+/// Same single-threaded-write contract as [`crate::sink::set_sink`](super::sink::set_sink).
+pub fn set_live_telemetry(backend: &'static mut dyn LiveTelemetryBackend) {
+    BACKEND_PRESENT.store(true, Ordering::Relaxed);
+    unsafe {
+        *BACKEND.0.get() = Some(backend as *mut dyn LiveTelemetryBackend);
+    }
+}
+
+/// Remove the installed backend (primarily for tests).
+pub fn clear_live_telemetry() {
+    BACKEND_PRESENT.store(false, Ordering::Relaxed);
+    unsafe {
+        *BACKEND.0.get() = None;
+    }
+}
+
+/// Dispatch one retry event to the installed backend, if any.
+pub fn emit_live_retry(block: &str, retry: usize, reason: &str, ts_ns: u64) {
+    if !BACKEND_PRESENT.load(Ordering::Relaxed) {
+        return;
+    }
+    unsafe {
+        let slot = &mut *BACKEND.0.get();
+        let Some(ptr) = slot else {
+            return;
+        };
+        let b: &mut dyn LiveTelemetryBackend = &mut **ptr;
+        b.on_live_retry(block, retry, reason, ts_ns);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering as AOrd};
+
+    static LIVE_TELEM_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct CountingBackend {
+        hits: &'static AtomicUsize,
+    }
+
+    impl LiveTelemetryBackend for CountingBackend {
+        fn on_live_retry(&mut self, block: &str, retry: usize, reason: &str, ts_ns: u64) {
+            self.hits.fetch_add(1, AOrd::Relaxed);
+            assert_eq!(block, "demo.rz:3");
+            assert_eq!(retry, 1);
+            assert!(reason.contains("fail"));
+            assert!(ts_ns > 0);
+        }
+    }
+
+    #[test]
+    fn emit_noops_without_backend() {
+        let _g = LIVE_TELEM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_live_telemetry();
+        emit_live_retry("x:1", 1, "r", 1);
+        clear_live_telemetry();
+    }
+
+    #[test]
+    fn emit_delivers_to_installed_backend() {
+        let _g = LIVE_TELEM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_live_telemetry();
+        static HITS: AtomicUsize = AtomicUsize::new(0);
+        HITS.store(0, AOrd::Relaxed);
+        let backend: &'static mut CountingBackend =
+            Box::leak(Box::new(CountingBackend { hits: &HITS }));
+        set_live_telemetry(backend);
+        emit_live_retry("demo.rz:3", 1, "forced fail", 99);
+        assert_eq!(HITS.load(AOrd::Relaxed), 1);
+        clear_live_telemetry();
+    }
+}

--- a/resilient/Cargo.lock
+++ b/resilient/Cargo.lock
@@ -1583,6 +1583,7 @@ dependencies = [
  "logos",
  "proptest",
  "rand_core 0.6.4",
+ "resilient-runtime",
  "resilient-span",
  "rustyline",
  "serde_json",
@@ -1591,6 +1592,10 @@ dependencies = [
  "tower-lsp",
  "z3",
 ]
+
+[[package]]
+name = "resilient-runtime"
+version = "0.1.0"
 
 [[package]]
 name = "resilient-span"

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -74,6 +74,7 @@ proptest = ["dep:proptest"]
 # thin `pub use resilient_span::*;` shim; `resilient-runtime`
 # does *not* take this dep (it stays no_std-clean).
 resilient-span = { path = "../resilient-span" }
+resilient-runtime = { path = "../resilient-runtime" }
 clap = { version = "4.4", features = ["derive"] }
 libloading = { version = "0.8", optional = true }
 logos = { version = "0.14", optional = true }

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::io;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -6559,6 +6559,76 @@ fn panic_on_fault_enabled() -> bool {
     PANIC_ON_FAULT.with(|c| c.get())
 }
 
+thread_local! {
+    static LIVE_SOURCE_BASENAME: RefCell<Option<String>> = const { RefCell::new(None) };
+    static LIVE_LOG_WRITER: RefCell<Option<BufWriter<fs::File>>> = const { RefCell::new(None) };
+}
+
+struct LiveRunTelemetryGuard;
+
+impl Drop for LiveRunTelemetryGuard {
+    fn drop(&mut self) {
+        LIVE_SOURCE_BASENAME.with(|b| *b.borrow_mut() = None);
+        LIVE_LOG_WRITER.with(|w| {
+            if let Some(mut wr) = w.borrow_mut().take() {
+                let _ = wr.flush();
+            }
+        });
+    }
+}
+
+fn install_live_run_telemetry(
+    basename: String,
+    log: Option<BufWriter<fs::File>>,
+) -> LiveRunTelemetryGuard {
+    LIVE_SOURCE_BASENAME.with(|b| *b.borrow_mut() = Some(basename));
+    LIVE_LOG_WRITER.with(|w| *w.borrow_mut() = log);
+    LiveRunTelemetryGuard
+}
+
+fn live_retry_block_label(span: span::Span) -> String {
+    LIVE_SOURCE_BASENAME.with(|b| {
+        let base = b.borrow();
+        let base = base.as_deref().unwrap_or("?");
+        format!("{}:{}", base, span.start.line)
+    })
+}
+
+fn live_retry_ts_ns() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+fn maybe_emit_live_retry_telemetry(block_span: span::Span, retry: usize, error: &str) {
+    let need_file = LIVE_LOG_WRITER.with(|w| w.borrow().is_some());
+    if !need_file && !resilient_runtime::live_telemetry::has_live_telemetry_backend() {
+        return;
+    }
+    let ts_ns = live_retry_ts_ns();
+    let block = live_retry_block_label(block_span);
+    if need_file
+        && let Ok(line_val) = serde_json::to_string(&serde_json::json!({
+            "block": &block,
+            "retry": retry,
+            "reason": error,
+            "ts_ns": ts_ns,
+        }))
+    {
+        let mut line = line_val;
+        line.push('\n');
+        LIVE_LOG_WRITER.with(|w| {
+            if let Some(writer) = w.borrow_mut().as_mut() {
+                let _ = writer
+                    .write_all(line.as_bytes())
+                    .and_then(|_| writer.flush());
+            }
+        });
+    }
+    resilient_runtime::live_telemetry::emit_live_retry(&block, retry, error, ts_ns);
+}
+
 struct LiveRetryGuard;
 
 impl LiveRetryGuard {
@@ -6725,7 +6795,7 @@ impl Interpreter {
                 invariants,
                 backoff,
                 timeout,
-                ..
+                span,
             } => {
                 // RES-142: unpack the `within <duration>` clause
                 // (if any) into a flat `u64 ns` so the runtime loop
@@ -6734,7 +6804,7 @@ impl Interpreter {
                     Node::DurationLiteral { nanos, .. } => Some(*nanos),
                     _ => None,
                 });
-                self.eval_live_block(body, invariants, backoff.as_ref(), timeout_ns)
+                self.eval_live_block(body, invariants, backoff.as_ref(), timeout_ns, *span)
             }
             // RES-142: duration literals are only legal inside a
             // `live ... within <duration> { ... }` clause — the
@@ -7318,6 +7388,7 @@ impl Interpreter {
         invariants: &[Node],
         backoff: Option<&BackoffConfig>,
         timeout_ns: Option<u64>,
+        block_span: span::Span,
     ) -> RResult<Value> {
         const MAX_RETRIES: usize = 3;
         let mut retry_count = 0;
@@ -7458,6 +7529,8 @@ impl Interpreter {
                             MAX_RETRIES, depth, error
                         ));
                     }
+
+                    maybe_emit_live_retry_telemetry(block_span, retry_count, &error);
 
                     eprintln!(
                         "\x1B[36m[LIVE BLOCK] Restoring environment to last known good state\x1B[0m"
@@ -8741,6 +8814,7 @@ fn execute_file(
     use_jit: bool,
     verifier_timeout_ms: u32,
     warn_unverified: bool,
+    live_log: Option<&Path>,
 ) -> RResult<()> {
     let contents =
         fs::read_to_string(filename).map_err(|e| format!("Error reading file: {}", e))?;
@@ -8893,6 +8967,20 @@ fn execute_file(
         }
         return Ok(());
     }
+
+    let basename = Path::new(filename)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| filename.to_string());
+    let log_writer = if let Some(p) = live_log {
+        let f = fs::File::create(p)
+            .map_err(|e| format!("could not create live telemetry log {}: {}", p.display(), e))?;
+        Some(BufWriter::new(f))
+    } else {
+        None
+    };
+    let _live_telemetry_guard = install_live_run_telemetry(basename, log_writer);
 
     let mut interpreter = Interpreter::new().with_proven_fns(proven_fns);
 
@@ -9873,6 +9961,7 @@ COMMON FLAGS:\n\
         --panic-on-fault         Disable live-block retry healing;\n\
                                  abort with exit 1 on the first fault\n\
         --no-panic-on-fault      Restore default retry behaviour\n\
+        --emit-live-log PATH     NDJSON log of live-block retries (RES-371)\n\
         --examples-dir DIR       REPL examples directory\n\
         --lsp                    Run the LSP server on stdio\n\
 \n\
@@ -9991,6 +10080,7 @@ fn main() {
     // diagnostic instead of being silently healed. Handy during
     // development — `--no-panic-on-fault` restores the default.
     let mut panic_on_fault_flag = false;
+    let mut emit_live_log: Option<PathBuf> = None;
     let mut filename = "";
 
     // Simple argument parsing
@@ -10112,6 +10202,15 @@ fn main() {
                 // retry behaviour even if an earlier arg or wrapper
                 // script set `--panic-on-fault`.
                 panic_on_fault_flag = false;
+            } else if arg == "--emit-live-log" {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("Error: --emit-live-log requires a file path");
+                    std::process::exit(2);
+                }
+                emit_live_log = Some(PathBuf::from(&args[i]));
+            } else if let Some(p) = arg.strip_prefix("--emit-live-log=") {
+                emit_live_log = Some(PathBuf::from(p));
             } else if arg == "--examples-dir" {
                 // RES-026: --examples-dir <DIR> for the REPL's
                 // `examples` command.
@@ -10254,6 +10353,7 @@ fn main() {
                 use_jit,
                 verifier_timeout_ms,
                 warn_unverified,
+                emit_live_log.as_deref(),
             );
             // RES-174: print cache stats on exit whenever the
             // flag is set, regardless of whether the run

--- a/resilient/tests/live_retry_log_cli.rs
+++ b/resilient/tests/live_retry_log_cli.rs
@@ -1,0 +1,115 @@
+//! RES-371: `--emit-live-log` writes one NDJSON record per live-block retry.
+
+use std::io::Write;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_resilient")
+}
+
+fn extract_u64_field<'a>(line: &'a str, key: &str) -> &'a str {
+    let needle = format!("\"{}\":", key);
+    let i = line
+        .find(&needle)
+        .unwrap_or_else(|| panic!("missing {key} in {line:?}"));
+    let start = i + needle.len();
+    let rest = &line[start..];
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    &rest[..end]
+}
+
+#[test]
+fn emit_live_log_writes_two_retry_records() {
+    let mut log_path = std::env::temp_dir();
+    log_path.push(format!(
+        "res371_emit_live_log_{}.ndjson",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&log_path);
+
+    let mut src_path = std::env::temp_dir();
+    src_path.push(format!("res371_emit_src_{}.rz", std::process::id()));
+
+    let src = "\
+static let fails_left = 2;\n\
+\n\
+fn maybe_fail() {\n\
+    if fails_left > 0 {\n\
+        fails_left = fails_left - 1;\n\
+        assert(false, \"forced fail\");\n\
+    }\n\
+    return 42;\n\
+}\n\
+\n\
+fn main(int _d) {\n\
+    live {\n\
+        let _r = maybe_fail();\n\
+        println(\"ok\");\n\
+    }\n\
+}\n\
+\n\
+main(0);\n\
+";
+
+    {
+        let mut f = std::fs::File::create(&src_path).expect("create temp source");
+        f.write_all(src.as_bytes()).expect("write source");
+    }
+
+    let src_basename = src_path
+        .file_name()
+        .expect("basename")
+        .to_str()
+        .expect("utf8 basename")
+        .to_string();
+
+    let output = Command::new(bin())
+        .arg("--emit-live-log")
+        .arg(&log_path)
+        .arg(&src_path)
+        .output()
+        .expect("spawn resilient");
+
+    let _ = std::fs::remove_file(&src_path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = std::fs::read_to_string(&log_path).expect("read log file");
+    let _ = std::fs::remove_file(&log_path);
+
+    let lines: Vec<&str> = log.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected 2 NDJSON lines for 2 retries before success; log:\n{log}"
+    );
+
+    let r0: usize = extract_u64_field(lines[0], "retry").parse().unwrap();
+    let r1: usize = extract_u64_field(lines[1], "retry").parse().unwrap();
+    assert_eq!(r0, 1);
+    assert_eq!(r1, 2);
+
+    assert!(
+        lines[0].contains("\"block\":")
+            && lines[0].contains(&src_basename)
+            && lines[0].contains(".rz:"),
+        "expected block label `basename:line`; line={}",
+        lines[0]
+    );
+    assert!(
+        lines[0].contains("forced fail"),
+        "reason should include failure text; line={}",
+        lines[0]
+    );
+    assert!(
+        lines[0].contains("\"ts_ns\":") && lines[1].contains("\"ts_ns\":"),
+        "ts_ns should be present; lines={lines:?}"
+    );
+}


### PR DESCRIPTION
Closes https://github.com/EricSpencer00/Resilient/issues/163

## Summary
- Added `--emit-live-log <path>` and `--emit-live-log=<path>` so each live-block retry appends one NDJSON object (block basename:line, retry index, failure reason, `ts_ns`) and flushes after each line.
- Fast path when telemetry is off: no serde or file work unless a log file is open or a `LiveTelemetryBackend` is registered.
- `resilient-runtime`: new `live_telemetry` module with `LiveTelemetryBackend`, `set_live_telemetry`, and `emit_live_retry` for `#![no_std]` hosts. The CLI wires the file path; embedders can register a backend without the flag.

## Testing
- `cargo test --manifest-path resilient/Cargo.toml --locked`
- `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Made with [Cursor](https://cursor.com)