### PR TITLE
RES-318: smt: static loop invariant verification

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,3 +1,12 @@
 {
-  "claims": {}
+  "claims": {
+    "resilient/src/typechecker.rs": {
+      "branch": "res-318-smt-loop-invariants",
+      "claimed_at": "2026-04-25T17:08:37Z"
+    },
+    "resilient/src/verifier_loop_invariants.rs": {
+      "branch": "res-318-smt-loop-invariants",
+      "claimed_at": "2026-04-25T17:08:37Z"
+    }
+  }
 }

--- a/resilient/examples/invariant_proven_demo.expected.txt
+++ b/resilient/examples/invariant_proven_demo.expected.txt
@@ -1,0 +1,2 @@
+ok
+Program executed successfully

--- a/resilient/examples/invariant_proven_demo.rz
+++ b/resilient/examples/invariant_proven_demo.rz
@@ -1,0 +1,28 @@
+// RES-318 demo: a `while` loop whose invariant the SMT verifier
+// statically discharges via Hoare-rule induction.
+//
+// The body is straight-line assignment, the condition + invariants
+// live in the integer subset Z3 understands, and the bindings (`n`)
+// stay constant across iterations. The verifier proves both:
+//   1. base case: `i >= 0` holds before entry (i = 0).
+//   2. inductive step: assuming `(i >= 0 /\ i < n)`, the post-body
+//      state `i' = i + 1` still satisfies `i' >= 0`.
+//
+// With `--verbose`, the driver prints
+//   `-- invariant proven, runtime check elided at L:C`
+// to stderr per discharged invariant. The runtime check still fires
+// (the codegen elision is a separate ticket); this golden only
+// asserts the printed program output.
+
+fn main() {
+    let i = 0;
+    let n = 5;
+    while i < n {
+        invariant i >= 0;
+        invariant i <= n;
+        i = i + 1;
+    }
+    println("ok");
+}
+
+main();

--- a/resilient/examples/invariant_unprovable_demo.expected.txt
+++ b/resilient/examples/invariant_unprovable_demo.expected.txt
@@ -1,0 +1,5 @@
+step
+step
+step
+done
+Program executed successfully

--- a/resilient/examples/invariant_unprovable_demo.rz
+++ b/resilient/examples/invariant_unprovable_demo.rz
@@ -1,0 +1,26 @@
+// RES-318 demo: a `while` loop whose invariant is TRUE at runtime
+// but the WP-substitution verifier cannot statically discharge —
+// the body contains a `println` call, which falls outside the
+// supported assignment-only subset, so weakest-precondition
+// substitution returns None and the proof bails.
+//
+// The verifier emits no certificate; the runtime check from RES-222
+// is the sole line of defense. Because the invariant actually holds
+// for every iteration, the runtime check passes and the program
+// completes normally.
+//
+// Together with `invariant_proven_demo.rz`, this is the second of
+// the two golden tests required by the ticket: provable + fallback.
+
+fn main() {
+    let i = 0;
+    let n = 3;
+    while i < n {
+        invariant i >= 0;
+        println("step");
+        i = i + 1;
+    }
+    println("done");
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -109,6 +109,13 @@ mod try_catch;
 // module per the feature-isolation pattern in CLAUDE.md.
 mod loop_invariants;
 
+// RES-318: Z3 inductive verification of loop invariants. Best-effort
+// pass — the runtime check from `loop_invariants` always fires;
+// the verifier only adds an SMT-LIB2 proof certificate + a verbose
+// `-- invariant proven, runtime check elided` line when both base
+// and inductive goals discharge.
+mod verifier_loop_invariants;
+
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
 
@@ -11832,6 +11839,7 @@ fn execute_file(
     use_jit: bool,
     verifier_timeout_ms: u32,
     warn_unverified: bool,
+    verbose_invariants: bool,
     live_log: Option<&Path>,
     #[cfg(feature = "z3")] z3_theory: verifier_z3::Z3Theory,
     no_cache: bool,
@@ -11929,7 +11937,10 @@ fn execute_file(
             // RES-217: `--no-warn-unverified` flips this off; the
             // default (on) surfaces `warning[partial-proof]`
             // diagnostics whenever Z3 returns Unknown.
-            .with_warn_unverified(warn_unverified);
+            .with_warn_unverified(warn_unverified)
+            // RES-318: `--verbose` opts into per-loop-invariant
+            // proof messages on stderr.
+            .with_verbose_loop_invariants(verbose_invariants);
         // RES-354: apply the --z3-theory flag when z3 feature is on.
         #[cfg(feature = "z3")]
         let mut tc = tc_base.with_z3_theory(z3_theory);
@@ -13143,6 +13154,8 @@ COMMON FLAGS:\n\
     -h, --help                   Show this help and exit\n\
     -t, --typecheck              Run the static type checker\n\
         --audit                  Print the verification audit trail\n\
+        --verbose                Print one stderr line per loop\n\
+                                 invariant statically proven (RES-318)\n\
         --explain-effects        Print the inferred effect (@pure / @io)\n\
                                  for every user function\n\
         --emit-certificate DIR   Dump SMT-LIB2 certs per obligation\n\
@@ -13241,6 +13254,10 @@ fn main() {
 
     let mut type_check = false;
     let mut audit = false;
+    // RES-318: --verbose enables one stderr line per loop invariant
+    // statically discharged by the Z3 verifier. Off by default so
+    // the regular build is silent.
+    let mut verbose_invariants = false;
     // RES-347: `--explain-effects` prints the inferred effect
     // (@pure / @io) for every user fn after typechecking. Implies
     // `--typecheck` so the fixpoint has run and `stats.fn_effects`
@@ -13304,6 +13321,13 @@ fn main() {
                 type_check = true;
             } else if arg == "--audit" {
                 audit = true;
+            } else if arg == "--verbose" {
+                // RES-318: emit one `-- invariant proven, runtime
+                // check elided at L:C` line per discharged loop
+                // invariant. Implies --typecheck so the verifier
+                // pass actually runs.
+                verbose_invariants = true;
+                type_check = true;
             } else if arg == "--deny-unproven-bounds" {
                 // RES-351: strict mode — unproven array-bounds
                 // accesses become compile errors instead of relying
@@ -13624,6 +13648,7 @@ fn main() {
                 use_jit,
                 verifier_timeout_ms,
                 warn_unverified,
+                verbose_invariants,
                 emit_live_log.as_deref(),
                 #[cfg(feature = "z3")]
                 z3_theory,

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -541,6 +541,11 @@ pub struct VerificationStats {
     /// callee). `false` = pure. Populated by
     /// `infer_fn_effects` during `check_program_with_source`.
     pub fn_effects: std::collections::HashMap<String, bool>,
+    /// RES-318: number of `invariant` annotations the loop verifier
+    /// statically discharged via Hoare-rule induction. Bumped per
+    /// invariant, not per loop. Zero without `--features z3`.
+    #[allow(dead_code)]
+    pub loop_invariants_proven: usize,
 }
 
 impl VerificationStats {
@@ -780,6 +785,11 @@ pub struct TypeChecker {
     /// overrides this from `--z3-theory <bv|lia|auto>`.
     #[cfg(feature = "z3")]
     z3_theory: crate::verifier_z3::Z3Theory,
+    /// RES-318: when `true`, the loop-invariant verifier prints a
+    /// `-- invariant proven, runtime check elided at L:C` line per
+    /// successfully discharged invariant. Defaults to `false` so the
+    /// regular build is silent; the driver flips it on for `--verbose`.
+    verbose_loop_invariants: bool,
 }
 
 impl TypeChecker {
@@ -1257,6 +1267,9 @@ impl TypeChecker {
             // RES-354: auto-detect theory by default.
             #[cfg(feature = "z3")]
             z3_theory: crate::verifier_z3::Z3Theory::Auto,
+            // RES-318: per-loop-invariant verbose stderr line is OFF
+            // by default. The driver flips it on via `--verbose`.
+            verbose_loop_invariants: false,
         }
     }
 
@@ -1289,6 +1302,49 @@ impl TypeChecker {
     pub fn with_z3_theory(mut self, theory: crate::verifier_z3::Z3Theory) -> Self {
         self.z3_theory = theory;
         self
+    }
+
+    /// RES-318: enable verbose stderr output from the loop-invariant
+    /// verifier. The driver flips this on via the `--verbose` flag.
+    pub fn with_verbose_loop_invariants(mut self, on: bool) -> Self {
+        self.verbose_loop_invariants = on;
+        self
+    }
+
+    /// RES-318: read accessor for the verifier pass.
+    #[allow(dead_code)]
+    pub(crate) fn verifier_timeout_ms(&self) -> u32 {
+        self.verifier_timeout_ms
+    }
+
+    /// RES-318: read accessor for the verifier pass.
+    #[allow(dead_code)]
+    pub(crate) fn verbose_loop_invariants(&self) -> bool {
+        self.verbose_loop_invariants
+    }
+
+    /// RES-318: push a loop-invariant proof certificate so it
+    /// participates in the regular `--emit-certificate <DIR>` dump.
+    #[allow(dead_code)]
+    pub(crate) fn push_loop_invariant_certificate(&mut self, idx: usize, smt2: String) {
+        self.certificates.push(CapturedCertificate {
+            fn_name: "<loop>".to_string(),
+            kind: "loop_invariant",
+            idx,
+            smt2,
+        });
+        self.stats.loop_invariants_proven += 1;
+    }
+
+    /// RES-318: helper for the verifier's unit tests — count proven
+    /// invariants by counting `loop_invariant`-kinded certificates.
+    #[cfg(feature = "z3")]
+    #[allow(dead_code)]
+    pub(crate) fn loop_invariant_certificate_count(&self) -> usize {
+        self.certificates
+            .iter()
+            .filter(|c| c.kind == "loop_invariant")
+            .count()
     }
 
     pub fn check_program(&mut self, program: &Node) -> Result<Type, String> {
@@ -1447,6 +1503,7 @@ impl TypeChecker {
                 crate::verifier_liveness::check(program, source_path)?;
                 crate::bounds_check::check_array_bounds(program, source_path)?;
                 crate::loop_invariants::check(program, source_path)?;
+                crate::verifier_loop_invariants::verify_and_capture(self, program);
                 // </EXTENSION_PASSES>
 
                 // RES-192: IO-effect inference. Binary lattice

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -1,0 +1,575 @@
+//! RES-318: Z3 inductive verification of `invariant` annotations on
+//! `while` loops. Standard Hoare-logic loop rule:
+//!
+//! 1. **Base**: prove the invariant holds before the first iteration.
+//! 2. **Inductive**: assume the invariant + the loop condition; prove
+//!    the invariant still holds after the body executes.
+//!
+//! When both goals discharge, we capture an SMT-LIB2 certificate (so
+//! `--emit-certificate <DIR>` writes one re-verifiable file per
+//! proven invariant) and bump a stats counter. With `--verbose` set,
+//! one `-- invariant proven, runtime check elided at L:C` line per
+//! discharged invariant is written to stderr.
+//!
+//! This module is a *best-effort* verifier — the runtime check
+//! emitted by `loop_invariants.rs` always fires regardless of the
+//! verdict here. An unprovable invariant is silent: the runtime check
+//! catches the violation. The static result is informational +
+//! a hook for future codegen elision (`G9`).
+//!
+//! Scope of the MVP weakest-precondition substitution:
+//!   - `while COND { ASSIGN ; ASSIGN ; ... }` bodies, where every
+//!     statement is either `Node::Assignment { name, value, .. }`
+//!     (plain `name = expr;`) or a no-op `InvariantStatement`.
+//!   - The condition + invariants must lie in the LIA / BV32 subset
+//!     understood by `verifier_z3::translate_bool` (integer arithmetic,
+//!     comparisons, boolean connectives). Anything richer makes the
+//!     translator return `None`, which is treated the same as
+//!     "unprovable" — runtime check stays in.
+//!   - Pre-loop integer constants declared as `let NAME = INT_LITERAL`
+//!     at program top level (or function top level) are threaded as
+//!     bindings. Constants whose names are reassigned inside the loop
+//!     body are dropped from the inductive-step bindings — they must
+//!     be free for the proof to be universal over iterations.
+//!
+//! Anything outside that scope causes the verifier to silently bail
+//! on that invariant; the runtime check fires unchanged.
+
+use crate::Node;
+#[cfg(feature = "z3")]
+use crate::span::Span;
+#[cfg(feature = "z3")]
+use std::collections::{BTreeSet, HashMap};
+
+/// Public entry point — feature-gated so callers don't need to do
+/// their own `#[cfg(feature = "z3")]` guards. Without `z3`, this is
+/// a no-op and the runtime check from `loop_invariants.rs` is the
+/// only line of defense.
+#[cfg(feature = "z3")]
+pub(crate) fn verify_and_capture(tc: &mut crate::typechecker::TypeChecker, program: &Node) {
+    let timeout_ms = tc.verifier_timeout_ms();
+    let verbose = tc.verbose_loop_invariants();
+    let mut bindings: HashMap<String, i64> = HashMap::new();
+    let mut next_idx = 0usize;
+    walk(
+        program,
+        &mut bindings,
+        tc,
+        &mut next_idx,
+        timeout_ms,
+        verbose,
+    );
+}
+
+#[cfg(not(feature = "z3"))]
+pub(crate) fn verify_and_capture(_tc: &mut crate::typechecker::TypeChecker, _program: &Node) {}
+
+/// Recursive walk of the program AST. Tracks the lexically-visible
+/// integer-literal bindings as we descend, so each loop sees the
+/// constants that are in scope at its declaration site. Bindings
+/// shadowed by a re-`let` are overwritten in the local map; the
+/// caller's snapshot is restored when the recursive call returns.
+#[cfg(feature = "z3")]
+fn walk(
+    node: &Node,
+    bindings: &mut HashMap<String, i64>,
+    tc: &mut crate::typechecker::TypeChecker,
+    next_idx: &mut usize,
+    timeout_ms: u32,
+    verbose: bool,
+) {
+    match node {
+        Node::Program(stmts) => {
+            // Top-level: the whole program shares a single bindings
+            // scope; we still snapshot so a stray non-program caller
+            // doesn't leak bindings.
+            let snap = bindings.clone();
+            for s in stmts {
+                walk(&s.node, bindings, tc, next_idx, timeout_ms, verbose);
+            }
+            *bindings = snap;
+        }
+        Node::Block { stmts, .. } => {
+            let snap = bindings.clone();
+            for s in stmts {
+                walk(s, bindings, tc, next_idx, timeout_ms, verbose);
+            }
+            *bindings = snap;
+        }
+        Node::Function { body, .. } | Node::FunctionLiteral { body, .. } => {
+            // Each fn body opens a fresh scope. Pre-loop constants
+            // declared inside the fn become bindings just for that
+            // fn; the outer caller's bindings are NOT visible (we
+            // don't track which globals get shadowed by params).
+            let mut fn_bindings: HashMap<String, i64> = HashMap::new();
+            walk(body, &mut fn_bindings, tc, next_idx, timeout_ms, verbose);
+        }
+        Node::LetStatement { name, value, .. } | Node::Const { name, value, .. } => {
+            if let Some(v) = literal_int(value) {
+                bindings.insert(name.clone(), v);
+            } else {
+                // Non-literal RHS — drop any prior binding so we
+                // don't carry a stale value.
+                bindings.remove(name);
+            }
+        }
+        Node::IfStatement {
+            consequence,
+            alternative,
+            ..
+        } => {
+            // Both branches walked under a snapshot — neither
+            // branch's bindings outlive the if.
+            let snap = bindings.clone();
+            walk(consequence, bindings, tc, next_idx, timeout_ms, verbose);
+            *bindings = snap.clone();
+            if let Some(alt) = alternative {
+                walk(alt, bindings, tc, next_idx, timeout_ms, verbose);
+                *bindings = snap;
+            }
+        }
+        Node::WhileStatement {
+            condition,
+            body,
+            invariants: pre_invariants,
+            span,
+        } => {
+            // First, walk the body itself in case it contains nested
+            // loops — those should also get verified, with the OUTER
+            // loop's pre-bindings still in scope. Recursion is safe
+            // because we snapshot at every Block boundary.
+            walk(body, bindings, tc, next_idx, timeout_ms, verbose);
+
+            // Collect the full invariant list — both pre-body
+            // (RES-132a) and statement-form (RES-222) variants.
+            let body_invs = crate::loop_invariants::collect_body_invariants(body);
+            let mut all: Vec<&Node> = Vec::new();
+            for inv in pre_invariants {
+                all.push(inv);
+            }
+            for inv in &body_invs {
+                all.push(*inv);
+            }
+            if all.is_empty() {
+                return;
+            }
+
+            // Compute the set of names assigned in the body — these
+            // become free in the inductive step.
+            let mut assigned: BTreeSet<String> = BTreeSet::new();
+            collect_assigned_names(body, &mut assigned);
+
+            for inv in all {
+                try_prove_invariant(
+                    tc, inv, condition, body, bindings, &assigned, span, next_idx, timeout_ms,
+                    verbose,
+                );
+            }
+        }
+        Node::ForInStatement { body, .. } => {
+            // RES-318 MVP: `for-in` invariants are not modeled yet.
+            // Recurse so nested while-loops still get verified.
+            walk(body, bindings, tc, next_idx, timeout_ms, verbose);
+        }
+        Node::LiveBlock { body, .. } => {
+            walk(body, bindings, tc, next_idx, timeout_ms, verbose);
+        }
+        Node::TryCatch { body, handlers, .. } => {
+            for s in body {
+                walk(s, bindings, tc, next_idx, timeout_ms, verbose);
+            }
+            for (_v, h) in handlers {
+                for s in h {
+                    walk(s, bindings, tc, next_idx, timeout_ms, verbose);
+                }
+            }
+        }
+        Node::ImplBlock { methods, .. } => {
+            for m in methods {
+                walk(m, bindings, tc, next_idx, timeout_ms, verbose);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Run the base + inductive proof for a single invariant. On success,
+/// captures one combined SMT-LIB2 certificate (concatenation of the
+/// two re-verifiable proofs) and emits a verbose stderr line.
+#[cfg(feature = "z3")]
+#[allow(clippy::too_many_arguments)]
+fn try_prove_invariant(
+    tc: &mut crate::typechecker::TypeChecker,
+    invariant: &Node,
+    condition: &Node,
+    body: &Node,
+    bindings: &HashMap<String, i64>,
+    assigned: &BTreeSet<String>,
+    loop_span: &Span,
+    next_idx: &mut usize,
+    timeout_ms: u32,
+    verbose: bool,
+) {
+    // -------- Base case --------
+    // Bindings include every pre-loop constant. If the invariant
+    // is provable from these alone, the entry obligation is met.
+    let (base_verdict, base_cert, _cx, _timed) =
+        crate::verifier_z3::prove_with_axioms_and_timeout(invariant, bindings, &[], timeout_ms);
+    if !matches!(base_verdict, Some(true)) {
+        return;
+    }
+
+    // -------- Inductive step --------
+    // Drop bindings for names assigned in the body so they're free.
+    let step_bindings: HashMap<String, i64> = bindings
+        .iter()
+        .filter(|(k, _)| !assigned.contains(k.as_str()))
+        .map(|(k, v)| (k.clone(), *v))
+        .collect();
+
+    // Build WP(body, invariant) by reverse substitution.
+    let wp = match weakest_precondition(body, invariant) {
+        Some(q) => q,
+        None => return, // body shape unsupported — bail
+    };
+
+    // Goal: (invariant /\ cond) => WP(body, invariant)
+    //     ≡ NOT(invariant /\ cond) || WP(body, invariant)
+    let goal = build_implication(invariant, condition, &wp);
+
+    // The inductive step needs the invariant itself as a hypothesis
+    // — we pass it as an axiom rather than embedding inside the
+    // implication so the SMT-LIB2 cert has a clean shape. (Embedding
+    // works equivalently; the ax form mirrors how `recovers_to`
+    // discharges its requires-precondition.)
+    let (step_verdict, step_cert, _cx, _timed) =
+        crate::verifier_z3::prove_with_axioms_and_timeout(&goal, &step_bindings, &[], timeout_ms);
+    if !matches!(step_verdict, Some(true)) {
+        return;
+    }
+
+    // -------- Both proven: capture certificate + emit message --------
+    let mut smt2 = String::new();
+    smt2.push_str("; RES-318 loop-invariant proof certificate\n");
+    smt2.push_str(&format!(
+        "; loop at line {}, col {}\n",
+        loop_span.start.line, loop_span.start.column
+    ));
+    smt2.push_str("; ----- base case -----\n");
+    if let Some(c) = base_cert {
+        smt2.push_str(&c.smt2);
+    }
+    smt2.push_str("; ----- inductive step -----\n");
+    if let Some(c) = step_cert {
+        smt2.push_str(&c.smt2);
+    }
+    let idx = *next_idx;
+    *next_idx += 1;
+    tc.push_loop_invariant_certificate(idx, smt2);
+
+    let inv_span = invariant_span(invariant).unwrap_or(loop_span);
+    if verbose {
+        eprintln!(
+            "-- invariant proven, runtime check elided at {}:{}",
+            inv_span.start.line, inv_span.start.column
+        );
+    }
+}
+
+/// `let NAME = INT_LITERAL` — extract the literal value.
+#[cfg(feature = "z3")]
+fn literal_int(node: &Node) -> Option<i64> {
+    if let Node::IntegerLiteral { value, .. } = node {
+        Some(*value)
+    } else if let Node::PrefixExpression {
+        operator, right, ..
+    } = node
+        && operator == "-"
+        && let Node::IntegerLiteral { value, .. } = right.as_ref()
+    {
+        Some(-*value)
+    } else {
+        None
+    }
+}
+
+/// Walk every assignment in `node` and accumulate the LHS names.
+/// Conservative — we walk past control flow because any reachable
+/// assignment counts. Unsupported assignment forms (`FieldAssignment`,
+/// `IndexAssignment`) record nothing; the WP step will bail on those
+/// bodies anyway.
+#[cfg(feature = "z3")]
+fn collect_assigned_names(node: &Node, out: &mut BTreeSet<String>) {
+    match node {
+        Node::Assignment { name, .. } => {
+            out.insert(name.clone());
+        }
+        Node::Block { stmts, .. } => {
+            for s in stmts {
+                collect_assigned_names(s, out);
+            }
+        }
+        Node::IfStatement {
+            consequence,
+            alternative,
+            ..
+        } => {
+            collect_assigned_names(consequence, out);
+            if let Some(alt) = alternative {
+                collect_assigned_names(alt, out);
+            }
+        }
+        Node::WhileStatement { body, .. } | Node::ForInStatement { body, .. } => {
+            collect_assigned_names(body, out);
+        }
+        _ => {}
+    }
+}
+
+/// Build WP(body, post). The body must be a block of supported
+/// statements (assignments + invariant no-ops); anything else
+/// returns `None` so the caller treats this loop as unprovable.
+#[cfg(feature = "z3")]
+fn weakest_precondition(body: &Node, post: &Node) -> Option<Node> {
+    let stmts = match body {
+        Node::Block { stmts, .. } => stmts,
+        _ => return None,
+    };
+    let mut current = post.clone();
+    for stmt in stmts.iter().rev() {
+        match stmt {
+            Node::Assignment { name, value, .. } => {
+                current = substitute(&current, name, value);
+            }
+            Node::InvariantStatement { .. } => {
+                // No state change; pass through.
+            }
+            _ => return None,
+        }
+    }
+    Some(current)
+}
+
+/// Substitute every free occurrence of `name` in `node` with a clone
+/// of `replacement`. Walks the integer/boolean expression subset that
+/// `verifier_z3::translate_bool` can encode — anything richer is
+/// passed through unchanged, which keeps WP sound when the invariant
+/// references opaque sub-expressions (the prover will then bail
+/// during translation).
+#[cfg(feature = "z3")]
+fn substitute(node: &Node, name: &str, replacement: &Node) -> Node {
+    match node {
+        Node::Identifier { name: n, .. } if n == name => replacement.clone(),
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            span,
+        } => Node::InfixExpression {
+            left: Box::new(substitute(left, name, replacement)),
+            operator: operator.clone(),
+            right: Box::new(substitute(right, name, replacement)),
+            span: *span,
+        },
+        Node::PrefixExpression {
+            operator,
+            right,
+            span,
+        } => Node::PrefixExpression {
+            operator: operator.clone(),
+            right: Box::new(substitute(right, name, replacement)),
+            span: *span,
+        },
+        _ => node.clone(),
+    }
+}
+
+/// Build the implication `(P /\ cond) => Q` as an AST that the Z3
+/// translator understands: `(! (P && cond)) || Q`.
+#[cfg(feature = "z3")]
+fn build_implication(p: &Node, cond: &Node, q: &Node) -> Node {
+    let p_and_cond = Node::InfixExpression {
+        left: Box::new(p.clone()),
+        operator: "&&".to_string(),
+        right: Box::new(cond.clone()),
+        span: Span::default(),
+    };
+    let neg_p_and_cond = Node::PrefixExpression {
+        operator: "!".to_string(),
+        right: Box::new(p_and_cond),
+        span: Span::default(),
+    };
+    Node::InfixExpression {
+        left: Box::new(neg_p_and_cond),
+        operator: "||".to_string(),
+        right: Box::new(q.clone()),
+        span: Span::default(),
+    }
+}
+
+/// Best-effort span of an invariant expression, for the verbose
+/// stderr line. Falls back to the loop span when the invariant's
+/// own node doesn't carry one.
+#[cfg(feature = "z3")]
+fn invariant_span(node: &Node) -> Option<&Span> {
+    match node {
+        Node::InfixExpression { span, .. }
+        | Node::PrefixExpression { span, .. }
+        | Node::Identifier { span, .. }
+        | Node::IntegerLiteral { span, .. }
+        | Node::BooleanLiteral { span, .. } => Some(span),
+        _ => None,
+    }
+}
+
+#[cfg(all(test, feature = "z3"))]
+mod tests {
+    use super::*;
+    use crate::typechecker::TypeChecker;
+    use crate::{Lexer, Parser};
+
+    fn parse(src: &str) -> Node {
+        let lexer = Lexer::new(src.to_string());
+        let mut parser = Parser::new(lexer);
+        parser.parse_program()
+    }
+
+    fn run(src: &str) -> usize {
+        let p = parse(src);
+        // Run the body of the loop_invariants check first so a bad
+        // program doesn't reach the verifier with an out-of-loop
+        // `invariant` statement.
+        crate::loop_invariants::check(&p, "<test>").expect("loop_invariants check failed");
+        let mut tc = TypeChecker::new().with_warn_unverified(false);
+        let before = tc.loop_invariant_certificate_count();
+        super::verify_and_capture(&mut tc, &p);
+        tc.loop_invariant_certificate_count() - before
+    }
+
+    #[test]
+    fn provable_counter_invariant_is_discharged() {
+        // `i` starts at 0, never goes negative under the body.
+        let src = r#"
+            let i = 0;
+            let n = 5;
+            while i < n {
+                invariant i >= 0;
+                i = i + 1;
+            }
+        "#;
+        let proven = run(src);
+        assert_eq!(proven, 1, "expected exactly one proven invariant");
+    }
+
+    #[test]
+    fn unprovable_invariant_falls_through_silently() {
+        // `i <= 3` is FALSE on iteration 4 — the proof must fail.
+        let src = r#"
+            let i = 0;
+            let n = 5;
+            while i < n {
+                invariant i <= 3;
+                i = i + 1;
+            }
+        "#;
+        let proven = run(src);
+        assert_eq!(proven, 0, "expected the invariant to be unprovable");
+    }
+
+    #[test]
+    fn pre_body_invariant_form_also_proven() {
+        // RES-132a `while c invariant p { ... }` form.
+        let src = r#"
+            let i = 0;
+            let n = 5;
+            while i < n invariant i >= 0 {
+                i = i + 1;
+            }
+        "#;
+        let proven = run(src);
+        assert_eq!(proven, 1);
+    }
+
+    #[test]
+    fn multiple_invariants_each_attempted() {
+        // Both should discharge.
+        let src = r#"
+            let i = 0;
+            let n = 5;
+            while i < n {
+                invariant i >= 0;
+                invariant i <= n;
+                i = i + 1;
+            }
+        "#;
+        let proven = run(src);
+        assert_eq!(proven, 2, "expected both invariants proven");
+    }
+
+    #[test]
+    fn body_with_unsupported_statement_silently_bails() {
+        // A `println` inside the body breaks WP substitution. The
+        // proof must NOT discharge — runtime check stays.
+        let src = r#"
+            let i = 0;
+            let n = 5;
+            while i < n {
+                invariant i >= 0;
+                println("step");
+                i = i + 1;
+            }
+        "#;
+        let proven = run(src);
+        assert_eq!(proven, 0);
+    }
+
+    #[test]
+    fn for_in_loop_invariants_are_skipped_for_now() {
+        // `for-in` is out of scope for the MVP. The body still has
+        // a runtime check; the verifier does NOT attempt a proof.
+        let src = r#"
+            let s = 0;
+            for x in [1, 2, 3] invariant s >= 0 {
+                s = s + x;
+            }
+        "#;
+        let proven = run(src);
+        assert_eq!(proven, 0);
+    }
+
+    #[test]
+    fn weakest_precondition_handles_two_assignments() {
+        // Body: `j = j + 1; i = i + 1;`  invariant: `i + j >= 0`
+        // After WP: `(i + 1) + (j + 1) >= 0`. With base bindings
+        // i = 0, j = 0, both base + step are provable.
+        let src = r#"
+            let i = 0;
+            let j = 0;
+            let n = 5;
+            while i < n {
+                invariant i + j >= 0;
+                j = j + 1;
+                i = i + 1;
+            }
+        "#;
+        let proven = run(src);
+        assert_eq!(proven, 1);
+    }
+
+    #[test]
+    fn binding_substitution_in_substitute_helper_is_local() {
+        // Make sure `substitute` doesn't accidentally rewrite bound
+        // names that aren't the target. Invariant uses `n`, body
+        // assigns `i` — `n` must NOT be substituted.
+        let src = r#"
+            let i = 0;
+            let n = 5;
+            while i < n {
+                invariant n >= 5;
+                i = i + 1;
+            }
+        "#;
+        let proven = run(src);
+        assert_eq!(proven, 1);
+    }
+}


### PR DESCRIPTION
## Summary

Z3-backed Hoare-rule discharger for `while` loop `invariant` annotations. Closes #110 — the explicit follow-up to RES-222 (which added the runtime check).

For each `while` loop, for each invariant, the verifier proves:

1. **Base case** — invariant holds before entry, with pre-loop integer-literal bindings pinned in the solver.
2. **Inductive step** — with names assigned in the body left free, prove `(P ∧ cond) → WP(body, P)` via straight-line WP-substitution: `WP(v=e, Q) = Q[v/e]`, reverse-chained across statement sequences.

Bodies that fall outside the assignment-only subset (calls, control flow) cause WP to return `None` and the proof bails — the RES-222 runtime check stays as the sole line of defense, so there is no soundness gap.

## What's new

- `resilient/src/verifier_loop_invariants.rs` — entire pass, behind `#[cfg(feature = "z3")]`. Without `z3` the function is a no-op stub.
- Wired into `typechecker.rs` via the `<EXTENSION_PASSES>` block (one line). Adds `with_verbose_loop_invariants(bool)` builder + `push_loop_invariant_certificate(idx, smt2)` hook + `loop_invariants_proven` stat.
- `main.rs` — adds `--verbose` flag; threaded into `execute_file()` via the existing chain.
- Each discharged invariant produces an SMT-LIB2 cert with a `; ----- base case -----` / `; ----- inductive step -----` separator, captured via the existing certificate hook so `--emit-certificate` and re-verification (RES-071) include them.
- With `--verbose`, the driver prints `-- invariant proven, runtime check elided at L:C` to stderr per discharge.

## Golden tests

- [`invariant_proven_demo.rz`](resilient/examples/invariant_proven_demo.rz) — counter loop, both `i >= 0` and `i <= n` discharge.
- [`invariant_unprovable_demo.rz`](resilient/examples/invariant_unprovable_demo.rz) — body contains a `println` call, WP bails, runtime check still fires and passes (invariant actually holds).

## Local CI

| Gate | Result |
|---|---|
| `cargo build` (default) | ✅ |
| `cargo test` (default) | ✅ 976 passed, 0 failed |
| `cargo test --features z3` | ✅ 1042 passed, 0 failed (+8 new unit tests) |
| `cargo clippy --all-targets -- -D warnings` (default) | ✅ |
| `cargo clippy --all-targets --features z3 -- -D warnings` | ✅ |
| `cargo fmt --all -- --check` | ✅ |

## Test plan

- [x] Provable counter discharges base + inductive
- [x] Unsupported body shape (println) bails cleanly, runtime check survives
- [x] Pre-body invariant statement-form parsed via `loop_invariants::collect_body_invariants`
- [x] Multiple invariants per loop discharge independently
- [x] Two-statement WP via reverse substitution (`weakest_precondition_handles_two_assignments`)
- [x] Free-vs-bound: assigned-in-body names dropped from inductive-step bindings to keep the proof universal
- [x] No regression in default-feature suite
- [x] Codegen elision is intentionally NOT done here — runtime check still emitted; that's a separate G9 ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)