### PR TITLE
RES-398: skip Rust CI on docs-only PRs (paths-ignore)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,21 @@ name: CI
 on:
   push:
     branches: [main]
+    # RES-398: docs-only changes don't affect Rust build/test/clippy
+    # output, so skip the heavy matrix when only docs/markdown change.
+    # Anything that touches code (.rs, Cargo.{toml,lock}, src/, tests/,
+    # benches/) still runs the full matrix because those paths are not
+    # in the ignore list.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
 
 # One job per push/PR is enough — cancel in-flight runs on rebase.
 concurrency:

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -13,8 +13,17 @@ name: embedded
 on:
   push:
     branches: [main]
+    # RES-398: skip cross-compile gate when only docs/markdown change.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/size_gate.yml
+++ b/.github/workflows/size_gate.yml
@@ -16,8 +16,18 @@ name: size-gate
 on:
   push:
     branches: [main]
+    # RES-398: docs/markdown-only changes can't move the .text size,
+    # so skip the cargo-bloat run when nothing relevant changed.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The actual paths-ignore PR. (PR #273 had the same branch listed by mistake — that one
ended up landing the RES-399 timeout fix instead, and the original PR
description got attached to the wrong commit. Re-opening with the
correct branch + content.)

## Summary

Adds \`paths-ignore\` to three workflows so docs-only PRs (TLA+ spec,
verification limitations doc, stdlib reference, future docs work)
don't sit through 2–3 minutes of \`cargo build --features z3\`,
\`cargo test\`, Cortex-M cross-compile, and \`cargo bloat\`.

| Workflow | Heaviest job | Was triggered on docs-only PRs | After |
|---|---|---|---|
| ci.yml | \`build / test with --features z3\` (~2–3 min) | yes | skipped |
| ci.yml | \`build / test / clippy\` (~30s) | yes | skipped |
| embedded.yml | three cross-compile jobs (~50s combined) | yes | skipped |
| size_gate.yml | cortex-m demo \`.text\` budget (~17s) | yes | skipped |

## Path filter

\`\`\`yaml
paths-ignore:
  - 'docs/**'
  - '**/*.md'
  - '.github/ISSUE_TEMPLATE/**'
\`\`\`

Applied to both \`push\` (main) and \`pull_request\` triggers in each
workflow. GitHub's behavior: a PR that touches ANY file outside the
ignore list still triggers the full matrix; only PRs where every
changed file matches the ignore list skip.

## Workflows deliberately NOT changed

- **perf_gate.yml** — already has a \`paths\` allowlist. Docs-only PRs
  already skip.
- **agent-guardrails.yml** — the diff-shape guardrail itself runs
  everywhere by design; its content-aware rules handle docs cleanly.
- **docs.yml** — opposite filter (\`paths: ['docs/**']\`); deploys Pages.
- **release\*.yml**, **fuzz.yml**, etc. — not triggered by PRs.

## Branch protection caveat

If branch protection currently lists any of the now-skippable jobs as
**required**, docs-only PRs will sit forever waiting on a check that
never runs. Two ways to handle:

1. Remove those jobs from required-checks for docs paths in repo
   settings (one-click).
2. Land a follow-up adding a stub \`docs-ok\` workflow on the inverse
   path filter that reports the same check names as instant passes.

This PR doesn't choose for you — option 1 is faster, option 2 is more
robust.

## Test plan

- [ ] Merge this PR
- [ ] Open the next docs-only PR and confirm fewer pending checks
- [ ] Open a code-touching PR and confirm the full Rust matrix still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)