### PR TITLE
RES-386: concurrency contracts — Z3 race-freedom for actors

### DIFF
--- a/resilient/examples/actor_commute.interactive
+++ b/resilient/examples/actor_commute.interactive
@@ -1,0 +1,4 @@
+RES-386: run this example only under `cargo test --features z3`.
+The actor commutativity verifier is z3-gated; the default build prints
+no verifier output, so the default golden harness has nothing stable
+to match against. See tests/examples_smoke.rs for the z3-gated smoke.

--- a/resilient/examples/actor_commute.rz
+++ b/resilient/examples/actor_commute.rz
@@ -1,0 +1,18 @@
+// RES-386: a Counter actor whose receive handlers trivially commute.
+// The verifier discharges the commutativity obligation for each
+// unordered pair using Z3. This example is run by the z3-gated smoke
+// test `actor_commute_example_proves_handlers_commute` in
+// tests/examples_smoke.rs — hence the `.interactive` sidecar marking
+// it exempt from the default golden harness (the verifier stays silent
+// on non-z3 builds).
+actor Counter {
+    state: int = 0;
+
+    receive increment() {
+        self.state = self.state + 1;
+    }
+
+    receive decrement() {
+        self.state = self.state - 1;
+    }
+}

--- a/resilient/examples/actor_noncommute.interactive
+++ b/resilient/examples/actor_noncommute.interactive
@@ -1,0 +1,2 @@
+RES-386: run this example only under `cargo test --features z3`.
+See sibling actor_commute.interactive for the rationale.

--- a/resilient/examples/actor_noncommute.rz
+++ b/resilient/examples/actor_noncommute.rz
@@ -1,0 +1,18 @@
+// RES-386: an Accumulator actor whose `inc` and `double` handlers do
+// NOT commute (inc-then-double != double-then-inc starting from any
+// integer). The Z3-backed commutativity verifier rejects the pair and
+// prints a counterexample. Driven by the z3-gated smoke test
+// `actor_noncommute_example_reports_counterexample` in
+// tests/examples_smoke.rs; the `.interactive` sidecar keeps it out of
+// the default golden harness for the same reason as actor_commute.rz.
+actor Accumulator {
+    state: int = 0;
+
+    receive inc() {
+        self.state = self.state + 1;
+    }
+
+    receive double() {
+        self.state = self.state * 2;
+    }
+}

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -762,6 +762,7 @@ fn node_line(n: &Node) -> Option<u32> {
         | Node::ImplBlock { span, .. }
         | Node::TypeAlias { span, .. }
         | Node::RegionDecl { span, .. }
+        | Node::Actor { span, .. }
         | Node::FunctionLiteral { span, .. } => span.start.line as u32,
 
         // RES-142: duration literal carries the span of its integer

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -202,6 +202,48 @@ impl Formatter {
                 self.write(&format!("region {};", name));
                 self.newline();
             }
+            // RES-386: re-emit an actor block. Handler bodies are
+            // printed via the shared block formatter so nested
+            // expressions stay indented correctly.
+            Node::Actor {
+                name,
+                state_type,
+                state_init,
+                concurrent_ensures,
+                handlers,
+                ..
+            } => {
+                self.write(&format!("actor {} {{", name));
+                self.newline();
+                self.indent();
+                self.write(&format!("state: {} = ", state_type));
+                self.fmt_expr(state_init);
+                self.write(";");
+                self.newline();
+                for ce in concurrent_ensures {
+                    self.write("concurrent_ensures: ");
+                    self.fmt_expr(ce);
+                    self.write(";");
+                    self.newline();
+                }
+                for h in handlers {
+                    self.write(&format!("receive {}()", h.name));
+                    for e in &h.ensures {
+                        self.newline();
+                        self.indent();
+                        self.write("ensures ");
+                        self.fmt_expr(e);
+                        self.write(";");
+                        self.dedent();
+                    }
+                    self.write(" ");
+                    self.fmt_block_like(&h.body);
+                    self.newline();
+                }
+                self.dedent();
+                self.write("}");
+                self.newline();
+            }
             Node::LetStatement {
                 name,
                 value,
@@ -735,6 +777,7 @@ impl Formatter {
             | Node::ImplBlock { .. }
             | Node::TypeAlias { .. }
             | Node::RegionDecl { .. }
+            | Node::Actor { .. }
             | Node::Use { .. }
             | Node::Extern { .. }
             | Node::LetDestructureStruct { .. }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -207,6 +207,12 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             }
         }
         Node::StructDecl { .. } | Node::TypeAlias { .. } | Node::RegionDecl { .. } => {}
+        // RES-386: actor declarations are verifier-only scaffolding
+        // and introduce no free variables at the program scope —
+        // the minimum slice doesn't lower them to callable fns, so
+        // their handler bodies don't participate in capture
+        // analysis.
+        Node::Actor { .. } => {}
 
         // ---- Statements ----
         Node::LetStatement { value, .. } | Node::StaticLet { value, .. } => {

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -210,6 +210,15 @@ enum Tok {
     Region,
     #[token("mut")]
     Mut,
+    // RES-386: actor / receive / concurrent_ensures keywords. Parity
+    // with the hand-rolled lexer's `"actor" => Token::Actor` arms so
+    // `--features logos-lexer` produces the same AST.
+    #[token("actor")]
+    Actor,
+    #[token("receive")]
+    Receive,
+    #[token("concurrent_ensures")]
+    ConcurrentEnsures,
     #[token("true")]
     True,
     #[token("false")]
@@ -539,6 +548,9 @@ fn convert(t: Tok) -> Token {
         Tok::Linear => Token::Linear,
         Tok::Region => Token::Region,
         Tok::Mut => Token::Mut,
+        Tok::Actor => Token::Actor,
+        Tok::Receive => Token::Receive,
+        Tok::ConcurrentEnsures => Token::ConcurrentEnsures,
         Tok::True => Token::BoolLiteral(true),
         Tok::False => Token::BoolLiteral(false),
         Tok::Underscore => Token::Underscore,

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -141,6 +141,18 @@ enum Token {
     /// outside of types the parser surfaces it as an ordinary
     /// unexpected-token error.
     Mut,
+    /// RES-386: `actor Name { state: T = expr; concurrent_ensures: ...;
+    /// receive name() ensures expr; { body } }` — actor declaration.
+    /// The minimum slice only uses the `actor` / `receive` /
+    /// `concurrent_ensures` keywords inside this block.
+    Actor,
+    /// RES-386: `receive name() ensures expr; { body }` — one
+    /// message handler inside an actor block.
+    Receive,
+    /// RES-386: `concurrent_ensures: expr;` — race-freedom
+    /// contract attached to an actor declaration. Proved by the
+    /// Z3 verifier's commutativity check.
+    ConcurrentEnsures,
 
     // Literals
     Identifier(String),
@@ -259,6 +271,9 @@ impl Token {
             Token::Linear => "`linear`".to_string(),
             Token::Region => "`region`".to_string(),
             Token::Mut => "`mut`".to_string(),
+            Token::Actor => "`actor`".to_string(),
+            Token::Receive => "`receive`".to_string(),
+            Token::ConcurrentEnsures => "`concurrent_ensures`".to_string(),
             Token::Underscore => "`_`".to_string(),
             Token::Default => "`default`".to_string(),
             Token::Dot => "`.`".to_string(),
@@ -648,6 +663,9 @@ impl Lexer {
                         "linear" => Token::Linear,
                         "region" => Token::Region,
                         "mut" => Token::Mut,
+                        "actor" => Token::Actor,
+                        "receive" => Token::Receive,
+                        "concurrent_ensures" => Token::ConcurrentEnsures,
                         "_" => Token::Underscore,
                         // RES-163: `default` is a reserved alias
                         // for `_` at the top of a match arm.
@@ -1524,6 +1542,66 @@ enum Node {
         #[allow(dead_code)]
         span: span::Span,
     },
+    /// RES-386: actor declaration.
+    ///
+    /// Parsed from:
+    /// ```text
+    /// actor <Name> {
+    ///     state: <Type> = <init-expr>;
+    ///     concurrent_ensures: <expr>;      // zero or more
+    ///     receive <handler_name>()
+    ///         ensures <expr>;              // zero or more per handler
+    ///     { <body> }
+    /// }
+    /// ```
+    ///
+    /// The verifier consumes this node shape to emit Z3
+    /// commutativity obligations for every pair of `receive`
+    /// handlers. The interpreter, compiler, JIT, and LSP treat
+    /// it as a no-op — the minimum slice is type-check-and-verify
+    /// only; full actor runtime semantics are tracked as a
+    /// follow-up (see RES-386 PR body).
+    Actor {
+        name: String,
+        /// RES-386: the per-instance state type, mirroring
+        /// `state: <Type> = <init>;`. Advisory today — the
+        /// verifier only supports integer state.
+        #[allow(dead_code)]
+        state_type: String,
+        /// RES-386: initializer for the actor's state. Kept on the
+        /// node so the (future) runtime can allocate the actor
+        /// without re-parsing.
+        #[allow(dead_code)]
+        state_init: Box<Node>,
+        /// RES-386: `concurrent_ensures: <expr>;` clauses attached
+        /// to the actor. Empty when the declaration carries only
+        /// `receive` handlers. Each clause is expected to be a
+        /// boolean expression over the actor's symbolic state
+        /// names (see `ActorHandler::body` for the assignment form
+        /// the verifier understands).
+        concurrent_ensures: Vec<Node>,
+        handlers: Vec<ActorHandler>,
+        #[allow(dead_code)]
+        span: span::Span,
+    },
+}
+
+/// RES-386: one `receive <name>()` handler inside an `actor` block.
+/// The minimum slice expects the body to be a block that assigns a
+/// single integer expression to `self.state`; any other shape is
+/// accepted at parse time but rejected (with a clean diagnostic) by
+/// the verifier.
+#[derive(Debug, Clone)]
+pub(crate) struct ActorHandler {
+    pub(crate) name: String,
+    /// Per-handler post-conditions. Treated the same way as fn
+    /// `ensures` — the verifier bolts them onto the handler's
+    /// symbolic state transition.
+    #[allow(dead_code)]
+    pub(crate) ensures: Vec<Node>,
+    pub(crate) body: Box<Node>,
+    #[allow(dead_code)]
+    pub(crate) span: span::Span,
 }
 
 /// FFI v1: one foreign fn declaration inside an `extern` block.
@@ -1656,6 +1734,7 @@ impl Parser {
             Token::Impl => Some(self.parse_impl_block()),
             Token::Type => Some(self.parse_type_alias()),
             Token::Region => Some(self.parse_region_decl()),
+            Token::Actor => Some(self.parse_actor_block()),
             Token::Extern => self.parse_extern_block(),
             Token::Use => self.parse_use_statement(),
             Token::Let => Some(self.parse_let_statement()),
@@ -4359,6 +4438,229 @@ impl Parser {
             name,
             fields,
             span: self.span_at_current(),
+        }
+    }
+
+    /// RES-386: parse an `actor Name { ... }` declaration.
+    ///
+    /// Grammar (minimum viable slice):
+    /// ```text
+    /// actor Counter {
+    ///     state: int = 0;
+    ///     concurrent_ensures: <expr>;          // zero or more
+    ///     receive <name>()
+    ///         ensures <expr>;                  // zero or more per handler
+    ///     { <body> }                           // usually `self.state = ...;`
+    /// }
+    /// ```
+    ///
+    /// On entry `current_token` is `actor`. On exit it sits on the
+    /// closing `}` of the actor body (mirroring `parse_struct_decl`'s
+    /// contract so `parse_program`'s `next_token` advances correctly).
+    /// Parse errors are recorded via `record_error` and best-effort
+    /// recovery falls through — we never panic on malformed input.
+    fn parse_actor_block(&mut self) -> Node {
+        let actor_span = self.span_at_current();
+        self.next_token(); // skip 'actor'
+
+        let name = match &self.current_token {
+            Token::Identifier(n) => n.clone(),
+            _ => {
+                let tok = self.current_token.clone();
+                self.record_error(format!("Expected identifier after 'actor', found {}", tok));
+                String::new()
+            }
+        };
+        self.next_token();
+
+        if self.current_token != Token::LeftBrace {
+            let tok = self.current_token.clone();
+            self.record_error(format!("Expected '{{' after actor name, found {}", tok));
+            return Node::Actor {
+                name,
+                state_type: String::new(),
+                state_init: Box::new(Node::IntegerLiteral {
+                    value: 0,
+                    span: span::Span::default(),
+                }),
+                concurrent_ensures: Vec::new(),
+                handlers: Vec::new(),
+                span: actor_span,
+            };
+        }
+        self.next_token(); // skip '{'
+
+        // `state: <Type> = <init>;` — required once.
+        let mut state_type = String::new();
+        let mut state_init: Node = Node::IntegerLiteral {
+            value: 0,
+            span: span::Span::default(),
+        };
+        let mut saw_state = false;
+
+        let mut concurrent_ensures: Vec<Node> = Vec::new();
+        let mut handlers: Vec<ActorHandler> = Vec::new();
+
+        while self.current_token != Token::RightBrace && self.current_token != Token::Eof {
+            match &self.current_token {
+                // `state: <Type> = <init>;`
+                Token::Identifier(n) if n == "state" => {
+                    self.next_token(); // skip 'state'
+                    if self.current_token != Token::Colon {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected ':' after 'state' in actor declaration, found {}",
+                            tok
+                        ));
+                        break;
+                    }
+                    self.next_token(); // skip ':'
+                    let ty = match self.parse_type_annotation("for actor state") {
+                        Some(t) => t,
+                        None => break,
+                    };
+                    state_type = ty;
+                    if self.current_token != Token::Assign {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected '=' after actor state type, found {}",
+                            tok
+                        ));
+                        break;
+                    }
+                    self.next_token(); // skip '='
+                    state_init = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+                        value: 0,
+                        span: span::Span::default(),
+                    });
+                    if self.peek_token == Token::Semicolon {
+                        self.next_token();
+                    }
+                    self.next_token(); // advance past `;` to next member
+                    saw_state = true;
+                }
+
+                Token::ConcurrentEnsures => {
+                    self.next_token(); // skip 'concurrent_ensures'
+                    if self.current_token != Token::Colon {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected ':' after 'concurrent_ensures', found {}",
+                            tok
+                        ));
+                        break;
+                    }
+                    self.next_token(); // skip ':'
+                    let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                        value: true,
+                        span: span::Span::default(),
+                    });
+                    concurrent_ensures.push(expr);
+                    if self.peek_token == Token::Semicolon {
+                        self.next_token();
+                    }
+                    self.next_token();
+                }
+
+                Token::Receive => {
+                    let handler_span = self.span_at_current();
+                    self.next_token(); // skip 'receive'
+                    let handler_name = match &self.current_token {
+                        Token::Identifier(n) => n.clone(),
+                        _ => {
+                            let tok = self.current_token.clone();
+                            self.record_error(format!(
+                                "Expected handler name after 'receive', found {}",
+                                tok
+                            ));
+                            break;
+                        }
+                    };
+                    self.next_token();
+                    if self.current_token != Token::LeftParen {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected '(' after handler name '{}', found {}",
+                            handler_name, tok
+                        ));
+                        break;
+                    }
+                    self.next_token(); // '('
+                    // Minimum slice: no parameters supported. RES-332
+                    // will add message payload params.
+                    if self.current_token != Token::RightParen {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected ')' after '(' in receive handler \
+                             (handler parameters not yet supported), found {}",
+                            tok
+                        ));
+                        break;
+                    }
+                    self.next_token(); // ')'
+
+                    // Optional `ensures <expr>;` clauses between the
+                    // signature and the body. Zero or more.
+                    let mut ensures: Vec<Node> = Vec::new();
+                    while self.current_token == Token::Ensures {
+                        self.next_token(); // skip 'ensures'
+                        let clause = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                            value: true,
+                            span: span::Span::default(),
+                        });
+                        ensures.push(clause);
+                        if self.peek_token == Token::Semicolon {
+                            self.next_token();
+                        }
+                        self.next_token();
+                    }
+
+                    if self.current_token != Token::LeftBrace {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected '{{' to open receive-handler body, found {}",
+                            tok
+                        ));
+                        break;
+                    }
+                    let body = self.parse_block_statement();
+                    handlers.push(ActorHandler {
+                        name: handler_name,
+                        ensures,
+                        body: Box::new(body),
+                        span: handler_span,
+                    });
+                    // parse_block_statement leaves current_token on
+                    // the closing `}`. Advance to the next member.
+                    self.next_token();
+                }
+
+                _ => {
+                    let tok = self.current_token.clone();
+                    self.record_error(format!(
+                        "Expected 'state', 'concurrent_ensures', 'receive', or '}}' \
+                         inside actor '{}', found {}",
+                        name, tok
+                    ));
+                    break;
+                }
+            }
+        }
+
+        if !saw_state {
+            self.record_error(format!(
+                "actor '{}' is missing a `state: <Type> = <init>;` declaration",
+                name
+            ));
+        }
+
+        Node::Actor {
+            name,
+            state_type,
+            state_init: Box::new(state_init),
+            concurrent_ensures,
+            handlers,
+            span: actor_span,
         }
     }
 
@@ -7784,6 +8086,10 @@ impl Interpreter {
                 // construction trusts the literal.
                 Ok(Value::Void)
             }
+            // RES-386: actor declarations are verifier-only today.
+            // The runtime never instantiates them — full actor
+            // semantics are tracked as a follow-up to RES-386.
+            Node::Actor { .. } => Ok(Value::Void),
             // RES-128: `type NAME = TARGET;` is purely a
             // typechecker / documentation concern. Runtime never
             // sees aliases — by the time `eval` runs, every use
@@ -9636,6 +9942,67 @@ fn emit_certificates(
     Ok(certificates.len())
 }
 
+/// RES-386: walk the top-level program, find every `actor` declaration,
+/// and run the Z3 commutativity check on each unordered pair of its
+/// `receive` handlers. Results are printed to stdout with a stable
+/// `verifier: actor <name>:` prefix so the golden-test harness can
+/// capture them deterministically.
+///
+/// Without the `z3` feature, this is a no-op — we silently skip actor
+/// verification rather than emit a diagnostic that would break the
+/// default-build golden tests. Any golden that exercises the actor
+/// verifier lives under `#[cfg(feature = "z3")]`.
+#[cfg(feature = "z3")]
+fn run_actor_verification(program: &Node) {
+    let Node::Program(statements) = program else {
+        return;
+    };
+    for spanned in statements {
+        if let Node::Actor { name, handlers, .. } = &spanned.node {
+            let verification = verifier_z3::check_actor_commutativity(name, handlers);
+            for (a, b, result) in &verification.pairs {
+                match result {
+                    verifier_z3::CommutativityResult::Commute => {
+                        println!(
+                            "verifier: actor {}: handlers `{}` and `{}` commute",
+                            verification.actor_name, a, b,
+                        );
+                    }
+                    verifier_z3::CommutativityResult::Diverge {
+                        pre_state,
+                        ab_state,
+                        ba_state,
+                    } => {
+                        println!(
+                            "verifier: actor {}: handlers `{}` and `{}` do not commute \
+                             — counterexample: pre_state={}, {}_then_{}={}, {}_then_{}={}",
+                            verification.actor_name,
+                            a,
+                            b,
+                            pre_state,
+                            a,
+                            b,
+                            ab_state,
+                            b,
+                            a,
+                            ba_state,
+                        );
+                    }
+                    verifier_z3::CommutativityResult::Unknown { reason } => {
+                        println!(
+                            "verifier: actor {}: handlers `{}` and `{}` — unknown ({})",
+                            verification.actor_name, a, b, reason,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "z3"))]
+fn run_actor_verification(_program: &Node) {}
+
 // Execute a Resilient source file
 #[allow(clippy::too_many_arguments)] // CLI glue fn — all args come from flags
 fn execute_file(
@@ -9708,6 +10075,11 @@ fn execute_file(
             region_errors.len()
         ));
     }
+
+    // RES-386: race-freedom / commutativity obligation per actor.
+    // Runs before typecheck so an invalid actor is a verifier-level
+    // diagnostic rather than a type error. No-op in non-z3 builds.
+    run_actor_verification(&program);
 
     // Type checking if enabled. --audit, --explain-effects, and
     // --emit-certificate all imply --typecheck (no point running

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1940,6 +1940,13 @@ impl TypeChecker {
             // and yields the inner type.
             Node::RegionDecl { .. } => Ok(Type::Void),
 
+            // RES-386: actor declarations type-check as Void. The
+            // verifier consumes them directly (see
+            // `verifier_z3::check_actor_commutativity`); handler
+            // bodies are not walked here because the minimum slice
+            // doesn't lower actors to callable fns yet.
+            Node::Actor { .. } => Ok(Type::Void),
+
             // RES-153: record the struct's (field, type) list so
             // `FieldAccess` / `FieldAssignment` downstream can check
             // field existence and surface typed-field errors

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -19,7 +19,7 @@
 // floats) makes us bail to None — the existing runtime check still
 // fires.
 
-use crate::Node;
+use crate::{ActorHandler, Node};
 use std::collections::{BTreeSet, HashMap};
 use z3::ast::{Ast, Bool, Int};
 
@@ -480,6 +480,292 @@ fn collect_len_args(node: &Node, out: &mut BTreeSet<String>) {
             }
         }
         _ => {}
+    }
+}
+
+// ============================================================
+// RES-386: actor commutativity check
+// ============================================================
+//
+// The minimum slice models an actor's per-handler state transition
+// as a pure function `f: Int -> Int` over a single integer-valued
+// `self.state`. For every pair of handlers `(A, B)` we ask the
+// solver whether running A-then-B from any symbolic pre-state
+// produces the same final state as B-then-A.
+//
+// This captures the "no lost updates" invariant the ticket body
+// motivates — if `Counter::increment` and `Counter::decrement`
+// commute, concurrent dispatchers can interleave them without
+// locks and still arrive at the same final count.
+//
+// Verdict shape:
+//   - Commute(name)                    — provable, no counterexample.
+//   - Diverge { a, b, pre, ab, ba, .. } — Z3 exhibited a model that
+//                                        falsifies the commutativity
+//                                        formula.
+//   - Unknown(name)                    — handler body isn't the
+//                                        supported `self.state = <int>;`
+//                                        shape (e.g. a branch, a call,
+//                                        or an assignment to a
+//                                        non-state field) or Z3
+//                                        returned Unknown.
+//
+// Anything beyond the supported body shape is reported as Unknown
+// so the driver can surface a clear diagnostic; it is never
+// silently treated as proof.
+
+/// RES-386: outcome of a commutativity check for one pair of actor
+/// handlers. The driver formats this into a user-facing diagnostic;
+/// tests consume the structured form directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommutativityResult {
+    /// Z3 proved `A(B(s)) == B(A(s))` for all integer pre-states.
+    Commute,
+    /// Z3 produced a concrete counterexample.
+    Diverge {
+        pre_state: String,
+        ab_state: String,
+        ba_state: String,
+    },
+    /// Handler body wasn't in the supported shape, or the solver
+    /// could not decide (typically a hard non-linear arithmetic
+    /// query). The driver emits a `warning`-flavoured diagnostic
+    /// rather than a hard error.
+    Unknown { reason: String },
+}
+
+/// RES-386: per-actor verification outcome, aggregating one
+/// `CommutativityResult` per ordered handler pair.
+#[derive(Debug, Clone)]
+pub struct ActorVerification {
+    pub actor_name: String,
+    /// Ordered `(handler_a, handler_b, result)` triples. The
+    /// verifier only emits each unordered pair once (a < b by
+    /// source order) — commutativity is symmetric.
+    pub pairs: Vec<(String, String, CommutativityResult)>,
+}
+
+/// RES-386: drive the commutativity check for every pair of
+/// `receive` handlers in the given actor. See module docs above
+/// for the semantic contract.
+pub fn check_actor_commutativity(actor_name: &str, handlers: &[ActorHandler]) -> ActorVerification {
+    let mut pairs: Vec<(String, String, CommutativityResult)> = Vec::new();
+    for i in 0..handlers.len() {
+        for j in (i + 1)..handlers.len() {
+            let a = &handlers[i];
+            let b = &handlers[j];
+            let result = check_pair_commute(a, b);
+            pairs.push((a.name.clone(), b.name.clone(), result));
+        }
+    }
+    ActorVerification {
+        actor_name: actor_name.to_string(),
+        pairs,
+    }
+}
+
+/// Check that running `a` then `b` produces the same final state
+/// as running `b` then `a`, starting from an arbitrary symbolic
+/// integer pre-state.
+fn check_pair_commute(a: &ActorHandler, b: &ActorHandler) -> CommutativityResult {
+    // Extract each handler's symbolic RHS expression (the expression
+    // that computes the new `self.state` from the old one). Anything
+    // outside the supported `self.state = <int_expr>;` shape fails
+    // fast with a descriptive `Unknown`.
+    let a_rhs = match extract_state_rhs(&a.body) {
+        Ok(n) => n,
+        Err(why) => {
+            return CommutativityResult::Unknown {
+                reason: format!("handler `{}`: {}", a.name, why),
+            };
+        }
+    };
+    let b_rhs = match extract_state_rhs(&b.body) {
+        Ok(n) => n,
+        Err(why) => {
+            return CommutativityResult::Unknown {
+                reason: format!("handler `{}`: {}", b.name, why),
+            };
+        }
+    };
+
+    let cfg = z3::Config::new();
+    let ctx = z3::Context::new(&cfg);
+
+    // Name conventions for the counterexample formatter:
+    //   state_0         — the symbolic pre-state.
+    //   state_after_<h> — abbreviations recovered from the model.
+    let pre = Int::new_const(&ctx, "state_0");
+
+    // Build the A-then-B chain.
+    let Some(ab_inter) = translate_state_rhs(&ctx, &a_rhs, &pre) else {
+        return CommutativityResult::Unknown {
+            reason: format!(
+                "handler `{}`: RHS contains unsupported operations (verifier only models +, -, *, /, %, and integer literals)",
+                a.name,
+            ),
+        };
+    };
+    let Some(ab_final) = translate_state_rhs(&ctx, &b_rhs, &ab_inter) else {
+        return CommutativityResult::Unknown {
+            reason: format!(
+                "handler `{}`: RHS contains unsupported operations (verifier only models +, -, *, /, %, and integer literals)",
+                b.name,
+            ),
+        };
+    };
+
+    // Build the B-then-A chain.
+    let Some(ba_inter) = translate_state_rhs(&ctx, &b_rhs, &pre) else {
+        return CommutativityResult::Unknown {
+            reason: format!(
+                "handler `{}`: RHS contains unsupported operations (verifier only models +, -, *, /, %, and integer literals)",
+                b.name,
+            ),
+        };
+    };
+    let Some(ba_final) = translate_state_rhs(&ctx, &a_rhs, &ba_inter) else {
+        return CommutativityResult::Unknown {
+            reason: format!(
+                "handler `{}`: RHS contains unsupported operations (verifier only models +, -, *, /, %, and integer literals)",
+                a.name,
+            ),
+        };
+    };
+
+    // Tautology question: is (ab_final != ba_final) UNSAT?
+    // If UNSAT → commute. If SAT → counterexample. If Unknown → Unknown.
+    let goal = ab_final._eq(&ba_final);
+    let negated = goal.not();
+    let solver = z3::Solver::new(&ctx);
+    solver.assert(&negated);
+    match solver.check() {
+        z3::SatResult::Unsat => CommutativityResult::Commute,
+        z3::SatResult::Sat => match solver.get_model() {
+            Some(model) => {
+                let pre_val = model
+                    .eval(&pre, true)
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "<?>".to_string());
+                let ab_val = model
+                    .eval(&ab_final, true)
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "<?>".to_string());
+                let ba_val = model
+                    .eval(&ba_final, true)
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "<?>".to_string());
+                CommutativityResult::Diverge {
+                    pre_state: pre_val,
+                    ab_state: ab_val,
+                    ba_state: ba_val,
+                }
+            }
+            None => CommutativityResult::Unknown {
+                reason: "Z3 reported Sat but provided no model".to_string(),
+            },
+        },
+        z3::SatResult::Unknown => CommutativityResult::Unknown {
+            reason:
+                "Z3 returned Unknown — the commutativity formula is outside the decided fragment"
+                    .to_string(),
+        },
+    }
+}
+
+/// Peel a handler body down to its single `self.state = <rhs>;`
+/// assignment. Returns the RHS expression on success. Any other
+/// body shape is rejected with a human-readable reason — the
+/// minimum slice deliberately narrows the accepted form rather
+/// than silently proving trivial-seeming commutativity on
+/// unrepresented control flow.
+fn extract_state_rhs(body: &Node) -> Result<Node, String> {
+    let stmts: &[Node] = match body {
+        Node::Block { stmts, .. } => stmts,
+        _ => {
+            return Err(
+                "body must be a block containing exactly `self.state = <int_expr>;`".to_string(),
+            );
+        }
+    };
+    if stmts.len() != 1 {
+        return Err(format!(
+            "body must contain exactly one statement (`self.state = ...`), found {}",
+            stmts.len()
+        ));
+    }
+    let expr_stmt = match &stmts[0] {
+        Node::ExpressionStatement { expr, .. } => expr.as_ref(),
+        other => other,
+    };
+    match expr_stmt {
+        Node::FieldAssignment {
+            target,
+            field,
+            value,
+            ..
+        } => {
+            let Node::Identifier { name, .. } = target.as_ref() else {
+                return Err("assignment target must be `self.state` (minimum slice)".to_string());
+            };
+            if name != "self" || field != "state" {
+                return Err(format!(
+                    "assignment target must be `self.state`, got `{}.{}`",
+                    name, field
+                ));
+            }
+            Ok((**value).clone())
+        }
+        _ => Err("body statement must be `self.state = <int_expr>;`".to_string()),
+    }
+}
+
+/// Translate a handler's RHS expression into a Z3 `Int`, with any
+/// `self.state` field access bound to `pre_state`. Supports the
+/// same integer subset as `translate_int`.
+fn translate_state_rhs<'c>(
+    ctx: &'c z3::Context,
+    node: &Node,
+    pre_state: &Int<'c>,
+) -> Option<Int<'c>> {
+    match node {
+        Node::IntegerLiteral { value, .. } => Some(Int::from_i64(ctx, *value)),
+        Node::FieldAccess { target, field, .. } => {
+            if let Node::Identifier { name, .. } = target.as_ref()
+                && name == "self"
+                && field == "state"
+            {
+                Some(pre_state.clone())
+            } else {
+                None
+            }
+        }
+        // A bare `self` with no field access is nonsensical here.
+        Node::Identifier { .. } => None,
+        Node::PrefixExpression {
+            operator, right, ..
+        } if operator == "-" => translate_state_rhs(ctx, right, pre_state).map(|v| v.unary_minus()),
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => {
+            let l = translate_state_rhs(ctx, left, pre_state)?;
+            let r = translate_state_rhs(ctx, right, pre_state)?;
+            Some(match operator.as_str() {
+                "+" => Int::add(ctx, &[&l, &r]),
+                "-" => Int::sub(ctx, &[&l, &r]),
+                "*" => Int::mul(ctx, &[&l, &r]),
+                "/" => l.div(&r),
+                "%" => l.rem(&r),
+                _ => return None,
+            })
+        }
+        _ => None,
     }
 }
 

--- a/resilient/tests/examples_smoke.rs
+++ b/resilient/tests/examples_smoke.rs
@@ -774,3 +774,62 @@ fn ffi_libm_example_calls_sqrt() {
         "expected sqrt(2.0) in stdout; got:\nstdout={stdout}\nstderr={stderr}"
     );
 }
+
+#[test]
+#[cfg(feature = "z3")]
+fn actor_commute_example_proves_handlers_commute() {
+    // RES-386: the Counter actor's `increment` and `decrement`
+    // handlers both rewrite `self.state` as `state + k`; Z3 proves
+    // (state + 1) - 1 == (state - 1) + 1 for all integers, so the
+    // verifier must print a `commute` diagnostic and the driver must
+    // exit 0. This exercises the entire commutativity pipeline
+    // end-to-end — parser → driver → verifier_z3::check_actor_commutativity.
+    let (stdout, stderr, code) = run_example("actor_commute.rz");
+    assert_eq!(
+        code,
+        Some(0),
+        "actor_commute.rz must exit 0; stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("verifier: actor Counter: handlers `increment` and `decrement` commute"),
+        "expected commutativity diagnostic in stdout; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("do not commute"),
+        "commutative pair should not produce a divergence diagnostic; got:\n{stdout}"
+    );
+}
+
+#[test]
+#[cfg(feature = "z3")]
+fn actor_noncommute_example_reports_counterexample() {
+    // RES-386: the Accumulator actor's `inc` (state + 1) and `double`
+    // (state * 2) handlers do not commute — starting from state = 0,
+    // inc-then-double yields 2 while double-then-inc yields 1. The
+    // verifier prints the counterexample line with both final states,
+    // and the driver still exits 0 (verifier diagnostics are advisory,
+    // not fatal, per the minimum-slice contract).
+    let (stdout, stderr, code) = run_example("actor_noncommute.rz");
+    assert_eq!(
+        code,
+        Some(0),
+        "actor_noncommute.rz must exit 0; stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("verifier: actor Accumulator: handlers `inc` and `double` do not commute"),
+        "expected divergence diagnostic in stdout; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("counterexample:"),
+        "expected counterexample marker in stdout; got:\n{stdout}"
+    );
+    // The verifier formats each final state as `a_then_b=<int>` and
+    // `b_then_a=<int>`. We check for both substrings rather than
+    // literal integers so the assertion tolerates any Z3 model choice
+    // (the solver is free to pick any state_0 that falsifies the
+    // commutativity query).
+    assert!(
+        stdout.contains("inc_then_double=") && stdout.contains("double_then_inc="),
+        "expected both order-specific final states in stdout; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Closes #204

## Scope (minimum viable slice)

- Parser / AST: `actor Name { state: Type = expr; concurrent_ensures: expr; receive <h>() ensures expr; { body } }` blocks. Adds `Node::Actor` plus `ActorHandler`, wired through typechecker, free-vars walker, compiler span extractor, formatter, and interpreter (no-op at runtime — see follow-ups).
- Verifier: `verifier_z3::check_actor_commutativity` iterates every unordered pair of `receive` handlers, builds `A(B(s)) == B(A(s))` over a symbolic `Int` pre-state, and calls Z3. The supported body shape is exactly `self.state = <int_expr>;` with +, -, *, /, %, unary-minus, and integer literals; anything else returns `Unknown` with a clean reason.
- Diagnostic: a new `run_actor_verification` pass in the driver prints one line per pair — `verifier: actor <name>: handlers ... commute`, `... do not commute — counterexample: pre_state=N, A_then_B=X, B_then_A=Y`, or `... — unknown (<reason>)`. The pass is a no-op in non-z3 builds so the default golden-file harness stays untouched.
- Examples: `resilient/examples/actor_commute.rz` (Counter with `increment`/`decrement` — provably commute) and `actor_noncommute.rz` (Accumulator with `inc`/`double` — rejected with counterexample). Each carries an `.interactive` sidecar so the default golden harness skips them; two z3-gated smoke tests in `tests/examples_smoke.rs` exercise both paths end-to-end.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml` — clean
- [x] `cargo build --manifest-path resilient/Cargo.toml --features z3` — clean
- [x] `cargo test --manifest-path resilient/Cargo.toml` — 756 / 756 pass, no regressions
- [x] `cargo test --manifest-path resilient/Cargo.toml --features z3` — 786 / 786 pass, including the two new actor smoke tests
- [x] `cargo clippy --all-targets -- -D warnings` — clean with and without `--features z3`
- [x] `cargo fmt --check` — clean

## Follow-ups

Intentionally out of scope for this ticket; each will be filed as a separate issue:

- Full actor runtime / mailbox and scheduling — interpreter currently treats the decl as a no-op.
- Multi-message interleavings beyond pairwise commutativity.
- Non-integer state (records, arrays, Option).
- `concurrent_ensures` / per-handler `ensures` as first-class post-conditions — currently accepted by the parser but ignored by the verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)