### PR TITLE
fix: dedupe Value::Option after RES-363/RES-375 merge collision

### DIFF
--- a/resilient/examples/optional_chaining.rz
+++ b/resilient/examples/optional_chaining.rz
@@ -15,13 +15,13 @@ fn main() {
     let v1 = cfg?.value;
     println(v1);
 
-    // None()?.value — short-circuits to None without touching .value.
-    let none_cfg = None();
+    // None?.value — short-circuits to None without touching .value.
+    let none_cfg = None;
     let v2 = none_cfg?.value;
     println(v2);
 
     // Three-level chain: a?.b?.c — None at the first step propagates.
-    let a = None();
+    let a = None;
     let b = a?.value;    // None (short-circuits on a)
     let c = b?.value;    // None (short-circuits on b)
     println(b);

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -683,11 +683,11 @@ impl Lexer {
                 self.read_char(); // consume second `?`
                 Token::DoubleQuestion
             }
-            '?' => Token::Question,
+            // RES-363: `?.` is the optional-chain operator. Peek one
+            // character ahead; if it is `.` emit QuestionDot and
+            // advance past the `.` so it is not re-consumed. Otherwise
+            // emit a lone `?` (RES-375 used in `??` already handled above).
             '?' => {
-                // RES-363: `?.` is the optional-chain operator. Peek one
-                // character ahead; if it is `.` emit QuestionDot and
-                // advance past the `.` so it is not re-consumed.
                 if self.peek_char() == '.' {
                     self.read_char(); // consume '.'
                     Token::QuestionDot
@@ -6338,17 +6338,13 @@ enum Value {
         ok: bool,
         payload: Box<Value>,
     },
-    /// RES-375: first-class Option type.
+    /// RES-363 + RES-375: first-class Option type.
     ///
-    /// `Some(None)` is `Value::Option(None)` — i.e. the outer `Option`
-    /// is the Rust-level discriminant, matching `None` / `Some(inner)`.
+    /// `Value::Option(None)` is the absent case — `?.` short-circuits to
+    /// this and `None` evaluates to it. `Value::Option(Some(v))` wraps a
+    /// present value; `Some(x)` constructs it and `?.` unwraps it before
+    /// performing a chained field/method access.
     Option(Option<Box<Value>>),
-    /// RES-363: first-class Option type for optional chaining.
-    ///
-    /// `Option(None)` is the absent case — `?.` short-circuits to this.
-    /// `Option(Some(v))` wraps a present value; `?.` unwraps it before
-    /// performing the chained field/method access.
-    Option(std::option::Option<Box<Value>>),
     Return(Box<Value>),
     Void,
     /// RES-148: associative map. Keys are restricted (via `MapKey`) to
@@ -6977,20 +6973,14 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("is_err", builtin_is_err),
     ("unwrap", builtin_unwrap),
     ("unwrap_err", builtin_unwrap_err),
-    // RES-375: Option<T> constructors and free-function methods.
-    // `None` is registered as a Value directly in Interpreter::new, not
-    // here, because the builtins table only holds functions.
-    ("Some", builtin_some),
-    ("is_some", builtin_is_some),
-    ("is_none", builtin_is_none),
-    ("option_unwrap", builtin_option_unwrap),
-    ("option_unwrap_or", builtin_option_unwrap_or),
-    // RES-363: Option type builtins.
+    // RES-363 + RES-375: Option<T> constructors and free-function methods.
     ("Some", builtin_some),
     ("None", builtin_none),
     ("is_some", builtin_is_some),
     ("is_none", builtin_is_none),
     ("unwrap_option", builtin_unwrap_option),
+    ("option_unwrap", builtin_option_unwrap),
+    ("option_unwrap_or", builtin_option_unwrap_or),
     // RES-143: file I/O. Std-only; the `resilient-runtime` crate has
     // no builtins table and stays no_std-clean.
     ("file_read", builtin_file_read),
@@ -7651,32 +7641,6 @@ fn builtin_unwrap_err(args: &[Value]) -> RResult<Value> {
 }
 
 // ─── RES-375: Option<T> builtins ───────────────────────────────────────────
-
-/// `Some(v)` — wrap a value as a present Option.
-fn builtin_some(args: &[Value]) -> RResult<Value> {
-    match args {
-        [v] => Ok(Value::Option(Some(Box::new(v.clone())))),
-        _ => Err(format!("Some: expected 1 argument, got {}", args.len())),
-    }
-}
-
-/// `is_some(opt)` — true iff `opt` is `Some(_)`.
-fn builtin_is_some(args: &[Value]) -> RResult<Value> {
-    match args {
-        [Value::Option(inner)] => Ok(Value::Bool(inner.is_some())),
-        [other] => Err(format!("is_some: expected Option, got {}", other)),
-        _ => Err(format!("is_some: expected 1 argument, got {}", args.len())),
-    }
-}
-
-/// `is_none(opt)` — true iff `opt` is `None`.
-fn builtin_is_none(args: &[Value]) -> RResult<Value> {
-    match args {
-        [Value::Option(inner)] => Ok(Value::Bool(inner.is_none())),
-        [other] => Err(format!("is_none: expected Option, got {}", other)),
-        _ => Err(format!("is_none: expected 1 argument, got {}", args.len())),
-    }
-}
 
 /// `option_unwrap(opt)` — return the inner value or runtime error.
 fn builtin_option_unwrap(args: &[Value]) -> RResult<Value> {

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1732,7 +1732,7 @@ impl TypeChecker {
                     let mut timed_out_flag = false;
                     if verdict.is_none() {
                         // RES-354: use theory-aware prover.
-                        let (v, _cert, c, _timed_out) = {
+                        let (_v, _cert, _c, _timed_out) = {
                             #[cfg(feature = "z3")]
                             {
                                 z3_prove_with_cert_theory(


### PR DESCRIPTION
## Summary

- PRs #239 and #245 both added `Value::Option`, duplicate builtins, and a duplicate `'?'` lexer arm. Main stopped compiling (E0428 × 4 + unreachable pattern). This PR collapses the duplicates into one canonical Option implementation.
- `resilient/examples/optional_chaining.rz` updated: uses `None` as a value (RES-375 form) instead of calling `None()` — expected output unchanged.
- This is the exact class of silent cross-PR collision that [agents/integration](https://github.com/EricSpencer00/Resilient/pull/255) is designed to catch before merge.

## Changes

- `resilient/src/main.rs`: one `Value::Option` variant, one builtins-table block, removed duplicate function bodies, merged the two `'?'` lexer arms.
- `resilient/src/typechecker.rs`: prefix unused theory-prover bindings with `_` (clippy -D warnings).
- `resilient/examples/optional_chaining.rz`: use `None` as a value.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings`
- [x] `cargo test --manifest-path resilient/Cargo.toml` (all suites green locally including `examples_golden`)
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)