### PR TITLE
RES-387: try/catch structured failure handlers

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,3 +1,16 @@
 {
-  "claims": {}
+  "claims": {
+    "resilient/src/main.rs": {
+      "branch": "res-224-try-catch",
+      "claimed_at": "2026-04-24T14:24:28Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-224-try-catch",
+      "claimed_at": "2026-04-24T14:24:28Z"
+    },
+    "resilient/src/lexer_logos.rs": {
+      "branch": "res-224-try-catch",
+      "claimed_at": "2026-04-24T14:24:28Z"
+    }
+  }
 }

--- a/resilient/examples/try_catch.expected.txt
+++ b/resilient/examples/try_catch.expected.txt
@@ -1,0 +1,2 @@
+42
+Program executed successfully

--- a/resilient/examples/try_catch.rz
+++ b/resilient/examples/try_catch.rz
@@ -1,0 +1,44 @@
+// RES-224 (RES-387 follow-up) — structured failure handler.
+//
+// The MVP of RES-387 required every `fails` variant to propagate on
+// the caller. This example exercises the OTHER legal option:
+// handling the failure at the call site with a `try { ... } catch V
+// { ... }` block. Once every declared variant is caught, the caller
+// may have an empty `fails` list — the propagation obligation is
+// fully discharged by the handler.
+//
+// Verification points this golden covers:
+//
+//   1. The parser accepts `try { ... } catch Variant { ... }` as a
+//      statement.
+//   2. Each `catch Variant` arm subtracts that variant from the set
+//      the caller would otherwise have to declare on its signature.
+//   3. An exhaustive handler (every callee variant caught) typechecks
+//      in a caller with NO `fails` clause of its own.
+//
+// The MVP fault model does not yet inject runtime Failure values, so
+// the callee returns normally and the handler body is statically-
+// verified but runtime-unreachable. Observed program output is the
+// happy-path result.
+
+fn read_sensor(int addr)
+    requires addr >= 0
+    fails Timeout
+{
+    return addr;
+}
+
+fn caller(int addr) {
+    try {
+        let v = read_sensor(addr);
+        println(v);
+    } catch Timeout {
+        println(-1);
+    }
+}
+
+fn main() {
+    caller(42);
+}
+
+main();

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -769,7 +769,8 @@ fn node_line(n: &Node) -> Option<u32> {
         | Node::Actor { span, .. }
         | Node::ActorDecl { span, .. }
         | Node::ClusterDecl { span, .. }
-        | Node::FunctionLiteral { span, .. } => span.start.line as u32,
+        | Node::FunctionLiteral { span, .. }
+        | Node::TryCatch { span, .. } => span.start.line as u32,
 
         // RES-142: duration literal carries the span of its integer
         // part; only emitted inside live-clause position so it

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -527,6 +527,28 @@ impl Formatter {
                 self.write(";");
                 self.newline();
             }
+            // RES-224: `try { ... } catch V { ... }` structured handler.
+            Node::TryCatch { body, handlers, .. } => {
+                self.write("try {");
+                self.newline();
+                self.indent();
+                for s in body {
+                    self.fmt_stmt(s);
+                }
+                self.dedent();
+                self.write("}");
+                for (variant, handler_body) in handlers {
+                    self.write(&format!(" catch {} {{", variant));
+                    self.newline();
+                    self.indent();
+                    for s in handler_body {
+                        self.fmt_stmt(s);
+                    }
+                    self.dedent();
+                    self.write("}");
+                }
+                self.newline();
+            }
             // FFI v1: extern blocks not yet formatted (Tasks 4-8).
             Node::Extern { .. } => {}
             // Anything else was an expression; dispatch to fmt_expr
@@ -858,6 +880,7 @@ impl Formatter {
             | Node::Use { .. }
             | Node::Extern { .. }
             | Node::LetDestructureStruct { .. }
+            | Node::TryCatch { .. }
             | Node::Program(_) => {
                 self.fmt_stmt(node);
             }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -390,6 +390,23 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
                 truncate_to(bound, snapshot);
             }
         }
+        // RES-224: `try { body } catch V { handler }` — each block
+        // is its own scope, and no variant-level binder is introduced
+        // by the current MVP (payload bindings are a follow-up).
+        Node::TryCatch { body, handlers, .. } => {
+            let snapshot = bound.len();
+            for s in body {
+                walk(s, bound, free);
+            }
+            truncate_to(bound, snapshot);
+            for (_, handler_body) in handlers {
+                let hsnap = bound.len();
+                for s in handler_body {
+                    walk(s, bound, free);
+                }
+                truncate_to(bound, hsnap);
+            }
+        }
     }
 }
 

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -219,6 +219,11 @@ enum Tok {
     ConcurrentEnsures,
     #[token("always")]
     Always,
+    // RES-224 (RES-387 follow-up): structured failure handler keywords.
+    #[token("try")]
+    Try,
+    #[token("catch")]
+    Catch,
     // </EXTENSION_TOKENS>
     #[token("true")]
     True,
@@ -554,6 +559,8 @@ fn convert(t: Tok) -> Token {
         Tok::Receive => Token::Receive,
         Tok::ConcurrentEnsures => Token::ConcurrentEnsures,
         Tok::Always => Token::Always,
+        Tok::Try => Token::Try,
+        Tok::Catch => Token::Catch,
         // </EXTENSION_KEYWORDS>
         Tok::True => Token::BoolLiteral(true),
         Tok::False => Token::BoolLiteral(false),

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -86,6 +86,11 @@ mod ffi_trampolines;
 // pass invoked from the typechecker.
 mod linear;
 
+// RES-224 (RES-387 follow-up): `try { ... } catch V { ... }` structured
+// failure handlers. Holds parser + typechecker logic for the feature;
+// the main module only touches the extension-point blocks.
+mod try_catch;
+
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
 
@@ -172,6 +177,12 @@ enum Token {
     ConcurrentEnsures,
     /// RES-388: actor-level `always: <expr>;` safety invariant.
     Always,
+    /// RES-224 (RES-387 follow-up): `try { ... } catch V { ... }`
+    /// structured failure handler — statement-level keyword.
+    Try,
+    /// RES-224 (RES-387 follow-up): `catch VariantName { ... }` arm
+    /// attached to a `try` block.
+    Catch,
     // </EXTENSION_TOKENS>
 
     // Literals
@@ -295,6 +306,8 @@ impl Token {
             Token::Receive => "`receive`".to_string(),
             Token::ConcurrentEnsures => "`concurrent_ensures`".to_string(),
             Token::Always => "`always`".to_string(),
+            Token::Try => "`try`".to_string(),
+            Token::Catch => "`catch`".to_string(),
             Token::Underscore => "`_`".to_string(),
             Token::Default => "`default`".to_string(),
             Token::Dot => "`.`".to_string(),
@@ -691,6 +704,8 @@ impl Lexer {
                         "receive" => Token::Receive,
                         "concurrent_ensures" => Token::ConcurrentEnsures,
                         "always" => Token::Always,
+                        "try" => Token::Try,
+                        "catch" => Token::Catch,
                         // </EXTENSION_KEYWORDS>
                         "_" => Token::Underscore,
                         // RES-163: `default` is a reserved alias
@@ -1608,6 +1623,23 @@ enum Node {
         #[allow(dead_code)]
         span: span::Span,
     },
+    /// RES-224 (RES-387 follow-up): structured failure handler.
+    ///
+    /// ```text
+    /// try { callee(x); } catch Timeout { recover(); }
+    /// ```
+    ///
+    /// Each `handlers` entry pairs a failure-variant name with the
+    /// handler block's statement list. The typechecker walks `body`
+    /// with the caught variants added to the in-scope `fails` set,
+    /// so a call that declares exactly those variants type-checks
+    /// even when the enclosing fn has an empty `fails` list.
+    TryCatch {
+        #[allow(dead_code)]
+        span: span::Span,
+        body: Vec<Node>,
+        handlers: Vec<(String, Vec<Node>)>,
+    },
 }
 
 /// RES-386/RES-390: one `receive <name>()` handler inside an `actor` block.
@@ -1765,6 +1797,7 @@ impl Parser {
             Token::Type => Some(self.parse_type_alias()),
             Token::Region => Some(self.parse_region_decl()),
             Token::Actor => Some(self.parse_actor_decl()),
+            Token::Try => Some(crate::try_catch::parse(self)),
             Token::Extern => self.parse_extern_block(),
             Token::Use => self.parse_use_statement(),
             Token::Let => Some(self.parse_let_statement()),
@@ -8490,6 +8523,19 @@ impl Interpreter {
             // compile-time-only. The verifier hooks proof obligations
             // out of `check_program_with_source`; no runtime lowering.
             Node::Actor { .. } | Node::ActorDecl { .. } | Node::ClusterDecl { .. } => {
+                Ok(Value::Void)
+            }
+            // RES-224 (RES-387 follow-up): runtime evaluation of
+            // `try { ... } catch V { ... }`. The MVP fault model does
+            // not surface a runtime Failure value yet — `fails` is
+            // statically verified and callees that declare a variant
+            // still return normally — so the handler bodies are
+            // unreachable at execution time. We still walk the body so
+            // any side-effectful statements inside it run.
+            Node::TryCatch { body, .. } => {
+                for stmt in body {
+                    self.eval(stmt)?;
+                }
                 Ok(Value::Void)
             }
             // RES-158: `impl <Struct> { ... }` evaluates each method

--- a/resilient/src/try_catch.rs
+++ b/resilient/src/try_catch.rs
@@ -1,0 +1,483 @@
+//! RES-387 follow-up (RES-224): structured failure handlers.
+//!
+//! The MVP of RES-387 requires every `fails` variant declared on a
+//! callee to be propagated on the caller's own `fails` list. This
+//! module implements the other legal option: handling the failure at
+//! the call site via a `try`/`catch` block.
+//!
+//! Syntax:
+//!
+//! ```text
+//! try {
+//!     callee(x);
+//! } catch Timeout {
+//!     recover();
+//! } catch HardwareFault {
+//!     log_fault();
+//! }
+//! ```
+//!
+//! Each `catch VariantName { ... }` arm subtracts that variant from
+//! the propagation obligation inside the `try` body. A fully-handled
+//! call (every declared failure caught) may appear in a caller with an
+//! empty `fails` set; a partially-handled call still requires the
+//! leftover variants on the caller's signature.
+//!
+//! This file owns:
+//!
+//! - [`parse`]: parser for the `try { ... } catch V { ... }` form.
+//! - [`check`]: top-level program walk that validates each `catch`
+//!   arm names a variant actually emitted inside the `try` body.
+//!
+//! The per-call-site subtraction (the part that makes an otherwise
+//! unhandled variant acceptable) is implemented in the typechecker's
+//! `Node::TryCatch` arm; see [`augmented_fn_fails`].
+//!
+//! Follow-ups tracked separately: binding the caught variant's
+//! payload inside the handler body, and a `catch _` wildcard.
+
+use crate::Node;
+use crate::span::Span;
+
+/// Sentinel inserted in place of a missing variant name when the
+/// parser recovers from a malformed `catch` arm. Nothing in the
+/// compiler ever emits a variant with an empty name, so the
+/// typechecker's "unknown variant" branch will reject it cleanly.
+const MISSING_VARIANT: &str = "";
+
+/// RES-224: parse a `try { ... } catch V { ... } (catch V { ... })*`
+/// statement. On entry, `current_token` must be `Token::Try`; on exit
+/// the parser cursor sits on the closing `}` of the last handler
+/// block (matching how every other block-statement parser leaves the
+/// cursor — the outer `parse_block_statement` advances past it).
+///
+/// The return value is always a `Node::TryCatch`. Parse errors are
+/// accumulated on the parser via `record_error`; on an unrecoverable
+/// error the node still comes out with whatever was parsed so far so
+/// the rest of the program can continue type-checking.
+pub(crate) fn parse(parser: &mut crate::Parser) -> Node {
+    let stmt_span = parser.span_at_current();
+    // Consume `try`.
+    parser.next_token();
+
+    // Parse the try-body. On exit the cursor sits on the closing `}`.
+    // Only advance past it if the next token is `catch` — otherwise
+    // leaving the cursor on `}` keeps us compatible with the outer
+    // dispatch loop's single advance.
+    let body = parse_block(parser, "try");
+    if parser.current_token == crate::Token::RightBrace && parser.peek_token == crate::Token::Catch
+    {
+        parser.next_token();
+    }
+
+    let mut handlers: Vec<(String, Vec<Node>)> = Vec::new();
+    while parser.current_token == crate::Token::Catch {
+        parser.next_token(); // consume `catch`
+        let variant = match &parser.current_token {
+            crate::Token::Identifier(n) => {
+                let name = n.clone();
+                parser.next_token();
+                name
+            }
+            other => {
+                let tok = other.clone();
+                parser.record_error(format!(
+                    "Expected failure-variant identifier after `catch`, found {}",
+                    tok
+                ));
+                MISSING_VARIANT.to_string()
+            }
+        };
+        let handler_body = parse_block(parser, "catch");
+        handlers.push((variant, handler_body));
+        // Peek past this handler's `}` to see if another `catch`
+        // follows. If the next non-trivial token is NOT `catch` we
+        // must NOT advance — leaving the cursor on `}` matches the
+        // convention every other block-statement parser uses, so the
+        // outer dispatch loop in `parse_block_statement` can do its
+        // single `next_token()` without skipping a top-level stmt.
+        if parser.peek_token == crate::Token::Catch {
+            parser.next_token();
+        } else {
+            break;
+        }
+    }
+
+    if handlers.is_empty() {
+        parser.record_error(
+            "`try { ... }` must be followed by at least one `catch VariantName { ... }` arm"
+                .to_string(),
+        );
+    }
+
+    Node::TryCatch {
+        span: stmt_span,
+        body,
+        handlers,
+    }
+}
+
+/// Parse a `{ stmt; stmt; ... }` block and return the inner
+/// statements. Leaves the parser cursor on the closing `}` — matching
+/// `parse_block_statement`'s convention so the dispatch loop in
+/// `parse_block_statement` can advance once to skip it.
+fn parse_block(parser: &mut crate::Parser, context: &str) -> Vec<Node> {
+    if parser.current_token != crate::Token::LeftBrace {
+        let tok = parser.current_token.clone();
+        parser.record_error(format!("Expected '{{' after `{}`, found {}", context, tok));
+        return Vec::new();
+    }
+    let mut stmts: Vec<Node> = Vec::new();
+    parser.next_token(); // skip `{`
+    while parser.current_token != crate::Token::RightBrace
+        && parser.current_token != crate::Token::Eof
+    {
+        if let Some(stmt) = parser.parse_statement() {
+            stmts.push(stmt);
+        }
+        parser.next_token();
+    }
+    stmts
+}
+
+/// Compute the `fails` set in scope for statements nested inside a
+/// `try { ... } catch V { ... }` block. Returns the outer scope's
+/// declared variants plus every variant named by a `catch` arm.
+///
+/// The typechecker swaps its `current_fn_fails` field to this vector
+/// before walking the try-body, so an otherwise-unhandled call inside
+/// the body type-checks as long as the caught variants cover it.
+pub(crate) fn augmented_fn_fails(
+    outer: Option<&Vec<String>>,
+    handlers: &[(String, Vec<Node>)],
+) -> Vec<String> {
+    let mut combined: Vec<String> = outer.cloned().unwrap_or_default();
+    for (variant, _) in handlers {
+        if !combined.iter().any(|v| v == variant) {
+            combined.push(variant.clone());
+        }
+    }
+    combined
+}
+
+/// RES-224 program-level pass. Validates that every `catch` arm
+/// references a failure variant that some callee inside the matching
+/// `try` body actually emits — a `catch Ghost` arm that will never
+/// fire would silently allow a broken propagation obligation, so it's
+/// a hard error.
+///
+/// Walks every top-level fn body (and every nested block / try-catch)
+/// and checks each TryCatch node in-place. Errors carry the
+/// `source_path:line:col: ` prefix the rest of the typechecker uses.
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    let Node::Program(statements) = program else {
+        return Ok(());
+    };
+    // Collect the table of each fn's declared `fails` set so we can
+    // resolve call sites inside try bodies without round-tripping
+    // through the main typechecker.
+    let mut fn_fails: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for stmt in statements {
+        if let Node::Function { name, fails, .. } = &stmt.node {
+            fn_fails.insert(name.clone(), fails.clone());
+        }
+    }
+    for stmt in statements {
+        if let Node::Function { body, .. } = &stmt.node {
+            walk(body, &fn_fails, source_path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Walk an AST subtree and validate every `TryCatch` encountered.
+fn walk(
+    node: &Node,
+    fn_fails: &std::collections::HashMap<String, Vec<String>>,
+    source_path: &str,
+) -> Result<(), String> {
+    match node {
+        Node::TryCatch {
+            span,
+            body,
+            handlers,
+        } => {
+            let emitted = collect_emitted_variants(body, fn_fails);
+            for (variant, handler_body) in handlers {
+                if variant.is_empty() {
+                    // Parser already emitted a recovery diagnostic.
+                    continue;
+                }
+                if !emitted.iter().any(|v| v == variant) {
+                    return Err(format_error(
+                        source_path,
+                        span,
+                        format!(
+                            "`catch {}` arm does not correspond to any failure variant emitted inside the `try` body",
+                            variant
+                        ),
+                    ));
+                }
+                for stmt in handler_body {
+                    walk(stmt, fn_fails, source_path)?;
+                }
+            }
+            for stmt in body {
+                walk(stmt, fn_fails, source_path)?;
+            }
+            Ok(())
+        }
+        Node::Block { stmts, .. } => {
+            for s in stmts {
+                walk(s, fn_fails, source_path)?;
+            }
+            Ok(())
+        }
+        Node::IfStatement {
+            consequence,
+            alternative,
+            ..
+        } => {
+            walk(consequence, fn_fails, source_path)?;
+            if let Some(alt) = alternative {
+                walk(alt, fn_fails, source_path)?;
+            }
+            Ok(())
+        }
+        Node::WhileStatement { body, .. }
+        | Node::ForInStatement { body, .. }
+        | Node::LiveBlock { body, .. } => walk(body, fn_fails, source_path),
+        _ => Ok(()),
+    }
+}
+
+/// Gather the set of failure variants any call inside `body` could
+/// produce, based on the statically-known `fails` declaration of each
+/// callee. Calls to unknown (non-user-declared) functions contribute
+/// nothing — those never carry a `fails` obligation in the current
+/// MVP, so a `catch` arm covering them would always be spurious.
+fn collect_emitted_variants(
+    body: &[Node],
+    fn_fails: &std::collections::HashMap<String, Vec<String>>,
+) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for stmt in body {
+        collect_from_node(stmt, fn_fails, &mut out);
+    }
+    out
+}
+
+fn collect_from_node(
+    node: &Node,
+    fn_fails: &std::collections::HashMap<String, Vec<String>>,
+    out: &mut Vec<String>,
+) {
+    match node {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
+            if let Node::Identifier { name, .. } = function.as_ref()
+                && let Some(variants) = fn_fails.get(name)
+            {
+                for v in variants {
+                    if !out.iter().any(|x| x == v) {
+                        out.push(v.clone());
+                    }
+                }
+            }
+            for arg in arguments {
+                collect_from_node(arg, fn_fails, out);
+            }
+        }
+        Node::ExpressionStatement { expr, .. } => collect_from_node(expr, fn_fails, out),
+        Node::ReturnStatement { value: Some(v), .. } => collect_from_node(v, fn_fails, out),
+        Node::LetStatement { value, .. }
+        | Node::StaticLet { value, .. }
+        | Node::Assignment { value, .. } => collect_from_node(value, fn_fails, out),
+        Node::InfixExpression { left, right, .. } => {
+            collect_from_node(left, fn_fails, out);
+            collect_from_node(right, fn_fails, out);
+        }
+        Node::PrefixExpression { right, .. } => collect_from_node(right, fn_fails, out),
+        Node::Block { stmts, .. } => {
+            for s in stmts {
+                collect_from_node(s, fn_fails, out);
+            }
+        }
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            collect_from_node(condition, fn_fails, out);
+            collect_from_node(consequence, fn_fails, out);
+            if let Some(alt) = alternative {
+                collect_from_node(alt, fn_fails, out);
+            }
+        }
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
+            collect_from_node(condition, fn_fails, out);
+            collect_from_node(body, fn_fails, out);
+        }
+        Node::ForInStatement { iterable, body, .. } => {
+            collect_from_node(iterable, fn_fails, out);
+            collect_from_node(body, fn_fails, out);
+        }
+        Node::TryCatch { body, handlers, .. } => {
+            // Variants caught by inner try/catch do NOT propagate out
+            // — the outer try should not see them unless some other
+            // call in its own body also emits them.
+            let inner_emitted = collect_emitted_variants(body, fn_fails);
+            let caught: std::collections::HashSet<&str> =
+                handlers.iter().map(|(v, _)| v.as_str()).collect();
+            for v in &inner_emitted {
+                if !caught.contains(v.as_str()) && !out.iter().any(|x| x == v) {
+                    out.push(v.clone());
+                }
+            }
+            for (_, hbody) in handlers {
+                for s in hbody {
+                    collect_from_node(s, fn_fails, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Format an error with the usual `source_path:line:col: ` prefix,
+/// matching how the typechecker prefixes its own diagnostics.
+fn format_error(source_path: &str, span: &Span, msg: String) -> String {
+    if span.start.line == 0 {
+        msg
+    } else {
+        format!(
+            "{}:{}:{}: {}",
+            source_path, span.start.line, span.start.column, msg
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse as parse_program;
+    use crate::typechecker::TypeChecker;
+
+    fn check_src(src: &str) -> Result<(), String> {
+        let (prog, errs) = parse_program(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut tc = TypeChecker::new();
+        tc.check_program_with_source(&prog, "<t>").map(|_| ())
+    }
+
+    #[test]
+    fn parser_accepts_single_catch_arm() {
+        let src = "\
+            fn risky(int x) fails Timeout { return x; }\n\
+            fn caller(int y) {\n\
+                try { risky(y); } catch Timeout { return; }\n\
+            }\n";
+        let (prog, errs) = parse_program(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        // Walk down to the TryCatch node and confirm its shape.
+        let mut found = false;
+        if let Node::Program(stmts) = &prog {
+            for stmt in stmts {
+                if let Node::Function { body, .. } = &stmt.node
+                    && let Node::Block { stmts, .. } = body.as_ref()
+                {
+                    for s in stmts {
+                        if let Node::TryCatch { handlers, .. } = s {
+                            assert_eq!(handlers.len(), 1);
+                            assert_eq!(handlers[0].0, "Timeout");
+                            found = true;
+                        }
+                    }
+                }
+            }
+        }
+        assert!(found, "expected a TryCatch node in the parsed program");
+    }
+
+    #[test]
+    fn exhaustive_handler_accepted_with_empty_caller_fails() {
+        // Caller declares no `fails` — the try block fully handles
+        // the callee's single variant.
+        let src = "\
+            fn risky(int x) fails Timeout { return x; }\n\
+            fn caller(int y) {\n\
+                try { risky(y); } catch Timeout { return; }\n\
+            }\n";
+        check_src(src).expect("exhaustive handler should typecheck");
+    }
+
+    #[test]
+    fn partial_handler_requires_leftover_on_caller() {
+        // Callee emits two variants; caller only catches one. The
+        // leftover MUST appear on caller's `fails` list — if it does
+        // not, the unhandled-variant diagnostic must fire.
+        let src_bad = "\
+            fn risky(int x) fails A, B { return x; }\n\
+            fn caller(int y) {\n\
+                try { risky(y); } catch A { return; }\n\
+            }\n";
+        let err = check_src(src_bad).expect_err("partial handler must require leftover");
+        assert!(
+            err.contains("unhandled failure variant B"),
+            "unexpected error: {err}"
+        );
+
+        // With the leftover declared, the caller typechecks.
+        let src_ok = "\
+            fn risky(int x) fails A, B { return x; }\n\
+            fn caller(int y) fails B {\n\
+                try { risky(y); } catch A { return; }\n\
+            }\n";
+        check_src(src_ok).expect("partial handler with leftover must typecheck");
+    }
+
+    #[test]
+    fn unhandled_variant_diagnostic_mentions_catch() {
+        // The plain propagation error (no try/catch in play) must
+        // still point at `catch` as a valid resolution option.
+        let src = "\
+            fn risky(int x) fails Timeout { return x; }\n\
+            fn caller(int y) { return risky(y); }\n";
+        let err = check_src(src).expect_err("unhandled variant must error");
+        assert!(
+            err.contains("catch"),
+            "diagnostic should mention `catch` as a resolution: {err}"
+        );
+    }
+
+    #[test]
+    fn catch_arm_for_unemitted_variant_is_rejected() {
+        // The `try` body emits only `Timeout`, but the handler catches
+        // `Ghost` — a dead arm that would mask a broken propagation
+        // obligation if accepted.
+        let src = "\
+            fn risky(int x) fails Timeout { return x; }\n\
+            fn caller(int y) fails Timeout {\n\
+                try { risky(y); } catch Ghost { return; }\n\
+            }\n";
+        let err = check_src(src).expect_err("dead catch arm must be rejected");
+        assert!(err.contains("`catch Ghost`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn multi_variant_fully_handled() {
+        let src = "\
+            fn risky(int x) fails A, B { return x; }\n\
+            fn caller(int y) {\n\
+                try { risky(y); } catch A { return; } catch B { return; }\n\
+            }\n";
+        check_src(src).expect("exhaustive multi-variant handler should typecheck");
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1254,6 +1254,7 @@ impl TypeChecker {
                 // Add new compiler pass calls here (append-only).
                 // Pattern: crate::your_feature::check(program, source_path)?;
                 // Merge conflicts: keep ALL calls from both sides.
+                crate::try_catch::check(program, source_path)?;
                 // </EXTENSION_PASSES>
 
                 // RES-192: IO-effect inference. Binary lattice
@@ -1996,6 +1997,27 @@ impl TypeChecker {
             // RES-391: `region <Name>;` is compile-time metadata — Void.
             Node::RegionDecl { .. } => Ok(Type::Void),
 
+            // RES-224 (RES-387 follow-up): `try { ... } catch V { ... }`.
+            // Extend the in-scope `fails` set with every caught
+            // variant while type-checking the body, then restore for
+            // the handler bodies (a handler is not inside its own
+            // `catch` scope — it runs once the body already failed).
+            Node::TryCatch { body, handlers, .. } => {
+                let augmented =
+                    crate::try_catch::augmented_fn_fails(self.current_fn_fails.as_ref(), handlers);
+                let saved = self.current_fn_fails.replace(augmented);
+                for stmt in body {
+                    self.check_node(stmt)?;
+                }
+                self.current_fn_fails = saved;
+                for (_, handler_body) in handlers {
+                    for stmt in handler_body {
+                        self.check_node(stmt)?;
+                    }
+                }
+                Ok(Type::Void)
+            }
+
             // RES-386: commutativity actor type-checks as Void.
             Node::Actor { .. } => Ok(Type::Void),
 
@@ -2393,8 +2415,8 @@ impl TypeChecker {
                         };
                         if !declared {
                             return Err(format!(
-                                "unhandled failure variant {} — declare `fails {}` on the caller or handle at call site (from call to `{}`)",
-                                variant, variant, callee_name
+                                "unhandled failure variant {} — declare `fails {}` on the caller or wrap the call in `try {{ ... }} catch {} {{ ... }}` (from call to `{}`)",
+                                variant, variant, variant, callee_name
                             ));
                         }
                     }


### PR DESCRIPTION
Closes #224

## Summary
- Adds `try { ... } catch VariantName { ... }` syntax for handling failure variants at the call site.
- Each catch arm subtracts its variant from the caller's propagation obligation — exhaustive handlers let the caller declare no `fails` at all; partial handlers forward the leftover variants.
- Unhandled-variant diagnostic now surfaces `try { ... } catch V` as a resolution option alongside `fails` propagation.
- New `resilient/src/try_catch.rs` holds parser + program-level `catch`-arm validation; touches to `main.rs` / `typechecker.rs` / `lexer_logos.rs` stay inside the designated extension-point blocks.

## Test plan
- [x] `cargo test --manifest-path resilient/Cargo.toml` — 913 tests pass, including 6 new `try_catch` unit tests.
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Golden test `examples/try_catch.rz` compiles, runs, and matches its `.expected.txt` sidecar.

## Acceptance criteria (from #224)
- [x] `try { ... } catch VariantName { ... }` parses as a statement.
- [x] Each `catch` arm subtracts handled variants from the propagation obligation.
- [x] Unhandled-variant diagnostic mentions `catch` as a resolution option.
- [x] Golden: `try { read_sensor(addr) } catch Timeout { ... }` typechecks in a caller with empty `fails`.
- [x] Unit tests: exhaustive handler accepted; partial handler requires leftovers on caller's `fails`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>