### PR TITLE
fix(ci): integration-follow-main bootstrap when branch missing

### DIFF
--- a/.github/workflows/integration-follow-main.yml
+++ b/.github/workflows/integration-follow-main.yml
@@ -28,13 +28,15 @@ jobs:
       - name: Fast-forward agents/integration to main
         run: |
           set -euo pipefail
-          git fetch origin agents/integration main
+          git fetch origin main
+          # agents/integration may not exist yet — tolerate failure.
+          git fetch origin agents/integration 2>/dev/null || true
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           if ! git rev-parse --verify origin/agents/integration >/dev/null 2>&1; then
             echo "agents/integration does not exist — creating from main"
-            git push origin main:refs/heads/agents/integration
+            git push origin "$(git rev-parse origin/main):refs/heads/agents/integration"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- First post-#255 run failed: \`fatal: couldn't find remote ref agents/integration\` under \`set -e\`.
- Split the fetch so the missing-branch case is tolerated; the existence check below is the intended gate.
- Push the resolved \`origin/main\` sha explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)