### PR TITLE
RES-VM: wire builtins through bytecode VM

### DIFF
--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -141,6 +141,19 @@ pub enum Op {
     /// `#[cfg(feature = "ffi")]` at dispatch time but the variant exists
     /// unconditionally so the compiler/disassembler don't need feature flags.
     CallForeign(u16),
+    /// RES-VM (issue #266): call a registered builtin function (`println`,
+    /// `len`, `to_upper`, etc.). `name_const` indexes into the chunk's
+    /// constant pool where the builtin's name lives as a `Value::String`,
+    /// and `arity` is the argument count compiled at the call site. The
+    /// VM pops `arity` values (rightmost first), looks the builtin up by
+    /// name, invokes it, and pushes the returned value. Mirrors the
+    /// tree-walker's `Value::Builtin` dispatch in `apply_function`.
+    ///
+    /// Storing the name (rather than a function pointer index) keeps the
+    /// `Op` enum `Copy` and avoids embedding a separate per-program
+    /// builtin table — the canonical `BUILTINS` slice in `main.rs` is
+    /// the single source of truth and is consulted at dispatch time.
+    CallBuiltin { name_const: u16, arity: u8 },
     /// RES-335: build a `Value::Struct` from `field_count` `(name, value)`
     /// pairs on the operand stack. Stack layout on entry (top → bottom):
     /// `[v_N, k_N, ..., v_1, k_1, struct_type_name, ...]` — each `k_i`

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -618,6 +618,22 @@ fn compile_expr(
             chunk.emit(Op::Const(idx), line);
             Ok(())
         }
+        // RES-VM (issue #266): string + float literals. Required so
+        // calls like `println("hello")` and `sin(1.5)` reach the
+        // bytecode VM. The constant pool already accepts `Value::String`
+        // and `Value::Float` (used today by struct/field name interning
+        // and dedup); routing the literal nodes here lets builtin args
+        // round-trip without touching the runtime.
+        Node::StringLiteral { value: s, .. } => {
+            let idx = chunk.add_constant(Value::String(s.clone()))?;
+            chunk.emit(Op::Const(idx), line);
+            Ok(())
+        }
+        Node::FloatLiteral { value: x, .. } => {
+            let idx = chunk.add_constant(Value::Float(*x))?;
+            chunk.emit(Op::Const(idx), line);
+            Ok(())
+        }
         Node::Identifier { name, .. } => {
             let idx = *locals
                 .get(name)
@@ -730,16 +746,40 @@ fn compile_expr(
                 chunk.emit(Op::CallForeign(idx), line);
                 return Ok(());
             }
-            let callee_idx = *fn_index
-                .get(&callee_name)
-                .ok_or_else(|| CompileError::UnknownFunction(callee_name.clone()))?;
-            // Push args left-to-right so the VM can pop them in reverse
-            // and assign to locals 0..arity in source order.
-            for arg in arguments {
-                compile_expr(arg, chunk, locals, fn_index, ffi_index, line)?;
+            // User-defined function next.
+            if let Some(&callee_idx) = fn_index.get(&callee_name) {
+                // Push args left-to-right so the VM can pop them in reverse
+                // and assign to locals 0..arity in source order.
+                for arg in arguments {
+                    compile_expr(arg, chunk, locals, fn_index, ffi_index, line)?;
+                }
+                chunk.emit(Op::Call(callee_idx), line);
+                return Ok(());
             }
-            chunk.emit(Op::Call(callee_idx), line);
-            Ok(())
+            // RES-VM (issue #266): fall back to the canonical builtin
+            // table. The tree walker dispatches builtins through
+            // `Value::Builtin`; the bytecode VM achieves the same by
+            // emitting `Op::CallBuiltin { name_const, arity }`. Limit
+            // arity to u8 so the opcode stays Copy + 4 bytes; calls
+            // with >255 args are rejected before any code is emitted.
+            if crate::lookup_builtin(&callee_name).is_some() {
+                if arguments.len() > u8::MAX as usize {
+                    return Err(CompileError::Unsupported("builtin call with > 255 args"));
+                }
+                let name_const = chunk.add_constant(Value::String(callee_name.clone()))?;
+                for arg in arguments {
+                    compile_expr(arg, chunk, locals, fn_index, ffi_index, line)?;
+                }
+                chunk.emit(
+                    Op::CallBuiltin {
+                        name_const,
+                        arity: arguments.len() as u8,
+                    },
+                    line,
+                );
+                return Ok(());
+            }
+            Err(CompileError::UnknownFunction(callee_name))
         }
         // RES-171a: `[a, b, c]` literal → emit each item's expression
         // left-to-right, then `Op::MakeArray { len }` which pops them
@@ -1253,6 +1293,59 @@ mod tests {
         let p = parse_one("nope();");
         let err = compile(&p).unwrap_err();
         assert!(matches!(err, CompileError::UnknownFunction(_)), "{:?}", err);
+    }
+
+    /// RES-VM (issue #266): `println("hi")` lowers to a `CallBuiltin`
+    /// op (not `Call`, which is for user functions). The constant pool
+    /// holds the builtin's name as a `Value::String`; arity is the
+    /// argument count.
+    #[test]
+    fn compile_println_emits_call_builtin() {
+        let p = parse_one("println(\"hi\");");
+        let prog = compile(&p).unwrap();
+        // Find the CallBuiltin op and verify its constant resolves
+        // to the builtin name.
+        let mut found = false;
+        for op in &prog.main.code {
+            if let Op::CallBuiltin { name_const, arity } = op {
+                let name = match prog.main.constants.get(*name_const as usize) {
+                    Some(Value::String(s)) => s.clone(),
+                    other => panic!("expected Value::String at name_const, got {:?}", other),
+                };
+                assert_eq!(name, "println");
+                assert_eq!(*arity, 1);
+                found = true;
+            }
+        }
+        assert!(
+            found,
+            "expected a CallBuiltin op in main.code: {:?}",
+            prog.main.code
+        );
+    }
+
+    /// RES-VM (issue #266): a user-defined function with the same
+    /// name as a builtin shadows the builtin. Compile path picks the
+    /// user fn (Call), not CallBuiltin — mirrors the tree walker's
+    /// lookup order where the user binding wins.
+    #[test]
+    fn compile_user_fn_shadows_builtin() {
+        let p = parse_one("fn println() { return 1; } println();");
+        let prog = compile(&p).unwrap();
+        assert!(
+            prog.main.code.iter().any(|op| matches!(op, Op::Call(_))),
+            "expected Call (user fn) in main.code: {:?}",
+            prog.main.code
+        );
+        assert!(
+            !prog
+                .main
+                .code
+                .iter()
+                .any(|op| matches!(op, Op::CallBuiltin { .. })),
+            "user fn must shadow builtin; got: {:?}",
+            prog.main.code
+        );
     }
 
     #[test]

--- a/resilient/src/disasm.rs
+++ b/resilient/src/disasm.rs
@@ -184,6 +184,15 @@ fn write_op(
         Op::StoreIndex => write!(out, "StoreIndex")?,
         // FFI v2.
         Op::CallForeign(idx) => write!(out, "CallForeign {idx:<6}")?,
+        // RES-VM (issue #266): builtin call. Annotate with the resolved
+        // name so a glance at the disassembly tells the reader which
+        // builtin this op invokes.
+        Op::CallBuiltin { name_const, arity } => {
+            write!(out, "CallBuiltin {} {}", name_const, arity)?;
+            if let Some(v) = chunk.constants.get(name_const as usize) {
+                write!(out, "  ; -> {}", v)?;
+            }
+        }
         // RES-335: struct-op disasm. The name is a constant-pool index
         // into a `Value::String`; resolve and annotate it.
         Op::StructLiteral {

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -7079,6 +7079,16 @@ pub(crate) fn builtin_names() -> impl Iterator<Item = &'static str> {
     BUILTINS.iter().map(|(name, _func)| *name)
 }
 
+/// RES-VM (issue #266): look up a builtin by name. Returns `Some(func)`
+/// when the name appears in the canonical `BUILTINS` table, `None`
+/// otherwise. Used by the bytecode compiler to decide whether a
+/// not-a-user-function call site should lower to `Op::CallBuiltin`,
+/// and by the VM to dispatch that opcode through the same function
+/// pointer the tree-walker invokes.
+pub(crate) fn lookup_builtin(name: &str) -> Option<BuiltinFn> {
+    BUILTINS.iter().find(|(n, _)| *n == name).map(|(_, f)| *f)
+}
+
 /// Canonical list of every native function visible in a fresh
 /// Resilient program.
 const BUILTINS: &[(&str, BuiltinFn)] = &[

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -57,6 +57,17 @@ pub enum VmError {
     },
     /// FFI v2: the trampoline returned an error string.
     ForeignCallFailed(String),
+    /// RES-VM (issue #266): a `CallBuiltin` op referenced a name that
+    /// isn't present in the canonical `BUILTINS` table. Should not
+    /// happen for chunks emitted by `compiler::compile` (which only
+    /// emits `CallBuiltin` after a positive lookup); guards hand-rolled
+    /// chunks and protects against a builtin being removed from the
+    /// table without recompiling cached bytecode.
+    UnknownBuiltin(String),
+    /// RES-VM (issue #266): the builtin function returned an `Err`.
+    /// Wraps the message it produced so the user sees the same
+    /// diagnostic the tree-walker would have emitted.
+    BuiltinCallFailed(String),
     /// RES-335: `GetField`/`SetField` on a struct value whose field
     /// table has no entry matching the requested name.
     UnknownField {
@@ -97,6 +108,8 @@ impl std::fmt::Display for VmError {
             ),
             VmError::AtLine { line, kind } => write!(f, "{} (line {})", kind, line),
             VmError::ForeignCallFailed(msg) => write!(f, "ffi call failed: {}", msg),
+            VmError::UnknownBuiltin(name) => write!(f, "vm: unknown builtin: {}", name),
+            VmError::BuiltinCallFailed(msg) => write!(f, "vm: builtin call failed: {}", msg),
             VmError::UnknownField { struct_name, field } => {
                 write!(f, "vm: struct {} has no field '{}'", struct_name, field)
             }
@@ -488,6 +501,34 @@ fn run_inner(program: &Program, last_pc: &mut (usize, usize)) -> Result<Value, V
                 return Err(VmError::Unsupported(
                     "CallForeign (build without --features ffi)",
                 ));
+            }
+            // RES-VM (issue #266): builtin call. Resolve the name from
+            // the constant pool, look it up in the canonical BUILTINS
+            // table, pop `arity` arguments (reversing into source
+            // order), invoke the function, and push the result. The
+            // builtin returns `RResult<Value>` (`Result<Value, String>`);
+            // we wrap the error string in `BuiltinCallFailed`.
+            Op::CallBuiltin { name_const, arity } => {
+                let name_val = chunk
+                    .constants
+                    .get(name_const as usize)
+                    .ok_or(VmError::ConstantOutOfBounds(name_const))?;
+                let name = match name_val {
+                    Value::String(s) => s.clone(),
+                    _ => return Err(VmError::TypeMismatch("CallBuiltin (non-string name)")),
+                };
+                let func = crate::lookup_builtin(&name)
+                    .ok_or_else(|| VmError::UnknownBuiltin(name.clone()))?;
+                let n = arity as usize;
+                if stack.len() < n {
+                    return Err(VmError::EmptyStack);
+                }
+                let mut args: Vec<Value> = (0..n)
+                    .map(|_| stack.pop().expect("checked above"))
+                    .collect();
+                args.reverse();
+                let result = func(&args).map_err(VmError::BuiltinCallFailed)?;
+                stack.push(result);
             }
             // ---- RES-171a: array ops ----
             Op::MakeArray { len } => {

--- a/resilient/tests/examples_smoke.rs
+++ b/resilient/tests/examples_smoke.rs
@@ -903,3 +903,80 @@ fn shift_bounds_example_runs_and_shifts_correctly() {
     // `shift_and_xor(16)` = (16 >> 4) ^ 0 = 1 ^ 0 = 1.
     assert!(stdout.contains("1"), "expected 1 in stdout; got:\n{stdout}");
 }
+
+#[test]
+fn bytecode_vm_runs_println_builtin() {
+    // RES-VM (issue #266): the bytecode VM previously rejected any
+    // call to a builtin (`println`, `len`, `to_upper`, ...) with
+    // `bytecode compile: unknown function: println`. Wire-up: the
+    // compiler emits `Op::CallBuiltin { name_const, arity }` for any
+    // call site whose callee isn't a user-defined fn or a foreign
+    // symbol, and the VM dispatches it through the same `BUILTINS`
+    // table the tree walker uses.
+    use std::io::Write;
+    let tmp = std::env::temp_dir().join(format!("res_vm_println_{}.rs", std::process::id()));
+    {
+        let mut f = std::fs::File::create(&tmp).expect("create tmp");
+        writeln!(f, "fn main() {{ println(\"hello-from-vm\"); return 0; }}").unwrap();
+        writeln!(f, "main();").unwrap();
+    }
+    let output = Command::new(bin())
+        .arg("--vm")
+        .arg(&tmp)
+        .output()
+        .expect("spawn resilient");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "vm println path must exit 0; stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown function"),
+        "regression: builtin lookup failed under --vm; stderr=\n{stderr}"
+    );
+    assert!(
+        stdout.contains("hello-from-vm"),
+        "expected `hello-from-vm` in stdout; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[test]
+fn bytecode_vm_runs_multiple_builtins() {
+    // RES-VM (issue #266): exercise three commonly-used builtins
+    // through the VM in a single program. `len` returns an i64 that
+    // round-trips back to the println dispatch; `to_upper` returns a
+    // String the VM must keep on the operand stack until the next
+    // `println` consumes it. Catches regressions where the dispatch
+    // arm forgets to push the result, or where the constant-pool
+    // name interning collides across distinct call sites.
+    use std::io::Write;
+    let tmp = std::env::temp_dir().join(format!("res_vm_builtins_{}.rs", std::process::id()));
+    {
+        let mut f = std::fs::File::create(&tmp).expect("create tmp");
+        writeln!(f, "println(\"hi\");").unwrap();
+        writeln!(f, "println(to_upper(\"resilient\"));").unwrap();
+        writeln!(f, "let s = \"hello\";").unwrap();
+        writeln!(f, "println(len(s));").unwrap();
+        writeln!(f, "return 0;").unwrap();
+    }
+    let output = Command::new(bin())
+        .arg("--vm")
+        .arg(&tmp)
+        .output()
+        .expect("spawn resilient");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "vm multi-builtin path must exit 0; stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("hi") && stdout.contains("RESILIENT") && stdout.contains("5"),
+        "expected hi / RESILIENT / 5 from println+to_upper+len; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_file(&tmp);
+}


### PR DESCRIPTION
Closes #266

## Summary

The bytecode VM rejected every call to a builtin (`println`, `len`, `to_upper`, ...) with `bytecode compile: unknown function: <name>` because the compiler only consulted user-fn and FFI tables at call sites. The tree walker hits the same names through `Value::Builtin`; the VM needed the same dispatch.

- New `Op::CallBuiltin { name_const: u16, arity: u8 }` opcode (4-byte envelope preserved). The builtin name lives in the constant pool as `Value::String`; arity is compiled at the call site.
- `pub(crate) fn lookup_builtin(name) -> Option<BuiltinFn>` in `main.rs` exposes the canonical `BUILTINS` table to sibling modules.
- Compiler falls through to `lookup_builtin` for any callee that isn't a user fn or FFI symbol. On hit it emits `CallBuiltin`; on miss it still surfaces `CompileError::UnknownFunction`.
- VM dispatches `CallBuiltin` by popping `arity` args (rightmost first → reverse to source order), invoking the same `fn(&[Value]) -> RResult<Value>` the tree walker uses, and pushing the result. Builtin `Err` returns surface as `VmError::BuiltinCallFailed`. Two new VM error variants (`UnknownBuiltin`, `BuiltinCallFailed`) keep the dispatch path fully typed.
- Compiler now also accepts `StringLiteral` and `FloatLiteral` as expressions — required so any builtin call with a literal arg actually reaches the VM (`println("hello")` previously failed at `unsupported construct: StringLiteral` long before the call-site lookup).

The full builtin surface (30+ entries) is now reachable under `--vm` because dispatch is by name through the canonical table. Verified locally with `println`, `len`, `to_upper`, `to_lower`, `abs`, `min`, `max`.

## Test changes

No existing tests modified. New tests:
- `compile_println_emits_call_builtin` (compiler unit) — verifies `println("hi")` lowers to a `CallBuiltin` op with the right name in the constant pool and `arity = 1`.
- `compile_user_fn_shadows_builtin` (compiler unit) — a user fn named `println` still wins over the builtin (mirrors tree-walker lookup order).
- `bytecode_vm_runs_println_builtin` (integration) — full parse → compile → VM → stdout for the issue's repro program.
- `bytecode_vm_runs_multiple_builtins` (integration) — exercises `println`, `to_upper`, and `len` in one VM run.

All existing 880+ tests still pass; clippy + rustfmt clean.

[Generated with Claude Code](https://claude.com/claude-code)