### PR TITLE
RES-306: diagnostics — did-you-mean for undefined identifiers

### DIFF
--- a/resilient/src/did_you_mean.rs
+++ b/resilient/src/did_you_mean.rs
@@ -1,0 +1,188 @@
+// RES-306: did-you-mean suggestions for undefined identifiers.
+//
+// When the typechecker (or any other diagnostic emitter) hits an
+// unknown name, it can call `suggest(target, candidates)` to get a
+// short, deduplicated list of in-scope names that are within
+// Levenshtein distance 2 of the typo. The caller is then free to
+// stitch the result into a diagnostic such as
+//   `Undefined variable 'lentgh' at 3:5 — did you mean `len`?`
+//
+// Design notes:
+// - Inputs shorter than 3 chars are skipped to avoid false positives
+//   (a 1-char typo of `x` matches every other 1-char binding).
+// - At most 3 candidates are returned, sorted by distance ascending
+//   then lexicographically. Ties beyond 3 are truncated.
+// - The function takes an iterator so callers can stream from
+//   multiple sources (locals + builtins + functions) without first
+//   materialising into a Vec.
+
+/// Suggest up to 3 in-scope names that are within Levenshtein
+/// distance 2 of `target`. Returns owned `String`s for ergonomic
+/// insertion into diagnostics. Returns an empty Vec if `target` is
+/// shorter than 3 chars or no candidate is close enough.
+pub fn suggest<'a>(target: &str, candidates: impl Iterator<Item = &'a str>) -> Vec<String> {
+    if target.chars().count() < 3 {
+        return Vec::new();
+    }
+
+    let mut scored: Vec<(usize, String)> = candidates
+        .filter(|c| !c.is_empty() && *c != target)
+        .map(|c| (levenshtein(target, c), c.to_string()))
+        .filter(|(d, _)| *d <= 2)
+        .collect();
+
+    // Stable sort: distance asc, then name asc. Dedup by name in case
+    // the caller fed overlapping iterators (e.g. a local that
+    // shadows a builtin).
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    scored.dedup_by(|a, b| a.1 == b.1);
+
+    scored.into_iter().take(3).map(|(_, n)| n).collect()
+}
+
+/// Plain Levenshtein distance with a rolling two-row buffer. Operates
+/// on Unicode scalar values (`char`) so multi-byte identifiers are
+/// counted correctly.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let n = a.len();
+    let m = b.len();
+
+    if n == 0 {
+        return m;
+    }
+    if m == 0 {
+        return n;
+    }
+
+    let mut prev: Vec<usize> = (0..=m).collect();
+    let mut curr: Vec<usize> = vec![0; m + 1];
+
+    for i in 1..=n {
+        curr[0] = i;
+        for j in 1..=m {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            curr[j] = (prev[j] + 1) // deletion
+                .min(curr[j - 1] + 1) // insertion
+                .min(prev[j - 1] + cost); // substitution
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[m]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(slice: &[&'static str]) -> Vec<&'static str> {
+        slice.to_vec()
+    }
+
+    #[test]
+    fn levenshtein_basic() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("a", ""), 1);
+        assert_eq!(levenshtein("", "a"), 1);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("len", "len"), 0);
+        assert_eq!(levenshtein("lentgh", "length"), 2);
+        assert_eq!(levenshtein("foo", "fob"), 1);
+    }
+
+    #[test]
+    fn typo_finds_close_match() {
+        let pool = names(&["len", "length", "println", "print"]);
+        let got = suggest("lentgh", pool.iter().copied());
+        assert!(got.contains(&"length".to_string()), "got = {:?}", got);
+    }
+
+    #[test]
+    fn no_match_returns_empty() {
+        let pool = names(&["println", "abs", "min", "max"]);
+        let got = suggest("totally_unrelated", pool.iter().copied());
+        assert!(got.is_empty(), "got = {:?}", got);
+    }
+
+    #[test]
+    fn multiple_candidates_returned_sorted() {
+        // All within distance 2 of "fob".
+        let pool = names(&["foo", "for", "fob", "fop", "fox"]);
+        let got = suggest("fox_", pool.iter().copied());
+        // distance("fox_","fox") = 1, others = 2; first must be `fox`.
+        assert_eq!(got.first().map(String::as_str), Some("fox"));
+        assert!(got.len() <= 3);
+    }
+
+    #[test]
+    fn caps_at_three_candidates() {
+        let pool = names(&["foo", "fop", "fob", "for", "fox", "fou", "foz"]);
+        let got = suggest("foa", pool.iter().copied());
+        assert_eq!(got.len(), 3);
+    }
+
+    #[test]
+    fn ties_sorted_by_distance_then_name() {
+        // distance 1 candidates: "len"  (delete 'g')  — wait, target is "leg"
+        // target = "leg":
+        //   "len" -> d=1 (sub), "leg" itself filtered, "let" d=1 (sub),
+        //   "lez" d=1, etc.
+        let pool = names(&["lez", "len", "let"]);
+        let got = suggest("leg", pool.iter().copied());
+        // All distance 1. Should be sorted alphabetically.
+        assert_eq!(got, vec!["len", "let", "lez"]);
+    }
+
+    #[test]
+    fn short_input_returns_empty() {
+        let pool = names(&["abs", "abc", "min"]);
+        // 2-char input — too short to suggest reliably.
+        let got = suggest("ab", pool.iter().copied());
+        assert!(got.is_empty(), "got = {:?}", got);
+
+        // 1-char input — also skipped.
+        let got = suggest("a", pool.iter().copied());
+        assert!(got.is_empty(), "got = {:?}", got);
+    }
+
+    #[test]
+    fn distance_three_not_suggested() {
+        // "hello" vs "world" — Levenshtein distance is 4.
+        let pool = names(&["world"]);
+        let got = suggest("hello", pool.iter().copied());
+        assert!(got.is_empty(), "got = {:?}", got);
+
+        // Distance exactly 3 must also be excluded.
+        // "abcdef" vs "ghidef" — distance is 3 (sub 3 chars).
+        let pool = names(&["ghidef"]);
+        let got = suggest("abcdef", pool.iter().copied());
+        assert!(got.is_empty(), "got = {:?}", got);
+    }
+
+    #[test]
+    fn target_itself_is_filtered() {
+        let pool = names(&["length", "lentgh", "len"]);
+        let got = suggest("lentgh", pool.iter().copied());
+        // The target name itself must not appear in the suggestions.
+        assert!(!got.iter().any(|s| s == "lentgh"));
+        // But near matches still come through.
+        assert!(got.contains(&"length".to_string()));
+    }
+
+    #[test]
+    fn empty_candidate_iterator() {
+        let got = suggest("foo", std::iter::empty());
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn dedups_overlapping_sources() {
+        // Simulate locals + builtins both containing "len".
+        let pool = vec!["len", "len", "len"];
+        let got = suggest("ln_", pool.into_iter());
+        // Should appear only once.
+        assert_eq!(got.iter().filter(|s| *s == "len").count(), 1);
+    }
+}

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -129,6 +129,10 @@ mod verifier_loop_invariants;
 // the module's top-of-file rationale).
 mod type_aliases;
 
+// RES-306: did-you-mean suggestions for undefined identifiers. Pure
+// helper consumed by the typechecker; no parser / lexer surface.
+mod did_you_mean;
+
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
 
@@ -21202,6 +21206,50 @@ mod tests {
         assert!(
             err.contains("undefined_thing") && err.contains("at "),
             "expected `at LINE:COL` from RES-078 identifier span; got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn undefined_identifier_appends_did_you_mean_hint() {
+        // RES-306: when an in-scope name is within edit distance 2,
+        // the typechecker appends a `did you mean` hint. Here we bind
+        // a long-enough local (`length`) and reference a typo
+        // (`lentgh`) of it; the diagnostic must mention both names.
+        let src = "let length = 5; let bad = lentgh;";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut tc = typechecker::TypeChecker::new();
+        let err = tc
+            .check_program(&program)
+            .expect_err("must reject undefined identifier");
+        assert!(
+            err.contains("did you mean"),
+            "expected did-you-mean hint, got: {}",
+            err
+        );
+        assert!(
+            err.contains("`length`"),
+            "expected `length` in suggestion, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn undefined_identifier_no_hint_when_no_close_match() {
+        // RES-306: when nothing in scope is within distance 2, the
+        // diagnostic stays bare. `qzwxyrst` is far from every builtin
+        // and from any user-defined name in this snippet.
+        let src = "let aaaa = 1; let bad = qzwxyrst;";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut tc = typechecker::TypeChecker::new();
+        let err = tc
+            .check_program(&program)
+            .expect_err("must reject undefined identifier");
+        assert!(
+            !err.contains("did you mean"),
+            "did not expect did-you-mean hint, got: {}",
             err
         );
     }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -488,6 +488,19 @@ impl TypeEnvironment {
     pub fn remove(&mut self, name: &str) {
         self.store.remove(name);
     }
+
+    /// RES-306: collect every name visible in this scope chain
+    /// (innermost first, walking outward). Used by the did-you-mean
+    /// helper when emitting "undefined identifier" diagnostics.
+    /// Inner shadowing is intentionally preserved — duplicate names
+    /// appear once per scope; the consumer is expected to dedup.
+    pub fn all_names(&self) -> Vec<String> {
+        let mut out: Vec<String> = self.store.keys().cloned().collect();
+        if let Some(outer) = &self.outer {
+            out.extend(outer.all_names());
+        }
+        out
+    }
 }
 
 /// RES-061: signature-and-contract record stored per top-level fn so
@@ -2825,12 +2838,31 @@ impl TypeChecker {
                 match self.env.get(name) {
                     Some(typ) => Ok(typ),
                     None => {
+                        // RES-306: append a did-you-mean hint when an
+                        // in-scope name is within Levenshtein distance 2
+                        // of the typo. The helper handles the
+                        // <3-char skip and the cap-at-3 ranking.
+                        let names = self.env.all_names();
+                        let suggestions = crate::did_you_mean::suggest(
+                            name.as_str(),
+                            names.iter().map(String::as_str),
+                        );
+                        let hint = if suggestions.is_empty() {
+                            String::new()
+                        } else {
+                            let body = suggestions
+                                .iter()
+                                .map(|s| format!("`{}`", s))
+                                .collect::<Vec<_>>()
+                                .join(", ");
+                            format!(" — did you mean {}?", body)
+                        };
                         if span.start.line == 0 {
-                            Err(format!("Undefined variable: {}", name))
+                            Err(format!("Undefined variable: {}{}", name, hint))
                         } else {
                             Err(format!(
-                                "Undefined variable '{}' at {}:{}",
-                                name, span.start.line, span.start.column
+                                "Undefined variable '{}' at {}:{}{}",
+                                name, span.start.line, span.start.column, hint
                             ))
                         }
                     }


### PR DESCRIPTION
Closes #98

## Summary

- New `resilient/src/did_you_mean.rs` module exporting `pub fn suggest(target, candidates) -> Vec<String>`. Computes Levenshtein distance, skips targets <3 chars, returns up to 3 in-scope candidates within distance 2 sorted by distance asc then name asc.
- Wired into `typechecker.rs` at the `Node::Identifier` undefined-name emission site. Gathers all names from the active scope chain via the new `TypeEnvironment::all_names()` helper (locals + builtins + functions all live in the same env). When suggestions are non-empty the diagnostic appends ` — did you mean \`a\`, \`b\`?`.
- One-line `mod did_you_mean;` declaration added to `main.rs`. No other surface touched.
- Existing snapshot test `typecheck_undefined_variable` uses a 1-char identifier (`x`) and is unaffected by the <3-char skip.

## Test changes

No existing tests modified. New tests added:

- `did_you_mean.rs` `#[cfg(test)]`: 11 unit tests — basic Levenshtein, exact typo, no match, multiple candidates, ties sorted by distance then name, cap-at-3, short input returns empty, distance-3 not suggested, target-self filtering, empty iterator, dedup across overlapping sources.
- `main.rs` `tests`: `undefined_identifier_appends_did_you_mean_hint` and `undefined_identifier_no_hint_when_no_close_match` exercise the typechecker emission shape end-to-end.

## Verification

- `cargo fmt --all` clean.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test` — all 1000+ tests pass; existing snapshot for the bare-undefined case unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)