### PR TITLE
RES-295: math builtins

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -27,12 +27,14 @@ This document is a human-facing summary grouped by category.
 | `abs(x)` | number → number | int or float |
 | `min(a, b)` | (number, number) → number | int↔float coercion |
 | `max(a, b)` | (number, number) → number | int↔float coercion |
-| `sqrt(x)` | number → float | |
+| `clamp(x, lo, hi)` | (number, number, number) → number | restrict to `[lo, hi]`; type-preserving for Int triples, promoted to Float otherwise; runtime error if `lo > hi` |
+| `sqrt(x)` | number → float | NaN on negative input |
 | `pow(a, b)` | (number, number) → float | `a^b` |
 | `floor(x)` | number → float | toward -∞ |
 | `ceil(x)` | number → float | toward +∞ |
 | `sin(x)` `cos(x)` `tan(x)` | float → float | std-only |
-| `ln(x)` `log(x)` `exp(x)` | float → float | std-only |
+| `atan2(y, x)` | (float, float) → float | std-only; returns angle of `(x, y)` in `(-π, π]` (note `y` first, matching IEEE / C) |
+| `ln(x)` `log(x)` `exp(x)` | float → float | std-only; `ln`/`log` runtime error on non-positive args |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -7105,6 +7105,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("abs", builtin_abs),
     ("min", builtin_min),
     ("max", builtin_max),
+    // RES-295: clamp(x, lo, hi) — restrict to [lo, hi]; Err if lo > hi.
+    ("clamp", builtin_clamp),
     // RES-130: explicit int ↔ float conversions.
     ("to_float", builtin_to_float),
     ("to_int", builtin_to_int),
@@ -7131,6 +7133,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("sin", builtin_sin),
     ("cos", builtin_cos),
     ("tan", builtin_tan),
+    // RES-295: atan2(y, x) — angle of vector (x, y) in radians.
+    ("atan2", builtin_atan2),
     ("ln", builtin_ln),
     ("log", builtin_log),
     ("exp", builtin_exp),
@@ -7434,6 +7438,25 @@ fn builtin_tan(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("tan: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-295: `atan2(y: Float, x: Float) -> Float` — angle of the
+/// 2-D vector `(x, y)`, in radians, in the range (-π, π]. Argument
+/// order matches C / IEEE — `atan2(y, x)`, **y first** — because
+/// every other language and standard library does. Float-only per
+/// RES-130; widen Ints with `to_float`. `atan2(0, 0) = 0` per IEEE.
+fn builtin_atan2(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(y), Value::Float(x)] => Ok(Value::Float(y.atan2(*x))),
+        [a, b] => Err(format!(
+            "atan2: expected (Float, Float), got ({:?}, {:?}) — argument order is (y, x); widen Ints via `to_float`",
+            a, b
+        )),
+        _ => Err(format!(
+            "atan2: expected 2 arguments (y, x), got {}",
+            args.len()
+        )),
     }
 }
 
@@ -8450,6 +8473,45 @@ fn builtin_max(args: &[Value]) -> RResult<Value> {
             a, b
         )),
         _ => Err(format!("max: expected 2 arguments, got {}", args.len())),
+    }
+}
+
+/// RES-295: `clamp(x, lo, hi)` — restrict `x` to the closed interval
+/// `[lo, hi]`. Type-preserving when all three args share Int or Float;
+/// any Float promotes the result to Float (matches min/max coercion
+/// rules). Returns an error if `lo > hi` — an empty interval is a
+/// caller bug, not a value to silently paper over.
+fn builtin_clamp(args: &[Value]) -> RResult<Value> {
+    let to_f = |v: &Value| -> Option<f64> {
+        match v {
+            Value::Int(i) => Some(*i as f64),
+            Value::Float(f) => Some(*f),
+            _ => None,
+        }
+    };
+    match args {
+        [Value::Int(x), Value::Int(lo), Value::Int(hi)] => {
+            if lo > hi {
+                return Err(format!("clamp: lo ({}) must be <= hi ({})", lo, hi));
+            }
+            Ok(Value::Int((*x).clamp(*lo, *hi)))
+        }
+        [x, lo, hi] => {
+            let (Some(xf), Some(lof), Some(hif)) = (to_f(x), to_f(lo), to_f(hi)) else {
+                return Err(format!(
+                    "clamp: expected numeric args, got {:?}, {:?}, {:?}",
+                    x, lo, hi
+                ));
+            };
+            if lof > hif {
+                return Err(format!("clamp: lo ({}) must be <= hi ({})", lof, hif));
+            }
+            Ok(Value::Float(xf.clamp(lof, hif)))
+        }
+        _ => Err(format!(
+            "clamp: expected 3 arguments (x, lo, hi), got {}",
+            args.len()
+        )),
     }
 }
 
@@ -19938,6 +20000,140 @@ mod tests {
         assert!(e_abs.contains("expected 1"), "{}", e_abs);
         let e_min = builtin_min(&[Value::Int(1)]).unwrap_err();
         assert!(e_min.contains("expected 2"), "{}", e_min);
+    }
+
+    // ---------- RES-295: clamp + atan2 ----------
+
+    #[test]
+    fn clamp_int_in_range_returns_x() {
+        match builtin_clamp(&[Value::Int(5), Value::Int(0), Value::Int(10)]).unwrap() {
+            Value::Int(5) => {}
+            other => panic!("clamp(5, 0, 10): expected Int(5), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn clamp_int_below_lo_clamps_to_lo() {
+        match builtin_clamp(&[Value::Int(-5), Value::Int(0), Value::Int(10)]).unwrap() {
+            Value::Int(0) => {}
+            other => panic!("clamp(-5, 0, 10): expected Int(0), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn clamp_int_above_hi_clamps_to_hi() {
+        match builtin_clamp(&[Value::Int(50), Value::Int(0), Value::Int(10)]).unwrap() {
+            Value::Int(10) => {}
+            other => panic!("clamp(50, 0, 10): expected Int(10), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn clamp_float_promotes_when_any_arg_float() {
+        match builtin_clamp(&[Value::Int(5), Value::Float(0.0), Value::Int(10)]).unwrap() {
+            Value::Float(v) => assert!((v - 5.0).abs() < 1e-9, "got {}", v),
+            other => panic!("clamp mixed: expected Float, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn clamp_float_all_floats() {
+        match builtin_clamp(&[Value::Float(1.5), Value::Float(2.0), Value::Float(3.0)]).unwrap() {
+            Value::Float(v) => assert!((v - 2.0).abs() < 1e-9, "got {}", v),
+            other => panic!("clamp(1.5, 2.0, 3.0): expected Float(2.0), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn clamp_rejects_lo_greater_than_hi() {
+        let err = builtin_clamp(&[Value::Int(5), Value::Int(10), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("lo") && err.contains("hi"), "err was: {}", err);
+        let err =
+            builtin_clamp(&[Value::Float(5.0), Value::Float(10.0), Value::Float(0.0)]).unwrap_err();
+        assert!(err.contains("lo") && err.contains("hi"), "err was: {}", err);
+    }
+
+    #[test]
+    fn clamp_rejects_non_numeric() {
+        let err =
+            builtin_clamp(&[Value::String("x".into()), Value::Int(0), Value::Int(10)]).unwrap_err();
+        assert!(err.contains("numeric"), "err was: {}", err);
+    }
+
+    #[test]
+    fn clamp_arity_check() {
+        let err = builtin_clamp(&[Value::Int(1), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected 3"), "err was: {}", err);
+    }
+
+    #[test]
+    fn atan2_quadrants() {
+        let pi = std::f64::consts::PI;
+        // atan2(0, 1) = 0
+        match builtin_atan2(&[Value::Float(0.0), Value::Float(1.0)]).unwrap() {
+            Value::Float(v) => assert!(v.abs() < 1e-9, "atan2(0, 1) = {}", v),
+            other => panic!("expected Float, got {:?}", other),
+        }
+        // atan2(1, 0) = π/2
+        match builtin_atan2(&[Value::Float(1.0), Value::Float(0.0)]).unwrap() {
+            Value::Float(v) => assert!((v - pi / 2.0).abs() < 1e-9, "atan2(1, 0) = {}", v),
+            other => panic!("expected Float, got {:?}", other),
+        }
+        // atan2(0, -1) = π
+        match builtin_atan2(&[Value::Float(0.0), Value::Float(-1.0)]).unwrap() {
+            Value::Float(v) => assert!((v - pi).abs() < 1e-9, "atan2(0, -1) = {}", v),
+            other => panic!("expected Float, got {:?}", other),
+        }
+        // atan2(-1, 0) = -π/2
+        match builtin_atan2(&[Value::Float(-1.0), Value::Float(0.0)]).unwrap() {
+            Value::Float(v) => assert!((v + pi / 2.0).abs() < 1e-9, "atan2(-1, 0) = {}", v),
+            other => panic!("expected Float, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn atan2_origin_returns_zero() {
+        // IEEE: atan2(0, 0) = 0 (not an error).
+        match builtin_atan2(&[Value::Float(0.0), Value::Float(0.0)]).unwrap() {
+            Value::Float(v) => assert_eq!(v, 0.0),
+            other => panic!("expected Float(0.0), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn atan2_rejects_int_per_res130() {
+        let err = builtin_atan2(&[Value::Int(1), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("Float"), "err was: {}", err);
+        assert!(
+            err.contains("to_float"),
+            "diagnostic must hint to_float: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn atan2_arity_check() {
+        let err = builtin_atan2(&[Value::Float(1.0)]).unwrap_err();
+        assert!(err.contains("expected 2"), "err was: {}", err);
+    }
+
+    #[test]
+    fn clamp_atan2_callable_from_source() {
+        // Tree-walker integration: both new builtins resolve through
+        // the BUILTINS table when called from Resilient source.
+        let src = r#"
+            let a = clamp(15, 0, 10);
+            let b = clamp(2.5, 1.0, 5.0);
+            let c = atan2(1.0, 0.0);
+        "#;
+        let (p, _e) = parse(src);
+        let mut interp = Interpreter::new();
+        interp.eval(&p).unwrap();
+        let get = |n: &str| interp.env.get(n).unwrap();
+        assert!(matches!(get("a"), Value::Int(10)));
+        assert!(matches!(get("b"), Value::Float(v) if (v - 2.5).abs() < 1e-9));
+        let pi_2 = std::f64::consts::FRAC_PI_2;
+        assert!(matches!(get("c"), Value::Float(v) if (v - pi_2).abs() < 1e-9));
     }
 
     #[test]

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -842,6 +842,16 @@ impl TypeChecker {
         env.set("min".to_string(), fn_any_any_to_any());
         env.set("max".to_string(), fn_any_any_to_any());
         env.set("pow".to_string(), fn_any_any_to_any());
+        // RES-295: clamp(x, lo, hi) — type-preserving for Int triples,
+        // promoted to Float if any arg is Float. Signed as
+        // (Any, Any, Any) -> Any to match abs/min/max precedent.
+        env.set(
+            "clamp".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
 
         // RES-146: transcendentals. Float-in / Float-out per
         // RES-130 (no implicit int↔float coercion).
@@ -856,6 +866,14 @@ impl TypeChecker {
         env.set("exp".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
+            Type::Function {
+                params: vec![Type::Float, Type::Float],
+                return_type: Box::new(Type::Float),
+            },
+        );
+        // RES-295: atan2(y, x) — Float-only per RES-130.
+        env.set(
+            "atan2".to_string(),
             Type::Function {
                 params: vec![Type::Float, Type::Float],
                 return_type: Box::new(Type::Float),
@@ -3497,6 +3515,9 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "abs",
         "min",
         "max",
+        // RES-295.
+        "clamp",
+        "atan2",
         "sqrt",
         "pow",
         "floor",

--- a/resilient/tests/examples_smoke.rs
+++ b/resilient/tests/examples_smoke.rs
@@ -980,3 +980,45 @@ fn bytecode_vm_runs_multiple_builtins() {
     );
     let _ = std::fs::remove_file(&tmp);
 }
+
+#[test]
+fn bytecode_vm_runs_clamp_and_atan2() {
+    // RES-295: the new math builtins (clamp, atan2) must dispatch
+    // through `Op::CallBuiltin` exactly like every other entry in
+    // `BUILTINS`. Acceptance criterion: "they also work under --vm
+    // (the new CallBuiltin path makes this automatic IF you register
+    // them in the canonical BUILTINS table)" — this test pins down
+    // that registration so a future revert of the registration line
+    // produces a red CI signal, not a silent VM-only regression.
+    use std::io::Write;
+    let tmp = std::env::temp_dir().join(format!("res_vm_res295_{}.rs", std::process::id()));
+    {
+        let mut f = std::fs::File::create(&tmp).expect("create tmp");
+        writeln!(f, "println(clamp(15, 0, 10));").unwrap();
+        writeln!(f, "println(clamp(-3, 0, 10));").unwrap();
+        writeln!(f, "println(atan2(0.0, 1.0));").unwrap();
+        writeln!(f, "return 0;").unwrap();
+    }
+    let output = Command::new(bin())
+        .arg("--vm")
+        .arg(&tmp)
+        .output()
+        .expect("spawn resilient");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "vm clamp/atan2 path must exit 0; stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown function"),
+        "regression: clamp/atan2 lookup failed under --vm; stderr=\n{stderr}"
+    );
+    // clamp(15, 0, 10) = 10; clamp(-3, 0, 10) = 0; atan2(0, 1) = 0.
+    assert!(
+        stdout.contains("10") && stdout.contains("0"),
+        "expected 10 and 0 in stdout; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_file(&tmp);
+}


### PR DESCRIPTION
Closes #87

## Summary

Of the 9 math builtins listed in the ticket, 7 (`min`, `max`, `abs`, `sqrt`, `log`/`ln`, `sin`, `cos`) already shipped under earlier tickets (RES-055, RES-146). This PR fills the remaining two — **`clamp`** and **`atan2`** — and wires them through the canonical `BUILTINS` table so they're automatically reachable under `--vm` via `Op::CallBuiltin` (PR #277).

- `clamp(x, lo, hi)` — type-preserving for `Int` triples, promotes to `Float` if any arg is `Float`. Clean runtime error (no panic) on `lo > hi`.
- `atan2(y, x)` — IEEE / C ordering (y first). Float-only per RES-130 with `to_float` hint on Int input. `atan2(0, 0) = 0`.

Both are added to:
- `BUILTINS` (dispatch table — `main.rs`)
- typechecker prelude (`typechecker.rs`)
- `PURE_BUILTINS` (deterministic; usable from `@pure` fns)

`STDLIB.md` updated with a row for each.

## Test changes

No existing tests modified. Added:
- 9 unit tests for `clamp` (in/below/above range, mixed-type promotion, all-float, `lo > hi` rejection, non-numeric rejection, arity, source-level call).
- 5 unit tests for `atan2` (four quadrants, origin, Int rejection, arity).
- 1 integration test (`bytecode_vm_runs_clamp_and_atan2`) confirming both dispatch through `Op::CallBuiltin` end-to-end under `--vm`.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml` — 922 unit + 15 examples_smoke pass.
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] New tests cover both tree-walker and bytecode-VM paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)