### PR TITLE
RES-325: named function arguments

### DIFF
--- a/resilient/examples/named_args.expected.txt
+++ b/resilient/examples/named_args.expected.txt
@@ -1,0 +1,4 @@
+123
+123
+123
+Program executed successfully

--- a/resilient/examples/named_args.rz
+++ b/resilient/examples/named_args.rz
@@ -1,0 +1,30 @@
+// RES-325 demo: named function arguments.
+//
+// A fn with three parameters, called with named args in reverse
+// declaration order — the post-parse `named_args::lower_program`
+// pass reorders the arg list to match the parameter slots before
+// the interpreter ever sees it, so call dispatch is identical to
+// `make(1, 2, 3)`.
+//
+// Mixing one positional arg with named args also works, as long
+// as every named arg comes after the last positional one.
+
+fn make(int x, int y, int z) -> int {
+    return x * 100 + y * 10 + z;
+}
+
+fn main() {
+    // Reverse-order named args.
+    let r1 = make(z: 3, y: 2, x: 1);
+    println(r1);
+
+    // One positional + named.
+    let r2 = make(1, z: 3, y: 2);
+    println(r2);
+
+    // All positional, unchanged shape.
+    let r3 = make(1, 2, 3);
+    println(r3);
+}
+
+main();

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1150,6 +1150,9 @@ fn node_line(n: &Node) -> Option<u32> {
         // Program is wrapped in Spanned<Node> at the call site, not
         // inside the Node enum itself.
         Node::Program(_) => 0,
+
+        // RES-325: NamedArg carries the span of its `name:` label.
+        Node::NamedArg { span, .. } => span.start.line as u32,
     };
     if line == 0 { None } else { Some(line) }
 }

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -749,6 +749,11 @@ impl Formatter {
                 }
                 self.write(")");
             }
+            // RES-325: `name: value` inside a call argument list.
+            Node::NamedArg { name, value, .. } => {
+                self.write(&format!("{}: ", name));
+                self.fmt_expr(value);
+            }
             Node::TryExpression { expr, .. } => {
                 self.fmt_expr(expr);
                 self.write("?");

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -446,6 +446,11 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
             walk(lo, bound, free);
             walk(hi, bound, free);
         }
+
+        // RES-325: a named argument's label is just metadata — it
+        // doesn't bind a name; only the value expression introduces
+        // free variables.
+        Node::NamedArg { value, .. } => walk(value, bound, free),
     }
 }
 

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -156,6 +156,13 @@ mod ranges;
 //   * CLI arg handling for `--feature` / `--target`.
 mod cfg_attr;
 
+// RES-325: named function arguments — `foo(x: 1, y: 2)`. The parser
+// emits `Node::NamedArg` nodes inside a call's argument list; this
+// module reorders them into positional slots using the callee's
+// parameter list at dispatch time. Parser-level validation (named
+// must follow positional, no duplicates) lives next to the parser.
+mod named_args;
+
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
 
@@ -1895,6 +1902,17 @@ enum Node {
         lo: Box<Node>,
         hi: Box<Node>,
         inclusive: bool,
+        span: span::Span,
+    },
+    /// RES-325: named function argument — `name: expr` at a call
+    /// site. Only valid inside `Node::CallExpression::arguments`;
+    /// the call-dispatch path (`apply_function`) reorders these
+    /// to match the callee's parameter positions before binding.
+    /// Encountered outside a call site is a parse error.
+    NamedArg {
+        name: String,
+        value: Box<Node>,
+        #[allow(dead_code)]
         span: span::Span,
     },
 }
@@ -5549,31 +5567,24 @@ impl Parser {
             value: 0,
             span: span::Span::default(),
         };
-        match self.parse_expression(0) {
-            Some(node) => args.push(node),
-            None => {
-                let tok = self.current_token.clone();
-                self.record_error(format!(
-                    "Expected expression in call arguments, found {}",
-                    tok
-                ));
-                args.push(placeholder());
-            }
+        // RES-325: track whether we've already seen a named argument
+        // and the names used so far so we can reject named-then-positional
+        // and duplicate-name cases at parse time with a clean diagnostic.
+        let mut seen_named = false;
+        let mut used_names: Vec<String> = Vec::new();
+        if let Some(node) = self.parse_one_call_argument(&mut seen_named, &mut used_names) {
+            args.push(node);
+        } else {
+            args.push(placeholder());
         }
 
         while self.peek_token == Token::Comma {
             self.next_token(); // Skip current
             self.next_token(); // Skip comma
-            match self.parse_expression(0) {
-                Some(node) => args.push(node),
-                None => {
-                    let tok = self.current_token.clone();
-                    self.record_error(format!(
-                        "Expected expression after `,` in call arguments, found {}",
-                        tok
-                    ));
-                    args.push(placeholder());
-                }
+            if let Some(node) = self.parse_one_call_argument(&mut seen_named, &mut used_names) {
+                args.push(node);
+            } else {
+                args.push(placeholder());
             }
         }
 
@@ -5585,6 +5596,69 @@ impl Parser {
         }
 
         args
+    }
+
+    /// RES-325: parse a single call argument, recognising `name: expr`
+    /// as a named-argument node. A call argument list may contain any
+    /// number of positional args followed by any number of named args;
+    /// once a named arg has appeared, every subsequent arg must also
+    /// be named. Duplicate named names within the same call are rejected.
+    fn parse_one_call_argument(
+        &mut self,
+        seen_named: &mut bool,
+        used_names: &mut Vec<String>,
+    ) -> Option<Node> {
+        // Lookahead for `IDENT :` — anything else parses as a positional
+        // expression. We must be careful not to swallow the colon used by
+        // type annotations etc., but call-argument position only allows
+        // expressions, so the only way `IDENT :` is legal here is as a
+        // named-argument label.
+        if let Token::Identifier(name) = self.current_token.clone()
+            && self.peek_token == Token::Colon
+        {
+            let label_span = self.span_at_current();
+            // Consume IDENT, then `:`, leaving current_token on the
+            // first token of the value expression.
+            self.next_token(); // now on `:`
+            self.next_token(); // now on first token of value
+            let value = match self.parse_expression(0) {
+                Some(v) => v,
+                None => {
+                    let tok = self.current_token.clone();
+                    self.record_error(format!(
+                        "Expected expression for named argument `{}`, found {}",
+                        name, tok
+                    ));
+                    return None;
+                }
+            };
+            if used_names.iter().any(|n| n == &name) {
+                self.record_error(format!("Duplicate named argument `{}` in call", name));
+            }
+            used_names.push(name.clone());
+            *seen_named = true;
+            return Some(Node::NamedArg {
+                name,
+                value: Box::new(value),
+                span: label_span,
+            });
+        }
+
+        // Positional argument.
+        if *seen_named {
+            self.record_error("Positional argument cannot follow a named argument".to_string());
+        }
+        match self.parse_expression(0) {
+            Some(node) => Some(node),
+            None => {
+                let tok = self.current_token.clone();
+                self.record_error(format!(
+                    "Expected expression in call arguments, found {}",
+                    tok
+                ));
+                None
+            }
+        }
     }
 
     /// Parse `struct NAME { TYPE FIELD, ... }`. current_token is `struct`
@@ -10635,6 +10709,29 @@ impl Interpreter {
                 let _ = self.env.reassign(&root_name, Value::Array(items));
                 Ok(Value::Void)
             }
+            // RES-325: a `NamedArg` outside an enclosing call site is
+            // an internal error — the parser only emits these inside
+            // a call's argument list. The CallExpression evaluator
+            // rewrites them away before reaching the generic eval
+            // path. Delegate to a sibling so its locals don't
+            // inflate this hot frame.
+            Node::NamedArg { .. } => self.eval_stray_named_arg(node),
+        }
+    }
+
+    /// RES-325: cold path for the (theoretically unreachable) case
+    /// where a `Node::NamedArg` reaches generic expression evaluation
+    /// outside a call site. Surface a clean diagnostic without
+    /// inflating the hot `eval` frame.
+    #[inline(never)]
+    fn eval_stray_named_arg(&self, node: &Node) -> RResult<Value> {
+        if let Node::NamedArg { name, .. } = node {
+            Err(format!(
+                "Internal: named argument `{}` evaluated outside of a call argument list",
+                name
+            ))
+        } else {
+            Err("Internal: eval_stray_named_arg called on non-NamedArg".to_string())
         }
     }
 
@@ -11949,10 +12046,17 @@ fn start_repl() -> RustylineResult<()> {
                 // Parse the input
                 let lexer = Lexer::new(input.to_string());
                 let mut parser = Parser::new(lexer);
-                let program = parser.parse_program();
+                let mut program = parser.parse_program();
 
                 // Skip evaluation if any parser errors were recorded
                 if !parser.errors.is_empty() {
+                    continue;
+                }
+                // RES-325: lower named call arguments to positional
+                // ones for known top-level fns so the interpreter's
+                // hot path stays free of named-arg awareness.
+                if let Err(e) = crate::named_args::lower_program(&mut program) {
+                    eprintln!("\x1B[31mError: {}\x1B[0m", e);
                     continue;
                 }
 
@@ -12175,8 +12279,16 @@ fn dump_tokens_to_stdout(src: &str) {
 fn parse(src: &str) -> (Node, Vec<String>) {
     let lexer = Lexer::new(src.to_string());
     let mut parser = Parser::new(lexer);
-    let program = parser.parse_program();
-    let errs: Vec<String> = parser.errors.into_iter().map(|e| e.to_string()).collect();
+    let mut program = parser.parse_program();
+    let mut errs: Vec<String> = parser.errors.into_iter().map(|e| e.to_string()).collect();
+    // RES-325: lower named call arguments to positional ones for
+    // every call whose callee is a known top-level fn or impl
+    // method. Failures here (unknown name, duplicate target, etc.)
+    // surface alongside parse errors so callers see them in one
+    // batch via the same `errs` channel.
+    if let Err(e) = crate::named_args::lower_program(&mut program) {
+        errs.push(e);
+    }
     (program, errs)
 }
 
@@ -12915,6 +13027,15 @@ fn execute_file(
     }
     if let Err(e) = imports::expand_uses(&mut program, &base_dir, &mut loaded) {
         return Err(format!("Import error: {}", e));
+    }
+
+    // RES-325: lower named call arguments to positional ones for
+    // every call whose callee is a now-resolvable top-level fn or
+    // impl method. Runs after `expand_uses` so calls into imported
+    // modules can also be lowered.
+    if let Err(e) = crate::named_args::lower_program(&mut program) {
+        eprintln!("\x1B[31mNamed-argument error: {}\x1B[0m", e);
+        return Err(format!("Named argument resolution failed: {}", e));
     }
 
     // RES-391: syntactic non-aliasing check over reference-type
@@ -15297,8 +15418,15 @@ mod tests {
     fn parse(input: &str) -> (Node, Vec<String>) {
         let lexer = Lexer::new(input.to_string());
         let mut parser = Parser::new(lexer);
-        let program = parser.parse_program();
-        (program, parser.errors)
+        let mut program = parser.parse_program();
+        let mut errs = parser.errors;
+        // RES-325: same post-parse named-arg lowering as the
+        // production driver (`crate::parse`), so test-mode programs
+        // see identical post-parse AST shape.
+        if let Err(e) = crate::named_args::lower_program(&mut program) {
+            errs.push(e);
+        }
+        (program, errs)
     }
 
     #[test]
@@ -23892,6 +24020,124 @@ mod tests {
         let mut interp = Interpreter::new();
         let result = interp.eval(&program).expect("should execute");
         assert!(matches!(result, Value::Int(100)));
+    }
+
+    // ----------------------------------------------------------------
+    // RES-325: named function arguments
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn named_args_all_named_in_reverse_order() {
+        // The textbook case from the ticket: a fn with three params
+        // called with named args in reverse declaration order.
+        let src = r#"
+            fn make(int x, int y, int z) {
+                return x * 100 + y * 10 + z;
+            }
+            let r = make(z: 3, y: 2, x: 1);
+        "#;
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        interp.eval(&program).expect("eval should succeed");
+        match interp.env.get("r").expect("r defined") {
+            Value::Int(v) => assert_eq!(v, 123),
+            other => panic!("expected Int(123), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn named_args_after_positional() {
+        // Mixed: positional fills slot 0, named fills slot 1.
+        let src = r#"
+            fn f(int x, int y) { return x * 10 + y; }
+            let r = f(1, y: 2);
+        "#;
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        interp.eval(&program).expect("eval should succeed");
+        assert!(matches!(interp.env.get("r").unwrap(), Value::Int(12)));
+    }
+
+    #[test]
+    fn named_args_reject_positional_after_named() {
+        // `f(x: 1, 2)` is invalid — positional args may not follow a
+        // named arg.
+        let src = r#"
+            fn f(int x, int y) { return x + y; }
+            let r = f(x: 1, 2);
+        "#;
+        let (_program, errs) = parse(src);
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("Positional argument cannot follow a named")),
+            "expected positional-after-named diagnostic, got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn named_args_reject_unknown_label() {
+        // `f(z: 1)` where `f` has no parameter `z`.
+        let src = r#"
+            fn f(int x) { return x; }
+            let r = f(z: 1);
+        "#;
+        let (_program, errs) = parse(src);
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("Unknown named argument") && e.contains("z")),
+            "expected unknown-named-arg diagnostic, got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn named_args_reject_duplicate_label() {
+        // `f(x: 1, x: 2)` — same named label twice.
+        let src = r#"
+            fn f(int x, int y) { return x + y; }
+            let r = f(x: 1, x: 2);
+        "#;
+        let (_program, errs) = parse(src);
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("Duplicate named argument") && e.contains("x")),
+            "expected duplicate-named-arg diagnostic, got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn named_args_reject_positional_and_named_target_same_param() {
+        // `f(1, x: 2)` — positional fills `x`, then named also targets `x`.
+        let src = r#"
+            fn f(int x, int y) { return x * 10 + y; }
+            let r = f(1, x: 99);
+        "#;
+        let (_program, errs) = parse(src);
+        assert!(
+            errs.iter().any(|e| e.contains("provided more than once")),
+            "expected duplicate-target diagnostic, got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn named_args_unknown_callee_offers_did_you_mean() {
+        // Levenshtein-1 typo: `timout` instead of `timeout`.
+        let src = r#"
+            fn connect(int timeout, int retries) { return timeout + retries; }
+            let r = connect(timout: 5, retries: 3);
+        "#;
+        let (_program, errs) = parse(src);
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("did you mean") && e.contains("timeout")),
+            "expected did-you-mean suggestion, got: {:?}",
+            errs
+        );
     }
 }
 

--- a/resilient/src/named_args.rs
+++ b/resilient/src/named_args.rs
@@ -1,0 +1,524 @@
+//! RES-325: named function arguments — `foo(x: 1, y: 2)`.
+//!
+//! Resolution happens as a single post-parse pass over the program:
+//! the parser leaves any `name: expr` pair as a `Node::NamedArg`
+//! node inside a call's `arguments` vector, and [`lower_program`]
+//! walks the program once, collects every top-level fn signature,
+//! and rewrites each call whose argument list mentions named args
+//! into a positional-only list. This keeps the hot interpreter
+//! path completely free of named-arg awareness — recursive
+//! programs like `fib` are very sensitive to per-call frame size
+//! in debug builds, so any `if has_named(...)` check inside the
+//! `eval` CallExpression arm is enough to push them past the
+//! 2 MiB default test-thread stack.
+//!
+//! Resolution rules:
+//!
+//! - Positional args occupy the first N parameter slots in order.
+//! - Each named arg targets the parameter whose name matches its
+//!   label, regardless of textual position.
+//! - It is an error if a named arg's label does not match any
+//!   parameter name (with a "did you mean?" suggestion).
+//! - It is an error if the same parameter is targeted by both a
+//!   positional and a named arg.
+//! - It is an error if two named args share the same label.
+//! - It is an error if a parameter ends up unbound after resolution.
+//!
+//! The lowering is best-effort: calls whose callee is not a
+//! statically-resolvable top-level fn (closures, builtins,
+//! method-receiver dispatch) keep their `Node::NamedArg` nodes
+//! and surface a runtime error if they ever execute. Acceptance
+//! criteria for RES-325 only require named args on top-level fns.
+
+use crate::Node;
+use crate::did_you_mean::suggest;
+use std::collections::HashMap;
+
+/// Reorder `arguments` (which may contain `Node::NamedArg` entries)
+/// into a flat positional vector matching `param_names`. Returns
+/// `Err(diagnostic)` on any of the resolution-rule violations
+/// described at the module level.
+pub fn resolve(
+    callee_label: &str,
+    param_names: &[String],
+    arguments: &[Node],
+) -> Result<Vec<Node>, String> {
+    // If no named args are present we can hand the original list
+    // back unchanged — preserves identity and avoids any clones for
+    // the existing positional-only call path.
+    if !arguments.iter().any(|n| matches!(n, Node::NamedArg { .. })) {
+        return Ok(arguments.to_vec());
+    }
+
+    // Pre-allocate one slot per parameter. `None` means the slot has
+    // not yet been bound; a duplicate write is a diagnostic.
+    let mut slots: Vec<Option<Node>> = vec![None; param_names.len()];
+
+    // Walk arguments left-to-right. Positional args fill the next
+    // available slot; named args resolve to the slot of the parameter
+    // they label.
+    let mut next_pos = 0usize;
+    for arg in arguments {
+        match arg {
+            Node::NamedArg { name, value, .. } => {
+                let Some(idx) = param_names.iter().position(|p| p == name) else {
+                    let suggestions = suggest(name, param_names.iter().map(String::as_str));
+                    return Err(match suggestions.first() {
+                        Some(hint) => format!(
+                            "Unknown named argument `{}` for {} — did you mean `{}`?",
+                            name, callee_label, hint
+                        ),
+                        None => format!("Unknown named argument `{}` for {}", name, callee_label),
+                    });
+                };
+                if slots[idx].is_some() {
+                    return Err(format!(
+                        "Argument for parameter `{}` of {} provided more than once",
+                        param_names[idx], callee_label
+                    ));
+                }
+                slots[idx] = Some((**value).clone());
+            }
+            other => {
+                if next_pos >= param_names.len() {
+                    return Err(format!(
+                        "Too many positional arguments for {} (expected {}, got more)",
+                        callee_label,
+                        param_names.len()
+                    ));
+                }
+                if slots[next_pos].is_some() {
+                    return Err(format!(
+                        "Argument for parameter `{}` of {} provided more than once",
+                        param_names[next_pos], callee_label
+                    ));
+                }
+                slots[next_pos] = Some(other.clone());
+                next_pos += 1;
+            }
+        }
+    }
+
+    // Every slot must be filled, otherwise the caller missed a
+    // parameter. The runtime previously left missing positional args
+    // unbound silently; with named args we surface the error.
+    let mut out = Vec::with_capacity(param_names.len());
+    for (i, slot) in slots.into_iter().enumerate() {
+        match slot {
+            Some(node) => out.push(node),
+            None => {
+                return Err(format!(
+                    "Missing argument for parameter `{}` of {}",
+                    param_names[i], callee_label
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// True if any element of `arguments` is a `Node::NamedArg`.
+pub fn has_named(arguments: &[Node]) -> bool {
+    arguments.iter().any(|n| matches!(n, Node::NamedArg { .. }))
+}
+
+/// Walk a parsed `Node::Program` and rewrite every CallExpression
+/// whose callee is a known top-level fn so its `arguments` list is
+/// in positional order. The pre-pass collects each top-level fn's
+/// declared parameter names, then a single post-order rewrite
+/// replaces named-arg lists with the resolved positional vector.
+/// Returns the first resolution error (with `line:col`) if any
+/// call's named args fail validation.
+pub fn lower_program(program: &mut Node) -> Result<(), String> {
+    let mut sigs: HashMap<String, Vec<String>> = HashMap::new();
+    collect_signatures(program, &mut sigs);
+    rewrite_calls(program, &sigs)
+}
+
+fn collect_signatures(node: &Node, sigs: &mut HashMap<String, Vec<String>>) {
+    match node {
+        Node::Program(stmts) => {
+            for s in stmts {
+                collect_signatures(&s.node, sigs);
+            }
+        }
+        Node::Function {
+            name, parameters, ..
+        } => {
+            // Top-level fn declarations register their parameter names
+            // here so call-site lowering can find them. Methods inside
+            // `impl` blocks come through the ImplBlock arm below.
+            sigs.insert(
+                name.clone(),
+                parameters.iter().map(|(_t, n)| n.clone()).collect(),
+            );
+        }
+        Node::ImplBlock { methods, .. } => {
+            // Methods get registered under their mangled `Struct$method`
+            // name, matching the eval-time lookup. The `self` parameter
+            // is stripped so the user-visible parameter set lines up
+            // with the call-site label set.
+            for m in methods {
+                if let Node::Function {
+                    name, parameters, ..
+                } = m
+                {
+                    let names: Vec<String> = parameters
+                        .iter()
+                        .skip(
+                            if parameters
+                                .first()
+                                .map(|(_, n)| n == "self")
+                                .unwrap_or(false)
+                            {
+                                1
+                            } else {
+                                0
+                            },
+                        )
+                        .map(|(_t, n)| n.clone())
+                        .collect();
+                    sigs.insert(name.clone(), names);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Post-order rewrite: visit children first so nested calls have
+/// their named args lowered before the outer call inspects them.
+/// Errors short-circuit at the first failure with a `line:col`
+/// prefix when the named arg carries a span.
+fn rewrite_calls(node: &mut Node, sigs: &HashMap<String, Vec<String>>) -> Result<(), String> {
+    match node {
+        Node::Program(stmts) => {
+            for s in stmts.iter_mut() {
+                rewrite_calls(&mut s.node, sigs)?;
+            }
+        }
+        Node::Block { stmts, .. } => {
+            for s in stmts.iter_mut() {
+                rewrite_calls(s, sigs)?;
+            }
+        }
+        Node::Function {
+            body,
+            requires,
+            ensures,
+            recovers_to,
+            ..
+        } => {
+            rewrite_calls(body, sigs)?;
+            for r in requires.iter_mut() {
+                rewrite_calls(r, sigs)?;
+            }
+            for e in ensures.iter_mut() {
+                rewrite_calls(e, sigs)?;
+            }
+            if let Some(rec) = recovers_to {
+                rewrite_calls(rec, sigs)?;
+            }
+        }
+        Node::FunctionLiteral {
+            body,
+            requires,
+            ensures,
+            recovers_to,
+            ..
+        } => {
+            rewrite_calls(body, sigs)?;
+            for r in requires.iter_mut() {
+                rewrite_calls(r, sigs)?;
+            }
+            for e in ensures.iter_mut() {
+                rewrite_calls(e, sigs)?;
+            }
+            if let Some(rec) = recovers_to {
+                rewrite_calls(rec, sigs)?;
+            }
+        }
+        Node::ImplBlock { methods, .. } => {
+            for m in methods.iter_mut() {
+                rewrite_calls(m, sigs)?;
+            }
+        }
+        Node::LetStatement { value, .. }
+        | Node::StaticLet { value, .. }
+        | Node::Const { value, .. }
+        | Node::Assignment { value, .. }
+        | Node::ExpressionStatement { expr: value, .. } => rewrite_calls(value, sigs)?,
+        Node::ReturnStatement { value: Some(v), .. } => {
+            rewrite_calls(v, sigs)?;
+        }
+        Node::ReturnStatement { value: None, .. } => {}
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            rewrite_calls(condition, sigs)?;
+            rewrite_calls(consequence, sigs)?;
+            if let Some(alt) = alternative {
+                rewrite_calls(alt, sigs)?;
+            }
+        }
+        Node::WhileStatement {
+            condition,
+            body,
+            invariants,
+            ..
+        } => {
+            rewrite_calls(condition, sigs)?;
+            rewrite_calls(body, sigs)?;
+            for inv in invariants.iter_mut() {
+                rewrite_calls(inv, sigs)?;
+            }
+        }
+        Node::ForInStatement {
+            iterable,
+            body,
+            invariants,
+            ..
+        } => {
+            rewrite_calls(iterable, sigs)?;
+            rewrite_calls(body, sigs)?;
+            for inv in invariants.iter_mut() {
+                rewrite_calls(inv, sigs)?;
+            }
+        }
+        Node::PrefixExpression { right, .. } => rewrite_calls(right, sigs)?,
+        Node::InfixExpression { left, right, .. } => {
+            rewrite_calls(left, sigs)?;
+            rewrite_calls(right, sigs)?;
+        }
+        Node::IndexExpression { target, index, .. } => {
+            rewrite_calls(target, sigs)?;
+            rewrite_calls(index, sigs)?;
+        }
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
+            rewrite_calls(target, sigs)?;
+            rewrite_calls(index, sigs)?;
+            rewrite_calls(value, sigs)?;
+        }
+        Node::FieldAccess { target, .. } => rewrite_calls(target, sigs)?,
+        Node::FieldAssignment { target, value, .. } => {
+            rewrite_calls(target, sigs)?;
+            rewrite_calls(value, sigs)?;
+        }
+        Node::ArrayLiteral { items, .. } => {
+            for it in items.iter_mut() {
+                rewrite_calls(it, sigs)?;
+            }
+        }
+        Node::MapLiteral { entries, .. } => {
+            for (k, v) in entries.iter_mut() {
+                rewrite_calls(k, sigs)?;
+                rewrite_calls(v, sigs)?;
+            }
+        }
+        Node::SetLiteral { items, .. } => {
+            for it in items.iter_mut() {
+                rewrite_calls(it, sigs)?;
+            }
+        }
+        Node::TryExpression { expr, .. } => rewrite_calls(expr, sigs)?,
+        Node::OptionalChain { object, access, .. } => {
+            rewrite_calls(object, sigs)?;
+            if let crate::ChainAccess::Method(_, args) = access {
+                for a in args.iter_mut() {
+                    rewrite_calls(a, sigs)?;
+                }
+            }
+        }
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
+            rewrite_calls(scrutinee, sigs)?;
+            for (_pat, guard, body) in arms.iter_mut() {
+                if let Some(g) = guard {
+                    rewrite_calls(g, sigs)?;
+                }
+                rewrite_calls(body, sigs)?;
+            }
+        }
+        Node::TryCatch { body, handlers, .. } => {
+            for s in body.iter_mut() {
+                rewrite_calls(s, sigs)?;
+            }
+            for (_v, handler_body) in handlers.iter_mut() {
+                for s in handler_body.iter_mut() {
+                    rewrite_calls(s, sigs)?;
+                }
+            }
+        }
+        Node::Quantifier { range, body, .. } => {
+            match range {
+                crate::quantifiers::QuantRange::Range { lo, hi } => {
+                    rewrite_calls(lo, sigs)?;
+                    rewrite_calls(hi, sigs)?;
+                }
+                crate::quantifiers::QuantRange::Iterable(expr) => rewrite_calls(expr, sigs)?,
+            }
+            rewrite_calls(body, sigs)?;
+        }
+        Node::Assert {
+            condition, message, ..
+        }
+        | Node::Assume {
+            condition, message, ..
+        } => {
+            rewrite_calls(condition, sigs)?;
+            if let Some(m) = message {
+                rewrite_calls(m, sigs)?;
+            }
+        }
+        Node::InvariantStatement { expr, .. } => rewrite_calls(expr, sigs)?,
+        Node::LiveBlock {
+            body, invariants, ..
+        } => {
+            rewrite_calls(body, sigs)?;
+            for inv in invariants.iter_mut() {
+                rewrite_calls(inv, sigs)?;
+            }
+        }
+        Node::StructLiteral { fields, .. } => {
+            for (_n, v) in fields.iter_mut() {
+                rewrite_calls(v, sigs)?;
+            }
+        }
+        // The CallExpression arm: lower nested calls first, then
+        // rewrite this call's argument list if it carries any
+        // named args and we know the callee's parameter names.
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
+            rewrite_calls(function, sigs)?;
+            for a in arguments.iter_mut() {
+                rewrite_calls(a, sigs)?;
+            }
+            if !has_named(arguments) {
+                return Ok(());
+            }
+            // Figure out the callee name we should look up. Two
+            // shapes carry resolvable names: a bare identifier
+            // (`f(...)`) and a struct method call (`obj.m(...)`)
+            // which goes through FieldAccess and the mangled
+            // `Struct$m` name. The latter is rewritten by the
+            // interpreter at dispatch — at parse time we only have
+            // the method name, not the struct type, so we can't
+            // resolve it eagerly here. Calls on other shapes keep
+            // their NamedArg nodes; the runtime path errors out.
+            let callee_name = if let Node::Identifier { name, .. } = function.as_ref() {
+                Some(name.clone())
+            } else {
+                None
+            };
+            if let Some(name) = callee_name
+                && let Some(param_names) = sigs.get(&name)
+            {
+                let label = format!("fn `{}`", name);
+                let lowered = resolve(&label, param_names, arguments)?;
+                *arguments = lowered;
+            }
+            // Otherwise leave NamedArg nodes in place; the runtime
+            // path raises a clean diagnostic if the call ever
+            // reaches eval with named args still present.
+        }
+        // Leaves and statements that don't carry sub-expressions:
+        // nothing to recurse into.
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::span::Span;
+
+    fn lit(v: i64) -> Node {
+        Node::IntegerLiteral {
+            value: v,
+            span: Span::default(),
+        }
+    }
+    fn named(name: &str, v: i64) -> Node {
+        Node::NamedArg {
+            name: name.to_string(),
+            value: Box::new(lit(v)),
+            span: Span::default(),
+        }
+    }
+
+    fn params(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn all_named_in_reverse_order_reorders_to_param_order() {
+        let p = params(&["x", "y", "z"]);
+        let args = vec![named("z", 30), named("y", 20), named("x", 10)];
+        let out = resolve("fn f", &p, &args).unwrap();
+        match &out[0] {
+            Node::IntegerLiteral { value, .. } => assert_eq!(*value, 10),
+            _ => panic!("slot 0 should be x=10"),
+        }
+        match &out[1] {
+            Node::IntegerLiteral { value, .. } => assert_eq!(*value, 20),
+            _ => panic!("slot 1 should be y=20"),
+        }
+        match &out[2] {
+            Node::IntegerLiteral { value, .. } => assert_eq!(*value, 30),
+            _ => panic!("slot 2 should be z=30"),
+        }
+    }
+
+    #[test]
+    fn positional_then_named_fills_correctly() {
+        let p = params(&["x", "y", "z"]);
+        let args = vec![lit(1), named("z", 3), named("y", 2)];
+        let out = resolve("fn f", &p, &args).unwrap();
+        match &out[2] {
+            Node::IntegerLiteral { value, .. } => assert_eq!(*value, 3),
+            _ => panic!("slot 2 should be z=3"),
+        }
+    }
+
+    #[test]
+    fn unknown_named_reports_with_suggestion() {
+        let p = params(&["timeout", "retries"]);
+        let args = vec![named("timout", 5)];
+        let err = resolve("fn f", &p, &args).unwrap_err();
+        assert!(err.contains("timout"), "diagnostic: {}", err);
+        assert!(err.contains("did you mean"), "diagnostic: {}", err);
+    }
+
+    #[test]
+    fn duplicate_target_via_positional_and_named_errors() {
+        let p = params(&["x", "y"]);
+        let args = vec![lit(1), named("x", 99)];
+        let err = resolve("fn f", &p, &args).unwrap_err();
+        assert!(
+            err.contains("provided more than once"),
+            "diagnostic: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn missing_param_after_named_resolution_errors() {
+        let p = params(&["x", "y"]);
+        let args = vec![named("y", 2)];
+        let err = resolve("fn f", &p, &args).unwrap_err();
+        assert!(err.contains("Missing argument"), "diagnostic: {}", err);
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -3274,6 +3274,13 @@ impl TypeChecker {
                     _ => Err(format!("Cannot call non-function type: {}", func_type)),
                 }
             }
+            // RES-325: a `NamedArg` can only appear inside a call's
+            // argument list — the call check above walks `arguments`
+            // directly and treats each labelled arg by inspecting the
+            // inner value. Encountering one in any other position is
+            // a parser/internal bug; surface a clean error rather
+            // than crashing the typechecker.
+            Node::NamedArg { value, .. } => self.check_node(value),
         }
     }
 


### PR DESCRIPTION
Closes #117

## Summary
- Adds `f(x: 1, y: 2)` call syntax with parser-level validation (positional first, then named; no dupes; unknown labels caught with a did-you-mean suggestion).
- A post-parse `named_args::lower_program` pass rewrites named arg lists into positional ones using each fn's declared parameters, so the interpreter's hot `eval(CallExpression)` frame is unchanged.
- Mixing one positional arg with named args also works (e.g. `f(1, y: 2)`); the issue body's "either all named or all positional" rule is liberalised here at the prompt's request.
- Golden example `examples/named_args.rz` plus 7 new unit tests covering reverse-order all-named, mixed pos+named, and every reject path.

## Test changes
No existing tests modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)