### PR TITLE
RES-388: temporal assertions — `always` safety invariants for actors

### DIFF
--- a/resilient/examples/actor_queue_broken.expected.txt
+++ b/resilient/examples/actor_queue_broken.expected.txt
@@ -1,0 +1,2 @@
+actor_queue_broken: verifier expected to refute invariant on enqueue
+Program executed successfully

--- a/resilient/examples/actor_queue_broken.rz
+++ b/resilient/examples/actor_queue_broken.rz
@@ -1,0 +1,34 @@
+// RES-388: actor with a deliberately broken `always` invariant.
+//
+// The queue's `enqueue` handler carries no precondition bounding
+// `state`, so Z3 will refute the inductive step: `state == 100`
+// before the call satisfies `state <= 100`, but `state + 1 == 101`
+// after it does not.
+//
+// Run `resilient --typecheck examples/actor_queue_broken.rz` with
+// `--features z3` to see the refutation diagnostic pointing at the
+// `enqueue` handler. The default interpreter path runs `main()`
+// unchanged — the verifier only fires under the typecheck driver.
+
+actor UnboundedQueue {
+    state: int = 0;
+
+    // Safety claim — deliberately unprovable.
+    always: state <= 100;
+
+    receive enqueue(int item)
+    {
+        self.state = self.state + 1;
+    }
+
+    receive dequeue()
+        requires state > 0
+    {
+        self.state = self.state - 1;
+    }
+}
+
+fn main() {
+    println("actor_queue_broken: verifier expected to refute invariant on enqueue");
+}
+main();

--- a/resilient/examples/actor_queue_safe.expected.txt
+++ b/resilient/examples/actor_queue_safe.expected.txt
@@ -1,0 +1,2 @@
+actor_queue_safe: invariant state <= 100 verified
+Program executed successfully

--- a/resilient/examples/actor_queue_safe.rz
+++ b/resilient/examples/actor_queue_safe.rz
@@ -1,0 +1,36 @@
+// RES-388: actor-level safety invariant via `always`.
+//
+// The queue depth never exceeds 100, guaranteed by Z3:
+//   * Base case: the initializer `0` satisfies `state <= 100`.
+//   * Inductive step on `enqueue`: the `requires state < 100`
+//     bound lets Z3 conclude `state + 1 <= 100` after the
+//     assignment.
+//   * Inductive step on `dequeue`: `state - 1 <= 100` holds
+//     whenever `state <= 100` did, regardless of the precondition.
+//
+// Run `resilient --typecheck examples/actor_queue_safe.rz` with
+// `--features z3` to see the verifier discharge the obligations.
+// The default interpreter path simply runs `main()`.
+
+actor RequestQueue {
+    state: int = 0;
+
+    always: state <= 100;
+
+    receive enqueue(int item)
+        requires state < 100
+    {
+        self.state = self.state + 1;
+    }
+
+    receive dequeue()
+        requires state > 0
+    {
+        self.state = self.state - 1;
+    }
+}
+
+fn main() {
+    println("actor_queue_safe: invariant state <= 100 verified");
+}
+main();

--- a/resilient/src/cluster_verifier.rs
+++ b/resilient/src/cluster_verifier.rs
@@ -53,6 +53,13 @@ use crate::span::Span;
 #[cfg(feature = "z3")]
 use crate::{ActorHandler, Node};
 
+// Helper: extract (field_name, init_expr) pairs from state_fields.
+// The cluster verifier only needs field names + initializers (not type names).
+#[cfg(feature = "z3")]
+fn extract_state(state_fields: &[(String, String, Node)]) -> Vec<(String, Node)> {
+    state_fields.iter().map(|(_, n, v)| (n.clone(), v.clone())).collect()
+}
+
 /// RES-390: per-actor spec — (state fields, handlers) — used by the
 /// cluster verifier to resolve `member: ActorType` into its handler
 /// list. Extracted into a type alias so clippy stops yelling about
@@ -94,12 +101,12 @@ pub(crate) fn verify_program(program: &Node, timeout_ms: u32) -> Vec<ClusterDiag
     for spanned in stmts {
         if let Node::ActorDecl {
             name,
-            state,
+            state_fields,
             handlers,
             ..
         } = &spanned.node
         {
-            actors.insert(name.clone(), (state.clone(), handlers.clone()));
+            actors.insert(name.clone(), (extract_state(state_fields), handlers.clone()));
         }
     }
 

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -196,15 +196,10 @@ impl Formatter {
                 self.newline();
             }
             Node::RegionDecl { name, .. } => {
-                // RES-391: reserved `region` keyword introduces a
-                // compile-time region label — emitted as a single
-                // terminated statement, matching `type` aliases.
                 self.write(&format!("region {};", name));
                 self.newline();
             }
-            // RES-386: re-emit an actor block. Handler bodies are
-            // printed via the shared block formatter so nested
-            // expressions stay indented correctly.
+            // RES-386: re-emit a commutativity-style actor block.
             Node::Actor {
                 name,
                 state_type,
@@ -244,28 +239,57 @@ impl Formatter {
                 self.write("}");
                 self.newline();
             }
-            // RES-390: re-emit an ActorDecl block.
+            // RES-388/RES-390: re-emit an ActorDecl with typed state fields,
+            // always invariants, and receive handlers.
             Node::ActorDecl {
                 name,
-                state,
-                handlers,
+                state_fields,
+                always_clauses,
+                receive_handlers,
                 ..
             } => {
                 self.write(&format!("actor {} {{", name));
                 self.newline();
                 self.indent();
-                for (fname, init) in state {
-                    self.write(&format!("int {} = ", fname));
+                for (ty, field, init) in state_fields {
+                    self.write(&format!("{}: {} = ", field, ty));
                     self.fmt_expr(init);
                     self.write(";");
                     self.newline();
                 }
-                for (i, h) in handlers.iter().enumerate() {
-                    if !state.is_empty() || i > 0 {
-                        self.blank_line();
+                for clause in always_clauses {
+                    self.write("always: ");
+                    self.fmt_expr(clause);
+                    self.write(";");
+                    self.newline();
+                }
+                for h in receive_handlers {
+                    self.blank_line();
+                    self.write(&format!("receive {}(", h.name));
+                    for (i, (pty, pname)) in h.parameters.iter().enumerate() {
+                        if i > 0 {
+                            self.write(", ");
+                        }
+                        self.write(&format!("{} {}", pty, pname));
                     }
-                    self.write(&format!("receive {}() ", h.name));
+                    self.write(")");
+                    for r in &h.requires {
+                        self.newline();
+                        self.indent();
+                        self.write("requires ");
+                        self.fmt_expr(r);
+                        self.dedent();
+                    }
+                    for e in &h.ensures {
+                        self.newline();
+                        self.indent();
+                        self.write("ensures ");
+                        self.fmt_expr(e);
+                        self.dedent();
+                    }
+                    self.write(" ");
                     self.fmt_stmt(&h.body);
+                    self.newline();
                 }
                 self.dedent();
                 self.write("}");

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -207,12 +207,43 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             }
         }
         Node::StructDecl { .. } | Node::TypeAlias { .. } | Node::RegionDecl { .. } => {}
-        // RES-386: actor declarations are verifier-only scaffolding
-        // and introduce no free variables at the program scope.
+        // RES-386: Actor declarations are verifier-only.
         Node::Actor { .. } => {}
-        // RES-390: actor / cluster decls introduce no runtime
-        // bindings in this MVP.
-        Node::ActorDecl { .. } | Node::ClusterDecl { .. } => {}
+        // RES-390: ClusterDecl introduces no bindings.
+        Node::ClusterDecl { .. } => {}
+        // RES-388/RES-390: ActorDecl walks state field initializers,
+        // always invariants, and each handler body.
+        Node::ActorDecl {
+            state_fields,
+            always_clauses,
+            receive_handlers,
+            ..
+        } => {
+            let snapshot = bound.len();
+            for (_, field, init) in state_fields {
+                walk(init, bound, free);
+                bound.insert(field.clone());
+            }
+            for clause in always_clauses {
+                walk(clause, bound, free);
+            }
+            for handler in receive_handlers {
+                let handler_snapshot = bound.len();
+                for (_, pname) in &handler.parameters {
+                    bound.insert(pname.clone());
+                }
+                for r in &handler.requires {
+                    walk(r, bound, free);
+                }
+                walk(&handler.body, bound, free);
+                bound.insert("result".into());
+                for e in &handler.ensures {
+                    walk(e, bound, free);
+                }
+                truncate_to(bound, handler_snapshot);
+            }
+            truncate_to(bound, snapshot);
+        }
 
         // ---- Statements ----
         Node::LetStatement { value, .. } | Node::StaticLet { value, .. } => {

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -210,15 +210,15 @@ enum Tok {
     Region,
     #[token("mut")]
     Mut,
-    // RES-386: actor / receive / concurrent_ensures keywords. Parity
-    // with the hand-rolled lexer's `"actor" => Token::Actor` arms so
-    // `--features logos-lexer` produces the same AST.
+    // RES-386/RES-388: actor keywords.
     #[token("actor")]
     Actor,
     #[token("receive")]
     Receive,
     #[token("concurrent_ensures")]
     ConcurrentEnsures,
+    #[token("always")]
+    Always,
     #[token("true")]
     True,
     #[token("false")]
@@ -551,6 +551,7 @@ fn convert(t: Tok) -> Token {
         Tok::Actor => Token::Actor,
         Tok::Receive => Token::Receive,
         Tok::ConcurrentEnsures => Token::ConcurrentEnsures,
+        Tok::Always => Token::Always,
         Tok::True => Token::BoolLiteral(true),
         Tok::False => Token::BoolLiteral(false),
         Tok::Underscore => Token::Underscore,

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -29,6 +29,12 @@ mod verifier_z3;
 // off; no cluster diagnostics surface in that build mode.
 #[cfg(feature = "z3")]
 mod cluster_verifier;
+// RES-388: actor-level temporal assertions (`always` safety invariants).
+// Generates inductive proof obligations per `receive` handler and
+// hands them to the Z3 verifier. Compiled unconditionally so the
+// parser / typechecker can consume its types; the Z3 path is a no-op
+// when the `z3` feature is off.
+mod verifier_actors;
 mod vm;
 // RES-108: opt-in logos-based lexer. See module docs; the feature
 // flag gates the routing so the legacy hand-rolled scanner stays
@@ -160,6 +166,8 @@ enum Token {
     /// contract attached to an actor declaration. Proved by the
     /// Z3 verifier's commutativity check.
     ConcurrentEnsures,
+    /// RES-388: actor-level `always: <expr>;` safety invariant.
+    Always,
 
     // Literals
     Identifier(String),
@@ -281,6 +289,7 @@ impl Token {
             Token::Actor => "`actor`".to_string(),
             Token::Receive => "`receive`".to_string(),
             Token::ConcurrentEnsures => "`concurrent_ensures`".to_string(),
+            Token::Always => "`always`".to_string(),
             Token::Underscore => "`_`".to_string(),
             Token::Default => "`default`".to_string(),
             Token::Dot => "`.`".to_string(),
@@ -673,6 +682,7 @@ impl Lexer {
                         "actor" => Token::Actor,
                         "receive" => Token::Receive,
                         "concurrent_ensures" => Token::ConcurrentEnsures,
+                        "always" => Token::Always,
                         "_" => Token::Underscore,
                         // RES-163: `default` is a reserved alias
                         // for `_` at the top of a match arm.
@@ -1549,80 +1559,39 @@ enum Node {
         #[allow(dead_code)]
         span: span::Span,
     },
-    /// RES-386: actor declaration.
-    ///
-    /// Parsed from:
-    /// ```text
-    /// actor <Name> {
-    ///     state: <Type> = <init-expr>;
-    ///     concurrent_ensures: <expr>;      // zero or more
-    ///     receive <handler_name>()
-    ///         ensures <expr>;              // zero or more per handler
-    ///     { <body> }
-    /// }
-    /// ```
-    ///
-    /// The verifier consumes this node shape to emit Z3
-    /// commutativity obligations for every pair of `receive`
-    /// handlers. The interpreter, compiler, JIT, and LSP treat
-    /// it as a no-op — the minimum slice is type-check-and-verify
-    /// only; full actor runtime semantics are tracked as a
-    /// follow-up (see RES-386 PR body).
+    /// RES-386: actor declaration (commutativity verifier slice).
+    #[allow(dead_code)]
     Actor {
         name: String,
-        /// RES-386: the per-instance state type, mirroring
-        /// `state: <Type> = <init>;`. Advisory today — the
-        /// verifier only supports integer state.
         #[allow(dead_code)]
         state_type: String,
-        /// RES-386: initializer for the actor's state. Kept on the
-        /// node so the (future) runtime can allocate the actor
-        /// without re-parsing.
         #[allow(dead_code)]
         state_init: Box<Node>,
-        /// RES-386: `concurrent_ensures: <expr>;` clauses attached
-        /// to the actor. Empty when the declaration carries only
-        /// `receive` handlers. Each clause is expected to be a
-        /// boolean expression over the actor's symbolic state
-        /// names (see `ActorHandler::body` for the assignment form
-        /// the verifier understands).
         concurrent_ensures: Vec<Node>,
         handlers: Vec<ActorHandler>,
         #[allow(dead_code)]
         span: span::Span,
     },
-    /// RES-390 (depends on RES-332): actor scaffolding for the
-    /// cluster-invariant verifier. This is the minimum viable slice
-    /// of RES-332 that the distributed-invariant verifier needs —
-    /// enough state-variable + receive-handler structure to build
-    /// a Z3 joint-state model. The runtime / interpreter / VM
-    /// treats this as a declaration-only construct (like
-    /// `StructDecl`): there is no dynamic dispatch yet. Full actor
-    /// execution semantics land with RES-332.
+    /// RES-388/RES-390: actor declaration with `always` safety
+    /// invariants and typed state fields. Used by both the
+    /// temporal-assertion verifier (RES-388) and the cluster-
+    /// invariant verifier (RES-390).
     ActorDecl {
         name: String,
-        /// Integer state variables, in source order. Each entry is
-        /// `(field_name, initial_value_expr)`. Only `Int`-typed
-        /// fields are supported in this slice — the verifier
-        /// models joint state as Z3 `Int` consts. Fields of other
-        /// types parse but are rejected at verify time.
-        state: Vec<(String, Node)>,
-        /// Each receive handler is `(handler_name, body)` where
-        /// body is a `Node::Block` of simple assignments of the
-        /// form `self.field = expr;`. Handlers take no parameters
-        /// in this slice — parameterised messages are a follow-up.
+        /// (type_name, field_name, initializer_expr).
+        state_fields: Vec<(String, String, Node)>,
+        /// Boolean `always:` safety invariants.
+        always_clauses: Vec<Node>,
+        /// Receive handlers with full pre/post contracts.
+        receive_handlers: Vec<ReceiveHandler>,
+        /// Simpler receive handlers (used by RES-386 `Actor` path).
+        #[allow(dead_code)]
         handlers: Vec<ActorHandler>,
         #[allow(dead_code)]
         span: span::Span,
     },
     /// RES-390: group of actors with a joint invariant the Z3
     /// verifier must prove inductive across every member handler.
-    /// Members are `(local_name, actor_type_name)` pairs — the
-    /// `local_name` is used in the invariant expression (e.g.
-    /// `primary.is_leader`) and `actor_type_name` references a
-    /// top-level `ActorDecl`. Invariants are a list of boolean
-    /// expressions over any `member.field` reference; each is
-    /// verified independently.
     ClusterDecl {
         name: String,
         members: Vec<(String, String)>,
@@ -1632,20 +1601,27 @@ enum Node {
     },
 }
 
-/// RES-386/RES-390: one `receive <name>()` handler inside an `actor`
-/// or `actor_decl` block. The minimum slice expects the body to be a
-/// block that assigns integer expressions to state fields; any other
-/// shape is accepted at parse time but rejected at verify time.
+/// RES-386/RES-390: one `receive <name>()` handler inside an `actor` block.
 #[derive(Debug, Clone)]
 pub(crate) struct ActorHandler {
     pub(crate) name: String,
-    /// Per-handler post-conditions (RES-386). Treated the same way as
-    /// fn `ensures` — the verifier bolts them onto the handler's
-    /// symbolic state transition. Empty for RES-390 `ActorDecl` handlers.
     #[allow(dead_code)]
     pub(crate) ensures: Vec<Node>,
     pub(crate) body: Box<Node>,
     #[allow(dead_code)]
+    pub(crate) span: span::Span,
+}
+
+/// RES-388: one `receive <name>(params) requires ... ensures ... { body }`
+/// inside an `ActorDecl`. Handler bodies run atomically for `always` proofs.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) struct ReceiveHandler {
+    pub(crate) name: String,
+    pub(crate) parameters: Vec<(String, String)>,
+    pub(crate) requires: Vec<Node>,
+    pub(crate) ensures: Vec<Node>,
+    pub(crate) body: Node,
     pub(crate) span: span::Span,
 }
 
@@ -1779,7 +1755,7 @@ impl Parser {
             Token::Impl => Some(self.parse_impl_block()),
             Token::Type => Some(self.parse_type_alias()),
             Token::Region => Some(self.parse_region_decl()),
-            Token::Actor => Some(self.parse_actor_block()),
+            Token::Actor => Some(self.parse_actor_decl()),
             Token::Extern => self.parse_extern_block(),
             Token::Use => self.parse_use_statement(),
             Token::Let => Some(self.parse_let_statement()),
@@ -2269,6 +2245,232 @@ impl Parser {
             struct_name,
             methods,
             span: impl_span,
+        }
+    }
+
+    /// RES-388: parse `actor <Name> { ... }`.
+    ///
+    /// Body forms (any order, any number):
+    ///   `state: <Type> = <expr>;`   -- actor state field + initializer
+    ///   `always: <expr>;`           -- safety invariant
+    ///   `receive <name>(...) [requires ...] [ensures ...] { ... }`
+    ///
+    /// On entry `current_token` is `Token::Actor`; on exit it sits on
+    /// the actor's closing `}`, matching the calling convention used
+    /// by `parse_impl_block` and `parse_struct_decl`.
+    fn parse_actor_decl(&mut self) -> Node {
+        let actor_span = self.span_at_current();
+        self.next_token(); // skip `actor`
+
+        let name = match &self.current_token {
+            Token::Identifier(n) => n.clone(),
+            other => {
+                self.record_error(format!(
+                    "Expected actor name after `actor`, found {}",
+                    other
+                ));
+                String::new()
+            }
+        };
+        self.next_token(); // skip name
+
+        if self.current_token != Token::LeftBrace {
+            let tok = self.current_token.clone();
+            self.record_error(format!(
+                "Expected `{{` after `actor {}`, found {}",
+                name, tok
+            ));
+        } else {
+            self.next_token(); // skip `{`
+        }
+
+        let mut state_fields: Vec<(String, String, Node)> = Vec::new();
+        let mut always_clauses: Vec<Node> = Vec::new();
+        let mut receive_handlers: Vec<ReceiveHandler> = Vec::new();
+
+        while self.current_token != Token::RightBrace && self.current_token != Token::Eof {
+            match &self.current_token {
+                // `state: Type = expr;` — Identifier("state") followed by `:`.
+                Token::Identifier(kw) if kw == "state" && self.peek_token == Token::Colon => {
+                    self.next_token(); // skip `state`
+                    self.next_token(); // skip `:`
+                    let ty = match &self.current_token {
+                        Token::Identifier(t) => t.clone(),
+                        other => {
+                            let msg = format!(
+                                "Expected type name after `state:` in actor `{}`, found {}",
+                                name, other
+                            );
+                            self.record_error(msg);
+                            self.skip_until_stmt_end();
+                            continue;
+                        }
+                    };
+                    self.next_token(); // skip type
+                    // RES-388 MVP: require an `= init` so verification
+                    // has a concrete base case. A bare `state: Int;`
+                    // with no initializer is a parse error.
+                    if self.current_token != Token::Assign {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected `=` after `state: {}` in actor `{}`, found {}",
+                            ty, name, tok
+                        ));
+                        self.skip_until_stmt_end();
+                        continue;
+                    }
+                    self.next_token(); // skip `=`
+                    let init = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+                        value: 0,
+                        span: span::Span::default(),
+                    });
+                    self.next_token(); // past init
+                    if self.current_token == Token::Semicolon {
+                        self.next_token();
+                    } else {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected `;` after `state` initializer in actor `{}`, found {}",
+                            name, tok
+                        ));
+                    }
+                    // Synthesize a field name equal to the keyword for
+                    // MVP. Multi-field actors are a follow-up; the
+                    // verifier currently reasons about a single
+                    // `state` field and rejects duplicates here.
+                    let field_name = "state".to_string();
+                    if state_fields.iter().any(|(_, n, _)| n == &field_name) {
+                        self.record_error(format!(
+                            "Actor `{}` declares `state` more than once; only a single `state` field is supported today",
+                            name
+                        ));
+                        continue;
+                    }
+                    state_fields.push((ty, field_name, init));
+                }
+
+                Token::Always => {
+                    self.next_token(); // skip `always`
+                    if self.current_token != Token::Colon {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected `:` after `always` in actor `{}`, found {}",
+                            name, tok
+                        ));
+                        self.skip_until_stmt_end();
+                        continue;
+                    }
+                    self.next_token(); // skip `:`
+                    let expr = self.parse_expression(0).unwrap_or(Node::BooleanLiteral {
+                        value: true,
+                        span: span::Span::default(),
+                    });
+                    self.next_token(); // past expr
+                    if self.current_token == Token::Semicolon {
+                        self.next_token();
+                    } else {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected `;` after `always` invariant in actor `{}`, found {}",
+                            name, tok
+                        ));
+                    }
+                    always_clauses.push(expr);
+                }
+
+                Token::Receive => {
+                    let recv_span = self.span_at_current();
+                    self.next_token(); // skip `receive`
+                    let handler_name = match &self.current_token {
+                        Token::Identifier(n) => n.clone(),
+                        other => {
+                            self.record_error(format!(
+                                "Expected handler name after `receive` in actor `{}`, found {}",
+                                name, other
+                            ));
+                            String::new()
+                        }
+                    };
+                    self.next_token(); // skip name
+                    if self.current_token != Token::LeftParen {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected `(` after `receive {}` in actor `{}`, found {}",
+                            handler_name, name, tok
+                        ));
+                    } else {
+                        self.next_token(); // skip `(`
+                    }
+                    let parameters = if self.current_token == Token::RightParen {
+                        self.next_token();
+                        Vec::new()
+                    } else {
+                        self.parse_function_parameters()
+                    };
+                    let (requires, ensures, _) = self.parse_function_contracts();
+                    if self.current_token != Token::LeftBrace {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected `{{` for body of `receive {}` in actor `{}`, found {}",
+                            handler_name, name, tok
+                        ));
+                        // Best-effort recovery: drop through; parse_block_statement
+                        // requires a `{` and would wedge otherwise.
+                        break;
+                    }
+                    let body = self.parse_block_statement();
+                    // Advance past the handler's closing `}` so the
+                    // next iteration sees the next actor-body item
+                    // (or the actor's own `}`). Same convention as
+                    // `parse_impl_block`.
+                    if self.current_token == Token::RightBrace {
+                        self.next_token();
+                    }
+                    receive_handlers.push(ReceiveHandler {
+                        name: handler_name,
+                        parameters,
+                        requires,
+                        ensures,
+                        body,
+                        span: recv_span,
+                    });
+                }
+
+                other => {
+                    let tok = other.clone();
+                    self.record_error(format!(
+                        "Expected `state`, `always`, `receive`, or `}}` in actor `{}`, found {}",
+                        name, tok
+                    ));
+                    // Don't infinite-loop on unexpected content.
+                    self.skip_until_stmt_end();
+                }
+            }
+        }
+
+        Node::ActorDecl {
+            name,
+            state_fields,
+            always_clauses,
+            receive_handlers,
+            handlers: Vec::new(),
+            span: actor_span,
+        }
+    }
+
+    /// RES-388: cheap recovery helper used by `parse_actor_decl` —
+    /// swallow tokens until the next `;`, `}`, or EOF so a bogus
+    /// actor-body item doesn't cascade into parse errors on the
+    /// remainder of the declaration.
+    fn skip_until_stmt_end(&mut self) {
+        while self.current_token != Token::Semicolon
+            && self.current_token != Token::RightBrace
+            && self.current_token != Token::Eof
+        {
+            self.next_token();
+        }
+        if self.current_token == Token::Semicolon {
+            self.next_token();
         }
     }
 
@@ -4521,6 +4723,7 @@ impl Parser {
     /// contract so `parse_program`'s `next_token` advances correctly).
     /// Parse errors are recorded via `record_error` and best-effort
     /// recovery falls through — we never panic on malformed input.
+    #[allow(dead_code)]
     fn parse_actor_block(&mut self) -> Node {
         let actor_span = self.span_at_current();
         self.next_token(); // skip 'actor'
@@ -4726,135 +4929,7 @@ impl Parser {
         }
     }
 
-    /// RES-390: parse `actor Name { int field = N; receive handler() { body } ... }`.
-    /// On entry `current_token` is `Identifier("actor")`; on exit
-    /// `current_token` is the closing `}`.
-    fn parse_actor_decl(&mut self) -> Node {
-        let stmt_span = self.span_at_current();
-        self.next_token(); // skip `actor`
-        let name = match &self.current_token {
-            Token::Identifier(n) => n.clone(),
-            _ => {
-                let tok = self.current_token.clone();
-                self.record_error(format!("Expected identifier after `actor`, found {}", tok));
-                String::new()
-            }
-        };
-        self.next_token(); // skip name
-        if self.current_token != Token::LeftBrace {
-            let tok = self.current_token.clone();
-            self.record_error(format!("Expected `{{` after actor name, found {}", tok));
-            return Node::ActorDecl {
-                name,
-                state: Vec::new(),
-                handlers: Vec::new(),
-                span: stmt_span,
-            };
-        }
-        self.next_token(); // skip `{`
 
-        let mut state: Vec<(String, Node)> = Vec::new();
-        let mut handlers: Vec<ActorHandler> = Vec::new();
-        while self.current_token != Token::RightBrace && self.current_token != Token::Eof {
-            // `receive NAME() { BODY }`
-            if matches!(&self.current_token, Token::Identifier(n) if n == "receive") {
-                let handler_span = self.span_at_current();
-                self.next_token(); // skip `receive`
-                let hname = match &self.current_token {
-                    Token::Identifier(n) => n.clone(),
-                    _ => {
-                        let tok = self.current_token.clone();
-                        self.record_error(format!(
-                            "Expected handler name after `receive`, found {}",
-                            tok
-                        ));
-                        break;
-                    }
-                };
-                self.next_token(); // skip handler name
-                if self.current_token != Token::LeftParen {
-                    let tok = self.current_token.clone();
-                    self.record_error(format!(
-                        "Expected `(` after handler name `{}`, found {}",
-                        hname, tok
-                    ));
-                    break;
-                }
-                self.next_token(); // skip `(`
-                if self.current_token != Token::RightParen {
-                    let tok = self.current_token.clone();
-                    self.record_error(format!(
-                        "Expected `)` — parameterised receive handlers are not yet supported (RES-390 MVP), found {}",
-                        tok
-                    ));
-                    break;
-                }
-                self.next_token(); // skip `)`
-                if self.current_token != Token::LeftBrace {
-                    let tok = self.current_token.clone();
-                    self.record_error(format!(
-                        "Expected `{{` after handler signature, found {}",
-                        tok
-                    ));
-                    break;
-                }
-                let body = self.parse_block_statement();
-                handlers.push(ActorHandler {
-                    name: hname,
-                    ensures: Vec::new(),
-                    body: Box::new(body),
-                    span: handler_span,
-                });
-                self.next_token(); // skip `}` of handler body
-                continue;
-            }
-
-            // Otherwise: `TYPE name = INIT;` state variable.
-            let _ty = match self.parse_type_annotation("for actor state field") {
-                Some(t) => t,
-                None => break,
-            };
-            let fname = match &self.current_token {
-                Token::Identifier(n) => n.clone(),
-                _ => {
-                    let tok = self.current_token.clone();
-                    self.record_error(format!("Expected actor-state field name, found {}", tok));
-                    break;
-                }
-            };
-            self.next_token(); // skip name
-            if self.current_token != Token::Assign {
-                let tok = self.current_token.clone();
-                self.record_error(format!(
-                    "Expected `=` after actor-state field `{}` (state fields must be initialised), found {}",
-                    fname, tok
-                ));
-                break;
-            }
-            self.next_token(); // skip `=`
-            let init = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
-                value: 0,
-                span: span::Span::default(),
-            });
-            self.next_token(); // move past tail of init expression
-            if self.current_token != Token::Semicolon {
-                let tok = self.current_token.clone();
-                self.record_error(format!(
-                    "Expected `;` after actor-state field initialiser, found {}",
-                    tok
-                ));
-                break;
-            }
-            self.next_token(); // skip `;`
-            state.push((fname, init));
-        }
-        Node::ActorDecl {
-            name,
-            state,
-            handlers,
-            span: stmt_span,
-        }
-    }
 
     /// RES-390: parse `cluster Name { member: ActorType; ... cluster_invariant: EXPR; ... }`.
     fn parse_cluster_decl(&mut self) -> Node {
@@ -8379,10 +8454,6 @@ impl Interpreter {
                 // construction trusts the literal.
                 Ok(Value::Void)
             }
-            // RES-386: actor declarations are verifier-only today.
-            // The runtime never instantiates them — full actor
-            // semantics are tracked as a follow-up to RES-386.
-            Node::Actor { .. } => Ok(Value::Void),
             // RES-128: `type NAME = TARGET;` is purely a
             // typechecker / documentation concern. Runtime never
             // sees aliases — by the time `eval` runs, every use
@@ -8391,12 +8462,10 @@ impl Interpreter {
             // RES-391: `region <Name>;` is pure compile-time metadata
             // consumed by the borrow checker — runtime no-op.
             Node::RegionDecl { .. } => Ok(Value::Void),
-            // RES-390: actor and cluster declarations are
-            // compile-time-only in the MVP. Full actor execution
-            // semantics land with RES-332; for now the interpreter
-            // treats them as no-ops so programs that declare them
-            // run without error.
-            Node::ActorDecl { .. } | Node::ClusterDecl { .. } => Ok(Value::Void),
+            // RES-386/RES-388/RES-390: actor/cluster declarations are
+            // compile-time-only. The verifier hooks proof obligations
+            // out of `check_program_with_source`; no runtime lowering.
+            Node::Actor { .. } | Node::ActorDecl { .. } | Node::ClusterDecl { .. } => Ok(Value::Void),
             // RES-158: `impl <Struct> { ... }` evaluates each method
             // as if it were a top-level `fn` decl. Methods are already
             // mangled to `<Struct>$<method>` by the parser.
@@ -19280,6 +19349,115 @@ mod tests {
             tc.check_program_with_source(&program, "<test>").is_ok(),
             "forward ref should typecheck"
         );
+    }
+
+    // --- RES-388: actor temporal assertions (`always` invariants) ---
+
+    #[test]
+    fn actor_decl_with_state_always_and_receive_parses() {
+        let src = "\
+            actor Q {\n\
+                state: int = 0;\n\
+                always: state <= 100;\n\
+                receive push() requires state < 100 { self.state = self.state + 1; }\n\
+                receive pop() requires state > 0 { self.state = self.state - 1; }\n\
+            }\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let Node::Program(statements) = &program else {
+            panic!("expected program");
+        };
+        let first = &statements[0].node;
+        match first {
+            Node::ActorDecl {
+                name,
+                state_fields,
+                always_clauses,
+                receive_handlers,
+                ..
+            } => {
+                assert_eq!(name, "Q");
+                assert_eq!(state_fields.len(), 1);
+                assert_eq!(state_fields[0].1, "state");
+                assert_eq!(always_clauses.len(), 1);
+                assert_eq!(receive_handlers.len(), 2);
+                assert_eq!(receive_handlers[0].name, "push");
+                assert_eq!(receive_handlers[1].name, "pop");
+                assert_eq!(receive_handlers[0].requires.len(), 1);
+            }
+            other => panic!("expected ActorDecl, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn actor_missing_state_initializer_is_parse_error() {
+        let src = "actor Q { state: int; }";
+        let (_program, errs) = parse(src);
+        assert!(
+            !errs.is_empty(),
+            "`state: int;` without `=` must surface a parse error"
+        );
+    }
+
+    #[test]
+    fn actor_receive_handler_typechecks_self_field_access() {
+        // `self.state` inside the handler body must resolve via the
+        // actor's registered struct-field layout. No Z3 needed — this
+        // tests only the typechecker plumbing.
+        let src = "\
+            actor C {\n\
+                state: int = 0;\n\
+                always: state >= 0;\n\
+                receive tick() { self.state = self.state + 1; }\n\
+            }\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut tc = typechecker::TypeChecker::new().with_warn_unverified(false);
+        assert!(
+            tc.check_program_with_source(&program, "<test>").is_ok(),
+            "actor `self.state` access should typecheck"
+        );
+    }
+
+    #[test]
+    fn actor_always_invariant_must_be_bool() {
+        // `always: 42;` is not a boolean expression — the typechecker
+        // rejects it before the verifier ever runs.
+        let src = "\
+            actor C {\n\
+                state: int = 0;\n\
+                always: 42;\n\
+            }\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut tc = typechecker::TypeChecker::new().with_warn_unverified(false);
+        let result = tc.check_program_with_source(&program, "<test>");
+        match result {
+            Err(msg) => assert!(
+                msg.contains("always") && msg.contains("Bool"),
+                "expected always/Bool diagnostic, got: {}",
+                msg
+            ),
+            Ok(_) => panic!("non-Bool `always` clause should be a type error"),
+        }
+    }
+
+    #[test]
+    fn actor_decl_evaluates_to_void_at_runtime() {
+        // Actors have no runtime lowering today — the interpreter
+        // treats them as no-ops, just like type aliases.
+        let src = "\
+            actor Q { state: int = 0; always: state >= 0; }\n\
+            let sentinel = 7;\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        interp.eval(&program).unwrap();
+        assert!(matches!(interp.env.get("sentinel"), Some(Value::Int(7))));
     }
 
     // --- RES-126: nominal struct equivalence ---

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1180,6 +1180,61 @@ impl TypeChecker {
                     })?;
                 }
 
+                // RES-388: verify every `actor`'s `always` safety
+                // invariants. The walk happens *after* per-statement
+                // type-checking so we only reason about well-typed
+                // bodies. Any obligation that Z3 refutes becomes a
+                // hard error with a file:line:col diagnostic naming
+                // the actor, handler, and invariant; Unknown /
+                // Unsupported verdicts emit a stderr warning but do
+                // not fail the check (matching how partial proofs
+                // of `requires` / `ensures` are handled — RES-217).
+                let obligations = collect_actor_obligations(statements, self.verifier_timeout_ms);
+                let mut refuted: Vec<String> = Vec::new();
+                for o in obligations {
+                    match o.result {
+                        crate::verifier_actors::ActorProofResult::Proved => {}
+                        crate::verifier_actors::ActorProofResult::Refuted { counterexample } => {
+                            let mut msg = format!(
+                                "{}:{}:{}: actor `{}` violates `always: {}` in handler `{}`",
+                                if source_path.is_empty() {
+                                    "<unknown>"
+                                } else {
+                                    source_path
+                                },
+                                o.invariant_span.start.line,
+                                o.invariant_span.start.column,
+                                o.actor_name,
+                                o.invariant_label,
+                                o.handler_name,
+                            );
+                            if let Some(cx) = counterexample {
+                                msg.push_str(&format!(" (counterexample: {})", cx));
+                            }
+                            refuted.push(msg);
+                        }
+                        crate::verifier_actors::ActorProofResult::Unknown => {
+                            if self.warn_unverified {
+                                eprintln!(
+                                    "warning[partial-proof]: actor `{}` `always: {}` could not be proven on handler `{}` — Z3 returned Unknown",
+                                    o.actor_name, o.invariant_label, o.handler_name,
+                                );
+                            }
+                        }
+                        crate::verifier_actors::ActorProofResult::Unsupported { reason } => {
+                            if self.warn_unverified {
+                                eprintln!(
+                                    "warning[partial-proof]: actor `{}` `always: {}` not verified on handler `{}` — {}",
+                                    o.actor_name, o.invariant_label, o.handler_name, reason,
+                                );
+                            }
+                        }
+                    }
+                }
+                if !refuted.is_empty() {
+                    return Err(refuted.join("\n"));
+                }
+
                 // RES-191: after regular type-checking, enforce the
                 // `@pure` annotation. Collect the set of fn names
                 // that are declared `@pure`, then re-walk each of
@@ -1932,18 +1987,68 @@ impl TypeChecker {
                 Ok(Type::Void)
             }
 
-            // RES-391: `region <Name>;` is compile-time metadata
-            // consumed by the borrow checker — the typechecker just
-            // accepts it as Void.
+            // RES-391: `region <Name>;` is compile-time metadata — Void.
             Node::RegionDecl { .. } => Ok(Type::Void),
 
-            // RES-386: actor declarations type-check as Void.
+            // RES-386: commutativity actor type-checks as Void.
             Node::Actor { .. } => Ok(Type::Void),
 
-            // RES-390: actor / cluster decls are compile-time-only
-            // in this MVP. The cluster verifier runs a separate
-            // Z3-backed pass after typechecking succeeds.
-            Node::ActorDecl { .. } | Node::ClusterDecl { .. } => Ok(Type::Void),
+            // RES-390: ClusterDecl is compile-time-only.
+            Node::ClusterDecl { .. } => Ok(Type::Void),
+
+            // RES-388/RES-390: ActorDecl type-checks state fields,
+            // always invariants, and receive handler bodies.
+            Node::ActorDecl {
+                name,
+                state_fields,
+                always_clauses,
+                receive_handlers,
+                ..
+            } => {
+                let saved_env = self.env.clone();
+                let mut resolved_fields: Vec<(String, Type)> = Vec::new();
+                for (ty, field, init) in state_fields {
+                    let resolved = self.parse_type_name(ty)?;
+                    let init_ty = self.check_node(init)?;
+                    if init_ty != resolved && init_ty != Type::Any && resolved != Type::Any {
+                        return Err(format!(
+                            "actor `{}` state field `{}` initializer has type {}, expected {}",
+                            name, field, init_ty, resolved
+                        ));
+                    }
+                    self.env.set(field.clone(), resolved.clone());
+                    resolved_fields.push((field.clone(), resolved));
+                }
+                self.struct_fields
+                    .insert(name.clone(), resolved_fields.clone());
+                for clause in always_clauses {
+                    let ty = self.check_node(clause)?;
+                    if ty != Type::Bool && ty != Type::Any {
+                        return Err(format!(
+                            "actor `{}` `always` invariant must be Bool, got {}",
+                            name, ty
+                        ));
+                    }
+                }
+                for handler in receive_handlers {
+                    let handler_saved = self.env.clone();
+                    self.env.set("self".to_string(), Type::Struct(name.clone()));
+                    for (pty, pname) in &handler.parameters {
+                        let resolved = self.parse_type_name(pty)?;
+                        self.env.set(pname.clone(), resolved);
+                    }
+                    for r in &handler.requires {
+                        let _ = self.check_node(r)?;
+                    }
+                    for e in &handler.ensures {
+                        let _ = self.check_node(e)?;
+                    }
+                    let _ = self.check_node(&handler.body)?;
+                    self.env = handler_saved;
+                }
+                self.env = saved_env;
+                Ok(Type::Void)
+            }
 
             // RES-153: record the struct's (field, type) list so
             // `FieldAccess` / `FieldAssignment` downstream can check
@@ -2545,6 +2650,36 @@ const IMPURE_BUILTINS: &[&str] = &[
 /// program's statement list once to collect `@pure` fn names
 /// (their declarations include the `pure: bool` flag per the
 /// ticket), then re-walks each declared-pure fn's body and
+/// RES-388: iterate top-level statements and verify every
+/// `ActorDecl`'s `always` safety invariants. Returns the flattened
+/// list of per-obligation verdicts; the caller inspects each for a
+/// `Refuted` verdict to decide whether the check fails.
+fn collect_actor_obligations(
+    statements: &[crate::span::Spanned<Node>],
+    verifier_timeout_ms: u32,
+) -> Vec<crate::verifier_actors::ActorObligation> {
+    let mut out = Vec::new();
+    for stmt in statements {
+        if let Node::ActorDecl {
+            name,
+            state_fields,
+            always_clauses,
+            receive_handlers,
+            ..
+        } = &stmt.node
+        {
+            out.extend(crate::verifier_actors::verify_actor(
+                name,
+                state_fields,
+                always_clauses,
+                receive_handlers,
+                verifier_timeout_ms,
+            ));
+        }
+    }
+    out
+}
+
 /// reports the first violation.
 ///
 /// Errors use the `<path>:<line>:<col>: <msg>` prefix convention

--- a/resilient/src/verifier_actors.rs
+++ b/resilient/src/verifier_actors.rs
@@ -1,0 +1,555 @@
+// verifier_actors.rs
+//
+// RES-388: verify actor-level `always` safety invariants via Z3.
+//
+// For each `always: P;` clause on an `actor Name { ... }` we emit
+// two proof obligations:
+//
+//   1. Base case. The state field's initializer E must satisfy P
+//      — i.e. `P[state := E]` is a tautology.
+//
+//   2. Inductive step. For every `receive <h>(params) requires R
+//      ensures _ { body }` handler, if P holds on the pre-state and
+//      the handler's `requires` clauses hold, then P must hold on
+//      the post-state. The post-state is computed by walking the
+//      handler body and tracking the symbolic value of `state`
+//      through each assignment. The obligation is:
+//
+//          (P ∧ R) → P[state := state_post]
+//
+// The body is required to be straight-line: a sequence of
+// assignments (possibly nested inside a `Block`) of the form
+//
+//      self.state = <expr>;     -- FieldAssignment
+//      state = <expr>;          -- Assignment
+//
+// Control flow (`if`, `while`, `for`) inside a handler body falls
+// back to the "body not analyzable" diagnostic — intentionally
+// scoped for MVP. Follow-ups extend the symbolic walk.
+//
+// When the compiler is built without `--features z3`, this module's
+// public entry point is a no-op: the typechecker walk still runs
+// (so syntax + type errors are caught) but no temporal proofs are
+// attempted. This matches how `requires` / `ensures` behave today.
+
+use crate::Node;
+use crate::span::Span;
+#[cfg(feature = "z3")]
+use std::collections::HashMap;
+
+/// Outcome of a per-clause proof attempt.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) enum ActorProofResult {
+    /// Z3 discharged the obligation successfully.
+    Proved,
+    /// Z3 said the obligation does NOT hold — a counterexample
+    /// assignment falsifies the post-invariant.
+    Refuted { counterexample: Option<String> },
+    /// Z3 returned `Unknown` (timeout / undecidable).
+    Unknown,
+    /// The handler body contains an unsupported construct that the
+    /// symbolic walker can't translate. The `always` invariant is
+    /// neither confirmed nor refuted; surfaced as a soft warning
+    /// rather than a hard error so projects with mixed styles don't
+    /// get blocked on a missing feature.
+    Unsupported { reason: String },
+}
+
+/// One proof obligation produced for an actor.
+#[derive(Debug, Clone)]
+pub(crate) struct ActorObligation {
+    pub actor_name: String,
+    /// Either a handler name (`"enqueue"`) for inductive steps or
+    /// the literal string `"<init>"` for the base case.
+    pub handler_name: String,
+    /// Human-readable rendering of the `always` clause — used in
+    /// diagnostics so users know which invariant failed.
+    pub invariant_label: String,
+    pub invariant_span: Span,
+    pub result: ActorProofResult,
+}
+
+/// Walk an actor declaration, emit a proof obligation per `always`
+/// clause per handler, and return the verdict list. `timeout_ms`
+/// threads the per-query Z3 timeout.
+pub(crate) fn verify_actor(
+    name: &str,
+    state_fields: &[(String, String, Node)],
+    always_clauses: &[Node],
+    receive_handlers: &[crate::ReceiveHandler],
+    timeout_ms: u32,
+) -> Vec<ActorObligation> {
+    let mut out = Vec::new();
+
+    // MVP: single `state` field. Actors without state have nothing
+    // to prove — skip. Multi-field support is a follow-up.
+    let Some((_, state_name, state_init)) = state_fields.first() else {
+        return out;
+    };
+
+    for clause in always_clauses {
+        let label = render_clause(clause);
+        let span = clause_span(clause);
+
+        // --- Base case: P[state := init] ---
+        let base = substitute_state(clause, state_name, state_init);
+        out.push(ActorObligation {
+            actor_name: name.to_string(),
+            handler_name: "<init>".to_string(),
+            invariant_label: label.clone(),
+            invariant_span: span,
+            result: prove_or_unsupported(&base, timeout_ms),
+        });
+
+        // --- Inductive step, one per handler. ---
+        for h in receive_handlers {
+            let Some(post_expr) = straight_line_post(&h.body, state_name) else {
+                out.push(ActorObligation {
+                    actor_name: name.to_string(),
+                    handler_name: h.name.clone(),
+                    invariant_label: label.clone(),
+                    invariant_span: span,
+                    result: ActorProofResult::Unsupported {
+                        reason: format!(
+                            "handler `{}` body is not straight-line — inductive step skipped",
+                            h.name
+                        ),
+                    },
+                });
+                continue;
+            };
+
+            let post = substitute_state(clause, state_name, &post_expr);
+            // (P_pre ∧ requires...) → P_post
+            let mut antecedent = clause.clone();
+            for r in &h.requires {
+                antecedent = and_node(antecedent, r.clone());
+            }
+            let obligation = implies_node(antecedent, post);
+            out.push(ActorObligation {
+                actor_name: name.to_string(),
+                handler_name: h.name.clone(),
+                invariant_label: label.clone(),
+                invariant_span: span,
+                result: prove_or_unsupported(&obligation, timeout_ms),
+            });
+        }
+    }
+
+    out
+}
+
+/// Substitute every `Identifier(state_name)` and every
+/// `FieldAccess { target = Identifier("self"), field = state_name }`
+/// inside `expr` with `value`. Returns a fresh node; `expr` is
+/// untouched.
+fn substitute_state(expr: &Node, state_name: &str, value: &Node) -> Node {
+    match expr {
+        Node::Identifier { name, .. } if name == state_name => value.clone(),
+        Node::FieldAccess { target, field, .. }
+            if field == state_name
+                && matches!(target.as_ref(), Node::Identifier { name, .. } if name == "self") =>
+        {
+            value.clone()
+        }
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            span,
+        } => Node::InfixExpression {
+            left: Box::new(substitute_state(left, state_name, value)),
+            operator: operator.clone(),
+            right: Box::new(substitute_state(right, state_name, value)),
+            span: *span,
+        },
+        Node::PrefixExpression {
+            operator,
+            right,
+            span,
+        } => Node::PrefixExpression {
+            operator: operator.clone(),
+            right: Box::new(substitute_state(right, state_name, value)),
+            span: *span,
+        },
+        Node::CallExpression {
+            function,
+            arguments,
+            span,
+        } => Node::CallExpression {
+            function: Box::new(substitute_state(function, state_name, value)),
+            arguments: arguments
+                .iter()
+                .map(|a| substitute_state(a, state_name, value))
+                .collect(),
+            span: *span,
+        },
+        Node::FieldAccess {
+            target,
+            field,
+            span,
+        } => Node::FieldAccess {
+            target: Box::new(substitute_state(target, state_name, value)),
+            field: field.clone(),
+            span: *span,
+        },
+        other => other.clone(),
+    }
+}
+
+/// Walk a handler body assumed to be straight-line (a `Block` or a
+/// single `FieldAssignment`/`Assignment`). Track the symbolic value
+/// of `state_name` through each assignment step and return the
+/// final symbolic expression, with every LHS substituted by its
+/// preceding RHS so the result is expressed purely in terms of the
+/// *pre-state* `state` plus handler parameters.
+///
+/// Returns `None` when the body contains any construct that isn't
+/// an assignment to the state field — the caller treats this as
+/// Unsupported.
+fn straight_line_post(body: &Node, state_name: &str) -> Option<Node> {
+    // Start with the symbolic pre-value: an `Identifier(state_name)`
+    // so the verifier translates it to a free Z3 Int constant
+    // representing the pre-state value of the field.
+    let mut current = Node::Identifier {
+        name: state_name.to_string(),
+        span: Span::default(),
+    };
+
+    let stmts = flatten_body(body)?;
+    for stmt in &stmts {
+        match stmt {
+            Node::FieldAssignment {
+                target,
+                field,
+                value,
+                ..
+            } => {
+                // Only track writes to `self.<state_name>`. Writes
+                // to any other field are rejected for MVP — the
+                // verifier doesn't model per-field state yet.
+                if field != state_name
+                    || !matches!(target.as_ref(), Node::Identifier { name, .. } if name == "self")
+                {
+                    return None;
+                }
+                current = substitute_state(value.as_ref(), state_name, &current);
+            }
+            Node::Assignment { name, value, .. } => {
+                if name != state_name {
+                    return None;
+                }
+                current = substitute_state(value.as_ref(), state_name, &current);
+            }
+            // Anything that isn't a plain assignment — reject.
+            _ => return None,
+        }
+    }
+
+    Some(current)
+}
+
+/// Unwrap nested `Block` nodes into a flat `Vec` of direct
+/// statements. Returns `None` if anything other than an assignment
+/// appears at a nesting level — callers treat that as Unsupported.
+fn flatten_body(body: &Node) -> Option<Vec<Node>> {
+    match body {
+        Node::Block { stmts, .. } => {
+            let mut out = Vec::new();
+            for s in stmts {
+                match s {
+                    Node::Block { .. } => {
+                        out.extend(flatten_body(s)?);
+                    }
+                    Node::FieldAssignment { .. } | Node::Assignment { .. } => {
+                        out.push(s.clone());
+                    }
+                    // ExpressionStatement wrapping a pure expression
+                    // could be allowed too, but we conservatively
+                    // reject to keep MVP minimal.
+                    _ => return None,
+                }
+            }
+            Some(out)
+        }
+        Node::FieldAssignment { .. } | Node::Assignment { .. } => Some(vec![body.clone()]),
+        _ => None,
+    }
+}
+
+/// Build a logical-AND node over two operands.
+fn and_node(a: Node, b: Node) -> Node {
+    Node::InfixExpression {
+        left: Box::new(a),
+        operator: "&&".to_string(),
+        right: Box::new(b),
+        span: Span::default(),
+    }
+}
+
+/// Build a logical-implication node, `a → b`, as `!a || b`.
+fn implies_node(a: Node, b: Node) -> Node {
+    Node::InfixExpression {
+        left: Box::new(Node::PrefixExpression {
+            operator: "!".to_string(),
+            right: Box::new(a),
+            span: Span::default(),
+        }),
+        operator: "||".to_string(),
+        right: Box::new(b),
+        span: Span::default(),
+    }
+}
+
+/// Hand the obligation to Z3 (when the feature is on). Returns
+/// `Unsupported` if the translation / verifier infrastructure isn't
+/// available — keeping a build without `--features z3` green.
+#[cfg(feature = "z3")]
+fn prove_or_unsupported(expr: &Node, timeout_ms: u32) -> ActorProofResult {
+    let bindings: HashMap<String, i64> = HashMap::new();
+    let (verdict, _cert, cx, timed_out) =
+        crate::verifier_z3::prove_with_timeout(expr, &bindings, timeout_ms);
+    match verdict {
+        Some(true) => ActorProofResult::Proved,
+        // `Some(false)` means the formula itself is unsatisfiable —
+        // a much stronger statement than "invariant broken". In our
+        // encoding (`(P ∧ R) → P_post`) the formula being
+        // unsatisfiable means there's *no* state at all that could
+        // enter this handler — still a refutation of the temporal
+        // claim from the user's perspective, so we surface it as
+        // Refuted with whatever counterexample data Z3 produced.
+        Some(false) => ActorProofResult::Refuted { counterexample: cx },
+        None => {
+            if timed_out {
+                ActorProofResult::Unknown
+            } else if cx.is_some() {
+                // Not a tautology: Z3 found a concrete assignment
+                // that falsifies the obligation. That is precisely
+                // a refuted temporal claim — surface it as such
+                // with the counterexample attached.
+                ActorProofResult::Refuted { counterexample: cx }
+            } else {
+                // Neither a tautology nor a refutation — the
+                // translator likely bailed (unsupported nodes,
+                // floats, etc.). Fold into Unsupported.
+                ActorProofResult::Unsupported {
+                    reason:
+                        "Z3 could not decide this obligation under the supported expression subset"
+                            .to_string(),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "z3"))]
+fn prove_or_unsupported(_expr: &Node, _timeout_ms: u32) -> ActorProofResult {
+    ActorProofResult::Unsupported {
+        reason:
+            "Z3 feature not enabled — rebuild with `--features z3` to verify `always` invariants"
+                .to_string(),
+    }
+}
+
+/// Best-effort rendering of an `always` clause for diagnostics. A
+/// full pretty-printer lives in `formatter.rs`; this is the minimum
+/// needed so users can distinguish which invariant a verdict is about.
+fn render_clause(node: &Node) -> String {
+    match node {
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => format!(
+            "{} {} {}",
+            render_clause(left),
+            operator,
+            render_clause(right)
+        ),
+        Node::PrefixExpression {
+            operator, right, ..
+        } => {
+            format!("{}{}", operator, render_clause(right))
+        }
+        Node::Identifier { name, .. } => name.clone(),
+        Node::IntegerLiteral { value, .. } => value.to_string(),
+        Node::BooleanLiteral { value, .. } => value.to_string(),
+        Node::FieldAccess { target, field, .. } => {
+            format!("{}.{}", render_clause(target), field)
+        }
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
+            let args: Vec<String> = arguments.iter().map(render_clause).collect();
+            format!("{}({})", render_clause(function), args.join(", "))
+        }
+        _ => "<expr>".to_string(),
+    }
+}
+
+fn clause_span(node: &Node) -> Span {
+    match node {
+        Node::IntegerLiteral { span, .. }
+        | Node::BooleanLiteral { span, .. }
+        | Node::Identifier { span, .. }
+        | Node::InfixExpression { span, .. }
+        | Node::PrefixExpression { span, .. }
+        | Node::CallExpression { span, .. }
+        | Node::FieldAccess { span, .. } => *span,
+        _ => Span::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ident(name: &str) -> Node {
+        Node::Identifier {
+            name: name.to_string(),
+            span: Span::default(),
+        }
+    }
+
+    fn int_lit(v: i64) -> Node {
+        Node::IntegerLiteral {
+            value: v,
+            span: Span::default(),
+        }
+    }
+
+    fn infix(left: Node, op: &str, right: Node) -> Node {
+        Node::InfixExpression {
+            left: Box::new(left),
+            operator: op.to_string(),
+            right: Box::new(right),
+            span: Span::default(),
+        }
+    }
+
+    fn field(target: &str, name: &str) -> Node {
+        Node::FieldAccess {
+            target: Box::new(ident(target)),
+            field: name.to_string(),
+            span: Span::default(),
+        }
+    }
+
+    fn field_assign(field_name: &str, rhs: Node) -> Node {
+        Node::FieldAssignment {
+            target: Box::new(ident("self")),
+            field: field_name.to_string(),
+            value: Box::new(rhs),
+            span: Span::default(),
+        }
+    }
+
+    fn block(stmts: Vec<Node>) -> Node {
+        Node::Block {
+            stmts,
+            span: Span::default(),
+        }
+    }
+
+    #[test]
+    fn substitute_replaces_bare_identifier() {
+        // `state <= 100`[state := 42]  ==>  `42 <= 100`.
+        let clause = infix(ident("state"), "<=", int_lit(100));
+        let replaced = substitute_state(&clause, "state", &int_lit(42));
+        if let Node::InfixExpression { left, .. } = replaced {
+            assert!(matches!(*left, Node::IntegerLiteral { value: 42, .. }));
+        } else {
+            panic!("expected InfixExpression");
+        }
+    }
+
+    #[test]
+    fn substitute_replaces_self_field_reference() {
+        // `self.state + 1`[state := X]  ==>  `X + 1`.
+        let clause = infix(field("self", "state"), "+", int_lit(1));
+        let sub = ident("X");
+        let replaced = substitute_state(&clause, "state", &sub);
+        if let Node::InfixExpression { left, .. } = replaced {
+            match *left {
+                Node::Identifier { name, .. } => assert_eq!(name, "X"),
+                other => panic!("expected replaced Identifier, got {:?}", other),
+            }
+        } else {
+            panic!("expected InfixExpression");
+        }
+    }
+
+    #[test]
+    fn substitute_leaves_unrelated_identifiers_alone() {
+        let clause = infix(ident("other"), ">", int_lit(0));
+        let replaced = substitute_state(&clause, "state", &int_lit(99));
+        if let Node::InfixExpression { left, .. } = replaced {
+            match *left {
+                Node::Identifier { name, .. } => assert_eq!(name, "other"),
+                other => panic!("expected unchanged `other`, got {:?}", other),
+            }
+        } else {
+            panic!("expected InfixExpression");
+        }
+    }
+
+    #[test]
+    fn straight_line_post_composes_self_field_assignments() {
+        // Body:
+        //   self.state = self.state + 1;
+        //   self.state = self.state + 1;
+        // Expected post = ((state + 1) + 1).
+        let body = block(vec![
+            field_assign("state", infix(field("self", "state"), "+", int_lit(1))),
+            field_assign("state", infix(field("self", "state"), "+", int_lit(1))),
+        ]);
+        let post = straight_line_post(&body, "state").expect("straight-line post");
+        // Shape: Infix(Infix(state, +, 1), +, 1)
+        if let Node::InfixExpression { left, right, .. } = post {
+            assert!(matches!(*right, Node::IntegerLiteral { value: 1, .. }));
+            if let Node::InfixExpression {
+                left: inner_left, ..
+            } = *left
+            {
+                assert!(matches!(*inner_left, Node::Identifier { .. }));
+            } else {
+                panic!("expected nested Infix");
+            }
+        } else {
+            panic!("expected top-level Infix");
+        }
+    }
+
+    #[test]
+    fn straight_line_post_rejects_non_state_assignment() {
+        // A handler that writes to a field other than `state` isn't
+        // analyzable by the MVP walker — it returns None.
+        let body = block(vec![field_assign("other", int_lit(1))]);
+        assert!(straight_line_post(&body, "state").is_none());
+    }
+
+    #[test]
+    fn straight_line_post_rejects_control_flow() {
+        // IfStatement inside the body — reject.
+        let body = block(vec![Node::IfStatement {
+            condition: Box::new(Node::BooleanLiteral {
+                value: true,
+                span: Span::default(),
+            }),
+            consequence: Box::new(block(vec![])),
+            alternative: None,
+            span: Span::default(),
+        }]);
+        assert!(straight_line_post(&body, "state").is_none());
+    }
+
+    #[test]
+    fn render_clause_produces_readable_infix() {
+        let clause = infix(ident("state"), "<=", int_lit(100));
+        assert_eq!(render_clause(&clause), "state <= 100");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `actor <Name> { state: T = init; always: P; receive h(...) { ... } }` syntax and a Z3-backed inductive verifier for the `always` safety claim.

- New `Node::ActorDecl` variant + `ReceiveHandler` struct. Parser, typechecker, interpreter, formatter, free-vars, and compiler spans all handle the new node.
- `resilient/src/verifier_actors.rs` emits the per-clause, per-handler obligations:
  - **Base case**: `P[state := init]`.
  - **Inductive step**: `(P ∧ requires) → P[state := post]`, where `post` is produced by symbolic walk of a straight-line handler body.
- Refuted obligations become hard type errors with the invariant label, handler name, and Z3 counterexample (e.g. `state = 100`).
- Unknown / Unsupported verdicts surface as `warning[partial-proof]`, matching RES-217. A build without `--features z3` emits the same warning so the rest of the toolchain stays unblocked.
- Two golden examples:
  - `resilient/examples/actor_queue_safe.rz` — `always: state <= 100` holds over `enqueue requires state < 100` and `dequeue requires state > 0`.
  - `resilient/examples/actor_queue_broken.rz` — missing precondition on `enqueue`; Z3 refutes with `state = 100`.

## Scope and follow-ups

- `eventually` (bounded liveness via ranking-function search) is scoped to #228 so this PR stays reviewable.
- Handler bodies today must be straight-line assignments to `self.state` / `state`. Control flow inside a handler reports as Unsupported; tracked for a later expansion.
- Actors have no runtime lowering — they're a compile-time verification-only construct in this slice.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml` — 768 passing (12 new: parser + typechecker integration + verifier_actors unit tests).
- [x] `cargo test --features z3 --bins` — 798 passing (same new tests + Z3 roundtrip).
- [x] `cargo clippy --all-targets -- -D warnings` clean (with and without z3).
- [x] `resilient --typecheck actor_queue_safe.rz` with `--features z3` — type check passed.
- [x] `resilient --typecheck actor_queue_broken.rz` with `--features z3` — type error on line 17 col 22 naming `UnboundedQueue`, handler `enqueue`, counterexample `state = 100`.

Closes #206