### PR TITLE
RES-392: recovers_to — final-state variant of recovery contract

### DIFF
--- a/resilient/examples/recovers_to_fail.res
+++ b/resilient/examples/recovers_to_fail.res
@@ -1,0 +1,29 @@
+// RES-392 demo — `recovers_to` that the verifier must reject at
+// runtime. The function declares a recovery invariant (`result == 0`
+// — the "safe default") but always returns a non-zero value, so the
+// final state falsifies the clause on every invocation.
+//
+// The Resilient driver surfaces this as:
+//
+//   Runtime error: Contract violation in fn init_actuator:
+//     recovers_to result == 0 failed — final-state counterexample:
+//     result = 3
+//
+// File extension is `.res` so the goldens-match harness (which walks
+// only `*.rz`) does not try to run this example as a passing program.
+// A dedicated smoke test (`recovers_to_smoke`) invokes the binary
+// against it and asserts the failure diagnostic.
+fn init_actuator(int id) -> int
+    requires id >= 0
+    recovers_to: result == 0;
+{
+    // Intentionally returns a non-safe value — the recovery
+    // invariant claims `result == 0` but the body returns 3.
+    return 3;
+}
+
+fn main() {
+    let mode = init_actuator(1);
+    println(mode);
+}
+main();

--- a/resilient/examples/recovers_to_ok.expected.txt
+++ b/resilient/examples/recovers_to_ok.expected.txt
@@ -1,0 +1,2 @@
+0
+Program executed successfully

--- a/resilient/examples/recovers_to_ok.rz
+++ b/resilient/examples/recovers_to_ok.rz
@@ -1,0 +1,35 @@
+// RES-392 demo — `recovers_to` postcondition (MVP: final-state variant).
+//
+// A function's `recovers_to` clause declares the invariant that must
+// hold after a crash-and-restart cycle. In the safety-critical
+// embedded setting this is the formal counterpart to Erlang/OTP's
+// supervisor restart: the verifier has to produce evidence that the
+// restarted state is safe.
+//
+// This MVP verifies only the **final state** of the function — i.e.
+// the clause is checked the way `ensures` is, with `result` in scope.
+// The full per-prefix bounded model check described in the ticket
+// (check every instruction boundary against the supervisor `init`)
+// is a deliberate follow-up. Accepting this example demonstrates:
+//
+//   1. The parser consumes `recovers_to: EXPR;` after the signature.
+//   2. The verifier treats it as a weaker postcondition.
+//   3. The runtime evaluates it after the body returns and the
+//      function exits cleanly when the invariant holds.
+//
+// The fn below always returns `0` — our stand-in for "safe default".
+// The `recovers_to` clause `result == 0` is satisfied by every exit
+// path, so the program runs to completion.
+fn init_actuator(int id) -> int
+    requires id >= 0
+    ensures result == 0
+    recovers_to: result == 0;
+{
+    return 0;
+}
+
+fn main() {
+    let mode = init_actuator(7);
+    println(mode);
+}
+main();

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -143,6 +143,7 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             body,
             requires,
             ensures,
+            recovers_to,
             ..
         } => {
             let snapshot = bound.len();
@@ -165,6 +166,11 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             for clause in ensures {
                 walk(clause, bound, free);
             }
+            // RES-392: `recovers_to` binds in the same env as
+            // `ensures` — `result` and the parameters are in scope.
+            if let Some(rec) = recovers_to {
+                walk(rec, bound, free);
+            }
             truncate_to(bound, pre_ensures);
             truncate_to(bound, snapshot);
         }
@@ -173,6 +179,7 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             body,
             requires,
             ensures,
+            recovers_to,
             ..
         } => {
             let snapshot = bound.len();
@@ -187,6 +194,9 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             bound.insert("result".into());
             for clause in ensures {
                 walk(clause, bound, free);
+            }
+            if let Some(rec) = recovers_to {
+                walk(rec, bound, free);
             }
             truncate_to(bound, pre_ensures);
             truncate_to(bound, snapshot);
@@ -530,6 +540,7 @@ mod tests {
             }),
             requires: Vec::new(),
             ensures: Vec::new(),
+            recovers_to: None,
             return_type: None,
             span: Span::default(),
         };
@@ -550,6 +561,7 @@ mod tests {
             }),
             requires: Vec::new(),
             ensures: Vec::new(),
+            recovers_to: None,
             return_type: None,
             span: Span::default(),
         };
@@ -580,6 +592,7 @@ mod tests {
             }),
             requires: Vec::new(),
             ensures: Vec::new(),
+            recovers_to: None,
             return_type: None,
             span: Span::default(),
         };
@@ -669,6 +682,7 @@ mod tests {
             }),
             requires: Vec::new(),
             ensures: Vec::new(),
+            recovers_to: None,
             return_type: None,
             span: Span::default(),
         };
@@ -683,6 +697,7 @@ mod tests {
             }),
             requires: Vec::new(),
             ensures: Vec::new(),
+            recovers_to: None,
             return_type: None,
             span: Span::default(),
         };

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -174,6 +174,8 @@ enum Tok {
     Requires,
     #[token("ensures")]
     Ensures,
+    #[token("recovers_to")]
+    RecoversTo,
     #[token("invariant")]
     Invariant,
     #[token("struct")]
@@ -512,6 +514,7 @@ fn convert(t: Tok) -> Token {
         Tok::In => Token::In,
         Tok::Requires => Token::Requires,
         Tok::Ensures => Token::Ensures,
+        Tok::RecoversTo => Token::RecoversTo,
         Tok::Invariant => Token::Invariant,
         Tok::Struct => Token::Struct,
         Tok::New => Token::New,

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -97,6 +97,10 @@ enum Token {
     In,
     Requires,
     Ensures,
+    /// RES-392: `recovers_to` — crash-recovery postcondition. MVP
+    /// verifies only the final state; per-prefix bounded model
+    /// checking is tracked as a follow-up.
+    RecoversTo,
     Invariant,
     Struct,
     New,
@@ -229,6 +233,7 @@ impl Token {
             Token::In => "`in`".to_string(),
             Token::Requires => "`requires`".to_string(),
             Token::Ensures => "`ensures`".to_string(),
+            Token::RecoversTo => "`recovers_to`".to_string(),
             Token::Invariant => "`invariant`".to_string(),
             Token::Struct => "`struct`".to_string(),
             Token::New => "`new`".to_string(),
@@ -614,6 +619,7 @@ impl Lexer {
                         "in" => Token::In,
                         "requires" => Token::Requires,
                         "ensures" => Token::Ensures,
+                        "recovers_to" => Token::RecoversTo,
                         "invariant" => Token::Invariant,
                         "struct" => Token::Struct,
                         "new" => Token::New,
@@ -1069,6 +1075,14 @@ enum Node {
         /// special identifier `result` is bound to the return value
         /// inside each clause's env.
         ensures: Vec<Node>,
+        /// RES-392: optional crash-recovery postcondition. MVP
+        /// semantics: verified as a weaker postcondition over the
+        /// function's final state (same evaluation environment as
+        /// `ensures`, with `result` bound). Proper per-prefix
+        /// bounded model checking — the real "crash at any
+        /// instruction" interpretation from the ticket — is tracked
+        /// as a follow-up. A value of `None` means no clause.
+        recovers_to: Option<Box<Node>>,
         /// RES-052: optional `-> TYPE` return-type annotation. Advisory.
         #[allow(dead_code)]
         return_type: Option<String>,
@@ -1329,6 +1343,9 @@ enum Node {
         body: Box<Node>,
         requires: Vec<Node>,
         ensures: Vec<Node>,
+        /// RES-392: optional crash-recovery postcondition. Same
+        /// MVP semantics as the named-fn variant: final-state only.
+        recovers_to: Option<Box<Node>>,
         #[allow(dead_code)]
         return_type: Option<String>,
         /// RES-088: span of the `fn` keyword. Consumed in follow-ups.
@@ -1910,6 +1927,7 @@ impl Parser {
                     }),
                     requires: Vec::new(),
                     ensures: Vec::new(),
+                    recovers_to: None,
                     return_type: None,
                     span: fn_span,
                     pure,
@@ -1925,6 +1943,7 @@ impl Parser {
                 body: Box::new(body),
                 requires: Vec::new(),
                 ensures: Vec::new(),
+                recovers_to: None,
                 return_type: None,
                 span: fn_span,
                 pure,
@@ -1943,7 +1962,8 @@ impl Parser {
         // RES-035: between the parameter list and the body, accept any
         // number of `requires EXPR` and `ensures EXPR` clauses, in any
         // order. Each clause parses as a single expression.
-        let (requires, ensures) = self.parse_function_contracts();
+        // RES-392: also accept an optional `recovers_to: EXPR;` clause.
+        let (requires, ensures, recovers_to) = self.parse_function_contracts();
 
         if self.current_token != Token::LeftBrace {
             self.record_error(format!(
@@ -1965,6 +1985,7 @@ impl Parser {
                     }),
                     requires,
                     ensures,
+                    recovers_to,
                     return_type,
                     span: fn_span,
                     pure,
@@ -1982,6 +2003,7 @@ impl Parser {
             body: Box::new(body),
             requires,
             ensures,
+            recovers_to,
             return_type,
             span: fn_span,
             pure,
@@ -2105,7 +2127,7 @@ impl Parser {
         }
 
         let return_type = self.parse_optional_return_type();
-        let (requires, ensures) = self.parse_function_contracts();
+        let (requires, ensures, recovers_to) = self.parse_function_contracts();
 
         if self.current_token != Token::LeftBrace {
             let tok = self.current_token.clone();
@@ -2122,6 +2144,7 @@ impl Parser {
             body: Box::new(body),
             requires,
             ensures,
+            recovers_to,
             return_type,
             span: fn_span,
             // Impl methods inherit no annotation today. When
@@ -2335,13 +2358,23 @@ impl Parser {
         }
     }
 
-    /// Parse zero or more `requires EXPR` / `ensures EXPR` clauses. On
-    /// entry current_token is whatever followed the parameter list's
-    /// `)`; on exit it's the `{` that starts the body (or whatever
-    /// caused parsing to give up).
-    fn parse_function_contracts(&mut self) -> (Vec<Node>, Vec<Node>) {
+    /// Parse zero or more `requires EXPR` / `ensures EXPR` clauses, and
+    /// an optional `recovers_to: EXPR;` clause (RES-392). On entry
+    /// current_token is whatever followed the parameter list's `)`;
+    /// on exit it's the `{` that starts the body (or whatever caused
+    /// parsing to give up).
+    ///
+    /// RES-392: `recovers_to` is syntactically a single expression
+    /// terminated with `;`. Multiple `recovers_to` clauses on one
+    /// function are rejected — a function has exactly one recovery
+    /// contract. The ticket's full semantics (per-prefix bounded
+    /// model check) is out of scope for the MVP; here we parse it
+    /// and carry it on the AST so the verifier can treat it as a
+    /// weaker postcondition over the function's final state.
+    fn parse_function_contracts(&mut self) -> (Vec<Node>, Vec<Node>, Option<Box<Node>>) {
         let mut requires = Vec::new();
         let mut ensures = Vec::new();
+        let mut recovers_to: Option<Box<Node>> = None;
         loop {
             match self.current_token {
                 Token::Requires => {
@@ -2362,10 +2395,43 @@ impl Parser {
                     self.next_token();
                     ensures.push(expr);
                 }
+                Token::RecoversTo => {
+                    self.next_token(); // skip `recovers_to`
+                    if self.current_token != Token::Colon {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected `:` after `recovers_to`, found {}",
+                            tok
+                        ));
+                    } else {
+                        self.next_token(); // skip `:`
+                    }
+                    let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                        value: true,
+                        span: span::Span::default(),
+                    });
+                    self.next_token(); // move past last token of expression
+                    // Optional terminator `;` — tolerate its absence so
+                    // the clause sits cleanly alongside `requires` /
+                    // `ensures` (which are not semicolon-terminated),
+                    // while accepting the form from the ticket's
+                    // proposed syntax.
+                    if self.current_token == Token::Semicolon {
+                        self.next_token();
+                    }
+                    if recovers_to.is_some() {
+                        self.record_error(
+                            "Multiple `recovers_to` clauses on one fn — at most one is allowed"
+                                .to_string(),
+                        );
+                    } else {
+                        recovers_to = Some(Box::new(expr));
+                    }
+                }
                 _ => break,
             }
         }
-        (requires, ensures)
+        (requires, ensures, recovers_to)
     }
 
     /// RES-124 (RES-124a): parse an optional `<T, U, ...>`
@@ -3201,7 +3267,17 @@ impl Parser {
 
         // Optional `requires EXPR` / `ensures EXPR` clauses (paren-less — Resilient
         // contract syntax; reuses parse_function_contracts).
-        let (requires, ensures) = self.parse_function_contracts();
+        let (requires, ensures, recovers_to) = self.parse_function_contracts();
+
+        // RES-392: `recovers_to` is a Resilient-defined function-level
+        // crash-recovery contract. It has no meaning on a foreign
+        // `extern` — the verifier cannot model arbitrary C state and
+        // we refuse to silently drop the clause.
+        if recovers_to.is_some() {
+            self.record_error(
+                "`recovers_to` is not supported on `extern fn` declarations".to_string(),
+            );
+        }
 
         // Terminator `;`.
         if !matches!(self.current_token, Token::Semicolon) {
@@ -4195,6 +4271,7 @@ impl Parser {
                 }),
                 requires: Vec::new(),
                 ensures: Vec::new(),
+                recovers_to: None,
                 return_type: None,
                 span: self.span_at_current(),
             };
@@ -4202,7 +4279,7 @@ impl Parser {
         self.next_token(); // skip '('
         let parameters = self.parse_function_parameters();
         let return_type = self.parse_optional_return_type();
-        let (requires, ensures) = self.parse_function_contracts();
+        let (requires, ensures, recovers_to) = self.parse_function_contracts();
         if self.current_token != Token::LeftBrace {
             let tok = self.current_token.clone();
             self.record_error(format!("Expected '{{' in anonymous fn, found {}", tok));
@@ -4214,6 +4291,7 @@ impl Parser {
                 }),
                 requires,
                 ensures,
+                recovers_to,
                 return_type,
                 span: self.span_at_current(),
             };
@@ -4224,6 +4302,7 @@ impl Parser {
             body: Box::new(body),
             requires,
             ensures,
+            recovers_to,
             return_type,
             span: self.span_at_current(),
         }
@@ -4628,6 +4707,7 @@ impl Parser {
             body: Box::new(body_block),
             requires: Vec::new(),
             ensures: Vec::new(),
+            recovers_to: None,
             return_type: None,
             span: bracket_span,
         };
@@ -4832,6 +4912,11 @@ enum Value {
         /// apply_function can check them. Empty when absent.
         requires: Vec<Node>,
         ensures: Vec<Node>,
+        /// RES-392: crash-recovery postcondition (MVP: final-state
+        /// variant, evaluated after the body returns — same env as
+        /// `ensures`, with `result` bound). `None` means no clause
+        /// was declared on the function.
+        recovers_to: Option<Box<Node>>,
         /// Function name — used for better contract-violation messages.
         name: String,
     },
@@ -7084,6 +7169,7 @@ impl Interpreter {
                 body,
                 requires,
                 ensures,
+                recovers_to,
                 ..
             } => {
                 // RES-068: if every observed call site for this fn was
@@ -7100,6 +7186,7 @@ impl Interpreter {
                     env: self.env.clone(),
                     requires: runtime_requires,
                     ensures: ensures.clone(),
+                    recovers_to: recovers_to.clone(),
                     name: name.clone(),
                 };
                 self.env.set(name.clone(), func);
@@ -7389,6 +7476,7 @@ impl Interpreter {
                 body,
                 requires,
                 ensures,
+                recovers_to,
                 ..
             } => Ok(Value::Function {
                 parameters: parameters.clone(),
@@ -7396,6 +7484,7 @@ impl Interpreter {
                 env: self.env.clone(),
                 requires: requires.clone(),
                 ensures: ensures.clone(),
+                recovers_to: recovers_to.clone(),
                 name: "<anon>".to_string(),
             }),
             Node::TryExpression { expr: inner, .. } => {
@@ -8164,6 +8253,7 @@ impl Interpreter {
                 env,
                 requires,
                 ensures,
+                recovers_to,
                 name,
             } => {
                 // RES-050: env.clone() is now an Rc bump, not a deep
@@ -8209,7 +8299,7 @@ impl Interpreter {
 
                 // RES-035: check each `ensures` clause AFTER, with the
                 // special identifier `result` bound to the return value.
-                if !ensures.is_empty() {
+                if !ensures.is_empty() || recovers_to.is_some() {
                     interpreter
                         .env
                         .set("result".to_string(), return_value.clone());
@@ -8220,6 +8310,26 @@ impl Interpreter {
                                 "Contract violation in fn {}: ensures {} failed (result = {})",
                                 name,
                                 format_contract_expr(clause),
+                                return_value
+                            ));
+                        }
+                    }
+                    // RES-392: `recovers_to` — MVP final-state check.
+                    // Evaluated in the same post-return environment as
+                    // `ensures`, i.e. with `result` bound to the
+                    // returned value and parameters still in scope.
+                    // On refutation the diagnostic surfaces the final
+                    // state counterexample so the author can see which
+                    // concrete return value falsified the recovery
+                    // invariant.
+                    if let Some(rec) = &recovers_to {
+                        let v = interpreter.eval(rec)?;
+                        if !interpreter.is_truthy(&v) {
+                            return Err(format!(
+                                "Contract violation in fn {}: recovers_to {} failed — \
+                                 final-state counterexample: result = {}",
+                                name,
+                                format_contract_expr(rec),
                                 return_value
                             ));
                         }
@@ -8840,6 +8950,7 @@ fn classify_lex_token(
         | Token::In
         | Token::Requires
         | Token::Ensures
+        | Token::RecoversTo
         | Token::Invariant
         | Token::Struct
         | Token::New

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1302,6 +1302,7 @@ impl TypeChecker {
                 body,
                 requires,
                 ensures,
+                recovers_to,
                 return_type: declared_rt,
                 ..
             } => {
@@ -1391,6 +1392,46 @@ impl TypeChecker {
                             self.stats.requires_tautology += 1;
                         }
                         None => {}
+                    }
+                }
+
+                // RES-392: verify the `recovers_to` crash-recovery
+                // postcondition against its MVP semantics — treat
+                // the clause as a universal obligation over the
+                // function's parameters (and `result`, if the clause
+                // mentions it) and try to discharge it via the same
+                // static folder / Z3 path used for requires/ensures.
+                //
+                // This deliberately verifies only the FINAL state,
+                // not per-prefix crash semantics. The proper
+                // per-instruction bounded model check described in
+                // the ticket is a follow-up; when it lands, this
+                // block becomes a weaker side-obligation.
+                //
+                // A provable contradiction (`Some(false)`) is a
+                // compile error — the recovery invariant can never
+                // hold. A proven tautology (`Some(true)`) is
+                // silently discharged; an undecidable verdict is
+                // left for runtime (the runtime check fires after
+                // every return and surfaces a clear diagnostic).
+                if let Some(clause) = recovers_to {
+                    let mut verdict = fold_const_bool(clause, &no_bindings);
+                    let mut cx: Option<String> = None;
+                    if verdict.is_none() {
+                        let (v, _cert, c, _timed_out) =
+                            z3_prove_with_cert(clause, &no_bindings, self.verifier_timeout_ms);
+                        verdict = v;
+                        cx = c;
+                    }
+                    if matches!(verdict, Some(false)) {
+                        let base = format!(
+                            "fn {}: `recovers_to` can never hold — the recovery invariant is a contradiction",
+                            name
+                        );
+                        return Err(match cx {
+                            Some(m) => format!("{} — counterexample (final state): {}", base, m),
+                            None => base,
+                        });
                     }
                 }
 

--- a/resilient/tests/recovers_to_smoke.rs
+++ b/resilient/tests/recovers_to_smoke.rs
@@ -1,0 +1,93 @@
+//! RES-392: integration tests for the `recovers_to` crash-recovery
+//! postcondition — MVP final-state variant.
+//!
+//! Two cases:
+//!
+//!   1. `examples/recovers_to_ok.rz` — the final-state satisfies the
+//!      clause, so the binary runs cleanly and prints the body's
+//!      output.
+//!
+//!   2. `examples/recovers_to_fail.res` — the body returns a value
+//!      that falsifies the recovery invariant at runtime. The
+//!      driver surfaces a `Contract violation` diagnostic that
+//!      mentions `recovers_to` and includes the counterexample.
+//!
+//! The `.res` extension on the failing example is intentional: the
+//! broader `examples_golden` harness only walks `*.rz` files, so
+//! the rejecting example won't be miscategorised as a passing
+//! program whose stdout should be compared against an
+//! `.expected.txt` sibling.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_resilient")
+}
+
+fn examples_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples")
+}
+
+#[test]
+fn recovers_to_final_state_satisfied_accepts() {
+    let ex = examples_dir().join("recovers_to_ok.rz");
+    assert!(ex.exists(), "missing example: {}", ex.display());
+
+    let output = Command::new(bin())
+        .arg(&ex)
+        .output()
+        .expect("spawn resilient binary");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        output.status.success(),
+        "expected successful run; stdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("0"),
+        "expected body output; stdout:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Program executed successfully"),
+        "expected clean exit marker; stdout:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn recovers_to_final_state_violated_rejects() {
+    let ex = examples_dir().join("recovers_to_fail.res");
+    assert!(ex.exists(), "missing example: {}", ex.display());
+
+    let output = Command::new(bin())
+        .arg(&ex)
+        .output()
+        .expect("spawn resilient binary");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let combined = format!("{}{}", stdout, stderr);
+
+    assert!(
+        combined.contains("Contract violation"),
+        "expected Contract violation diagnostic; combined output:\n{}",
+        combined
+    );
+    assert!(
+        combined.contains("recovers_to"),
+        "diagnostic must name recovers_to; combined output:\n{}",
+        combined
+    );
+    assert!(
+        combined.contains("result = 3"),
+        "diagnostic must carry the final-state counterexample; \
+         combined output:\n{}",
+        combined
+    );
+}


### PR DESCRIPTION
Closes #210.

## Scope — read carefully

**This PR lands the MVP only.** What's in:

- Parser accepts `recovers_to: EXPR;` as a function-signature annotation alongside `requires` / `ensures`, on both named functions and `fn(...)` literals.
- AST carries the clause as `Option<Box<Node>>` on `Node::Function` and `Node::FunctionLiteral`.
- `free_vars` walks the clause with `result` and the parameters in scope (same binding rules as `ensures`).
- Typechecker runs the same static-fold + Z3 path used for `requires` / `ensures`. A provable contradiction is a compile error; a proven tautology is silently discharged; everything else is left for runtime.
- Runtime evaluates the clause after the body returns, in the same environment as `ensures` (so `result` is bound). A refutation surfaces a `Contract violation in fn X: recovers_to EXPR failed — final-state counterexample: result = V` diagnostic.

**What's explicitly NOT in this PR — safety-critical reviewers please note:**

- **Per-prefix bounded model checking.** The original ticket spec is "the invariant must hold after a crash at *any* instruction boundary, composed with the supervisor's `init`." This PR only verifies the **final state** of the function — the weaker variant, closer to a plain postcondition than a crash-recovery contract. A function that fully satisfies this MVP check can still have intermediate states that violate the recovery invariant; without CFG extraction + per-prefix checks we cannot claim otherwise.
- Supervisor `init` composition.
- CFG extraction for prefix analysis.

These are tracked as the follow-up ticket #212 so the roadmap stays honest.

## Coordination with RES-387 (#205)

RES-387 also mentions `recovers_to`. This PR defines the parsing and AST representation once so both tickets can share it:
- Lexer token: `Token::RecoversTo` (keyword `recovers_to`).
- Parser: `parse_function_contracts` returns `(requires, ensures, Option<Box<Node>>)`.
- AST field on `Node::Function` / `Node::FunctionLiteral`.

RES-387 should consume the same AST node rather than redefine it.

## Test plan

- [x] `cargo build` clean.
- [x] `cargo test` — 756 unit + all integration tests pass.
- [x] `cargo test --features z3` — 786 unit + all integration tests pass.
- [x] `cargo fmt -- --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean (with and without `z3`).
- [x] New `tests/recovers_to_smoke.rs` — 2 integration tests covering the accepted + rejected examples.
- [x] `examples/recovers_to_ok.rz` + `.expected.txt` — picked up automatically by the `examples_golden` harness.
- [x] `examples/recovers_to_fail.res` — `.res` extension so the golden harness (which walks only `*.rz`) skips it; a dedicated smoke test asserts the runtime diagnostic.

## Test changes

None. No existing tests were modified. The only touch to test code was adding `recovers_to: None` to the already-existing struct literals in `free_vars.rs`'s test module that were `Node::FunctionLiteral { ... }` bare-field initializers, solely to keep them compiling after the field was added. No assertions or behavioural expectations changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)