### PR TITLE
RES-291: range expressions (for-in, tree-walker)

### DIFF
--- a/resilient/examples/range_for.expected.txt
+++ b/resilient/examples/range_for.expected.txt
@@ -1,0 +1,2 @@
+10
+Program executed successfully

--- a/resilient/examples/range_for.rz
+++ b/resilient/examples/range_for.rz
@@ -1,0 +1,13 @@
+// RES-291: half-open range `lo..hi` as the iterable of a `for-in`.
+// Iterates [0, 5) — i.e. 0, 1, 2, 3, 4 — summing to 10.
+// Tree-walker only; VM and JIT support is a follow-up ticket.
+
+fn main() {
+    let total = 0;
+    for i in 0..5 {
+        total = total + i;
+    }
+    println(total);
+}
+
+main();

--- a/resilient/examples/range_inclusive_for.expected.txt
+++ b/resilient/examples/range_inclusive_for.expected.txt
@@ -1,0 +1,2 @@
+15
+Program executed successfully

--- a/resilient/examples/range_inclusive_for.rz
+++ b/resilient/examples/range_inclusive_for.rz
@@ -1,0 +1,12 @@
+// RES-291: inclusive range `lo..=hi` as the iterable of a `for-in`.
+// Iterates [1, 5] — i.e. 1, 2, 3, 4, 5 — summing to 15.
+
+fn main() {
+    let total = 0;
+    for i in 1..=5 {
+        total = total + i;
+    }
+    println(total);
+}
+
+main();

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1136,6 +1136,11 @@ fn node_line(n: &Node) -> Option<u32> {
         | Node::TryCatch { span, .. }
         | Node::Quantifier { span, .. } => span.start.line as u32,
 
+        // RES-291: integer range expression. Only emitted from the
+        // tree-walker frontend today; bytecode lowering treats it as
+        // unsupported.
+        Node::Range { span, .. } => span.start.line as u32,
+
         // RES-142: duration literal carries the span of its integer
         // part; only emitted inside live-clause position so it
         // shouldn't round-trip through the compiler, but match it

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -934,6 +934,18 @@ impl Formatter {
                 self.write(": ");
                 self.fmt_expr(body);
             }
+            // RES-291: integer range expression `lo..hi` / `lo..=hi`.
+            Node::Range {
+                lo, hi, inclusive, ..
+            } => {
+                self.fmt_expr(lo);
+                if *inclusive {
+                    self.write("..=");
+                } else {
+                    self.write("..");
+                }
+                self.fmt_expr(hi);
+            }
             // Statement-shaped nodes that ended up in expression
             // position: degrade gracefully to their statement form.
             Node::Block { .. }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -440,6 +440,12 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             walk(body, bound, free);
             truncate_to(bound, snapshot);
         }
+        // RES-291: integer range — both bounds are sub-expressions
+        // whose free vars must propagate.
+        Node::Range { lo, hi, .. } => {
+            walk(lo, bound, free);
+            walk(hi, bound, free);
+        }
     }
 }
 

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -141,6 +141,12 @@ mod did_you_mean;
 // so they can be unit-tested in isolation.
 mod parser_recovery;
 
+// RES-291: integer range expressions `lo..hi` and `lo..=hi`. Currently
+// only legal as the iterable of `for x in <range>` or as the RHS of a
+// `let r = <range>;` binding. The tree-walker iterates lazily; VM and
+// JIT support is a follow-up.
+mod ranges;
+
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
 
@@ -1855,6 +1861,18 @@ enum Node {
     /// occurrences are rejected by the typechecker pass
     /// [`crate::loop_invariants::check`].
     InvariantStatement { expr: Box<Node>, span: span::Span },
+    /// RES-291: `lo..hi` (half-open) and `lo..=hi` (inclusive) integer
+    /// range expressions. Currently only legal as the iterable of a
+    /// `for x in <range>` statement or the RHS of a `let r = <range>;`
+    /// binding (rejected elsewhere by the typechecker). Iterated lazily
+    /// by the tree-walker — never materialized into an array. VM and
+    /// JIT support is a follow-up.
+    Range {
+        lo: Box<Node>,
+        hi: Box<Node>,
+        inclusive: bool,
+        span: span::Span,
+    },
 }
 
 /// RES-386/RES-390: one `receive <name>()` handler inside an `actor` block.
@@ -3736,11 +3754,25 @@ impl Parser {
             };
         }
         self.next_token(); // skip 'in'
-        let iterable = self.parse_expression(0).unwrap_or(Node::ArrayLiteral {
+        let lo_or_iter = self.parse_expression(0).unwrap_or(Node::ArrayLiteral {
             items: Vec::new(),
             span: span::Span::default(),
         });
         self.next_token(); // advance past the expression's tail (RES-014 invariant)
+
+        // RES-291: if `..` follows the parsed expression, fold it into a
+        // `Range` node. Otherwise the expression itself is the iterable
+        // (an array, identifier, etc.).
+        let iterable = if let Some(range) =
+            crate::ranges::parse_range_tail(self, lo_or_iter.clone(), stmt_span)
+        {
+            // parse_range_tail leaves us on the tail of `hi`; advance
+            // past it per RES-014.
+            self.next_token();
+            range
+        } else {
+            lo_or_iter
+        };
 
         // RES-132a: collect any `invariant EXPR` clauses that sit between
         // the iterable and `{`. Mirrors the LiveBlock invariant loop
@@ -4053,6 +4085,27 @@ impl Parser {
                     span: span::Span::default(),
                 }
             }
+        };
+
+        // RES-291: detect a trailing `..hi` / `..=hi` and fold the
+        // already-parsed `value` into a `Range`. We only act when the
+        // *peek* token is `..` because parse_expression leaves
+        // current_token on the last token of the expression — calling
+        // `next_token` here lines us up the same way the quantifier
+        // parser does it. If there is no `..`, leave `value` untouched.
+        let value = if self.peek_token == Token::DotDot {
+            self.next_token(); // step past the lo expression's tail
+            // Unreachable fallback: peek_token confirmed `..`, so
+            // parse_range_tail must succeed. Fall back to a zero
+            // literal to keep the parser typed and panic-free.
+            crate::ranges::parse_range_tail(self, value, stmt_span).unwrap_or(
+                Node::IntegerLiteral {
+                    value: 0,
+                    span: stmt_span,
+                },
+            )
+        } else {
+            value
         };
 
         if self.peek_token == Token::Semicolon {
@@ -9888,6 +9941,14 @@ impl Interpreter {
             // occurrences are rejected by the typechecker pass, so
             // this arm only fires inside a loop body.
             Node::InvariantStatement { .. } => Ok(Value::Void),
+            // RES-291: range as a value — only reachable when used as
+            // the RHS of `let r = <range>;`. Materializes into an
+            // integer array so downstream consumers (e.g. `for x in r`)
+            // can iterate. The for-in fast path bypasses materialization
+            // when the range is the immediate iterable.
+            Node::Range {
+                lo, hi, inclusive, ..
+            } => self.eval_range_value(lo, hi, *inclusive),
             Node::Block {
                 stmts: statements, ..
             } => self.eval_block_statement(statements),
@@ -9980,28 +10041,7 @@ impl Interpreter {
                 body,
                 invariants,
                 span,
-            } => {
-                let iter_val = self.eval(iterable)?;
-                let items = match iter_val {
-                    Value::Array(v) => v,
-                    other => return Err(format!("`for` iterable must be an array, got {}", other)),
-                };
-                // RES-222: extract body-level invariants once.
-                let body_invs = crate::loop_invariants::collect_body_invariants(body);
-                for item in items {
-                    self.env.set(name.clone(), item);
-                    // RES-222: invariant holds at the top of every
-                    // iteration with the loop variable bound.
-                    crate::loop_invariants::check_invariants_at_iteration(
-                        self, invariants, &body_invs, span,
-                    )?;
-                    let result = self.eval(body)?;
-                    if let Value::Return(_) = result {
-                        return Ok(result);
-                    }
-                }
-                Ok(Value::Void)
-            }
+            } => self.eval_for_in(name, iterable, body, invariants, span),
             Node::WhileStatement {
                 condition,
                 body,
@@ -10695,6 +10735,90 @@ impl Interpreter {
                 }
             )),
         }
+    }
+
+    /// RES-291: helper for `Node::ForInStatement`, factored out of
+    /// `eval` so that branch's stack frame stays small. Inlining the
+    /// range-fast-path into `eval` directly bloats the (already huge)
+    /// `eval` frame enough to overflow the test-thread stack on
+    /// recursive programs like `fib(10)`.
+    #[inline(never)]
+    fn eval_for_in(
+        &mut self,
+        name: &str,
+        iterable: &Node,
+        body: &Node,
+        invariants: &[Node],
+        span: &span::Span,
+    ) -> RResult<Value> {
+        // RES-222: extract body-level invariants once.
+        let body_invs = crate::loop_invariants::collect_body_invariants(body);
+        // RES-291: range fast-path — iterate lazily without
+        // materializing into a Vec<Value>.
+        if let Node::Range {
+            lo, hi, inclusive, ..
+        } = iterable
+        {
+            let lo_v = self.eval(lo)?;
+            let hi_v = self.eval(hi)?;
+            let lo_i = match lo_v {
+                Value::Int(n) => n,
+                other => return Err(format!("range lower bound must be Int, got {}", other)),
+            };
+            let hi_i = match hi_v {
+                Value::Int(n) => n,
+                other => return Err(format!("range upper bound must be Int, got {}", other)),
+            };
+            for i in crate::ranges::iterate_range(lo_i, hi_i, *inclusive) {
+                self.env.set(name.to_string(), Value::Int(i));
+                crate::loop_invariants::check_invariants_at_iteration(
+                    self, invariants, &body_invs, span,
+                )?;
+                let result = self.eval(body)?;
+                if let Value::Return(_) = result {
+                    return Ok(result);
+                }
+            }
+            return Ok(Value::Void);
+        }
+        let iter_val = self.eval(iterable)?;
+        let items = match iter_val {
+            Value::Array(v) => v,
+            other => return Err(format!("`for` iterable must be an array, got {}", other)),
+        };
+        for item in items {
+            self.env.set(name.to_string(), item);
+            crate::loop_invariants::check_invariants_at_iteration(
+                self, invariants, &body_invs, span,
+            )?;
+            let result = self.eval(body)?;
+            if let Value::Return(_) = result {
+                return Ok(result);
+            }
+        }
+        Ok(Value::Void)
+    }
+
+    /// RES-291: helper for `Node::Range` evaluation as a value (RHS of
+    /// `let r = <range>;`). Materializes into a `Value::Array`. Pulled
+    /// out of `eval` for the same stack-frame-size reason as
+    /// [`Self::eval_for_in`].
+    #[inline(never)]
+    fn eval_range_value(&mut self, lo: &Node, hi: &Node, inclusive: bool) -> RResult<Value> {
+        let lo_v = self.eval(lo)?;
+        let hi_v = self.eval(hi)?;
+        let lo_i = match lo_v {
+            Value::Int(n) => n,
+            other => return Err(format!("range lower bound must be Int, got {}", other)),
+        };
+        let hi_i = match hi_v {
+            Value::Int(n) => n,
+            other => return Err(format!("range upper bound must be Int, got {}", other)),
+        };
+        let items: Vec<Value> = crate::ranges::iterate_range(lo_i, hi_i, inclusive)
+            .map(Value::Int)
+            .collect();
+        Ok(Value::Array(items))
     }
 
     fn eval_program(&mut self, statements: &[span::Spanned<Node>]) -> RResult<Value> {

--- a/resilient/src/ranges.rs
+++ b/resilient/src/ranges.rs
@@ -1,0 +1,274 @@
+//! RES-291: integer range expressions `lo..hi` (half-open) and `lo..=hi`
+//! (inclusive) for iteration.
+//!
+//! Initial scope is intentionally narrow — ranges are only legal in two
+//! USAGE contexts:
+//!
+//! 1. Right side of `for x in <range> { ... }`.
+//! 2. Right side of a `let r = <range>;` binding.
+//!
+//! The parser hook lives at the bottom of `parse_for_in_statement` and
+//! `parse_let_statement`, so a stray range elsewhere falls through to a
+//! normal parser error. Iteration is lazy: the tree-walker materializes
+//! one `Value::Int` at a time, never an array.
+//!
+//! VM and JIT support are explicit follow-ups — for now, both paths
+//! reject ranges with an "unsupported" message rather than silently
+//! producing wrong results.
+//!
+//! Layout of this file:
+//!
+//! - `parse_range_tail` — call-site helper used by `for-in` and `let`.
+//! - `check` — typechecker pass: `lo` and `hi` must be `Int`.
+//! - `iterate_range` — driver loop used by `for-in` evaluation.
+//!
+//! Token reuse: the existing `Token::DotDot` (added in RES-330 for
+//! quantifier ranges) doubles as the half-open separator. Inclusive
+//! `..=` is detected by peeking for `Token::Assign` immediately after a
+//! `DotDot` rather than introducing a new lexer token.
+
+use crate::{Node, Token, span};
+
+/// Try to extend an already-parsed lower-bound expression into a full
+/// `Range` node. Caller passes the parsed `lo` expression; this function
+/// inspects the parser's current token. If it is `..` (or `..=`), the
+/// range is built and returned as `Some(node)`. Otherwise the function
+/// returns `None` and the caller keeps `lo` as the original expression.
+///
+/// On success, the parser's `current_token` sits on the last token of
+/// `hi` (the standard RES-014 invariant — caller calls `next_token()`
+/// once to advance past it).
+pub(crate) fn parse_range_tail(
+    parser: &mut crate::Parser,
+    lo: Node,
+    span: span::Span,
+) -> Option<Node> {
+    if parser.current_token != Token::DotDot {
+        return None;
+    }
+    parser.next_token(); // skip `..`
+    // Inclusive form `..=` — the lexer emits `..` followed by `=`, so
+    // we detect it here without a dedicated lexer token.
+    let inclusive = parser.current_token == Token::Assign;
+    if inclusive {
+        parser.next_token(); // skip `=`
+    }
+    let hi = parser
+        .parse_expression(0)
+        .unwrap_or(Node::IntegerLiteral { value: 0, span });
+    Some(Node::Range {
+        lo: Box::new(lo),
+        hi: Box::new(hi),
+        inclusive,
+        span,
+    })
+}
+
+/// Typecheck pass — walk the program and reject any `Range` whose
+/// bounds are not `Int`, or whose surrounding context disallows ranges.
+/// Today the only legal contexts are `ForInStatement.iterable` and the
+/// RHS of a `LetStatement.value`.
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    let stmts = match program {
+        Node::Program(stmts) => stmts,
+        _ => return Ok(()),
+    };
+    for stmt in stmts {
+        check_stmt(&stmt.node, source_path)?;
+    }
+    Ok(())
+}
+
+fn check_stmt(node: &Node, source_path: &str) -> Result<(), String> {
+    match node {
+        Node::ForInStatement { iterable, body, .. } => {
+            // Ranges are allowed at the top of `iterable` — descend
+            // through it but allow the immediate Range. Anywhere else
+            // (including inside the body) ranges are still rejected.
+            check_iterable_or_let_rhs(iterable, source_path)?;
+            check_stmt(body, source_path)?;
+            Ok(())
+        }
+        Node::LetStatement { value, .. } => {
+            check_iterable_or_let_rhs(value, source_path)?;
+            Ok(())
+        }
+        Node::Block { stmts, .. } => {
+            for s in stmts {
+                check_stmt(s, source_path)?;
+            }
+            Ok(())
+        }
+        Node::IfStatement {
+            consequence,
+            alternative,
+            ..
+        } => {
+            check_stmt(consequence, source_path)?;
+            if let Some(alt) = alternative {
+                check_stmt(alt, source_path)?;
+            }
+            Ok(())
+        }
+        Node::WhileStatement { body, .. } => check_stmt(body, source_path),
+        Node::Function { body, .. } => check_stmt(body, source_path),
+        Node::Range { span, .. } => Err(format_err(
+            span,
+            source_path,
+            "range expressions are only allowed in `for x in <range>` or `let r = <range>;`",
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn check_iterable_or_let_rhs(node: &Node, source_path: &str) -> Result<(), String> {
+    match node {
+        Node::Range { lo, hi, span, .. } => {
+            if !is_intlike(lo) {
+                return Err(format_err(
+                    span,
+                    source_path,
+                    "range lower bound must be an integer expression",
+                ));
+            }
+            if !is_intlike(hi) {
+                return Err(format_err(
+                    span,
+                    source_path,
+                    "range upper bound must be an integer expression",
+                ));
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Conservative shape check: accept literals, identifiers, calls,
+/// arithmetic infix exprs. Anything else (string literal, array
+/// literal, etc.) is rejected. Final type confirmation happens at
+/// runtime — this is a lightweight gate to catch obvious misuse early.
+fn is_intlike(n: &Node) -> bool {
+    matches!(
+        n,
+        Node::IntegerLiteral { .. }
+            | Node::Identifier { .. }
+            | Node::PrefixExpression { .. }
+            | Node::InfixExpression { .. }
+            | Node::CallExpression { .. }
+            | Node::IndexExpression { .. }
+            | Node::FieldAccess { .. }
+    )
+}
+
+fn format_err(span: &span::Span, source_path: &str, msg: &str) -> String {
+    if source_path.is_empty() {
+        format!("{}:{}: {}", span.start.line, span.start.column, msg)
+    } else {
+        format!(
+            "{}:{}:{}: {}",
+            source_path, span.start.line, span.start.column, msg
+        )
+    }
+}
+
+/// Iterator over the integer values produced by a range. `inclusive`
+/// includes `hi`; `!inclusive` is the standard half-open `[lo, hi)`.
+/// Empty when `lo > hi`.
+pub(crate) fn iterate_range(lo: i64, hi: i64, inclusive: bool) -> impl Iterator<Item = i64> {
+    let end = if inclusive { hi.saturating_add(1) } else { hi };
+    // `lo..end` is empty iff lo >= end, which is the right behaviour
+    // for both half-open (`lo > hi`) and inclusive (`lo > hi`) cases.
+    lo..end
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_program(src: &str) -> Node {
+        let lexer = crate::Lexer::new(src.to_string());
+        let mut p = crate::Parser::new(lexer);
+        p.parse_program()
+    }
+
+    #[test]
+    fn half_open_range_iterates_lo_inclusive_hi_exclusive() {
+        let v: Vec<i64> = iterate_range(0, 5, false).collect();
+        assert_eq!(v, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn inclusive_range_includes_hi() {
+        let v: Vec<i64> = iterate_range(1, 5, true).collect();
+        assert_eq!(v, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn empty_range_when_lo_eq_hi_half_open() {
+        let v: Vec<i64> = iterate_range(3, 3, false).collect();
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn singleton_range_when_lo_eq_hi_inclusive() {
+        let v: Vec<i64> = iterate_range(7, 7, true).collect();
+        assert_eq!(v, vec![7]);
+    }
+
+    #[test]
+    fn empty_range_when_lo_gt_hi() {
+        let v: Vec<i64> = iterate_range(10, 3, false).collect();
+        assert!(v.is_empty());
+        let v: Vec<i64> = iterate_range(10, 3, true).collect();
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn parse_for_in_range_half_open() {
+        let prog = parse_program("for i in 0..3 { println(i); }");
+        let stmts = match prog {
+            crate::Node::Program(stmts) => stmts,
+            _ => panic!("expected program"),
+        };
+        match &stmts[0].node {
+            crate::Node::ForInStatement { iterable, .. } => match iterable.as_ref() {
+                crate::Node::Range { inclusive, .. } => assert!(!inclusive),
+                other => panic!("expected Range, got {:?}", other),
+            },
+            other => panic!("expected ForInStatement, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_for_in_range_inclusive() {
+        let prog = parse_program("for i in 0..=3 { println(i); }");
+        let stmts = match prog {
+            crate::Node::Program(stmts) => stmts,
+            _ => panic!("expected program"),
+        };
+        match &stmts[0].node {
+            crate::Node::ForInStatement { iterable, .. } => match iterable.as_ref() {
+                crate::Node::Range { inclusive, .. } => assert!(inclusive),
+                other => panic!("expected Range, got {:?}", other),
+            },
+            other => panic!("expected ForInStatement, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_let_range_binds_a_range_node() {
+        let prog = parse_program("let r = 0..5;\n");
+        let stmts = match prog {
+            crate::Node::Program(stmts) => stmts,
+            _ => panic!("expected program"),
+        };
+        match &stmts[0].node {
+            crate::Node::LetStatement { value, .. } => match value.as_ref() {
+                crate::Node::Range { inclusive, .. } => assert!(!inclusive),
+                other => panic!("expected Range on let RHS, got {:?}", other),
+            },
+            other => panic!("expected LetStatement, got {:?}", other),
+        }
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1684,6 +1684,7 @@ impl TypeChecker {
                 crate::loop_invariants::check(program, source_path)?;
                 crate::verifier_loop_invariants::verify_and_capture(self, program);
                 crate::type_aliases::check(program, source_path)?;
+                crate::ranges::check(program, source_path)?;
                 // </EXTENSION_PASSES>
 
                 // RES-192: IO-effect inference. Binary lattice
@@ -2159,6 +2160,23 @@ impl TypeChecker {
             // (nanosecond count) — defensive; should never fire in
             // well-formed programs.
             Node::DurationLiteral { .. } => Ok(Type::Int),
+
+            // RES-291: integer range. The bounds must be `Int`; the
+            // expression itself has type `Array` so it can flow through
+            // a `for x in <range>` (where the loop variable then gets
+            // typed `Int`) or a `let r = <range>;` binding.
+            Node::Range { lo, hi, .. } => {
+                let lo_t = self.check_node(lo)?;
+                let hi_t = self.check_node(hi)?;
+                let ok = |t: &Type| matches!(t, Type::Int | Type::Any);
+                if !ok(&lo_t) {
+                    return Err(format!("range lower bound must be Int, got {}", lo_t));
+                }
+                if !ok(&hi_t) {
+                    return Err(format!("range upper bound must be Int, got {}", hi_t));
+                }
+                Ok(Type::Array)
+            }
 
             Node::Assert {
                 condition, message, ..


### PR DESCRIPTION
Closes #83

## Summary

Add `lo..hi` (half-open) and `lo..=hi` (inclusive) integer range expressions, scoped to two USAGE contexts only:

- Right side of `for x in <range> { ... }`.
- Right side of `let r = <range>;`.

Tree-walker only — VM and JIT support is tracked as a follow-up. The `..` token already existed (RES-330, quantifier ranges); inclusive `..=` is detected by peeking for `=` so quantifier parsing is unchanged.

The for-in fast path iterates lazily without materializing a `Vec`. Used as a let RHS, a range materializes into `Value::Array`. The for-in eval body is factored into a separate function so the `eval` match's stack frame stays small enough for `fib(10)`-style recursion.

## Test changes

No existing tests modified. Adds:

- `resilient/src/ranges.rs` `#[cfg(test)]` unit tests for the iterator and parser hooks.
- `resilient/examples/range_for.rz` + `.expected.txt` (sums `0..5` to 10).
- `resilient/examples/range_inclusive_for.rz` + `.expected.txt` (sums `1..=5` to 15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)