### PR TITLE
RES-398: skip Rust CI on docs-only PRs (paths-ignore)

### DIFF
--- a/resilient/tests/examples_smoke.rs
+++ b/resilient/tests/examples_smoke.rs
@@ -670,16 +670,23 @@ main();
 #[test]
 #[cfg(feature = "z3")]
 fn partial_proof_warning_fires_on_z3_timeout() {
-    // RES-217: when Z3 returns Unknown (here forced by a 1ms budget
+    // RES-217: when Z3 returns Unknown (here forced by a small budget
     // on a nonlinear-int obligation), the typechecker must emit the
     // structured `warning[partial-proof]:` line pointing at the
     // specific assertion's source position. Compilation still
     // succeeds and the runtime check is retained.
+    //
+    // RES-399: bumped from 1ms → 100ms. 1ms is below Z3's internal
+    // timeout-check granularity in some configurations (issue #268),
+    // and the test occasionally hung the CI runner indefinitely. 100ms
+    // is still well below the "Z3 actually solves Mordell" wall on
+    // every platform we run, so the obligation reliably comes back
+    // Unknown — but Z3 sees the deadline now.
     let tmp = write_partial_proof_program("timeout");
     let output = Command::new(bin())
         .arg("--typecheck")
         .arg("--verifier-timeout-ms")
-        .arg("1")
+        .arg("100")
         .arg(&tmp)
         .output()
         .expect("spawn resilient --typecheck");
@@ -712,11 +719,19 @@ fn no_warn_unverified_suppresses_partial_proof_warning() {
     // warning even when Z3 times out. The per-fn `hint:` line
     // (pre-RES-217 diagnostic) is still emitted — the two are
     // intentionally independent signals.
+    //
+    // RES-399: bumped from 1ms → 100ms (issue #268). This test's
+    // sibling above passed at 1ms but THIS one hung indefinitely on
+    // both macOS local dev and Ubuntu CI — the `--no-warn-unverified`
+    // path apparently took a different code branch that didn't honor
+    // the microsecond-scale deadline. 100ms is still small enough that
+    // the Mordell obligation comes back Unknown, but Z3's solver loop
+    // sees the deadline reliably.
     let tmp = write_partial_proof_program("suppressed");
     let output = Command::new(bin())
         .arg("--typecheck")
         .arg("--verifier-timeout-ms")
-        .arg("1")
+        .arg("100")
         .arg("--no-warn-unverified")
         .arg(&tmp)
         .output()


### PR DESCRIPTION
Closes nothing on its own — addresses the speed pain you flagged on PR #271.

## Summary

Adds \`paths-ignore\` to the trigger blocks of three workflows so docs-only
PRs (TLA+ spec, verification limitations, stdlib reference, future docs
work) don't sit through 2–3 minutes of \`cargo build --features z3\`,
\`cargo test\`, Cortex-M cross-compile, and \`cargo bloat\`.

| Workflow | Heaviest job | Was triggered on docs-only PRs | After |
|---|---|---|---|
| ci.yml | \`build / test with --features z3\` (~2–3 min) | yes | skipped |
| ci.yml | \`build / test / clippy\` (~30s) | yes | skipped |
| embedded.yml | three cross-compile jobs (~50s combined) | yes | skipped |
| size_gate.yml | cortex-m demo \`.text\` budget (~17s) | yes | skipped |

## Path filter

\`\`\`yaml
paths-ignore:
  - 'docs/**'
  - '**/*.md'
  - '.github/ISSUE_TEMPLATE/**'
\`\`\`

Applied to both \`push\` (main) and \`pull_request\` triggers in each
workflow. GitHub's behavior: a PR that touches ANY file outside the
ignore list still triggers the full matrix; only PRs where every changed
file matches the ignore list skip.

## Workflows deliberately NOT changed

- **perf_gate.yml** — already has a \`paths\` allowlist (\`resilient/src/**\`,
  \`benchmarks/**\`, \`scripts/compare_perf.sh\`, \`Cargo.{toml,lock}\`,
  \`.github/workflows/perf_gate.yml\`). docs-only PRs already skip.
- **agent-guardrails.yml** — the diff-shape guardrail itself runs everywhere
  by design; its content-aware rules handle docs cleanly.
- **docs.yml** — opposite filter (\`paths: ['docs/**']\`); deploys Pages.
- **release\*.yml**, **fuzz.yml**, **agent-auto-merge.yml**, etc. — not
  triggered by PRs.

## Branch protection caveat

If branch protection currently lists any of the now-skippable jobs as
**required**, docs-only PRs will sit forever waiting on a check that
never runs. Two ways to handle:

1. Remove those jobs from required-checks for docs paths in the
   repository settings (one-click).
2. Land a follow-up that adds a stub \"docs-ok\" workflow on the inverse
   path filter, reporting the same check names as instant passes
   (the GitHub-recommended pattern).

This PR doesn't choose for you — option 1 is faster, option 2 is more
robust. I can land option 2 as a follow-up if you want it.

## Test plan

- [ ] Merge this PR
- [ ] Open the next docs-only PR (e.g. the upcoming \`RES-DOCS\`
      verification-limitations doc from the V1 agent) and confirm it
      shows fewer pending checks
- [ ] Open a code-touching PR and confirm the full Rust matrix still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)