### PR TITLE
RES-335: VM struct literal and field access opcodes

### DIFF
--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -141,6 +141,27 @@ pub enum Op {
     /// `#[cfg(feature = "ffi")]` at dispatch time but the variant exists
     /// unconditionally so the compiler/disassembler don't need feature flags.
     CallForeign(u16),
+    /// RES-335: build a `Value::Struct` from `field_count` `(name, value)`
+    /// pairs on the operand stack. Stack layout on entry (top → bottom):
+    /// `[v_N, k_N, ..., v_1, k_1, struct_type_name, ...]` — each `k_i`
+    /// is a `Value::String` holding the field name and `v_i` is its
+    /// value. The struct type name is carried as an interned constant
+    /// at `name_const`, not popped from the stack, so the compiler can
+    /// assert the shape statically.
+    ///
+    /// Field names live in the constant pool as `Value::String` so
+    /// `Op` stays `Copy` and `sizeof::<Op>() <= 8`.
+    StructLiteral { name_const: u16, field_count: u16 },
+    /// RES-335: pop a `Value::Struct`, push the value of the field
+    /// whose name is `chunk.constants[name_const]` (a `Value::String`).
+    /// Missing field surfaces as `VmError::UnknownField`.
+    GetField { name_const: u16 },
+    /// RES-335: pop a value `v`, pop a `Value::Struct`, write
+    /// `struct.fields[name] = v`, then push the modified struct back
+    /// so the enclosing compile pattern (`StoreLocal` after
+    /// `SetField`) can commit the update to the binding. Name is
+    /// `chunk.constants[name_const]` (a `Value::String`).
+    SetField { name_const: u16 },
 }
 
 /// One compiled chunk of bytecode. `code` is the instruction stream;

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -168,9 +168,15 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
         // Skip fn/extern decls — handled in earlier passes.
         // RES-391: `region <Name>;` is compile-time metadata only;
         // it emits no code in either the tree-walker or the VM.
+        // RES-335: `struct <Name> { ... }` decls are likewise
+        // compile-time metadata — the `StructLiteral` opcode carries
+        // the type name directly and does not consult a decl table.
         if matches!(
             spanned.node,
-            Node::Function { .. } | Node::Extern { .. } | Node::RegionDecl { .. }
+            Node::Function { .. }
+                | Node::Extern { .. }
+                | Node::RegionDecl { .. }
+                | Node::StructDecl { .. }
         ) {
             continue;
         }
@@ -279,6 +285,42 @@ fn compile_stmt(
             compile_expr(index, chunk, locals, fn_index, ffi_index, line)?;
             compile_expr(value, chunk, locals, fn_index, ffi_index, line)?;
             chunk.emit(Op::StoreIndex, line);
+            chunk.emit(Op::StoreLocal(slot), line);
+            Ok(())
+        }
+        // RES-335: `p.field = v;` where `p` is a bare Identifier.
+        // Lowered as:
+        //   LoadLocal(p), <v>, SetField { field }, StoreLocal(p)
+        // The struct on top of the stack after `SetField` IS the
+        // mutated one (VM dispatch pushes it back), so writing it
+        // through `StoreLocal` commits the update. Mirrors the
+        // `IndexAssignment` lowering.
+        Node::FieldAssignment {
+            target,
+            field,
+            value,
+            ..
+        } => {
+            let local_name = match target.as_ref() {
+                Node::Identifier { name, .. } => name.clone(),
+                _ => {
+                    return Err(CompileError::Unsupported(
+                        "nested field assignment (non-identifier target)",
+                    ));
+                }
+            };
+            let slot = *locals
+                .get(&local_name)
+                .ok_or_else(|| CompileError::UnknownIdentifier(local_name.clone()))?;
+            chunk.emit(Op::LoadLocal(slot), line);
+            compile_expr(value, chunk, locals, fn_index, ffi_index, line)?;
+            let fname_idx = chunk.add_constant(Value::String(field.clone()))?;
+            chunk.emit(
+                Op::SetField {
+                    name_const: fname_idx,
+                },
+                line,
+            );
             chunk.emit(Op::StoreLocal(slot), line);
             Ok(())
         }
@@ -451,6 +493,38 @@ fn compile_stmt_in_fn(
             compile_expr(index, chunk, locals, fn_index, ffi_index, line)?;
             compile_expr(value, chunk, locals, fn_index, ffi_index, line)?;
             chunk.emit(Op::StoreIndex, line);
+            chunk.emit(Op::StoreLocal(slot), line);
+            Ok(())
+        }
+        // RES-335: `p.field = v;` inside a fn body. Mirrors the
+        // `compile_stmt` arm above; duplicated because the two
+        // dispatchers handle `return` differently.
+        Node::FieldAssignment {
+            target,
+            field,
+            value,
+            ..
+        } => {
+            let local_name = match target.as_ref() {
+                Node::Identifier { name, .. } => name.clone(),
+                _ => {
+                    return Err(CompileError::Unsupported(
+                        "nested field assignment (non-identifier target)",
+                    ));
+                }
+            };
+            let slot = *locals
+                .get(&local_name)
+                .ok_or_else(|| CompileError::UnknownIdentifier(local_name.clone()))?;
+            chunk.emit(Op::LoadLocal(slot), line);
+            compile_expr(value, chunk, locals, fn_index, ffi_index, line)?;
+            let fname_idx = chunk.add_constant(Value::String(field.clone()))?;
+            chunk.emit(
+                Op::SetField {
+                    name_const: fname_idx,
+                },
+                line,
+            );
             chunk.emit(Op::StoreLocal(slot), line);
             Ok(())
         }
@@ -696,6 +770,44 @@ fn compile_expr(
             chunk.emit(Op::LoadIndex, line);
             Ok(())
         }
+        // RES-335: `Name { f1: e1, f2: e2 }` struct literal. Lowered
+        // as alternating `(field-name-const, value)` pushes followed
+        // by `StructLiteral { name_const, field_count }`. Field names
+        // live in the constant pool so `Op` stays `Copy`.
+        Node::StructLiteral { name, fields, .. } => {
+            if fields.len() > u16::MAX as usize {
+                return Err(CompileError::TooManyFields(name.clone()));
+            }
+            let name_const = chunk.add_constant(Value::String(name.clone()))?;
+            for (field_name, field_expr) in fields {
+                let fname_idx = chunk.add_constant(Value::String(field_name.clone()))?;
+                chunk.emit(Op::Const(fname_idx), line);
+                compile_expr(field_expr, chunk, locals, fn_index, ffi_index, line)?;
+            }
+            chunk.emit(
+                Op::StructLiteral {
+                    name_const,
+                    field_count: fields.len() as u16,
+                },
+                line,
+            );
+            Ok(())
+        }
+        // RES-335: `target.field` read → push target, emit `GetField`.
+        // Nested reads (`a.b.c`) fall out of the recursion because
+        // `compile_expr(target)` re-enters this arm for inner
+        // `FieldAccess` nodes.
+        Node::FieldAccess { target, field, .. } => {
+            compile_expr(target, chunk, locals, fn_index, ffi_index, line)?;
+            let fname_idx = chunk.add_constant(Value::String(field.clone()))?;
+            chunk.emit(
+                Op::GetField {
+                    name_const: fname_idx,
+                },
+                line,
+            );
+            Ok(())
+        }
         other => Err(CompileError::Unsupported(node_kind(other))),
     }
 }
@@ -813,6 +925,9 @@ fn node_kind(n: &Node) -> &'static str {
         Node::IndexExpression { .. } => "IndexExpression",
         Node::IndexAssignment { .. } => "IndexAssignment",
         Node::RegionDecl { .. } => "RegionDecl",
+        Node::StructLiteral { .. } => "StructLiteral",
+        Node::FieldAccess { .. } => "FieldAccess",
+        Node::FieldAssignment { .. } => "FieldAssignment",
         _ => "<other>",
     }
 }

--- a/resilient/src/disasm.rs
+++ b/resilient/src/disasm.rs
@@ -184,6 +184,29 @@ fn write_op(
         Op::StoreIndex => write!(out, "StoreIndex")?,
         // FFI v2.
         Op::CallForeign(idx) => write!(out, "CallForeign {idx:<6}")?,
+        // RES-335: struct-op disasm. The name is a constant-pool index
+        // into a `Value::String`; resolve and annotate it.
+        Op::StructLiteral {
+            name_const,
+            field_count,
+        } => {
+            write!(out, "StructLiteral {} {}", name_const, field_count)?;
+            if let Some(v) = chunk.constants.get(name_const as usize) {
+                write!(out, "  ; type = {}", v)?;
+            }
+        }
+        Op::GetField { name_const } => {
+            write!(out, "GetField {}", name_const)?;
+            if let Some(v) = chunk.constants.get(name_const as usize) {
+                write!(out, "      ; field = {}", v)?;
+            }
+        }
+        Op::SetField { name_const } => {
+            write!(out, "SetField {}", name_const)?;
+            if let Some(v) = chunk.constants.get(name_const as usize) {
+                write!(out, "      ; field = {}", v)?;
+            }
+        }
     }
     Ok(())
 }

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -57,6 +57,12 @@ pub enum VmError {
     },
     /// FFI v2: the trampoline returned an error string.
     ForeignCallFailed(String),
+    /// RES-335: `GetField`/`SetField` on a struct value whose field
+    /// table has no entry matching the requested name.
+    UnknownField {
+        struct_name: String,
+        field: String,
+    },
 }
 
 impl VmError {
@@ -91,6 +97,9 @@ impl std::fmt::Display for VmError {
             ),
             VmError::AtLine { line, kind } => write!(f, "{} (line {})", kind, line),
             VmError::ForeignCallFailed(msg) => write!(f, "ffi call failed: {}", msg),
+            VmError::UnknownField { struct_name, field } => {
+                write!(f, "vm: struct {} has no field '{}'", struct_name, field)
+            }
         }
     }
 }
@@ -536,7 +545,104 @@ fn run_inner(program: &Program, last_pc: &mut (usize, usize)) -> Result<Value, V
                 // can write it into the local slot.
                 stack.push(Value::Array(items));
             }
+            // ---- RES-335: struct ops ----
+            Op::StructLiteral {
+                name_const,
+                field_count,
+            } => {
+                let name = constant_as_string(chunk, name_const, "StructLiteral (type name)")?;
+                let n = field_count as usize;
+                // Stack layout on entry (top → bottom):
+                //   [v_N, k_N, ..., v_1, k_1, ...]
+                // Drain the top `2 * n` values as a flat vec and
+                // destructure into (key, value) pairs in push order.
+                let needed = n.checked_mul(2).ok_or(VmError::EmptyStack)?;
+                if stack.len() < needed {
+                    return Err(VmError::EmptyStack);
+                }
+                let split_at = stack.len() - needed;
+                let flat: Vec<Value> = stack.drain(split_at..).collect();
+                let mut fields: Vec<(String, Value)> = Vec::with_capacity(n);
+                let mut it = flat.into_iter();
+                for _ in 0..n {
+                    let k = it.next().ok_or(VmError::EmptyStack)?;
+                    let v = it.next().ok_or(VmError::EmptyStack)?;
+                    let Value::String(field_name) = k else {
+                        return Err(VmError::TypeMismatch("StructLiteral (non-string key)"));
+                    };
+                    fields.push((field_name, v));
+                }
+                stack.push(Value::Struct { name, fields });
+            }
+            Op::GetField { name_const } => {
+                let field = constant_as_string(chunk, name_const, "GetField (field name)")?;
+                let v = stack.pop().ok_or(VmError::EmptyStack)?;
+                let Value::Struct {
+                    name: sname,
+                    fields,
+                } = v
+                else {
+                    return Err(VmError::TypeMismatch("GetField (non-struct target)"));
+                };
+                let found = fields
+                    .iter()
+                    .find(|(k, _)| k == &field)
+                    .map(|(_, v)| v.clone());
+                match found {
+                    Some(val) => stack.push(val),
+                    None => {
+                        return Err(VmError::UnknownField {
+                            struct_name: sname,
+                            field,
+                        });
+                    }
+                }
+            }
+            Op::SetField { name_const } => {
+                let field = constant_as_string(chunk, name_const, "SetField (field name)")?;
+                let v = stack.pop().ok_or(VmError::EmptyStack)?;
+                let tgt = stack.pop().ok_or(VmError::EmptyStack)?;
+                let Value::Struct {
+                    name: sname,
+                    mut fields,
+                } = tgt
+                else {
+                    return Err(VmError::TypeMismatch("SetField (non-struct target)"));
+                };
+                let slot = fields.iter_mut().find(|(k, _)| k == &field);
+                match slot {
+                    Some((_, existing)) => *existing = v,
+                    None => {
+                        return Err(VmError::UnknownField {
+                            struct_name: sname,
+                            field,
+                        });
+                    }
+                }
+                // Push the modified struct back so the enclosing
+                // compile pattern (`StoreLocal` after `SetField`) can
+                // write it into the local slot. Mirrors `StoreIndex`.
+                stack.push(Value::Struct {
+                    name: sname,
+                    fields,
+                });
+            }
         }
+    }
+}
+
+/// RES-335: pull a `Value::String` out of `chunk.constants[idx]` or
+/// surface a type-shaped VM error. Used by the struct opcodes, all of
+/// which carry field/type names via the constant pool to keep
+/// `Op: Copy`.
+fn constant_as_string(chunk: &Chunk, idx: u16, context: &'static str) -> Result<String, VmError> {
+    let v = chunk
+        .constants
+        .get(idx as usize)
+        .ok_or(VmError::ConstantOutOfBounds(idx))?;
+    match v {
+        Value::String(s) => Ok(s.clone()),
+        _ => Err(VmError::TypeMismatch(context)),
     }
 }
 
@@ -1272,6 +1378,161 @@ mod tests {
             err.kind(),
             VmError::ArrayIndexOutOfBounds { index: 5, len: 2 }
         ));
+    }
+
+    // ============================================================
+    // RES-335: struct opcodes
+    // ============================================================
+
+    #[test]
+    fn res335_struct_literal_constructs_value() {
+        // Synthetic chunk: build `Point { x: 1, y: 2 }` and return it.
+        let mut main = Chunk::new();
+        let type_const = main.add_constant(Value::String("Point".into())).unwrap();
+        let x_const = main.add_constant(Value::String("x".into())).unwrap();
+        let y_const = main.add_constant(Value::String("y".into())).unwrap();
+        let one = main.add_constant(Value::Int(1)).unwrap();
+        let two = main.add_constant(Value::Int(2)).unwrap();
+        main.emit(Op::Const(x_const), 1);
+        main.emit(Op::Const(one), 1);
+        main.emit(Op::Const(y_const), 1);
+        main.emit(Op::Const(two), 1);
+        main.emit(
+            Op::StructLiteral {
+                name_const: type_const,
+                field_count: 2,
+            },
+            1,
+        );
+        main.emit(Op::Return, 1);
+        let prog = Program {
+            main,
+            functions: vec![],
+            #[cfg(feature = "ffi")]
+            foreign_syms: vec![],
+        };
+        let result = run(&prog).unwrap();
+        match result {
+            Value::Struct { name, fields } => {
+                assert_eq!(name, "Point");
+                assert_eq!(fields.len(), 2);
+                assert_eq!(fields[0].0, "x");
+                assert!(matches!(fields[0].1, Value::Int(1)));
+                assert_eq!(fields[1].0, "y");
+                assert!(matches!(fields[1].1, Value::Int(2)));
+            }
+            other => panic!("expected Struct, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn res335_get_field_pushes_field_value() {
+        assert_int(
+            compile_run(
+                "struct Point { int x, int y, } \
+                 fn main() -> int { let p = new Point { x: 1, y: 42 }; return p.y; } \
+                 main();",
+            )
+            .unwrap(),
+            42,
+        );
+    }
+
+    #[test]
+    fn res335_set_field_updates_in_place() {
+        assert_int(
+            compile_run(
+                "struct Point { int x, int y, } \
+                 fn main() -> int { \
+                     let p = new Point { x: 1, y: 2 }; \
+                     p.x = 10; \
+                     p.y = 20; \
+                     return p.x + p.y; \
+                 } \
+                 main();",
+            )
+            .unwrap(),
+            30,
+        );
+    }
+
+    #[test]
+    fn res335_get_field_on_non_struct_errors() {
+        // Build chunk that pushes an int then GetField — type mismatch.
+        let mut main = Chunk::new();
+        let f_const = main.add_constant(Value::String("x".into())).unwrap();
+        let v_const = main.add_constant(Value::Int(5)).unwrap();
+        main.emit(Op::Const(v_const), 1);
+        main.emit(
+            Op::GetField {
+                name_const: f_const,
+            },
+            1,
+        );
+        main.emit(Op::Return, 1);
+        let prog = Program {
+            main,
+            functions: vec![],
+            #[cfg(feature = "ffi")]
+            foreign_syms: vec![],
+        };
+        let err = run(&prog).unwrap_err();
+        assert!(
+            matches!(err.kind(), VmError::TypeMismatch(_)),
+            "got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn res335_get_field_unknown_field_errors() {
+        let mut main = Chunk::new();
+        let type_const = main.add_constant(Value::String("Point".into())).unwrap();
+        let x_const = main.add_constant(Value::String("x".into())).unwrap();
+        let one = main.add_constant(Value::Int(1)).unwrap();
+        let missing = main.add_constant(Value::String("z".into())).unwrap();
+        main.emit(Op::Const(x_const), 1);
+        main.emit(Op::Const(one), 1);
+        main.emit(
+            Op::StructLiteral {
+                name_const: type_const,
+                field_count: 1,
+            },
+            1,
+        );
+        main.emit(
+            Op::GetField {
+                name_const: missing,
+            },
+            1,
+        );
+        main.emit(Op::Return, 1);
+        let prog = Program {
+            main,
+            functions: vec![],
+            #[cfg(feature = "ffi")]
+            foreign_syms: vec![],
+        };
+        let err = run(&prog).unwrap_err();
+        match err.kind() {
+            VmError::UnknownField { struct_name, field } => {
+                assert_eq!(struct_name, "Point");
+                assert_eq!(field, "z");
+            }
+            other => panic!("expected UnknownField, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn res335_sizeof_op_stays_bounded() {
+        // The bytecode module claims sizeof::<Op>() <= 8. RES-335 added
+        // variants carrying `u16 + u16` payloads; verify the envelope
+        // didn't inflate.
+        assert!(
+            std::mem::size_of::<Op>() <= 8,
+            "sizeof(Op) = {} bytes; struct opcodes should not inflate this",
+            std::mem::size_of::<Op>()
+        );
     }
 
     #[cfg(feature = "ffi")]


### PR DESCRIPTION
Closes #127

## Summary
- Adds `Op::StructLiteral { name_const, field_count }`, `Op::GetField { name_const }`, `Op::SetField { name_const }`. Names live in the chunk constant pool (interned `Value::String`) so `Op: Copy` and `sizeof::<Op>() <= 8` are preserved.
- Bytecode compiler emits the new opcodes for `Node::StructLiteral`, `Node::FieldAccess`, and `Node::FieldAssignment` instead of falling back with `CompileError::Unsupported`.
- `Node::StructDecl` is recognized as compile-time-only metadata in pass 3 (mirrors `RegionDecl` handling).
- `VmError::UnknownField { struct_name, field }` is surfaced when a field read/write names a slot the struct doesn't carry.
- Disassembler renders the new ops with a resolved-name comment.

## Stack protocol
- `StructLiteral { name_const, field_count }` pops `field_count * 2` values; the source lowering pushes alternating `(field-name-const, value-expr)` so stack layout is `[k1, v1, k2, v2, ...]` bottom-to-top.
- `GetField` pops a struct, pushes the named field's value.
- `SetField` pops `(struct, v)`, writes `v`, and pushes the modified struct back so the enclosing compile pattern (`StoreLocal`) can commit the update — same shape as `StoreIndex`.

## Test plan
- [x] New VM unit tests: struct literal construction, GetField, SetField, non-struct target → TypeMismatch, unknown field → UnknownField, sizeof(Op) guard.
- [x] Integration via `compile_run` for end-to-end struct construction, field read, and field-assignment arithmetic.
- [x] Manual `--vm` smoke on a Point-struct program returns the right value.
- [x] `cargo test` full suite (807 passing).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>