### PR TITLE
RES-391: ownership regions — syntactic non-aliasing by region labels

### DIFF
--- a/resilient-runtime/src/ffi_static.rs
+++ b/resilient-runtime/src/ffi_static.rs
@@ -112,7 +112,11 @@ impl StaticRegistry {
 
     /// Look up a registered function by name. O(N) scan.
     pub fn lookup(&self, name: &str) -> Option<&Entry> {
-        self.slots[..self.len].iter().flatten().find(|&e| e.name == name).map(|v| v as _)
+        self.slots[..self.len]
+            .iter()
+            .flatten()
+            .find(|&e| e.name == name)
+            .map(|v| v as _)
     }
 
     /// Number of registered entries.

--- a/resilient-runtime/src/sink.rs
+++ b/resilient-runtime/src/sink.rs
@@ -203,9 +203,7 @@ mod tests {
     /// tests never run long enough for the leak to matter, and
     /// the `'static` lifetime is what `set_sink` needs.
     fn leak_buf_sink() -> &'static mut BufSink {
-        alloc::boxed::Box::leak(alloc::boxed::Box::new(BufSink {
-            buf: Vec::new(),
-        }))
+        alloc::boxed::Box::leak(alloc::boxed::Box::new(BufSink { buf: Vec::new() }))
     }
 
     #[test]
@@ -254,8 +252,7 @@ mod tests {
     #[test]
     fn failing_sink_surfaces_write_failed() {
         let _g = SINK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let sink: &'static mut FailSink =
-            alloc::boxed::Box::leak(alloc::boxed::Box::new(FailSink));
+        let sink: &'static mut FailSink = alloc::boxed::Box::leak(alloc::boxed::Box::new(FailSink));
         set_sink(sink);
         let err = print("anything").unwrap_err();
         clear_sink();
@@ -277,12 +274,8 @@ mod tests {
         print("to-second").unwrap();
 
         clear_sink();
-        let first_seen = unsafe {
-            String::from_utf8((*first_ptr).buf.clone()).unwrap()
-        };
-        let second_seen = unsafe {
-            String::from_utf8((*second_ptr).buf.clone()).unwrap()
-        };
+        let first_seen = unsafe { String::from_utf8((*first_ptr).buf.clone()).unwrap() };
+        let second_seen = unsafe { String::from_utf8((*second_ptr).buf.clone()).unwrap() };
         assert_eq!(first_seen, "to-first");
         assert_eq!(second_seen, "to-second");
     }

--- a/resilient/examples/region_aliasing_err.rz
+++ b/resilient/examples/region_aliasing_err.rz
@@ -1,0 +1,16 @@
+// RES-391: two mutable references that share the SAME declared
+// region label alias — the borrow checker rejects the fn. Swapping
+// `B` for `A` on the second parameter would also be accepted; the
+// Z3 fallback (follow-up RES-392) will relax this using `requires`
+// preconditions.
+region A;
+
+fn same_region_bad(&mut[A] int a, &mut[A] int b) {
+    println("should never reach this — borrow check rejects same-region mut refs");
+}
+
+fn main() {
+    same_region_bad(1, 2);
+}
+
+main();

--- a/resilient/examples/region_distinct_ok.expected.txt
+++ b/resilient/examples/region_distinct_ok.expected.txt
@@ -1,0 +1,2 @@
+swap_buffers accepted — distinct regions A vs B
+Program executed successfully

--- a/resilient/examples/region_distinct_ok.rz
+++ b/resilient/examples/region_distinct_ok.rz
@@ -1,0 +1,16 @@
+// RES-391: two mutable references carrying distinct region labels
+// are provably non-aliasing. The borrow checker accepts this fn
+// without complaint — region A and region B were both declared at
+// top level, and the labels are different.
+region A;
+region B;
+
+fn swap_buffers(&mut[A] int a, &mut[B] int b) {
+    println("swap_buffers accepted — distinct regions A vs B");
+}
+
+fn main() {
+    swap_buffers(1, 2);
+}
+
+main();

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -166,7 +166,12 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
     let mut main_next_local: u16 = 0;
     for spanned in stmts {
         // Skip fn/extern decls — handled in earlier passes.
-        if matches!(spanned.node, Node::Function { .. } | Node::Extern { .. }) {
+        // RES-391: `region <Name>;` is compile-time metadata only;
+        // it emits no code in either the tree-walker or the VM.
+        if matches!(
+            spanned.node,
+            Node::Function { .. } | Node::Extern { .. } | Node::RegionDecl { .. }
+        ) {
             continue;
         }
         let line = spanned.span.start.line as u32;
@@ -756,6 +761,7 @@ fn node_line(n: &Node) -> Option<u32> {
         | Node::StructLiteral { span, .. }
         | Node::ImplBlock { span, .. }
         | Node::TypeAlias { span, .. }
+        | Node::RegionDecl { span, .. }
         | Node::FunctionLiteral { span, .. } => span.start.line as u32,
 
         // RES-142: duration literal carries the span of its integer
@@ -799,6 +805,7 @@ fn node_kind(n: &Node) -> &'static str {
         Node::ArrayLiteral { .. } => "ArrayLiteral",
         Node::IndexExpression { .. } => "IndexExpression",
         Node::IndexAssignment { .. } => "IndexAssignment",
+        Node::RegionDecl { .. } => "RegionDecl",
         _ => "<other>",
     }
 }

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -195,6 +195,13 @@ impl Formatter {
                 self.write(&format!("type {} = {};", name, target));
                 self.newline();
             }
+            Node::RegionDecl { name, .. } => {
+                // RES-391: reserved `region` keyword introduces a
+                // compile-time region label — emitted as a single
+                // terminated statement, matching `type` aliases.
+                self.write(&format!("region {};", name));
+                self.newline();
+            }
             Node::LetStatement {
                 name,
                 value,
@@ -727,6 +734,7 @@ impl Formatter {
             | Node::StructDecl { .. }
             | Node::ImplBlock { .. }
             | Node::TypeAlias { .. }
+            | Node::RegionDecl { .. }
             | Node::Use { .. }
             | Node::Extern { .. }
             | Node::LetDestructureStruct { .. }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -196,7 +196,7 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
                 walk(m, bound, free);
             }
         }
-        Node::StructDecl { .. } | Node::TypeAlias { .. } => {}
+        Node::StructDecl { .. } | Node::TypeAlias { .. } | Node::RegionDecl { .. } => {}
 
         // ---- Statements ----
         Node::LetStatement { value, .. } | Node::StaticLet { value, .. } => {
@@ -386,6 +386,13 @@ fn collect_top_level_binder(node: &Node, bound: &mut BTreeSet<String>) {
             bound.insert(name.clone());
         }
         Node::TypeAlias { name, .. } => {
+            bound.insert(name.clone());
+        }
+        Node::RegionDecl { name, .. } => {
+            // RES-391: region declarations introduce a compile-time
+            // name (consumed by the borrow checker). No runtime
+            // binding, but treat it like other declarations for the
+            // scoping walk so sibling statements see the name.
             bound.insert(name.clone());
         }
         Node::LetStatement { name, .. } | Node::StaticLet { name, .. } => {

--- a/resilient/src/jit_backend.rs
+++ b/resilient/src/jit_backend.rs
@@ -159,6 +159,7 @@ fn count_nodes(n: &Node) -> usize {
         | Node::DurationLiteral { .. }
         | Node::Use { .. }
         | Node::TypeAlias { .. }
+        | Node::RegionDecl { .. }
         | Node::StructDecl { .. } => 0,
         Node::PrefixExpression { right, .. } => count_nodes(right),
         Node::InfixExpression { left, right, .. } => count_nodes(left) + count_nodes(right),

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -196,6 +196,12 @@ enum Tok {
     // RES-385: `linear` prefix on a type annotation.
     #[token("linear")]
     Linear,
+    // RES-391: `region <Name>;` declaration keyword and the `mut`
+    // qualifier used inside reference types (`&mut[A] T`).
+    #[token("region")]
+    Region,
+    #[token("mut")]
+    Mut,
     #[token("true")]
     True,
     #[token("false")]
@@ -520,6 +526,8 @@ fn convert(t: Tok) -> Token {
         Tok::Impl => Token::Impl,
         Tok::Type => Token::Type,
         Tok::Linear => Token::Linear,
+        Tok::Region => Token::Region,
+        Tok::Mut => Token::Mut,
         Tok::True => Token::BoolLiteral(true),
         Tok::False => Token::BoolLiteral(false),
         Tok::Underscore => Token::Underscore,

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -124,6 +124,15 @@ enum Token {
     /// RES-385: `linear` prefix on a type annotation — marks a
     /// resource the type checker enforces single-use on.
     Linear,
+    /// RES-391: `region <Name>;` — declares a memory region name
+    /// used as a label on reference types (`&[Name] T`, `&mut[Name] T`)
+    /// for syntactic non-aliasing checks.
+    Region,
+    /// RES-391: `mut` qualifier on reference types (`&mut T`,
+    /// `&mut[A] T`). Only recognized inside a type position today;
+    /// outside of types the parser surfaces it as an ordinary
+    /// unexpected-token error.
+    Mut,
 
     // Literals
     Identifier(String),
@@ -238,6 +247,8 @@ impl Token {
             Token::Impl => "`impl`".to_string(),
             Token::Type => "`type`".to_string(),
             Token::Linear => "`linear`".to_string(),
+            Token::Region => "`region`".to_string(),
+            Token::Mut => "`mut`".to_string(),
             Token::Underscore => "`_`".to_string(),
             Token::Default => "`default`".to_string(),
             Token::Dot => "`.`".to_string(),
@@ -623,6 +634,8 @@ impl Lexer {
                         "impl" => Token::Impl,
                         "type" => Token::Type,
                         "linear" => Token::Linear,
+                        "region" => Token::Region,
+                        "mut" => Token::Mut,
                         "_" => Token::Underscore,
                         // RES-163: `default` is a reserved alias
                         // for `_` at the top of a match arm.
@@ -1472,6 +1485,17 @@ enum Node {
         #[allow(dead_code)]
         span: span::Span,
     },
+    /// RES-391: `region <Name>;` top-level declaration. Introduces a
+    /// named region label used inside reference types
+    /// (`&[Name] T`, `&mut[Name] T`) for syntactic non-aliasing
+    /// checks. Region declarations carry no runtime representation —
+    /// they are metadata consumed by the borrow checker
+    /// (`check_region_aliasing`).
+    RegionDecl {
+        name: String,
+        #[allow(dead_code)]
+        span: span::Span,
+    },
 }
 
 /// FFI v1: one foreign fn declaration inside an `extern` block.
@@ -1603,6 +1627,7 @@ impl Parser {
             Token::Struct => Some(self.parse_struct_decl()),
             Token::Impl => Some(self.parse_impl_block()),
             Token::Type => Some(self.parse_type_alias()),
+            Token::Region => Some(self.parse_region_decl()),
             Token::Extern => self.parse_extern_block(),
             Token::Use => self.parse_use_statement(),
             Token::Let => Some(self.parse_let_statement()),
@@ -2192,6 +2217,45 @@ impl Parser {
         }
     }
 
+    /// RES-391: parse `region <Name>;` — a top-level region
+    /// declaration. Region declarations introduce a named memory
+    /// region used as a label on reference types (`&[Name] T`,
+    /// `&mut[Name] T`) for the borrow checker's non-aliasing rule.
+    ///
+    /// Parse-error recovery mirrors `parse_type_alias`: missing name
+    /// or missing trailing `;` records a diagnostic but still emits
+    /// a `RegionDecl` so downstream passes see something
+    /// well-shaped.
+    fn parse_region_decl(&mut self) -> Node {
+        let kw_span = self.span_at_current();
+        self.next_token(); // skip `region`
+
+        let name = match &self.current_token {
+            Token::Identifier(n) => n.clone(),
+            other => {
+                let tok = other.clone();
+                self.record_error(format!(
+                    "Expected region name after 'region', found {}",
+                    tok
+                ));
+                String::new()
+            }
+        };
+        self.next_token(); // skip name
+
+        // Trailing `;` — match the `type` alias convention.
+        if self.current_token == Token::Semicolon {
+            // cursor on `;`; parse_program advances past it
+        } else if self.peek_token == Token::Semicolon {
+            self.next_token();
+        }
+
+        Node::RegionDecl {
+            name,
+            span: kw_span,
+        }
+    }
+
     /// Parse an optional `-> TYPE`. If present, current_token advances
     /// past the type identifier. If absent, no tokens are consumed.
     fn parse_optional_return_type(&mut self) -> Option<String> {
@@ -2236,6 +2300,59 @@ impl Parser {
             false
         };
         let base = match &self.current_token {
+            // RES-391: reference type — `& T`, `&mut T`, `&[A] T`, or
+            // `&mut[A] T`. The optional region label `[A]` lives
+            // between `&mut`/`&` and the inner type. Encoded as a
+            // string (matching the existing single-string type
+            // convention): `"&mut[A] Int"`, `"&[A] Int"`, `"&mut Int"`,
+            // `"& Int"`. The borrow checker (`check_region_aliasing`)
+            // reparses this string to extract mutability and region.
+            Token::BitAnd => {
+                self.next_token(); // skip `&`
+                let is_mut = if self.current_token == Token::Mut {
+                    self.next_token(); // skip `mut`
+                    true
+                } else {
+                    false
+                };
+                let region = if self.current_token == Token::LeftBracket {
+                    self.next_token(); // skip `[`
+                    let label = match &self.current_token {
+                        Token::Identifier(n) => n.clone(),
+                        other => {
+                            let tok = other.clone();
+                            self.record_error(format!(
+                                "Expected region name inside `&{}[...]` {}, found {}",
+                                if is_mut { "mut" } else { "" },
+                                ctx,
+                                tok
+                            ));
+                            return None;
+                        }
+                    };
+                    self.next_token(); // skip region name
+                    if self.current_token != Token::RightBracket {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected ']' to close region label `[{}` {}, found {}",
+                            label, ctx, tok
+                        ));
+                        return None;
+                    }
+                    self.next_token(); // skip `]`
+                    Some(label)
+                } else {
+                    None
+                };
+                let inner = self.parse_type_annotation(ctx)?;
+                let prefix = match (is_mut, region) {
+                    (true, Some(r)) => format!("&mut[{}] ", r),
+                    (false, Some(r)) => format!("&[{}] ", r),
+                    (true, None) => "&mut ".to_string(),
+                    (false, None) => "& ".to_string(),
+                };
+                Some(format!("{}{}", prefix, inner))
+            }
             Token::Identifier(t) => {
                 let ty = t.clone();
                 self.next_token(); // advance past the identifier
@@ -7477,6 +7594,9 @@ impl Interpreter {
             // sees aliases — by the time `eval` runs, every use
             // site has already been resolved by the typechecker.
             Node::TypeAlias { .. } => Ok(Value::Void),
+            // RES-391: `region <Name>;` is pure compile-time metadata
+            // consumed by the borrow checker — runtime no-op.
+            Node::RegionDecl { .. } => Ok(Value::Void),
             // RES-158: `impl <Struct> { ... }` evaluates each method
             // as if it were a top-level `fn` decl. Methods are already
             // mangled to `<Struct>$<method>` by the parser.
@@ -8712,6 +8832,157 @@ fn parse(src: &str) -> (Node, Vec<String>) {
     (program, errs)
 }
 
+/// RES-391: a parsed reference-type annotation. The parser encodes
+/// reference types as strings (matching the single-string type
+/// convention used for every parameter type today); this helper
+/// unpacks them back into `(mutable, region_label)`.
+///
+/// The string forms accepted:
+/// * `"&mut[NAME] T"` → `(true, Some("NAME"))`
+/// * `"&[NAME] T"`    → `(false, Some("NAME"))`
+/// * `"&mut T"`       → `(true, None)`
+/// * `"& T"`          → `(false, None)`
+/// * anything else    → `None` (not a reference type)
+fn parse_ref_type(ty: &str) -> Option<(bool, Option<String>)> {
+    let rest = ty.strip_prefix('&')?;
+    // After `&`, optional `mut`, then optional `[LABEL]`, then a
+    // mandatory space and the inner type. The inner type itself is
+    // ignored here — the borrow checker only cares about the
+    // mutability + region pair.
+    let (is_mut, rest) = if let Some(r) = rest.strip_prefix("mut") {
+        (true, r)
+    } else {
+        (false, rest)
+    };
+    let rest = rest.trim_start();
+    if let Some(after_bracket) = rest.strip_prefix('[') {
+        let close = after_bracket.find(']')?;
+        let label = after_bracket[..close].trim().to_string();
+        if label.is_empty() {
+            return Some((is_mut, None));
+        }
+        Some((is_mut, Some(label)))
+    } else {
+        Some((is_mut, None))
+    }
+}
+
+/// RES-391: syntactic non-aliasing check over every `fn` in the
+/// program. Returns a list of error strings (each already prefixed
+/// with `<file>:<line>:<col>: `).
+///
+/// The rule, mirroring the ticket's MVP slice:
+/// * A reference parameter `&[LABEL] T` or `&mut[LABEL] T` must name
+///   a region declared elsewhere in the program via `region LABEL;`.
+/// * Two `&mut` parameters in the same fn are rejected whenever they
+///   could potentially alias — i.e. when they share the same region
+///   label, or when either one is unlabeled (`&mut T` with no
+///   `[LABEL]`). Distinct, declared labels are accepted as
+///   statically disjoint.
+///
+/// Out of scope for the MVP (filed as follow-up tickets):
+///   * RES-392: Z3 fallback proof using `requires` preconditions.
+///   * RES-393: region inference for unlabeled references.
+///   * RES-394: region polymorphism (`fn<'R> ...`).
+pub(crate) fn check_region_aliasing(program: &Node, source_path: &str) -> Vec<String> {
+    let mut errors: Vec<String> = Vec::new();
+    let stmts = match program {
+        Node::Program(s) => s,
+        _ => return errors,
+    };
+
+    // Collect the set of declared region names.
+    let mut declared: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for stmt in stmts {
+        if let Node::RegionDecl { name, .. } = &stmt.node
+            && !name.is_empty()
+        {
+            declared.insert(name.clone());
+        }
+    }
+
+    let prefix = |span: span::Span, msg: &str| -> String {
+        if span.start.line == 0 {
+            format!("E: {}", msg)
+        } else {
+            format!(
+                "{}:{}:{}: E: {}",
+                source_path, span.start.line, span.start.column, msg
+            )
+        }
+    };
+
+    for stmt in stmts {
+        if let Node::Function {
+            name: fn_name,
+            parameters,
+            span,
+            ..
+        } = &stmt.node
+        {
+            // Per-parameter pass: every labeled reference must name
+            // a declared region.
+            let mut refs: Vec<(usize, bool, Option<String>, String)> = Vec::new();
+            for (idx, (ty, pname)) in parameters.iter().enumerate() {
+                if let Some((is_mut, label)) = parse_ref_type(ty) {
+                    if let Some(l) = &label
+                        && !declared.contains(l)
+                    {
+                        errors.push(prefix(
+                            *span,
+                            &format!(
+                                "undeclared region `{}` in parameter `{}` of fn `{}` — add a top-level `region {};`",
+                                l, pname, fn_name, l
+                            ),
+                        ));
+                    }
+                    refs.push((idx, is_mut, label, pname.clone()));
+                }
+            }
+
+            // Pairwise aliasing check over mutable references.
+            for i in 0..refs.len() {
+                for j in (i + 1)..refs.len() {
+                    let (_, i_mut, i_lbl, i_name) = &refs[i];
+                    let (_, j_mut, j_lbl, j_name) = &refs[j];
+                    // Only two mutable references can alias
+                    // destructively. Two `&[A]` shared references
+                    // pointing into the same region is fine (no
+                    // write conflict possible). A `&mut[A]` paired
+                    // with a `&[A]` is also aliasing, and rejected
+                    // here for the same reason.
+                    if !i_mut && !j_mut {
+                        continue;
+                    }
+                    let (ok, i_show, j_show) = match (i_lbl, j_lbl) {
+                        (Some(a), Some(b)) if a != b => {
+                            (true, format!("[{}]", a), format!("[{}]", b))
+                        }
+                        (Some(a), Some(b)) => (false, format!("[{}]", a), format!("[{}]", b)),
+                        (Some(a), None) => (false, format!("[{}]", a), String::new()),
+                        (None, Some(b)) => (false, String::new(), format!("[{}]", b)),
+                        (None, None) => (false, String::new(), String::new()),
+                    };
+                    if ok {
+                        continue;
+                    }
+                    let i_kind = if *i_mut { "&mut" } else { "&" };
+                    let j_kind = if *j_mut { "&mut" } else { "&" };
+                    errors.push(prefix(
+                        *span,
+                        &format!(
+                            "potential aliasing between `{}{}` parameter `{}` and `{}{}` parameter `{}` of fn `{}` — add distinct region or see docs",
+                            i_kind, i_show, i_name, j_kind, j_show, j_name, fn_name
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+
+    errors
+}
+
 /// RES-187: semantic-token type indices. Must match the legend
 /// `lsp_server::SEMANTIC_TOKEN_TYPES` declares in its capability
 /// advertisement. Keep in sync — the LSP spec encodes these as
@@ -9200,6 +9471,24 @@ fn execute_file(
     }
     if let Err(e) = imports::expand_uses(&mut program, &base_dir, &mut loaded) {
         return Err(format!("Import error: {}", e));
+    }
+
+    // RES-391: syntactic non-aliasing check over reference-type
+    // parameters. Runs unconditionally — a borrow-check violation is
+    // a compile-time error regardless of `--typecheck`. The check is
+    // intentionally conservative; the Z3 fallback (RES-392 follow-up)
+    // relaxes it for programs whose `requires` preconditions prove
+    // disjointness.
+    let region_errors = check_region_aliasing(&program, filename);
+    if !region_errors.is_empty() {
+        for e in &region_errors {
+            eprintln!("\x1B[31m{}\x1B[0m", e);
+            eprintln!("{}", render_with_caret(&contents, e, "Borrow check"));
+        }
+        return Err(format!(
+            "Borrow check failed: {} error(s)",
+            region_errors.len()
+        ));
     }
 
     // Type checking if enabled. --audit, --explain-effects, and
@@ -18602,6 +18891,163 @@ mod tests {
         // First token starts at column 0 of line 0.
         assert_eq!(wire[0], 0, "first dLine should be 0");
         assert_eq!(wire[1], 0, "first dStart should be 0");
+    }
+
+    // ------------------------------------------------------------
+    // RES-391: ownership-region parser and borrow-check unit tests.
+    // ------------------------------------------------------------
+
+    #[test]
+    fn res391_parses_top_level_region_decl() {
+        let (program, errs) = parse("region A;\nregion Bank1;\n");
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let stmts = match &program {
+            Node::Program(s) => s,
+            _ => unreachable!(),
+        };
+        assert_eq!(stmts.len(), 2);
+        match &stmts[0].node {
+            Node::RegionDecl { name, .. } => assert_eq!(name, "A"),
+            other => panic!("expected RegionDecl, got {:?}", other),
+        }
+        match &stmts[1].node {
+            Node::RegionDecl { name, .. } => assert_eq!(name, "Bank1"),
+            other => panic!("expected RegionDecl, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn res391_parses_labeled_mut_reference_param() {
+        let src = "region A; fn f(&mut[A] int x) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let stmts = match &program {
+            Node::Program(s) => s,
+            _ => unreachable!(),
+        };
+        let params = match &stmts[1].node {
+            Node::Function { parameters, .. } => parameters.clone(),
+            other => panic!("expected Function, got {:?}", other),
+        };
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].0, "&mut[A] int");
+        assert_eq!(params[0].1, "x");
+    }
+
+    #[test]
+    fn res391_parses_shared_labeled_reference_param() {
+        let src = "region A; fn g(&[A] int y) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let stmts = match &program {
+            Node::Program(s) => s,
+            _ => unreachable!(),
+        };
+        let params = match &stmts[1].node {
+            Node::Function { parameters, .. } => parameters.clone(),
+            other => panic!("expected Function, got {:?}", other),
+        };
+        assert_eq!(params[0].0, "&[A] int");
+    }
+
+    #[test]
+    fn res391_parses_unlabeled_mut_reference_param() {
+        let src = "fn h(&mut int z) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let stmts = match &program {
+            Node::Program(s) => s,
+            _ => unreachable!(),
+        };
+        let params = match &stmts[0].node {
+            Node::Function { parameters, .. } => parameters.clone(),
+            _ => panic!(),
+        };
+        assert_eq!(params[0].0, "&mut int");
+    }
+
+    #[test]
+    fn res391_distinct_regions_are_accepted() {
+        let src = "region A; region B; fn f(&mut[A] int a, &mut[B] int b) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert!(
+            borrow_errs.is_empty(),
+            "distinct-region fn should be accepted, got: {:?}",
+            borrow_errs
+        );
+    }
+
+    #[test]
+    fn res391_same_region_mut_refs_rejected() {
+        let src = "region A; fn f(&mut[A] int a, &mut[A] int b) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert_eq!(borrow_errs.len(), 1, "got: {:?}", borrow_errs);
+        assert!(
+            borrow_errs[0].contains("potential aliasing")
+                && borrow_errs[0].contains("&mut[A]")
+                && borrow_errs[0].contains("add distinct region"),
+            "message shape wrong: {}",
+            borrow_errs[0]
+        );
+    }
+
+    #[test]
+    fn res391_unlabeled_mut_pair_rejected() {
+        // `&mut` with no region label is treated as possibly aliasing
+        // with any other `&mut`. The MVP rejects; the follow-up
+        // RES-393 region-inference ticket relaxes this.
+        let src = "fn f(&mut int a, &mut int b) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert_eq!(borrow_errs.len(), 1);
+        assert!(borrow_errs[0].contains("potential aliasing"));
+    }
+
+    #[test]
+    fn res391_mixed_labeled_and_unlabeled_mut_rejected() {
+        let src = "region A; fn f(&mut[A] int a, &mut int b) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert_eq!(borrow_errs.len(), 1, "got: {:?}", borrow_errs);
+    }
+
+    #[test]
+    fn res391_two_shared_refs_same_region_are_fine() {
+        // Two `&[A]` shared refs cannot conflict (no writes), so the
+        // borrow checker accepts them even in the same region.
+        let src = "region A; fn f(&[A] int a, &[A] int b) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert!(
+            borrow_errs.is_empty(),
+            "two shared refs should be fine, got: {:?}",
+            borrow_errs
+        );
+    }
+
+    #[test]
+    fn res391_undeclared_region_rejected() {
+        // Using a region label that was never declared is an error.
+        let src = "fn f(&mut[Ghost] int a) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert!(
+            !borrow_errs.is_empty(),
+            "undeclared region should be rejected"
+        );
+        assert!(
+            borrow_errs.iter().any(|e| e.contains("undeclared region")),
+            "expected undeclared-region message, got: {:?}",
+            borrow_errs
+        );
     }
 }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1861,6 +1861,14 @@ impl TypeChecker {
                 Ok(Type::Void)
             }
 
+            // RES-391: `region <Name>;` is compile-time metadata
+            // consumed by the borrow checker — the typechecker just
+            // accepts it as Void. Region-scoped reference types
+            // (`&[A] T`, `&mut[A] T`) surface in parameter positions,
+            // where `parse_type_name` strips the reference prefix
+            // and yields the inner type.
+            Node::RegionDecl { .. } => Ok(Type::Void),
+
             // RES-153: record the struct's (field, type) list so
             // `FieldAccess` / `FieldAssignment` downstream can check
             // field existence and surface typed-field errors
@@ -2333,6 +2341,25 @@ impl TypeChecker {
     /// as a diagnostic instead of looping forever or stack-
     /// overflowing.
     fn parse_type_name_inner(&self, name: &str, seen: &mut Vec<String>) -> Result<Type, String> {
+        // RES-391: strip the reference prefix — `& T`, `&mut T`,
+        // `&[A] T`, `&mut[A] T` — before resolving the inner type.
+        // The borrow checker (`main::check_region_aliasing`) has
+        // already consumed the region / mutability info; downstream
+        // type resolution cares only about the pointee.
+        if let Some(rest) = name.strip_prefix('&') {
+            let rest = rest.strip_prefix("mut").unwrap_or(rest);
+            let rest = rest.trim_start();
+            let rest = if let Some(after) = rest.strip_prefix('[') {
+                // Skip to the first `]`.
+                match after.find(']') {
+                    Some(end) => after[end + 1..].trim_start(),
+                    None => rest, // malformed, fall through
+                }
+            } else {
+                rest
+            };
+            return self.parse_type_name_inner(rest, seen);
+        }
         match name {
             "int" => Ok(Type::Int),
             "float" => Ok(Type::Float),


### PR DESCRIPTION
Closes #209.

## Summary

- New top-level `region Name;` declaration syntax.
- Reference parameter types: `& T`, `&mut T`, `&[R] T`, `&mut[R] T`.
- New borrow-check pass on function signatures: rejects two `&mut`
  parameters that share a declared region (or where either is
  unlabeled), while accepting pairs with distinct declared regions.
- Two golden examples (`region_distinct_ok.rz`, `region_aliasing_err.rz`).
- Ten parser / borrow-check unit tests.

## Scope / out of scope

This is the minimum viable slice of RES-391. Out-of-scope pieces are
tracked as separate tickets:

- RES-392 — Z3-backed alias analysis (#219)
- RES-393 — region inference for unlabeled references (#220)
- RES-394 — region polymorphism (#221)

## Test plan

- [x] `cargo test` — 862 pass, 0 fail.
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Golden examples match (`examples_golden` integration test).
- [x] `region_distinct_ok.rz` exits 0 with accepted-message stdout.
- [x] `region_aliasing_err.rz` exits 1 with the expected borrow-check diagnostic.