### PR TITLE
chore: harden agent orchestration guardrails

### DIFF
--- a/.github/workflows/release-file-claims.yml
+++ b/.github/workflows/release-file-claims.yml
@@ -25,10 +25,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet .claude/file-claims.json; then
+          if git diff --quiet agent-scripts/file-claims.json; then
             echo "No claims to release."
           else
-            git add .claude/file-claims.json
+            git add agent-scripts/file-claims.json
             git commit -m "chore: release file claims for ${{ github.event.pull_request.head.ref }}"
             git push
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,9 @@ Full setup, feature flags, and cross-compile instructions are in
 1. Browse [open issues](https://github.com/EricSpencer00/Resilient/issues?q=is%3Aissue+is%3Aopen).
 2. Comment to claim, then create a branch `res-NNN-short-title`.
 3. Open a draft PR early with `Closes #N` in the body.
-4. On merge, the issue closes automatically.
+4. Use `agent-scripts/ready-or-bail.sh --pr N` to leave draft state.
+   Do not call `gh pr ready` directly for agent PRs.
+5. On merge, the issue closes automatically.
 
 Commit format: `RES-NNN: short description` (≤72 chars).
 
@@ -52,6 +54,8 @@ Commit format: `RES-NNN: short description` (≤72 chars).
 - Fix clippy warnings and formatting issues anywhere in the codebase.
 - Expand documentation (README, docs/, SYNTAX.md).
 - Open and update draft PRs on feature branches.
+- Write PR handoff comments with `agent-scripts/agent-handoff.sh` so work
+  can resume after model context loss.
 
 ## What requires human approval
 
@@ -62,6 +66,8 @@ Commit format: `RES-NNN: short description` (≤72 chars).
 - Dependency version bumps beyond patch level.
 - Changes to `.github/workflows/` CI definitions.
 - Any action that bypasses CI or commit hooks.
+- Any direct draft-to-ready transition that bypasses
+  `agent-scripts/ready-or-bail.sh`.
 
 ---
 
@@ -115,6 +121,16 @@ Rules:
 `cargo build --locked` · `cargo test --locked` · `cargo clippy -- -D warnings`
 · `cargo fmt --check` · embedded cross-compile · size gate (≤ 64 KiB .text)
 · perf gate · fuzz
+
+Agent PRs must also pass the local guardrail path:
+
+```bash
+agent-scripts/ready-or-bail.sh --pr <number>
+```
+
+That script runs `verify-scope.sh`, syncs through `agents/integration`,
+posts a durable handoff comment, and marks the PR ready only after the
+local gate is green.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,13 @@ Optional features: `--features z3` (SMT verifier), `--features lsp`,
    agent-scripts/claim-files.sh res-NNN-short-title resilient/src/main.rs resilient/src/typechecker.rs resilient/src/lexer_logos.rs
    ```
 5. Open a **draft PR** early with `Closes #N` in the body — this signals the ticket is taken.
-6. When the PR is ready, mark it ready for review; the issue closes automatically on merge.
+6. Write a handoff comment with `agent-scripts/agent-handoff.sh` whenever
+   dispatch starts, guardrails fail, guardrails pass, or you stop with
+   unfinished work. Assume another model may need to resume without your
+   context.
+7. When the PR is ready, run `agent-scripts/ready-or-bail.sh --pr N`.
+   Do not call `gh pr ready` directly; the guardrail owns the draft-to-ready
+   transition. The issue closes automatically on merge.
    Claims are auto-released by CI on merge (see `.github/workflows/release-file-claims.yml`).
 
 Commit format: `RES-NNN: short description` (≤72 chars on the first line).
@@ -160,6 +166,7 @@ the 3-line extension blocks — conflicts that are always safe to resolve by kee
 - Open draft PRs and push to feature branches.
 - Resolve merge conflicts on any PR branch, including checking out branches,
   editing conflicting files, and force-pushing to unblock stalled PRs.
+- Post durable handoff comments on your PR with `agent-scripts/agent-handoff.sh`.
 
 ## Agent autonomy — STOP and ask first
 
@@ -171,6 +178,7 @@ the 3-line extension blocks — conflicts that are always safe to resolve by kee
 - Changes to `.github/workflows/` CI definitions.
 - Force-pushing or amending commits that have already been reviewed.
 - Anything that bypasses CI (`--no-verify`, skipping hooks).
+- Directly marking an agent PR ready without `agent-scripts/ready-or-bail.sh`.
 
 ---
 

--- a/agent-scripts/README.md
+++ b/agent-scripts/README.md
@@ -11,8 +11,9 @@ file-claims + extension-point system introduced in PR #230.
 | `claim-files.sh` | Register files owned by a branch |
 | `release-claims.sh` | Release claims (called by CI on PR merge) |
 | `pick-ticket.sh` | Select the next `agent-ready` ticket not already in an open PR |
-| `dispatch-agent.sh` | Create worktree + branch + draft PR for a ticket |
-| `agent-status.sh` | One-screen view of worktrees, open PRs, claims, and the next ticket |
+| `dispatch-agent.sh` | Create worktree + branch + draft PR for a ticket, then record inferred file claims |
+| `agent-handoff.sh` | Post resumable PR handoff comments when model context is lost |
+| `agent-status.sh` | One-screen or JSON view of worktrees, open PRs, claims, and the next ticket |
 | **`verify-scope.sh`** | Guardrail: diff-shape + fmt + clippy + test + overlap, writes JSON report |
 | **`ready-or-bail.sh`** | Runs `verify-scope.sh`; marks PR ready on green, posts failure comment on red |
 | **`orchestrator.sh`** | The grand loop: pick → dispatch → sub-agent → ready-or-bail |
@@ -24,9 +25,12 @@ catch regressions the agent can't see itself. We enforce at four layers:
 
 1. **Pre-dispatch** (`check-overlaps.sh` + `pick-ticket.sh`) — refuse to
    start work that would collide with another open PR or an active claim.
+   `dispatch-agent.sh` extracts expected files from the issue form and
+   commits those claims before opening the draft PR.
 2. **In-agent** — `CLAUDE.md` in the repo root tells the sub-agent the
    rules (no test edits, no new `unsafe`, no CI edits, bounded blast
-   radius). Self-enforcement; cheap and fast.
+   radius). `agent-handoff.sh` writes durable PR comments so another
+   agent can resume after context loss. Self-enforcement; cheap and fast.
 3. **Pre-ready** (`verify-scope.sh` via `ready-or-bail.sh`) — the
    gatekeeper. Only this script marks a draft PR ready. If it fails, the
    PR stays draft with a structured failure comment.
@@ -52,6 +56,9 @@ agent-scripts/orchestrator.sh --loop
 
 # Plan without mutating anything.
 agent-scripts/orchestrator.sh --dry-run
+
+# Feed a visual board or monitor.
+agent-scripts/agent-status.sh --json
 ```
 
 Under the hood each iteration does:
@@ -103,6 +110,13 @@ own pipeline) with `--skip tests --skip clippy --skip fmt`.
 - Does **not** run the agent itself. The caller (a human, another
   script, or a spawned Claude agent) does the actual work inside the
   worktree.
+
+## Formal model
+
+`docs/agent-orchestration.tla` models the hardened orchestration state
+machine. The key safety invariants are: live PRs never share claimed files,
+ready PRs have passed guardrails, merged PRs passed guardrails + integration
+sync + CI, and merged/abandoned PRs release claims.
 
 ## Why not GitHub Projects?
 

--- a/agent-scripts/agent-handoff.sh
+++ b/agent-scripts/agent-handoff.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# agent-handoff.sh — write a durable, resumable status note to an agent PR.
+#
+# The note is intentionally a PR comment instead of a checked-in artifact:
+# it survives model context loss, follows the branch on GitHub, and does not
+# create repository churn for every intermediate agent thought.
+#
+# Usage:
+#   agent-scripts/agent-handoff.sh --pr 123 --issue 57 --phase dispatched \
+#     --status "draft opened" --summary "Executor has not started yet."
+
+set -euo pipefail
+
+PR=""
+ISSUE=""
+PHASE="unknown"
+STATUS="unknown"
+SUMMARY=""
+WORKTREE=""
+BRANCH=""
+FILES=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr) PR="$2"; shift 2 ;;
+    --issue) ISSUE="$2"; shift 2 ;;
+    --phase) PHASE="$2"; shift 2 ;;
+    --status) STATUS="$2"; shift 2 ;;
+    --summary) SUMMARY="$2"; shift 2 ;;
+    --worktree) WORKTREE="$2"; shift 2 ;;
+    --branch) BRANCH="$2"; shift 2 ;;
+    --files) FILES="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$PR" ]; then
+  BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
+  PR="$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number' 2>/dev/null || true)"
+fi
+
+if [ -z "$PR" ] || [ "$PR" = "null" ]; then
+  echo "Could not infer open PR. Pass --pr N." >&2
+  exit 2
+fi
+
+if [ -z "$ISSUE" ]; then
+  ISSUE="$(gh pr view "$PR" --json body -q '.body' | sed -nE 's/.*[Cc]loses #([0-9]+).*/\1/p' | head -1 || true)"
+fi
+
+BRANCH="${BRANCH:-$(gh pr view "$PR" --json headRefName -q .headRefName 2>/dev/null || true)}"
+NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+FILES_MD="- (none recorded)"
+if [ -n "$FILES" ]; then
+  FILES_MD="$(printf '%s\n' $FILES | sed 's/^/- `/; s/$/`/')"
+fi
+
+BODY="$(cat <<EOF
+<!-- resilient-agent-handoff -->
+## Agent Handoff
+
+- Time: \`${NOW}\`
+- Issue: ${ISSUE:+#${ISSUE}}
+- PR: #${PR}
+- Branch: \`${BRANCH:-unknown}\`
+- Worktree: \`${WORKTREE:-unknown}\`
+- Phase: \`${PHASE}\`
+- Status: ${STATUS}
+
+### Claimed files
+${FILES_MD}
+
+### Resume summary
+${SUMMARY:-No summary provided.}
+EOF
+)"
+
+gh pr comment "$PR" --body "$BODY"

--- a/agent-scripts/agent-status.sh
+++ b/agent-scripts/agent-status.sh
@@ -7,9 +7,19 @@
 #   - unclaimed open PRs (no `Closes #N` in body)
 #   - stale PRs (>72h without an update)
 #
-# Usage: agent-scripts/agent-status.sh
+# Usage:
+#   agent-scripts/agent-status.sh
+#   agent-scripts/agent-status.sh --json
 
 set -euo pipefail
+
+WANT_JSON=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) WANT_JSON=1; shift ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
 
 GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
 PRIMARY_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
@@ -17,13 +27,64 @@ PRIMARY_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
 bold() { printf '\033[1m%s\033[0m\n' "$1"; }
 dim()  { printf '\033[2m%s\033[0m\n' "$1"; }
 
+PRS_JSON="$(gh pr list --state open --limit 100 \
+  --json number,title,headRefName,isDraft,author,updatedAt,body 2>/dev/null || echo '[]')"
+CLAIMS_FILE="$PRIMARY_ROOT/agent-scripts/file-claims.json"
+WORKTREES_RAW="$(git -C "$PRIMARY_ROOT" worktree list --porcelain)"
+WORKTREES_JSON="$(WORKTREES_RAW="$WORKTREES_RAW" python3 <<'PYEOF'
+import json
+import os
+import sys
+
+items = []
+cur = {}
+for line in os.environ.get("WORKTREES_RAW", "").splitlines():
+    line = line.rstrip("\n")
+    if not line:
+        if cur:
+            items.append(cur)
+            cur = {}
+        continue
+    key, _, value = line.partition(" ")
+    if key == "worktree":
+        cur["path"] = value
+    elif key == "HEAD":
+        cur["head"] = value
+    elif key == "branch":
+        cur["branch"] = value.removeprefix("refs/heads/")
+if cur:
+    items.append(cur)
+print(json.dumps(items))
+PYEOF
+)"
+CLAIMS_JSON="$(if [ -f "$CLAIMS_FILE" ]; then cat "$CLAIMS_FILE"; else printf '{"claims":{}}'; fi)"
+NEXT_TICKET="$(bash "$(dirname "$0")/pick-ticket.sh" 2>/dev/null || true)"
+
+if (( WANT_JSON == 1 )); then
+  WORKTREES_JSON="$WORKTREES_JSON" PRS_JSON="$PRS_JSON" CLAIMS_JSON="$CLAIMS_JSON" NEXT_TICKET="$NEXT_TICKET" python3 <<'PYEOF'
+import json
+import os
+
+print(json.dumps({
+    "worktrees": json.loads(os.environ["WORKTREES_JSON"]),
+    "pull_requests": json.loads(os.environ["PRS_JSON"]),
+    "file_claims": json.loads(os.environ["CLAIMS_JSON"]).get("claims", {}),
+    "next_ticket": os.environ.get("NEXT_TICKET") or None,
+}, indent=2))
+PYEOF
+  exit 0
+fi
+
 bold "Worktrees"
-git -C "$PRIMARY_ROOT" worktree list | awk '{printf "  %-60s %s\n", $1, $3}'
+WORKTREES_JSON="$WORKTREES_JSON" python3 <<'PYEOF'
+import json
+import os
+for wt in json.loads(os.environ["WORKTREES_JSON"]):
+    print(f"  {wt.get('path',''):<60} {wt.get('branch','')}")
+PYEOF
 
 echo
 bold "Open PRs"
-PRS_JSON="$(gh pr list --state open --limit 100 \
-  --json number,title,headRefName,isDraft,author,updatedAt,body 2>/dev/null || echo '[]')"
 PRS_JSON="$PRS_JSON" python3 <<'PYEOF'
 import json, os, sys, re, datetime as dt
 
@@ -48,12 +109,9 @@ PYEOF
 
 echo
 bold "File claims"
-CLAIMS_FILE="$PRIMARY_ROOT/agent-scripts/file-claims.json"
-if [ -f "$CLAIMS_FILE" ]; then
-  python3 - "$CLAIMS_FILE" <<'PYEOF'
-import json, sys
-with open(sys.argv[1]) as f:
-    data = json.load(f)
+CLAIMS_JSON="$CLAIMS_JSON" python3 <<'PYEOF'
+import json, os
+data = json.loads(os.environ["CLAIMS_JSON"])
 claims = data.get("claims", {})
 if not claims:
     print("  (none)")
@@ -66,10 +124,11 @@ else:
         for f in fs:
             print(f"    {f}")
 PYEOF
-else
-  echo "  (claims file missing — run after #230 merges)"
-fi
 
 echo
 bold "Next agent-ready ticket"
-bash "$(dirname "$0")/pick-ticket.sh" 2>/dev/null || echo "  (none)"
+if [ -n "$NEXT_TICKET" ]; then
+  printf '%s\n' "$NEXT_TICKET"
+else
+  echo "  (none)"
+fi

--- a/agent-scripts/check-overlaps.sh
+++ b/agent-scripts/check-overlaps.sh
@@ -44,7 +44,9 @@ if [ "$CHECK_MODE" = "pr-files" ]; then
     echo "ERROR: --pr-files requires a branch name" >&2
     exit 1
   fi
-  mapfile -t FILES_TO_CHECK < <(git diff --name-only "origin/main...${BRANCH}" 2>/dev/null || true)
+  while IFS= read -r file; do
+    [ -n "$file" ] && FILES_TO_CHECK+=("$file")
+  done < <(git diff --name-only "origin/main...${BRANCH}" 2>/dev/null || true)
 fi
 
 if [ ${#FILES_TO_CHECK[@]} -eq 0 ]; then

--- a/agent-scripts/dispatch-agent.sh
+++ b/agent-scripts/dispatch-agent.sh
@@ -5,14 +5,18 @@
 #   1. Picks the next agent-ready ticket (or uses --issue N).
 #   2. Creates a fresh git worktree at .claude/worktrees/res-<N>/ on a
 #      new branch `res-<N>-<short-slug>` based on origin/main.
-#   3. Opens a draft PR against origin/main with `Closes #<N>` so the
+#   3. Extracts expected file ownership from the issue form and refuses
+#      overlapping dispatches before the agent starts editing.
+#   4. Opens a draft PR against origin/main with `Closes #<N>` so the
 #      ticket is visibly claimed.
-#   4. Prints the worktree path + branch + PR URL.
+#   5. Prints the worktree path + branch + PR URL.
 #
 # Usage:
 #   agent-scripts/dispatch-agent.sh
 #   agent-scripts/dispatch-agent.sh --issue 167
 #   agent-scripts/dispatch-agent.sh --issue 167 --dry-run
+#   agent-scripts/dispatch-agent.sh --issue 167 --claim resilient/src/main.rs
+#   agent-scripts/dispatch-agent.sh --issue 167 --no-auto-claim
 #
 # Does NOT run the agent itself — that's the caller's job. This
 # script only prepares the workspace.
@@ -28,10 +32,14 @@ PRIMARY_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
 
 ISSUE=""
 DRY_RUN=0
+AUTO_CLAIM=1
+CLAIM_FILES=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --issue) ISSUE="$2"; shift 2 ;;
+    --claim) CLAIM_FILES+=("$2"); shift 2 ;;
+    --no-auto-claim) AUTO_CLAIM=0; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     *) echo "Unknown flag: $1" >&2; exit 2 ;;
   esac
@@ -45,8 +53,66 @@ if [ -z "$ISSUE" ]; then
   fi
   ISSUE="$(printf '%s' "$LINE" | cut -f1)"
   TITLE="$(printf '%s' "$LINE" | cut -f2-)"
+  ISSUE_BODY="$(gh issue view "$ISSUE" --json body -q .body)"
 else
-  TITLE="$(gh issue view "$ISSUE" --json title -q .title)"
+  ISSUE_JSON="$(gh issue view "$ISSUE" --json title,body)"
+  TITLE="$(printf '%s' "$ISSUE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin)["title"])')"
+  ISSUE_BODY="$(printf '%s' "$ISSUE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body") or "")')"
+fi
+
+if [ "$AUTO_CLAIM" = "1" ]; then
+  ISSUE_BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/resilient-issue-body.XXXXXX")"
+  ISSUE_CLAIMS_FILE="$(mktemp "${TMPDIR:-/tmp}/resilient-issue-claims.XXXXXX")"
+  printf '%s' "$ISSUE_BODY" > "$ISSUE_BODY_FILE"
+  python3 - "$PRIMARY_ROOT" "$ISSUE_BODY_FILE" > "$ISSUE_CLAIMS_FILE" <<'PYEOF'
+import os
+import re
+import sys
+
+root = sys.argv[1]
+with open(sys.argv[2], encoding="utf-8") as handle:
+    body = handle.read().splitlines()
+in_section = False
+paths = []
+
+heading = re.compile(r"^#{1,6}\s+(.+?)\s*$")
+tick = chr(96)
+pathish = re.compile(tick + r"([^" + tick + r"]+)" + tick + r"|(?:^|\s)([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.@+-]+)+)")
+
+for raw in body:
+    line = raw.strip()
+    h = heading.match(line)
+    if h:
+        title = h.group(1).lower()
+        if title.startswith("files / modules to touch") or title.startswith("files to touch"):
+            in_section = True
+            continue
+        if in_section:
+            break
+    if not in_section:
+        continue
+    if not line or line.lower() in {"none", "n/a", "_no response_"}:
+        continue
+    for match in pathish.finditer(line):
+        candidate = next(group for group in match.groups() if group)
+        candidate = candidate.strip(".,;:)")
+        if candidate.startswith(("http://", "https://")):
+            continue
+        if candidate.startswith(("-", "*")):
+            candidate = candidate[1:]
+        if os.path.isabs(candidate):
+            continue
+        if candidate.startswith((".github/", ".board/", "agent-scripts/", "resilient/", "resilient-runtime/", "fuzz/", "docs/", "vscode-extension/", "benchmarks/")) or os.path.exists(os.path.join(root, candidate)):
+            paths.append(candidate)
+
+for path in dict.fromkeys(paths):
+    print(path)
+PYEOF
+  while IFS= read -r f; do
+    [ -n "$f" ] && CLAIM_FILES+=("$f")
+  done < "$ISSUE_CLAIMS_FILE"
+  rm -f "$ISSUE_BODY_FILE"
+  rm -f "$ISSUE_CLAIMS_FILE"
 fi
 
 SLUG="$(printf '%s' "$TITLE" \
@@ -59,6 +125,12 @@ WORKTREE="${PRIMARY_ROOT}/.claude/worktrees/res-${ISSUE}"
 echo "Ticket  : #${ISSUE} — ${TITLE}"
 echo "Branch  : ${BRANCH}"
 echo "Worktree: ${WORKTREE}"
+if [ ${#CLAIM_FILES[@]} -gt 0 ]; then
+  echo "Claims  :"
+  printf '  %s\n' "${CLAIM_FILES[@]}"
+else
+  echo "Claims  : (none inferred)"
+fi
 
 if [ "$DRY_RUN" = "1" ]; then
   echo "(dry-run, stopping here)"
@@ -75,13 +147,28 @@ if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
   exit 1
 fi
 
+if [ ${#CLAIM_FILES[@]} -gt 0 ]; then
+  bash "$SCRIPT_DIR/check-overlaps.sh" "${CLAIM_FILES[@]}"
+fi
+
 git -C "$PRIMARY_ROOT" fetch origin main >/dev/null 2>&1
 git -C "$PRIMARY_ROOT" worktree add -b "$BRANCH" "$WORKTREE" origin/main
 
-# Open a draft PR so the ticket shows as claimed. Use an empty commit
-# to give gh something to compare against main.
-git -C "$WORKTREE" commit --allow-empty -m "res-${ISSUE}: claim ticket — ${TITLE}" >/dev/null
+# Open a draft PR so the ticket shows as claimed. File claims, when known,
+# live in the claim commit so CI and sibling agents can inspect them.
+if [ ${#CLAIM_FILES[@]} -gt 0 ]; then
+  (cd "$WORKTREE" && bash "$SCRIPT_DIR/claim-files.sh" "$BRANCH" "${CLAIM_FILES[@]}") >/dev/null
+  git -C "$WORKTREE" add agent-scripts/file-claims.json
+  git -C "$WORKTREE" commit -m "res-${ISSUE}: claim ticket — ${TITLE}" >/dev/null
+else
+  git -C "$WORKTREE" commit --allow-empty -m "res-${ISSUE}: claim ticket — ${TITLE}" >/dev/null
+fi
 git -C "$WORKTREE" push -u origin "$BRANCH" >/dev/null 2>&1
+
+CLAIM_BLOCK="(none inferred from issue)"
+if [ ${#CLAIM_FILES[@]} -gt 0 ]; then
+  CLAIM_BLOCK="$(printf -- '- %s\n' "${CLAIM_FILES[@]}")"
+fi
 
 PR_URL="$(cd "$WORKTREE" && gh pr create --draft --base main --head "$BRANCH" \
   --title "RES-${ISSUE}: ${TITLE#RES-*: }" \
@@ -93,8 +180,25 @@ ticket. The agent will push real work here shortly.
 
 Branch: \`${BRANCH}\`
 Worktree: \`${WORKTREE#${PRIMARY_ROOT}/}\`
+
+## Agent claims
+
+${CLAIM_BLOCK}
 EOF
 )" 2>&1 | tail -1)"
+
+PR_NUMBER="${PR_URL##*/}"
+if [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] && [ -x "$SCRIPT_DIR/agent-handoff.sh" ]; then
+  "$SCRIPT_DIR/agent-handoff.sh" \
+    --pr "$PR_NUMBER" \
+    --issue "$ISSUE" \
+    --phase dispatched \
+    --status "draft PR opened and file claims recorded" \
+    --worktree "$WORKTREE" \
+    --branch "$BRANCH" \
+    --summary "Executor has not started yet." \
+    --files "${CLAIM_FILES[*]:-}" >/dev/null || true
+fi
 
 echo
 echo "Draft PR: ${PR_URL}"
@@ -102,4 +206,4 @@ echo
 echo "Next steps:"
 echo "  cd \"${WORKTREE}\""
 echo "  # edit files, commit, push — the draft PR will update automatically"
-echo "  # when ready:  gh pr ready ${PR_URL}"
+echo "  # when ready:  agent-scripts/ready-or-bail.sh --pr ${PR_NUMBER:-<pr>}"

--- a/agent-scripts/orchestrator.sh
+++ b/agent-scripts/orchestrator.sh
@@ -64,6 +64,13 @@ run_one() {
   local pr
   pr="$(printf '%s' "$dispatch_out" | awk -F'/pull/' '/Draft PR/ {print $2; exit}')"
   log "worktree=$worktree pr=$pr"
+  "$SCRIPT_DIR/agent-handoff.sh" \
+    --pr "$pr" \
+    --issue "$issue" \
+    --phase executor-starting \
+    --status "sub-agent prompt prepared" \
+    --worktree "$worktree" \
+    --summary "The orchestrator is launching the executor. Resume from the issue body, branch diff, latest commits, CI status, and this handoff thread." >/dev/null || true
 
   local body_file="/tmp/issue-${issue}.md"
   gh issue view "$issue" --json title,body -q '.title + "\n\n" + .body' > "$body_file"
@@ -102,6 +109,14 @@ EOF
 
   # Best-effort: if the agent forgot, run the guardrail ourselves.
   (cd "$worktree" && bash "$SCRIPT_DIR/ready-or-bail.sh" --pr "$pr") || true
+
+  "$SCRIPT_DIR/agent-handoff.sh" \
+    --pr "$pr" \
+    --issue "$issue" \
+    --phase executor-finished \
+    --status "orchestrator iteration complete" \
+    --worktree "$worktree" \
+    --summary "Executor process returned. Inspect the branch diff, latest PR comments, and guardrail report to resume." >/dev/null || true
 
   log "finished #${issue}"
 }

--- a/agent-scripts/ready-or-bail.sh
+++ b/agent-scripts/ready-or-bail.sh
@@ -48,6 +48,11 @@ if bash "$SCRIPT_DIR/verify-scope.sh" --report "$REPORT"; then
     fi
     gh pr ready "$PR" 2>&1 | tail -2
     gh pr comment "$PR" --body "Guardrail passed ✓ — fmt, clippy, tests, diff-shape, overlap. Synced against \`agents/integration\`. Auto-merge will fire once remaining checks complete." >/dev/null
+    "$SCRIPT_DIR/agent-handoff.sh" \
+      --pr "$PR" \
+      --phase guardrail-green \
+      --status "ready for review after local guardrail and integration sync" \
+      --summary "Local guardrail passed; branch was synced against agents/integration and marked ready." >/dev/null || true
   else
     echo "(dry-run) would also run sync-integration.sh"
   fi
@@ -71,6 +76,11 @@ print("\n".join(lines))
 PYEOF
 )"
     gh pr comment "$PR" --body "$BODY" >/dev/null
+    "$SCRIPT_DIR/agent-handoff.sh" \
+      --pr "$PR" \
+      --phase guardrail-red \
+      --status "left draft after guardrail failure" \
+      --summary "$BODY" >/dev/null || true
   else
     echo "(dry-run) would comment:"
     cat "$REPORT"

--- a/docs/agent-orchestration.md
+++ b/docs/agent-orchestration.md
@@ -1,0 +1,52 @@
+# Agent Orchestration Hardening
+
+Resilient uses GitHub Issues and pull requests as the source of truth for
+agent work. The local scripts provide scheduling and guardrails, but they
+must not create a second canonical board.
+
+## Control Plane
+
+The orchestration loop has five phases:
+
+1. **Pick** an `agent-ready` issue that has no open PR claim.
+2. **Dispatch** a fresh branch and worktree from `origin/main`.
+3. **Claim** expected files before the executor starts editing.
+4. **Verify** with `verify-scope.sh` and CI before a PR leaves draft.
+5. **Sync** through `agents/integration` before auto-merge.
+
+`agent-scripts/agent-status.sh --json` is the dashboard feed. A Kanban UI
+may be built on top of that JSON, but the UI must remain a projection of
+issues, PRs, CI, worktrees, and file claims.
+
+## Resumability
+
+Agents should assume model context can disappear at any point. The durable
+handoff is a PR comment emitted by `agent-handoff.sh` at dispatch,
+executor start, guardrail failure, guardrail success, and orchestrator
+finish. A replacement agent resumes from:
+
+- the linked issue body,
+- the PR body and latest handoff comments,
+- branch commits and changed files,
+- CI check state,
+- the latest guardrail report.
+
+## Conflict Policy
+
+File claims are leases, not ownership forever. Dispatch refuses known
+overlaps before work begins, `verify-scope.sh` checks overlap before a PR
+is marked ready, and merge releases claims through
+`release-file-claims.yml`.
+
+Hard conflicts require human resolution. Append-only extension conflicts
+may be handled by `sync-integration.sh` and `auto-resolve-extensions.sh`.
+
+## Formal Model
+
+The TLA+ model in `docs/agent-orchestration.tla` captures the safety
+invariants this workflow is meant to preserve:
+
+- no two live PRs own the same claimed file,
+- a ready PR has passed guardrails,
+- an auto-mergeable PR has passed guardrails and integration sync,
+- merged PRs have released their file claims.

--- a/docs/agent-orchestration.tla
+++ b/docs/agent-orchestration.tla
@@ -1,0 +1,176 @@
+-------------------------- MODULE AgentOrchestration --------------------------
+EXTENDS Naturals, FiniteSets, Sequences
+
+(*
+This model specifies the safety contract for Resilient's agent
+orchestration. It abstracts away GitHub and shell details and keeps only
+the state transitions that matter for correctness.
+
+Model constants:
+  Agents  - set of agent identities
+  Issues  - set of issue identities
+  Files   - set of repository file identities
+
+Suggested TLC constraints:
+  Agents = {a1, a2}
+  Issues = {i1, i2, i3}
+  Files  = {f1, f2, f3}
+*)
+
+CONSTANTS Agents, Issues, Files
+
+ASSUME Agents # {} /\ Issues # {} /\ Files # {}
+
+States == {
+    "open",
+    "dispatched",
+    "running",
+    "guardrail_failed",
+    "guardrail_passed",
+    "synced",
+    "ready",
+    "merged",
+    "abandoned"
+}
+
+VARIABLES
+    state,          \* issue -> lifecycle state
+    owner,          \* issue -> agent or None
+    prOpen,         \* issue -> whether a PR exists and is still live
+    claims,         \* issue -> claimed file set
+    guardrailOk,    \* issue -> local guardrail passed
+    syncedOk,       \* issue -> branch synced through agents/integration
+    ciOk,           \* issue -> required CI checks passed
+    handoff         \* issue -> durable handoff event count
+
+None == "none"
+
+TypeOK ==
+    /\ state \in [Issues -> States]
+    /\ owner \in [Issues -> Agents \cup {None}]
+    /\ prOpen \in [Issues -> BOOLEAN]
+    /\ claims \in [Issues -> SUBSET Files]
+    /\ guardrailOk \in [Issues -> BOOLEAN]
+    /\ syncedOk \in [Issues -> BOOLEAN]
+    /\ ciOk \in [Issues -> BOOLEAN]
+    /\ handoff \in [Issues -> Nat]
+
+Init ==
+    /\ state = [i \in Issues |-> "open"]
+    /\ owner = [i \in Issues |-> None]
+    /\ prOpen = [i \in Issues |-> FALSE]
+    /\ claims = [i \in Issues |-> {}]
+    /\ guardrailOk = [i \in Issues |-> FALSE]
+    /\ syncedOk = [i \in Issues |-> FALSE]
+    /\ ciOk = [i \in Issues |-> FALSE]
+    /\ handoff = [i \in Issues |-> 0]
+
+LiveIssues == {i \in Issues : prOpen[i] /\ state[i] \notin {"merged", "abandoned"}}
+
+NoClaimOverlap ==
+    \A i, j \in LiveIssues :
+        i # j => claims[i] \cap claims[j] = {}
+
+ReadyRequiresGuardrail ==
+    \A i \in Issues :
+        state[i] = "ready" => guardrailOk[i]
+
+MergeRequiresFullGate ==
+    \A i \in Issues :
+        state[i] = "merged" => guardrailOk[i] /\ syncedOk[i] /\ ciOk[i]
+
+MergedReleasesClaims ==
+    \A i \in Issues :
+        state[i] = "merged" => claims[i] = {}
+
+Dispatch(i, a, fs) ==
+    /\ state[i] = "open"
+    /\ a \in Agents
+    /\ fs \subseteq Files
+    /\ \A j \in LiveIssues : fs \cap claims[j] = {}
+    /\ state' = [state EXCEPT ![i] = "dispatched"]
+    /\ owner' = [owner EXCEPT ![i] = a]
+    /\ prOpen' = [prOpen EXCEPT ![i] = TRUE]
+    /\ claims' = [claims EXCEPT ![i] = fs]
+    /\ handoff' = [handoff EXCEPT ![i] = @ + 1]
+    /\ UNCHANGED <<guardrailOk, syncedOk, ciOk>>
+
+Start(i) ==
+    /\ state[i] = "dispatched"
+    /\ state' = [state EXCEPT ![i] = "running"]
+    /\ handoff' = [handoff EXCEPT ![i] = @ + 1]
+    /\ UNCHANGED <<owner, prOpen, claims, guardrailOk, syncedOk, ciOk>>
+
+GuardrailFail(i) ==
+    /\ state[i] = "running"
+    /\ state' = [state EXCEPT ![i] = "guardrail_failed"]
+    /\ guardrailOk' = [guardrailOk EXCEPT ![i] = FALSE]
+    /\ handoff' = [handoff EXCEPT ![i] = @ + 1]
+    /\ UNCHANGED <<owner, prOpen, claims, syncedOk, ciOk>>
+
+GuardrailPass(i) ==
+    /\ state[i] \in {"running", "guardrail_failed"}
+    /\ state' = [state EXCEPT ![i] = "guardrail_passed"]
+    /\ guardrailOk' = [guardrailOk EXCEPT ![i] = TRUE]
+    /\ handoff' = [handoff EXCEPT ![i] = @ + 1]
+    /\ UNCHANGED <<owner, prOpen, claims, syncedOk, ciOk>>
+
+Sync(i) ==
+    /\ state[i] = "guardrail_passed"
+    /\ guardrailOk[i]
+    /\ state' = [state EXCEPT ![i] = "synced"]
+    /\ syncedOk' = [syncedOk EXCEPT ![i] = TRUE]
+    /\ handoff' = [handoff EXCEPT ![i] = @ + 1]
+    /\ UNCHANGED <<owner, prOpen, claims, guardrailOk, ciOk>>
+
+MarkReady(i) ==
+    /\ state[i] = "synced"
+    /\ guardrailOk[i]
+    /\ syncedOk[i]
+    /\ state' = [state EXCEPT ![i] = "ready"]
+    /\ handoff' = [handoff EXCEPT ![i] = @ + 1]
+    /\ UNCHANGED <<owner, prOpen, claims, guardrailOk, syncedOk, ciOk>>
+
+CiPass(i) ==
+    /\ state[i] \in {"synced", "ready"}
+    /\ ciOk' = [ciOk EXCEPT ![i] = TRUE]
+    /\ UNCHANGED <<state, owner, prOpen, claims, guardrailOk, syncedOk, handoff>>
+
+Merge(i) ==
+    /\ state[i] = "ready"
+    /\ guardrailOk[i] /\ syncedOk[i] /\ ciOk[i]
+    /\ state' = [state EXCEPT ![i] = "merged"]
+    /\ prOpen' = [prOpen EXCEPT ![i] = FALSE]
+    /\ claims' = [claims EXCEPT ![i] = {}]
+    /\ handoff' = [handoff EXCEPT ![i] = @ + 1]
+    /\ UNCHANGED <<owner, guardrailOk, syncedOk, ciOk>>
+
+Abandon(i) ==
+    /\ state[i] \notin {"merged", "abandoned"}
+    /\ state' = [state EXCEPT ![i] = "abandoned"]
+    /\ prOpen' = [prOpen EXCEPT ![i] = FALSE]
+    /\ claims' = [claims EXCEPT ![i] = {}]
+    /\ handoff' = [handoff EXCEPT ![i] = @ + 1]
+    /\ UNCHANGED <<owner, guardrailOk, syncedOk, ciOk>>
+
+Next ==
+    \/ \E i \in Issues, a \in Agents, fs \in SUBSET Files : Dispatch(i, a, fs)
+    \/ \E i \in Issues : Start(i)
+    \/ \E i \in Issues : GuardrailFail(i)
+    \/ \E i \in Issues : GuardrailPass(i)
+    \/ \E i \in Issues : Sync(i)
+    \/ \E i \in Issues : MarkReady(i)
+    \/ \E i \in Issues : CiPass(i)
+    \/ \E i \in Issues : Merge(i)
+    \/ \E i \in Issues : Abandon(i)
+
+Spec == Init /\ [][Next]_<<state, owner, prOpen, claims, guardrailOk, syncedOk, ciOk, handoff>>
+
+Safety ==
+    TypeOK
+    /\ NoClaimOverlap
+    /\ ReadyRequiresGuardrail
+    /\ MergeRequiresFullGate
+    /\ MergedReleasesClaims
+
+=============================================================================


### PR DESCRIPTION
## Summary

Hardens the Resilient agent orchestration system around a formally modeled workflow:

- Adds `docs/agent-orchestration.tla`, a TLA+ state machine for dispatch, file claims, guardrails, integration sync, readiness, merge, and claim release.
- Adds `docs/agent-orchestration.md` as the operator-facing contract for the hardened system.
- Adds `agent-scripts/agent-handoff.sh` so PR comments become durable resume points when model context is exhausted.
- Makes `dispatch-agent.sh` infer expected file claims from issue-form bodies, check overlaps before worktree creation, commit claims into the claim commit, and include claims in the draft PR body.
- Adds `agent-status.sh --json` as a dashboard/Kanban feed while keeping GitHub Issues and PRs the canonical state store.
- Wires handoff comments into `orchestrator.sh` and `ready-or-bail.sh`.
- Fixes claim-release CI to update `agent-scripts/file-claims.json` instead of the stale `.claude/file-claims.json` path.
- Removes Bash 4-only `mapfile` from `check-overlaps.sh` so local guardrails work on macOS Bash 3.2.
- Updates `AGENTS.md` and `CLAUDE.md` so agents follow the same ready-or-bail and handoff contract enforced by the scripts.

## TLA+ model

The model captures these safety invariants:

- live PRs never share claimed files,
- ready PRs have passed guardrails,
- merged PRs passed guardrails, integration sync, and CI,
- merged or abandoned PRs release claims.

## Test evidence

```bash
bash -n agent-scripts/*.sh
agent-scripts/agent-status.sh --json | python3 -m json.tool
agent-scripts/dispatch-agent.sh --issue 216 --dry-run
agent-scripts/verify-scope.sh --skip tests --skip clippy --skip fmt --report /tmp/orchestration-guardrail.json
cargo fmt --manifest-path resilient/Cargo.toml --all -- --check
cargo fmt --manifest-path resilient-runtime/Cargo.toml --all -- --check
```

`cargo fmt --all -- --check` from the repository root was also attempted and fails because this repo has no root `Cargo.toml`; the manifest-specific fmt checks above are the applicable checks.

## Notes for reviewers

This intentionally changes `.github/workflows/release-file-claims.yml` because the old path prevented claim release from committing the file actually used by the scripts.
