### PR TITLE
RES-340: rich type-mismatch diagnostics

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -687,6 +687,60 @@ fn clause_span(node: &Node) -> Span {
     }
 }
 
+/// RES-340: gate for the rich type-mismatch diagnostic format.
+/// The legacy short message (`Type mismatch in argument N: expected
+/// X, got Y`) is emitted by default so existing callers — including
+/// every `.expected.txt` golden — stay byte-identical. Setting
+/// `RESILIENT_RICH_DIAG=1` switches to a rustc-style multi-block
+/// diagnostic that includes a primary span on the offending argument
+/// and a secondary span on the function declaration.
+fn rich_diag_enabled() -> bool {
+    std::env::var("RESILIENT_RICH_DIAG").as_deref() == Ok("1")
+}
+
+/// RES-340: format a rich type-mismatch diagnostic. Loads source
+/// on demand from `source_path` (best-effort — falls back to the
+/// terse format if the file can't be read, which keeps the path
+/// safe under unit tests where the source lives in memory only).
+///
+/// The shape mirrors rustc's E0308:
+///
+/// ```text
+/// error[E0007]: type mismatch in argument N
+///    fn callee(int dist) { ... }
+///       ^^^^^^ expected `T` because of this declaration
+///    drive(elapsed)
+///          ^^^^^^^ found `U`
+/// ```
+fn render_rich_arg_type_mismatch(
+    source_path: &str,
+    arg_span: crate::span::Span,
+    decl_span: Option<crate::span::Span>,
+    arg_idx_one_based: usize,
+    expected: &str,
+    actual: &str,
+) -> String {
+    let primary_msg = format!(
+        "type mismatch in argument {}: expected `{}`, found `{}`",
+        arg_idx_one_based, expected, actual
+    );
+    let mut diag =
+        crate::diag::Diagnostic::new(crate::diag::Severity::Error, arg_span, primary_msg)
+            .with_code(crate::diag::codes::E0007);
+    if let Some(ds) = decl_span {
+        diag = diag.with_note(
+            ds,
+            format!("expected `{}` because of this declaration", expected),
+        );
+    }
+    let src = if source_path.is_empty() {
+        String::new()
+    } else {
+        std::fs::read_to_string(source_path).unwrap_or_default()
+    };
+    crate::diag::format_diagnostic_terminal(&src, &diag)
+}
+
 /// RES-217: format + print the partial-proof warning to stderr.
 /// The message follows the ticket's mandated shape:
 ///
@@ -736,6 +790,12 @@ pub struct TypeChecker {
     /// RES-061: top-level function name → its parameters + contract clauses.
     /// Populated by check_program's first pass; consulted by CallExpression.
     contract_table: HashMap<String, ContractInfo>,
+    /// RES-340: top-level function name → span of its `fn` keyword.
+    /// Populated by the same pre-pass that fills `contract_table`. Read
+    /// by the rich-diagnostic path in `CallExpression` to attach a
+    /// secondary "expected `T` because of this parameter" label
+    /// pointing at the function declaration.
+    fn_decl_spans: HashMap<String, Span>,
     /// RES-063: identifier → known constant integer value.
     const_bindings: HashMap<String, i64>,
     /// RES-066: verification audit counters.
@@ -1362,6 +1422,7 @@ impl TypeChecker {
         TypeChecker {
             env,
             contract_table: HashMap::new(),
+            fn_decl_spans: HashMap::new(),
             const_bindings: HashMap::new(),
             stats: VerificationStats::default(),
             certificates: Vec::new(),
@@ -1501,6 +1562,7 @@ impl TypeChecker {
                             requires,
                             ensures,
                             fails,
+                            span,
                             ..
                         } => {
                             self.contract_table.insert(
@@ -1512,6 +1574,10 @@ impl TypeChecker {
                                     fails: fails.clone(),
                                 },
                             );
+                            // RES-340: remember the fn keyword's span so
+                            // the rich type-mismatch path can point at
+                            // the declaration.
+                            self.fn_decl_spans.insert(name.clone(), *span);
                         }
                         Node::TypeAlias { name, target, .. } => {
                             self.type_aliases.insert(name.clone(), target.clone());
@@ -2985,7 +3051,7 @@ impl TypeChecker {
             Node::CallExpression {
                 function,
                 arguments,
-                ..
+                span: call_span,
             } => {
                 let func_type = self.check_node(function)?;
 
@@ -3140,6 +3206,41 @@ impl TypeChecker {
                                 && *param_type != Type::Any
                                 && arg_type != Type::Any
                             {
+                                // RES-340: when RESILIENT_RICH_DIAG=1
+                                // emit a rustc-style multi-block
+                                // diagnostic with a secondary label
+                                // pointing at the fn declaration. The
+                                // legacy short form remains the
+                                // default to keep every existing
+                                // golden byte-identical.
+                                if rich_diag_enabled() {
+                                    // Fall back to the call's `(`
+                                    // span when the argument node
+                                    // doesn't carry one (literal
+                                    // sub-trees produced before
+                                    // RES-077 spans were threaded).
+                                    let mut arg_span = clause_span(arg);
+                                    if arg_span.start.line == 0 {
+                                        arg_span = *call_span;
+                                    }
+                                    let decl_span = if let Node::Identifier {
+                                        name: callee_name,
+                                        ..
+                                    } = function.as_ref()
+                                    {
+                                        self.fn_decl_spans.get(callee_name).copied()
+                                    } else {
+                                        None
+                                    };
+                                    return Err(render_rich_arg_type_mismatch(
+                                        &self.source_path,
+                                        arg_span,
+                                        decl_span,
+                                        i + 1,
+                                        &param_type.to_string(),
+                                        &arg_type.to_string(),
+                                    ));
+                                }
                                 return Err(format!(
                                     "Type mismatch in argument {}: expected {}, got {}",
                                     i + 1,
@@ -4759,6 +4860,212 @@ mod fault_model_tests {
         assert!(
             err.contains("unhandled failure variant Timeout"),
             "unexpected error: {err}"
+        );
+    }
+}
+
+// ============================================================
+// RES-340: rich type-mismatch diagnostics
+// ============================================================
+//
+// Default behaviour is byte-identical to before the ticket — the
+// short `Type mismatch in argument N: expected X, got Y` form is
+// what the typechecker still emits unless the user opts in via
+// `RESILIENT_RICH_DIAG=1`. The opt-in produces a rustc-style
+// multi-block diagnostic with a primary span on the offending
+// argument and a secondary span on the function's declaration.
+//
+// These tests exercise the renderer helper directly so they don't
+// depend on (and cannot perturb) the global environment variable
+// other tests might be reading. End-to-end coverage of the gate
+// itself lives in the `legacy_default_remains` test below: it
+// scrubs the env var locally, then asserts the legacy text comes
+// back through the full pipeline.
+#[cfg(test)]
+mod res340_rich_type_mismatch_tests {
+    use super::*;
+    use crate::parse;
+    use crate::span::Pos;
+
+    fn span(start_line: usize, start_col: usize, end_line: usize, end_col: usize) -> Span {
+        Span::new(
+            Pos::new(start_line, start_col, 0),
+            Pos::new(end_line, end_col, 0),
+        )
+    }
+
+    fn check(src: &str) -> Result<(), String> {
+        let (prog, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut tc = TypeChecker::new();
+        tc.check_program_with_source(&prog, "<t>").map(|_| ())
+    }
+
+    #[test]
+    fn legacy_default_remains_byte_identical() {
+        // Without the env var, the short form is what the
+        // typechecker emits. Goldens depend on this — the test
+        // pins the exact substring so a regression here would
+        // also be a regression in any `.expected.txt` that
+        // captured the line.
+        //
+        // We deliberately do NOT touch `RESILIENT_RICH_DIAG`
+        // here — both removing and setting it would race against
+        // any concurrent test that reads it. Instead we trust
+        // that `cargo test` runs in a clean process where the
+        // var is unset by default; if a contributor exports it
+        // in their shell, the assertion below trips and tells
+        // them to unset it before running tests, which is the
+        // correct invariant.
+        let src = "\
+            fn drive(int dist) { return dist; }\n\
+            fn caller() { return drive(\"oops\"); }\n";
+        let err = check(src).expect_err("call with wrong arg type must be rejected");
+        if std::env::var("RESILIENT_RICH_DIAG").as_deref() == Ok("1") {
+            // Contributor has the rich-diag flag exported in
+            // their shell. Verify the rich path instead — both
+            // formats are correct, just different.
+            assert!(
+                err.contains("error[E0007]: type mismatch"),
+                "rich path must produce the rustc-style header: {err}"
+            );
+            return;
+        }
+        assert!(
+            err.contains("Type mismatch in argument 1: expected int, got string"),
+            "default format must remain the legacy short message; got: {err}"
+        );
+        // The rich block markers must NOT appear by default.
+        assert!(
+            !err.contains("error[E0007]"),
+            "rich format leaked into default output: {err}"
+        );
+    }
+
+    #[test]
+    fn rich_helper_includes_primary_and_secondary_spans() {
+        // Construct a synthetic source whose layout we control,
+        // then ask the renderer for the rich block. We use a
+        // tempfile so the helper can read it back.
+        let src = "fn drive(int dist) { return dist; }\nlet r = drive(\"oops\");\n";
+        let dir = std::env::temp_dir().join("res340_rich_helper");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("rich.rz");
+        std::fs::write(&path, src).expect("write tempfile");
+        // Primary on the bad argument, secondary on the fn decl.
+        let arg_span = span(2, 15, 2, 21); // "oops" string literal
+        let decl_span = Some(span(1, 1, 1, 3)); // "fn"
+        let out = render_rich_arg_type_mismatch(
+            path.to_str().unwrap(),
+            arg_span,
+            decl_span,
+            1,
+            "int",
+            "string",
+        );
+        assert!(
+            out.contains(
+                "error[E0007]: type mismatch in argument 1: expected `int`, found `string`"
+            ),
+            "rich header missing or wrong: {out}"
+        );
+        assert!(
+            out.contains("note: expected `int` because of this declaration"),
+            "secondary label missing: {out}"
+        );
+        // Both source lines should appear (primary + note snippet).
+        assert!(
+            out.contains("let r = drive(\"oops\")"),
+            "primary snippet missing: {out}"
+        );
+        assert!(
+            out.contains("fn drive(int dist)"),
+            "declaration snippet missing: {out}"
+        );
+        // Carets must underline both spans.
+        assert!(
+            out.matches('^').count() >= 2,
+            "expected both spans to be underlined: {out}"
+        );
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rich_helper_drops_secondary_when_decl_unknown() {
+        // Calls through a function value (no Identifier callee) —
+        // we have no fn declaration span, so the secondary block
+        // is omitted but the primary is still rich.
+        let src = "let f = drive;\nf(\"oops\");\n";
+        let dir = std::env::temp_dir().join("res340_no_decl");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("nodecl.rz");
+        std::fs::write(&path, src).expect("write tempfile");
+        let out = render_rich_arg_type_mismatch(
+            path.to_str().unwrap(),
+            span(2, 3, 2, 9),
+            None,
+            1,
+            "int",
+            "string",
+        );
+        assert!(
+            out.contains("error[E0007]: type mismatch in argument 1"),
+            "primary header missing: {out}"
+        );
+        assert!(
+            !out.contains("note: expected"),
+            "secondary block leaked when no decl span was passed: {out}"
+        );
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rich_helper_falls_back_safely_when_source_missing() {
+        // Empty source path → renderer falls back to a no-snippet
+        // diagnostic. Must still include the header so a user
+        // reading the LSP / REPL output sees something useful.
+        let out = render_rich_arg_type_mismatch(
+            "",
+            span(1, 1, 1, 5),
+            Some(span(2, 1, 2, 3)),
+            2,
+            "Meters",
+            "Seconds",
+        );
+        assert!(
+            out.contains(
+                "error[E0007]: type mismatch in argument 2: expected `Meters`, found `Seconds`"
+            ),
+            "header missing on no-source path: {out}"
+        );
+        assert!(
+            out.contains("note: expected `Meters` because of this declaration"),
+            "note missing on no-source path: {out}"
+        );
+    }
+
+    #[test]
+    fn fn_decl_span_table_is_populated_for_top_level_fns() {
+        // Internal invariant: the pre-pass that fills
+        // `contract_table` also fills `fn_decl_spans` keyed by fn
+        // name. The rich-diag path depends on this; failing here
+        // would silently degrade error quality.
+        let src = "fn drive(int dist) { return dist; }\nfn caller() { return 0; }\n";
+        let (prog, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut tc = TypeChecker::new();
+        let _ = tc.check_program_with_source(&prog, "<t>");
+        assert!(
+            tc.fn_decl_spans.contains_key("drive"),
+            "fn_decl_spans missing entry for drive: {:?}",
+            tc.fn_decl_spans.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            tc.fn_decl_spans.contains_key("caller"),
+            "fn_decl_spans missing entry for caller: {:?}",
+            tc.fn_decl_spans.keys().collect::<Vec<_>>()
         );
     }
 }

--- a/resilient/tests/rich_diag_smoke.rs
+++ b/resilient/tests/rich_diag_smoke.rs
@@ -1,0 +1,107 @@
+//! RES-340: end-to-end smoke for `RESILIENT_RICH_DIAG=1`.
+//!
+//! Subprocess-isolated so the env var doesn't leak between tests.
+//! Default behaviour (no env var) is exercised by the in-tree unit
+//! tests in `typechecker::res340_rich_type_mismatch_tests`; this
+//! file covers the gate flipping the format on at the CLI seam.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_dir(tag: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let p = std::env::temp_dir().join(format!(
+        "res340_rich_diag_smoke_{}_{}_{}",
+        tag,
+        std::process::id(),
+        n
+    ));
+    std::fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+const BAD_SRC: &str = "fn drive(int dist) { return dist; }\nfn main() { let r = drive(\"oops\"); return r; }\nmain();\n";
+
+#[test]
+fn rich_diag_off_by_default_uses_legacy_format() {
+    let dir = tmp_dir("default");
+    let src = dir.join("bad.rz");
+    std::fs::write(&src, BAD_SRC).unwrap();
+
+    let output = Command::new(bin())
+        .arg("check")
+        .arg(&src)
+        // Explicitly clear any inherited setting.
+        .env_remove("RESILIENT_RICH_DIAG")
+        .output()
+        .expect("spawn resilient check");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "type error must exit 1; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Type mismatch in argument 1: expected int, got string"),
+        "default format should be the legacy short message; stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("error[E0007]"),
+        "rich format must NOT appear by default; stderr={stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rich_diag_env_var_enables_rustc_style_block() {
+    let dir = tmp_dir("rich");
+    let src = dir.join("bad.rz");
+    std::fs::write(&src, BAD_SRC).unwrap();
+
+    let output = Command::new(bin())
+        .arg("check")
+        .arg(&src)
+        .env("RESILIENT_RICH_DIAG", "1")
+        .output()
+        .expect("spawn resilient check with rich diag");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "type error must still exit 1; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error[E0007]: type mismatch in argument 1"),
+        "rich header must appear; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("expected `int`"),
+        "rich expected-type label missing; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("found `string`"),
+        "rich found-type label missing; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("note: expected `int` because of this declaration"),
+        "secondary note pointing at the declaration is missing; stderr={stderr}"
+    );
+    // Secondary span renders the fn declaration line in the snippet.
+    assert!(
+        stderr.contains("fn drive(int dist)"),
+        "declaration snippet missing from rich output; stderr={stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Closes #132

## Summary

Adds a rustc-style multi-block diagnostic format for argument type-mismatch errors. The new format attaches both the primary span on the offending argument AND a secondary "note: expected `T` because of this declaration" label pointing at the function declaration — mirroring rustc's E0308.

## Gating strategy (Option A)

Per CLAUDE.md's test-protection policy, the new format is gated behind the `RESILIENT_RICH_DIAG=1` environment variable. **Default behaviour is byte-identical to before this PR** — the legacy short message (`Type mismatch in argument N: expected X, got Y`) is what every existing `.expected.txt` golden continues to see.

This precedent matches `RESILIENT_CONST_FOLD=1` already in the codebase (see `const_fold.rs`).

## Example output

Source `bad.rz`:
```rz
fn drive(int dist) { return dist; }
fn main() { let r = drive("oops"); return r; }
main();
```

Default (legacy):
```
bad.rz:2:4: Type mismatch in argument 1: expected int, got string
```

With `RESILIENT_RICH_DIAG=1`:
```
bad.rz:2:4: error[E0007]: type mismatch in argument 1: expected `int`, found `string`
   fn main() { let r = drive("oops"); return r; }
                                   ^
note: expected `int` because of this declaration
   fn drive(int dist) { return dist; }
      ^
```

## Implementation notes

- Reuses the existing `Diagnostic` infrastructure in `resilient/src/diag.rs` (no new types, no changes to that file). `Diagnostic::with_note` + `format_diagnostic_terminal` already handle secondary spans.
- Adds a `fn_decl_spans: HashMap<String, Span>` table on `TypeChecker`, populated in the same pre-pass that fills `contract_table`. The rich-diag path looks up the callee's declaration span via this table.
- The renderer reads source on demand from `source_path` (best-effort — falls back to a header-only diagnostic if the file is unavailable, e.g. in REPL/in-memory contexts).
- Tagged with `DiagCode E0007` from the existing registry (`diag::codes::E0007 = "Type mismatch"`).

## Test changes

**No existing tests modified. No `.expected.txt` files modified.** Default behaviour stays byte-identical.

New tests added:
- `typechecker::res340_rich_type_mismatch_tests::legacy_default_remains_byte_identical` — pins the legacy short form so any future regression is caught immediately.
- `typechecker::res340_rich_type_mismatch_tests::rich_helper_includes_primary_and_secondary_spans` — exercises the renderer directly with both spans + a tempfile source.
- `typechecker::res340_rich_type_mismatch_tests::rich_helper_drops_secondary_when_decl_unknown` — covers the indirect-callee path where no fn span is available.
- `typechecker::res340_rich_type_mismatch_tests::rich_helper_falls_back_safely_when_source_missing` — covers the no-source-path fallback used by REPL / unit tests.
- `typechecker::res340_rich_type_mismatch_tests::fn_decl_span_table_is_populated_for_top_level_fns` — pins the internal pre-pass invariant.
- `tests/rich_diag_smoke.rs` — two subprocess-isolated end-to-end tests: one with the env var unset (legacy), one with `RESILIENT_RICH_DIAG=1` (rich). Subprocess isolation avoids env-var races in `cargo test`'s parallel runner.

## Verification

- `cargo build --manifest-path resilient/Cargo.toml` — clean.
- `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean.
- `cargo fmt --all --manifest-path resilient/Cargo.toml -- --check` — clean.
- `cargo test --manifest-path resilient/Cargo.toml` — all green; lib test count went from 986 → 991 (+5 new); integration tests added 2 in `rich_diag_smoke.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)