### PR TITLE
RES-399: bump z3 timeout-test deadline 1ms → 100ms (closes #268)

### DIFF
--- a/resilient/tests/examples_smoke.rs
+++ b/resilient/tests/examples_smoke.rs
@@ -670,16 +670,23 @@ main();
 #[test]
 #[cfg(feature = "z3")]
 fn partial_proof_warning_fires_on_z3_timeout() {
-    // RES-217: when Z3 returns Unknown (here forced by a 1ms budget
+    // RES-217: when Z3 returns Unknown (here forced by a small budget
     // on a nonlinear-int obligation), the typechecker must emit the
     // structured `warning[partial-proof]:` line pointing at the
     // specific assertion's source position. Compilation still
     // succeeds and the runtime check is retained.
+    //
+    // RES-399: bumped from 1ms → 100ms. 1ms is below Z3's internal
+    // timeout-check granularity in some configurations (issue #268),
+    // and the test occasionally hung the CI runner indefinitely. 100ms
+    // is still well below the "Z3 actually solves Mordell" wall on
+    // every platform we run, so the obligation reliably comes back
+    // Unknown — but Z3 sees the deadline now.
     let tmp = write_partial_proof_program("timeout");
     let output = Command::new(bin())
         .arg("--typecheck")
         .arg("--verifier-timeout-ms")
-        .arg("1")
+        .arg("100")
         .arg(&tmp)
         .output()
         .expect("spawn resilient --typecheck");
@@ -712,11 +719,19 @@ fn no_warn_unverified_suppresses_partial_proof_warning() {
     // warning even when Z3 times out. The per-fn `hint:` line
     // (pre-RES-217 diagnostic) is still emitted — the two are
     // intentionally independent signals.
+    //
+    // RES-399: bumped from 1ms → 100ms (issue #268). This test's
+    // sibling above passed at 1ms but THIS one hung indefinitely on
+    // both macOS local dev and Ubuntu CI — the `--no-warn-unverified`
+    // path apparently took a different code branch that didn't honor
+    // the microsecond-scale deadline. 100ms is still small enough that
+    // the Mordell obligation comes back Unknown, but Z3's solver loop
+    // sees the deadline reliably.
     let tmp = write_partial_proof_program("suppressed");
     let output = Command::new(bin())
         .arg("--typecheck")
         .arg("--verifier-timeout-ms")
-        .arg("1")
+        .arg("100")
         .arg("--no-warn-unverified")
         .arg(&tmp)
         .output()


### PR DESCRIPTION
Closes #268.

## Summary

Two tests in \`resilient/tests/examples_smoke.rs\` use \`--verifier-timeout-ms 1\`
to force Z3 into Unknown on a Mordell-curve obligation. The first
(\`partial_proof_warning_fires_on_z3_timeout\`) passes reliably. The second
(\`no_warn_unverified_suppresses_partial_proof_warning\`) hung indefinitely
on both macOS local dev and Ubuntu CI when PR #264 ran — sat for 30+
minutes before manual cancellation. Same code passed in 1m7s on PR #263
the same day. Flake.

Root cause hypothesis: Z3's solver loop doesn't poll its deadline between
every internal step; at 1ms the deadline can fall in a setup window the
loop never re-checks, and the \`--no-warn-unverified\` path hits that
window more often than its sibling. The proper fix is an audit of the
per-query timeout plumbing in \`verifier_z3.rs\`; that's the scope of
issue #268 itself.

This PR is the **workaround**: bump both tests' deadline to 100ms. Z3's
solver loop reliably hits the deadline check; NIA still comes back
Unknown on the Mordell obligation; flake disappears. The hypothesis +
workaround are documented in the test comments so the proper fix
doesn't lose context.

## Why bump both, not just the flaky one

Symmetry — the two tests are deliberately a pair (with and without
\`--no-warn-unverified\`). Keeping their timeouts identical makes diff
review against future changes easier and avoids confusion about which
value is intentional.

## Test changes

Modified two existing tests:

- \`partial_proof_warning_fires_on_z3_timeout\`: timeout literal
  \`\"1\"\` → \`\"100\"\`. **No assertions changed.** Same 4 \`assert!\` calls
  proving Z3 returns Unknown and the warning fires.
- \`no_warn_unverified_suppresses_partial_proof_warning\`: same literal
  swap. Same 1 negated \`assert!\` proving the warning is suppressed.

Net assertion count: 5 before, 5 after. The diff-shape guardrail's
content-aware test rule (RES-219) allows this — no test deletion, no
weakening, just a literal-value tweak.

## Verification

- \`cargo build --tests --manifest-path resilient/Cargo.toml\`: clean
- \`cargo fmt --check\`: clean
- \`cargo test --features z3\`: full z3 run will exercise both tests in
  this PR's CI run; incidentally proves the workaround.

## Test plan

- [ ] CI's \`build / test with --features z3\` job completes in <2 minutes
      (was 1m7s on the green run, ~indefinite on the flaky run)
- [ ] Both renamed tests pass
- [ ] No regression in any other test

🤖 Generated with [Claude Code](https://claude.com/claude-code)