### PR TITLE
RES-347: --explain-effects flag surfaces inferred @pure/@io tags

### DIFF
--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8808,6 +8808,7 @@ fn execute_file(
     filename: &str,
     type_check: bool,
     audit: bool,
+    explain_effects: bool,
     emit_cert_dir: Option<&Path>,
     sign_cert_key: Option<&Path>,
     use_vm: bool,
@@ -8856,9 +8857,10 @@ fn execute_file(
         return Err(format!("Import error: {}", e));
     }
 
-    // Type checking if enabled. --audit and --emit-certificate both
-    // imply --typecheck (no point running them without it).
-    let want_typecheck = type_check || audit || emit_cert_dir.is_some();
+    // Type checking if enabled. --audit, --explain-effects, and
+    // --emit-certificate all imply --typecheck (no point running
+    // them without it).
+    let want_typecheck = type_check || audit || explain_effects || emit_cert_dir.is_some();
     let mut proven_fns: HashSet<String> = HashSet::new();
     if want_typecheck {
         println!("Running type checker...");
@@ -8891,6 +8893,13 @@ fn execute_file(
         proven_fns = tc.stats.fully_provable_fns();
         if audit {
             print_verification_audit(&tc.stats);
+        }
+        // RES-347: `--explain-effects` dumps a deterministic,
+        // non-colored table of inferred effects after typecheck.
+        // Printed regardless of `--audit` so tooling can consume it
+        // without grepping through the audit's colored prose.
+        if explain_effects {
+            print_effect_explanation(&tc.stats);
         }
         // RES-071: dump SMT-LIB2 certificates for every Z3-discharged
         // obligation so a downstream consumer can re-verify with
@@ -9111,6 +9120,33 @@ fn print_verification_audit(stats: &typechecker::VerificationStats) {
             println!("    {:<32} {}", name, tag);
         }
     }
+}
+
+/// RES-347: deterministic, non-colored dump of the per-fn inferred
+/// effect set. Intended for tool consumption (golden tests, editor
+/// integrations, `grep`-friendly CI pipelines). The format is:
+///
+/// ```text
+/// --- Effects ---
+///   <fn_name>: @pure
+///   <fn_name>: @io
+/// --- End effects ---
+/// ```
+///
+/// Function names are sorted alphabetically so the output is stable
+/// across runs. A program with no user fns still emits the header
+/// and footer so consumers don't have to special-case the empty
+/// case.
+fn print_effect_explanation(stats: &typechecker::VerificationStats) {
+    let mut names: Vec<&String> = stats.fn_effects.keys().collect();
+    names.sort();
+    println!("--- Effects ---");
+    for name in names {
+        let has_io = stats.fn_effects.get(name).copied().unwrap_or(false);
+        let tag = if has_io { "@io" } else { "@pure" };
+        println!("  {}: {}", name, tag);
+    }
+    println!("--- End effects ---");
 }
 
 // Example programs
@@ -9950,6 +9986,8 @@ COMMON FLAGS:\n\
     -h, --help                   Show this help and exit\n\
     -t, --typecheck              Run the static type checker\n\
         --audit                  Print the verification audit trail\n\
+        --explain-effects        Print the inferred effect (@pure / @io)\n\
+                                 for every user function\n\
         --emit-certificate DIR   Dump SMT-LIB2 certs per obligation\n\
         --sign-cert PATH         Ed25519-sign the emitted certificate\n\
         --vm                     Route through the bytecode VM\n\
@@ -10043,6 +10081,11 @@ fn main() {
 
     let mut type_check = false;
     let mut audit = false;
+    // RES-347: `--explain-effects` prints the inferred effect
+    // (@pure / @io) for every user fn after typechecking. Implies
+    // `--typecheck` so the fixpoint has run and `stats.fn_effects`
+    // is populated.
+    let mut explain_effects = false;
     let mut emit_cert_dir: Option<PathBuf> = None;
     // RES-194: Ed25519 signing key — when present, the driver
     // writes `cert.sig` alongside the `.smt2` files.
@@ -10092,6 +10135,10 @@ fn main() {
                 type_check = true;
             } else if arg == "--audit" {
                 audit = true;
+            } else if arg == "--explain-effects" {
+                // RES-347: dump one line per user fn with its
+                // inferred effect. Implies --typecheck.
+                explain_effects = true;
             } else if arg == "--emit-certificate" {
                 // RES-071: --emit-certificate <DIR>
                 i += 1;
@@ -10347,6 +10394,7 @@ fn main() {
                 filename,
                 type_check,
                 audit,
+                explain_effects,
                 emit_cert_dir.as_deref(),
                 sign_cert_key.as_deref(),
                 use_vm,

--- a/resilient/tests/explain_effects_cli.rs
+++ b/resilient/tests/explain_effects_cli.rs
@@ -1,0 +1,202 @@
+//! RES-347: `--explain-effects` prints the inferred effect
+//! (@pure / @io) for every user fn after typechecking.
+//!
+//! The pipeline under test is `pure_leaf -> pure_middle -> io_caller`:
+//! the two callees never touch IO and must be reported `@pure`; the
+//! outer fn calls `println` and must be reported `@io`. The
+//! inference is a fixpoint over the call graph, so this also
+//! exercises transitive propagation: an intermediate fn that only
+//! relays a pure callee stays pure.
+//!
+//! We assert on the deterministic block printed by
+//! `print_effect_explanation` — sorted by fn name, no ANSI
+//! escapes — so the format is stable enough to grep from tooling.
+use std::io::Write;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_resilient")
+}
+
+fn write_temp(stem: &str, src: &str) -> std::path::PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "res347_{}_{}_{}.rz",
+        stem,
+        std::process::id(),
+        // Using the nanoseconds-since-UNIX-epoch defeats parallel test
+        // collisions without pulling in a uuid crate.
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0)
+    ));
+    let mut f = std::fs::File::create(&path).expect("create temp source");
+    f.write_all(src.as_bytes()).expect("write source");
+    path
+}
+
+/// Strip ANSI CSI sequences so the assertion ignores the
+/// colorization `--audit` uses elsewhere. `--explain-effects` itself
+/// does not emit colors, but `Type check passed` upstream does.
+fn strip_ansi(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            i += 2;
+            while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
+                i += 1;
+            }
+            if i < bytes.len() {
+                i += 1;
+            }
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Extract the `--- Effects ---` … `--- End effects ---` block
+/// from the driver's stdout so the assertion isn't fragile to
+/// unrelated prefix/suffix lines (seed banner, "Program executed
+/// successfully", etc.).
+fn extract_effects_block(stdout: &str) -> String {
+    let plain = strip_ansi(stdout);
+    let mut inside = false;
+    let mut lines = Vec::new();
+    for line in plain.lines() {
+        if line == "--- Effects ---" {
+            inside = true;
+        }
+        if inside {
+            lines.push(line.to_string());
+            if line == "--- End effects ---" {
+                break;
+            }
+        }
+    }
+    lines.join("\n")
+}
+
+#[test]
+fn explain_effects_reports_pure_pure_io_pipeline() {
+    let src = "\
+fn pure_leaf(int x) {\n\
+    return x * x;\n\
+}\n\
+\n\
+fn pure_middle(int x) {\n\
+    return pure_leaf(x) + 1;\n\
+}\n\
+\n\
+fn io_caller(int x) {\n\
+    println(\"calling\");\n\
+    return pure_middle(x);\n\
+}\n\
+\n\
+io_caller(3);\n\
+";
+    let path = write_temp("pipeline", src);
+
+    let output = Command::new(bin())
+        .arg("--explain-effects")
+        .arg(&path)
+        .output()
+        .expect("spawn resilient");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let block = extract_effects_block(&stdout);
+
+    let expected = "\
+--- Effects ---\n  \
+io_caller: @io\n  \
+pure_leaf: @pure\n  \
+pure_middle: @pure\n\
+--- End effects ---";
+
+    assert_eq!(block, expected, "full stdout=\n{stdout}");
+}
+
+#[test]
+fn explain_effects_without_user_fns_emits_empty_block() {
+    // A one-liner script has no user fns; the flag should still
+    // emit the header/footer so tooling never has to special-case
+    // the empty case.
+    let src = "let x = 1 + 2;\n";
+    let path = write_temp("empty", src);
+
+    let output = Command::new(bin())
+        .arg("--explain-effects")
+        .arg(&path)
+        .output()
+        .expect("spawn resilient");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let block = extract_effects_block(&stdout);
+
+    let expected = "--- Effects ---\n--- End effects ---";
+    assert_eq!(block, expected, "full stdout=\n{stdout}");
+}
+
+#[test]
+fn explain_effects_rejects_pure_annotation_on_io_body() {
+    // Manual `@pure` on a function that reaches IO is still a
+    // type error — the inference pass runs after the purity check,
+    // so the existing diagnostic is preserved.
+    let src = "\
+@pure fn bad(int x) {\n\
+    println(\"oops\");\n\
+    return x;\n\
+}\n\
+\n\
+bad(1);\n\
+";
+    let path = write_temp("bad", src);
+
+    let output = Command::new(bin())
+        .arg("--explain-effects")
+        .arg(&path)
+        .output()
+        .expect("spawn resilient");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "expected non-zero exit; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("@pure fn `bad`"),
+        "expected @pure violation diagnostic; combined output=\n{combined}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #139 (RES-347 — Effect inference: automatic `@pure` / `@io` classification).

The IO-effect fixpoint (`infer_fn_effects`, RES-192) already runs as a post-pass after typechecking and populates `VerificationStats::fn_effects` with a binary lattice tag per user fn. What was missing from the ticket:

1. A CLI switch that dumps the inferred effect for every function in a form a tool or golden test can consume.
2. A golden test asserting that a `pure → pure → io` pipeline is classified correctly.

This PR fills those gaps.

### What changed

- **New flag `--explain-effects`** — wired through `main` → `execute_file`. Implies `--typecheck` so the fixpoint actually runs. Surfaced in `--help`.
- **`print_effect_explanation(stats)`** — prints a deterministic, color-free block:
  ```
  --- Effects ---
    io_caller: @io
    pure_leaf: @pure
    pure_middle: @pure
  --- End effects ---
  ```
  Functions are alphabetically sorted; empty programs still emit the header/footer so downstream tools never have to special-case zero user fns.
- Manual annotations stay authoritative — `@pure` on an IO body is still a type error (pre-existing behaviour covered by a new integration test).

### Acceptance criteria mapping

| AC | Status |
|---|---|
| Effect inference runs as a post-pass after type checking | Already done (RES-192); unchanged |
| Fns with no IO builtins / `@io` callees → `@pure` | Already done; now visible via `--explain-effects` |
| Fns that call `println`, `file_read`, etc. → `@io` | Already done; now visible |
| Manual annotations honoured; `@pure` on IO is a type error | Unchanged; integration test added |
| `--explain-effects` flag prints the inferred effect for every function | **New** |
| Golden test: pipeline of pure → pure → io; assert inference | **New** (`tests/explain_effects_cli.rs`) |

### Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo fmt --manifest-path resilient/Cargo.toml -- --check`
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings`
- [x] `cargo test --manifest-path resilient/Cargo.toml` — 748+ tests pass, including the 3 new integration tests
- [x] `cargo test --manifest-path resilient-runtime/Cargo.toml`
- [x] Manual smoke: `resilient --explain-effects <program.rz>` prints the expected block and the program still runs normally

### Test changes

None. No existing test was modified; only new tests were added.

https://claude.ai/code/session_01VX2antgxQDug9F2K9wc1tk