### PR TITLE
RES-316: add variadic FFI printf path

### DIFF
--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -51,6 +51,11 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
                     .resolve_block(library, decls)
                     .map_err(|e| CompileError::FfiError(e.to_string()))?;
                 for d in decls {
+                    if d.is_variadic {
+                        return Err(CompileError::Unsupported(
+                            "variadic extern calls are supported by the tree-walker only",
+                        ));
+                    }
                     if let Some(sym) = ffi_loader.lookup(&d.resilient_name) {
                         if ffi_index.len() >= u16::MAX as usize {
                             return Err(CompileError::Unsupported(

--- a/resilient/src/ffi.rs
+++ b/resilient/src/ffi.rs
@@ -513,6 +513,7 @@ mod tests {
             requires: Vec::new(),
             ensures: Vec::new(),
             trusted: false,
+            is_variadic: false,
             span: Span::default(),
         }
     }

--- a/resilient/src/ffi_trampolines.rs
+++ b/resilient/src/ffi_trampolines.rs
@@ -24,6 +24,7 @@
 //! the wrong ABI.
 use crate::ffi::{FfiError, FfiType, ForeignSymbol, struct_layout};
 use crate::{RResult, Value};
+use std::ffi::CString;
 
 #[allow(dead_code)]
 #[derive(Copy, Clone)]
@@ -77,7 +78,67 @@ pub fn call_foreign(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
         }
     }
 
-    dispatch_explicit(sym, args)
+    dispatch_explicit(sym, args, false)
+}
+
+/// RES-316: call a C variadic function.
+///
+/// This first slice supports the common `printf`-style shape
+/// `fn f(fmt: String, ...) -> Int` with up to 16 integer variadic slots.
+/// The fixed prefix is checked against the declared extern signature; the
+/// variadic tail is selected from runtime `Value` discriminators.
+#[allow(dead_code)]
+pub fn call_foreign_variadic(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
+    let fixed = sym.sig.params.len();
+    if args.len() < fixed {
+        return Err(format!(
+            "FFI: arity mismatch calling variadic `{}`: expected at least {}, got {}",
+            sym.name,
+            fixed,
+            args.len()
+        ));
+    }
+    if args.len() > 17 {
+        return Err(format!(
+            "FFI: variadic call `{}` has {} arguments; supported maximum is 17 (1 fixed + 16 variadic)",
+            sym.name,
+            args.len()
+        ));
+    }
+    if sym
+        .sig
+        .params
+        .iter()
+        .any(|t| matches!(t, FfiType::Callback | FfiType::Struct { .. }))
+        || matches!(sym.sig.ret, FfiType::Callback | FfiType::Struct { .. })
+    {
+        return Err(format!(
+            "FFI: variadic extern `{}` supports only scalar fixed params and scalar return",
+            sym.name
+        ));
+    }
+
+    for (i, (arg, want)) in args
+        .iter()
+        .take(fixed)
+        .zip(sym.sig.params.iter())
+        .enumerate()
+    {
+        if !value_matches_ffi_type(arg, want) {
+            return Err(format!(
+                "FFI: type mismatch calling variadic `{}` arg #{}: expected {:?}, got {:?}",
+                sym.name, i, want, arg
+            ));
+        }
+    }
+
+    match (&sym.sig.params[..], &sym.sig.ret) {
+        ([FfiType::Str], FfiType::Int) => dispatch_explicit(sym, args, true),
+        (params, ret) => Err(format!(
+            "FFI: unsupported variadic signature for `{}`: ({:?}) -> {:?}",
+            sym.name, params, ret
+        )),
+    }
 }
 
 #[allow(dead_code)]
@@ -248,12 +309,12 @@ fn read_field(buf: &[u8], offset: usize, fty: &FfiType) -> Result<Value, String>
 }
 
 #[allow(dead_code)]
-fn dispatch_explicit(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
+fn dispatch_explicit(sym: &ForeignSymbol, args: &[Value], variadic: bool) -> RResult<Value> {
     let params: &[FfiType] = &sym.sig.params;
     let ret: &FfiType = &sym.sig.ret;
 
     // Extract scalars up front.
-    let mut ints: [i64; 8] = [0; 8];
+    let mut ints: [i64; 16] = [0; 16];
     let mut floats: [f64; 8] = [0.0; 8];
     let mut bools: [bool; 8] = [false; 8];
     let mut strs: [CStr; 8] = [CStr {
@@ -294,6 +355,40 @@ fn dispatch_explicit(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
         }
     }
 
+    let variadic_fmt = if variadic {
+        match &args[0] {
+            Value::String(s) => Some(CString::new(s.as_str()).map_err(|_| {
+                format!(
+                    "FFI: variadic `{}` format string contains an interior NUL byte",
+                    sym.name
+                )
+            })?),
+            other => {
+                return Err(format!(
+                    "FFI internal: expected String fixed arg for variadic `{}`, got {:?}",
+                    sym.name, other
+                ));
+            }
+        }
+    } else {
+        None
+    };
+    if variadic {
+        for (slot, arg) in args[params.len()..].iter().enumerate() {
+            match arg {
+                Value::Int(v) => ints[slot] = *v,
+                other => {
+                    return Err(format!(
+                        "FFI: unsupported variadic `{}` arg #{}: expected Int, got {:?}",
+                        sym.name,
+                        slot + params.len(),
+                        other
+                    ));
+                }
+            }
+        }
+    }
+
     // RES-317: dispatch struct-bearing signatures separately. They live
     // outside the giant scalar-arms match so we can keep the scalar table
     // unchanged and re-use the packed `u64` representation.
@@ -312,564 +407,620 @@ fn dispatch_explicit(sym: &ForeignSymbol, args: &[Value]) -> RResult<Value> {
     // `live_strs` vector keeps any borrowed String bytes alive across
     // the call.
     let out = unsafe {
-        match (params, ret) {
-            // ---- Arity 0 ----
-            (&[], FfiType::Int) => Value::Int(std::mem::transmute::<
-                *const (),
-                extern "C" fn() -> i64,
-            >(sym.ptr)()),
-            (&[], FfiType::Float) => Value::Float(std::mem::transmute::<
-                *const (),
-                extern "C" fn() -> f64,
-            >(sym.ptr)()),
-            (&[], FfiType::Bool) => Value::Bool(std::mem::transmute::<
-                *const (),
-                extern "C" fn() -> bool,
-            >(sym.ptr)()),
-            (&[], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn()>(sym.ptr)();
-                Value::Void
+        if variadic {
+            let fmt = variadic_fmt
+                .as_ref()
+                .expect("variadic format was prepared")
+                .as_ptr();
+            macro_rules! call_variadic_ints {
+                ($($idx:expr),*) => {{
+                    let f = std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(*const core::ffi::c_char, ...) -> i32,
+                    >(sym.ptr);
+                    Value::Int(i64::from(f(fmt $(, ints[$idx])*)))
+                }};
             }
-
-            // ---- Arity 1 ----
-            ([FfiType::Int], FfiType::Int) => Value::Int(std::mem::transmute::<
-                *const (),
-                extern "C" fn(i64) -> i64,
-            >(sym.ptr)(ints[0])),
-            ([FfiType::Int], FfiType::Float) => Value::Float(std::mem::transmute::<
-                *const (),
-                extern "C" fn(i64) -> f64,
-            >(sym.ptr)(ints[0])),
-            ([FfiType::Int], FfiType::Bool) => Value::Bool(std::mem::transmute::<
-                *const (),
-                extern "C" fn(i64) -> bool,
-            >(sym.ptr)(ints[0])),
-            ([FfiType::Int], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(i64)>(sym.ptr)(ints[0]);
-                Value::Void
+            match args.len() - params.len() {
+                0 => call_variadic_ints!(),
+                1 => call_variadic_ints!(0),
+                2 => call_variadic_ints!(0, 1),
+                3 => call_variadic_ints!(0, 1, 2),
+                4 => call_variadic_ints!(0, 1, 2, 3),
+                5 => call_variadic_ints!(0, 1, 2, 3, 4),
+                6 => call_variadic_ints!(0, 1, 2, 3, 4, 5),
+                7 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6),
+                8 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6, 7),
+                9 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6, 7, 8),
+                10 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+                11 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+                12 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+                13 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+                14 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+                15 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),
+                16 => call_variadic_ints!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+                _ => unreachable!("variadic tail length was bounded above"),
             }
-            ([FfiType::Float], FfiType::Int) => Value::Int(std::mem::transmute::<
-                *const (),
-                extern "C" fn(f64) -> i64,
-            >(sym.ptr)(floats[0])),
-            ([FfiType::Float], FfiType::Float) => Value::Float(std::mem::transmute::<
-                *const (),
-                extern "C" fn(f64) -> f64,
-            >(sym.ptr)(floats[0])),
-            ([FfiType::Float], FfiType::Bool) => Value::Bool(std::mem::transmute::<
-                *const (),
-                extern "C" fn(f64) -> bool,
-            >(sym.ptr)(floats[0])),
-            ([FfiType::Float], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(f64)>(sym.ptr)(floats[0]);
-                Value::Void
-            }
-            ([FfiType::Bool], FfiType::Int) => Value::Int(std::mem::transmute::<
-                *const (),
-                extern "C" fn(bool) -> i64,
-            >(sym.ptr)(bools[0])),
-            ([FfiType::Bool], FfiType::Bool) => Value::Bool(std::mem::transmute::<
-                *const (),
-                extern "C" fn(bool) -> bool,
-            >(sym.ptr)(bools[0])),
-            ([FfiType::Bool], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(bool)>(sym.ptr)(bools[0]);
-                Value::Void
-            }
-
-            // ---- RES-215: OpaquePtr arms (arity 0 and 1) ----
-            (&[], FfiType::OpaquePtr) => {
-                Value::OpaquePtr(crate::ffi::OpaquePtrHandle(std::mem::transmute::<
+        } else {
+            match (params, ret) {
+                // ---- Arity 0 ----
+                (&[], FfiType::Int) => Value::Int(std::mem::transmute::<
                     *const (),
-                    extern "C" fn() -> *mut core::ffi::c_void,
-                >(sym.ptr)()))
-            }
-            ([FfiType::OpaquePtr], FfiType::OpaquePtr) => {
-                Value::OpaquePtr(crate::ffi::OpaquePtrHandle(std::mem::transmute::<
+                    extern "C" fn() -> i64,
+                >(sym.ptr)()),
+                (&[], FfiType::Float) => Value::Float(std::mem::transmute::<
                     *const (),
-                    extern "C" fn(*mut core::ffi::c_void) -> *mut core::ffi::c_void,
+                    extern "C" fn() -> f64,
+                >(sym.ptr)()),
+                (&[], FfiType::Bool) => Value::Bool(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn() -> bool,
+                >(sym.ptr)()),
+                (&[], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn()>(sym.ptr)();
+                    Value::Void
+                }
+
+                // ---- Arity 1 ----
+                ([FfiType::Int], FfiType::Int) => Value::Int(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn(i64) -> i64,
+                >(sym.ptr)(ints[0])),
+                ([FfiType::Int], FfiType::Float) => {
+                    Value::Float(std::mem::transmute::<*const (), extern "C" fn(i64) -> f64>(
+                        sym.ptr,
+                    )(ints[0]))
+                }
+                ([FfiType::Int], FfiType::Bool) => Value::Bool(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn(i64) -> bool,
+                >(sym.ptr)(ints[0])),
+                ([FfiType::Int], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(i64)>(sym.ptr)(ints[0]);
+                    Value::Void
+                }
+                ([FfiType::Float], FfiType::Int) => {
+                    Value::Int(std::mem::transmute::<*const (), extern "C" fn(f64) -> i64>(
+                        sym.ptr,
+                    )(floats[0]))
+                }
+                ([FfiType::Float], FfiType::Float) => {
+                    Value::Float(std::mem::transmute::<*const (), extern "C" fn(f64) -> f64>(
+                        sym.ptr,
+                    )(floats[0]))
+                }
+                ([FfiType::Float], FfiType::Bool) => Value::Bool(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn(f64) -> bool,
                 >(sym.ptr)(
-                    ptrs[0]
-                )))
-            }
-            ([FfiType::OpaquePtr], FfiType::Int) => Value::Int(std::mem::transmute::<
-                *const (),
-                extern "C" fn(*mut core::ffi::c_void) -> i64,
-            >(sym.ptr)(ptrs[0])),
-            ([FfiType::OpaquePtr], FfiType::Float) => Value::Float(std::mem::transmute::<
-                *const (),
-                extern "C" fn(*mut core::ffi::c_void) -> f64,
-            >(sym.ptr)(ptrs[0])),
-            ([FfiType::OpaquePtr], FfiType::Bool) => Value::Bool(std::mem::transmute::<
-                *const (),
-                extern "C" fn(*mut core::ffi::c_void) -> bool,
-            >(sym.ptr)(ptrs[0])),
-            ([FfiType::OpaquePtr], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(*mut core::ffi::c_void)>(sym.ptr)(
-                    ptrs[0],
-                );
-                Value::Void
-            }
-
-            // ---- Arity 2 (minimal — extend when examples need more) ----
-            ([FfiType::Float, FfiType::Float], FfiType::Float) => {
-                Value::Float(std::mem::transmute::<
+                    floats[0]
+                )),
+                ([FfiType::Float], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(f64)>(sym.ptr)(floats[0]);
+                    Value::Void
+                }
+                ([FfiType::Bool], FfiType::Int) => Value::Int(std::mem::transmute::<
                     *const (),
-                    extern "C" fn(f64, f64) -> f64,
-                >(sym.ptr)(floats[0], floats[1]))
-            }
-            ([FfiType::Int, FfiType::Int], FfiType::Int) => {
-                Value::Int(std::mem::transmute::<
+                    extern "C" fn(bool) -> i64,
+                >(sym.ptr)(bools[0])),
+                ([FfiType::Bool], FfiType::Bool) => Value::Bool(std::mem::transmute::<
                     *const (),
-                    extern "C" fn(i64, i64) -> i64,
-                >(sym.ptr)(ints[0], ints[1]))
-            }
-
-            // ---- Arity 2 (missing arms) ----
-            ([FfiType::Int, FfiType::Int], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(i64, i64)>(sym.ptr)(
-                    ints[0], ints[1],
-                );
-                Value::Void
-            }
-            ([FfiType::Int, FfiType::Int], FfiType::Float) => {
-                Value::Float(std::mem::transmute::<
-                    *const (),
-                    extern "C" fn(i64, i64) -> f64,
-                >(sym.ptr)(ints[0], ints[1]))
-            }
-            ([FfiType::Float, FfiType::Float], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(f64, f64)>(sym.ptr)(
-                    floats[0], floats[1],
-                );
-                Value::Void
-            }
-            ([FfiType::Float, FfiType::Float], FfiType::Int) => {
-                Value::Int(std::mem::transmute::<
-                    *const (),
-                    extern "C" fn(f64, f64) -> i64,
-                >(sym.ptr)(floats[0], floats[1]))
-            }
-            ([FfiType::OpaquePtr, FfiType::Int], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(*mut core::ffi::c_void, i64)>(
-                    sym.ptr,
-                )(ptrs[0], ints[1]);
-                Value::Void
-            }
-            ([FfiType::Int, FfiType::OpaquePtr], FfiType::OpaquePtr) => {
-                Value::OpaquePtr(crate::ffi::OpaquePtrHandle(std::mem::transmute::<
-                    *const (),
-                    extern "C" fn(i64, *mut core::ffi::c_void) -> *mut core::ffi::c_void,
+                    extern "C" fn(bool) -> bool,
                 >(sym.ptr)(
-                    ints[0], ptrs[1]
-                )))
-            }
+                    bools[0]
+                )),
+                ([FfiType::Bool], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(bool)>(sym.ptr)(bools[0]);
+                    Value::Void
+                }
 
-            // ---- Arity 3 ----
-            ([FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Int) => {
-                Value::Int(std::mem::transmute::<
-                    *const (),
-                    extern "C" fn(i64, i64, i64) -> i64,
-                >(sym.ptr)(ints[0], ints[1], ints[2]))
-            }
-            ([FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(i64, i64, i64)>(sym.ptr)(
-                    ints[0], ints[1], ints[2],
-                );
-                Value::Void
-            }
-            ([FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Float) => {
-                Value::Float(std::mem::transmute::<
-                    *const (),
-                    extern "C" fn(i64, i64, i64) -> f64,
-                >(sym.ptr)(ints[0], ints[1], ints[2]))
-            }
-            ([FfiType::Float, FfiType::Float, FfiType::Float], FfiType::Float) => {
-                Value::Float(std::mem::transmute::<
-                    *const (),
-                    extern "C" fn(f64, f64, f64) -> f64,
-                >(sym.ptr)(floats[0], floats[1], floats[2]))
-            }
-            ([FfiType::Float, FfiType::Float, FfiType::Float], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(f64, f64, f64)>(sym.ptr)(
-                    floats[0], floats[1], floats[2],
-                );
-                Value::Void
-            }
-            ([FfiType::Int, FfiType::Float, FfiType::Float], FfiType::Float) => {
-                Value::Float(std::mem::transmute::<
-                    *const (),
-                    extern "C" fn(i64, f64, f64) -> f64,
-                >(sym.ptr)(ints[0], floats[1], floats[2]))
-            }
-            ([FfiType::OpaquePtr, FfiType::Int, FfiType::Int], FfiType::Int) => {
-                Value::Int(std::mem::transmute::<
-                    *const (),
-                    extern "C" fn(*mut core::ffi::c_void, i64, i64) -> i64,
-                >(sym.ptr)(ptrs[0], ints[1], ints[2]))
-            }
-            ([FfiType::OpaquePtr, FfiType::Int, FfiType::Int], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(*mut core::ffi::c_void, i64, i64)>(
-                    sym.ptr,
-                )(ptrs[0], ints[1], ints[2]);
-                Value::Void
-            }
+                // ---- RES-215: OpaquePtr arms (arity 0 and 1) ----
+                (&[], FfiType::OpaquePtr) => {
+                    Value::OpaquePtr(crate::ffi::OpaquePtrHandle(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn() -> *mut core::ffi::c_void,
+                    >(sym.ptr)(
+                    )))
+                }
+                ([FfiType::OpaquePtr], FfiType::OpaquePtr) => {
+                    Value::OpaquePtr(crate::ffi::OpaquePtrHandle(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(*mut core::ffi::c_void) -> *mut core::ffi::c_void,
+                    >(sym.ptr)(
+                        ptrs[0]
+                    )))
+                }
+                ([FfiType::OpaquePtr], FfiType::Int) => {
+                    Value::Int(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(*mut core::ffi::c_void) -> i64,
+                    >(sym.ptr)(ptrs[0]))
+                }
+                ([FfiType::OpaquePtr], FfiType::Float) => {
+                    Value::Float(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(*mut core::ffi::c_void) -> f64,
+                    >(sym.ptr)(ptrs[0]))
+                }
+                ([FfiType::OpaquePtr], FfiType::Bool) => {
+                    Value::Bool(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(*mut core::ffi::c_void) -> bool,
+                    >(sym.ptr)(ptrs[0]))
+                }
+                ([FfiType::OpaquePtr], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(*mut core::ffi::c_void)>(
+                        sym.ptr,
+                    )(ptrs[0]);
+                    Value::Void
+                }
 
-            // ---- RES-FFI-V3: Arity 4 ----
-            ([FfiType::Int, FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Int) => {
-                Value::Int(std::mem::transmute::<
+                // ---- Arity 2 (minimal — extend when examples need more) ----
+                ([FfiType::Float, FfiType::Float], FfiType::Float) => {
+                    Value::Float(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(f64, f64) -> f64,
+                    >(sym.ptr)(floats[0], floats[1]))
+                }
+                ([FfiType::Int, FfiType::Int], FfiType::Int) => {
+                    Value::Int(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(i64, i64) -> i64,
+                    >(sym.ptr)(ints[0], ints[1]))
+                }
+
+                // ---- Arity 2 (missing arms) ----
+                ([FfiType::Int, FfiType::Int], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(i64, i64)>(sym.ptr)(
+                        ints[0], ints[1],
+                    );
+                    Value::Void
+                }
+                ([FfiType::Int, FfiType::Int], FfiType::Float) => {
+                    Value::Float(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(i64, i64) -> f64,
+                    >(sym.ptr)(ints[0], ints[1]))
+                }
+                ([FfiType::Float, FfiType::Float], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(f64, f64)>(sym.ptr)(
+                        floats[0], floats[1],
+                    );
+                    Value::Void
+                }
+                ([FfiType::Float, FfiType::Float], FfiType::Int) => {
+                    Value::Int(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(f64, f64) -> i64,
+                    >(sym.ptr)(floats[0], floats[1]))
+                }
+                ([FfiType::OpaquePtr, FfiType::Int], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(*mut core::ffi::c_void, i64)>(
+                        sym.ptr,
+                    )(ptrs[0], ints[1]);
+                    Value::Void
+                }
+                ([FfiType::Int, FfiType::OpaquePtr], FfiType::OpaquePtr) => {
+                    Value::OpaquePtr(crate::ffi::OpaquePtrHandle(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(i64, *mut core::ffi::c_void) -> *mut core::ffi::c_void,
+                    >(sym.ptr)(
+                        ints[0], ptrs[1]
+                    )))
+                }
+
+                // ---- Arity 3 ----
+                ([FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Int) => {
+                    Value::Int(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(i64, i64, i64) -> i64,
+                    >(sym.ptr)(ints[0], ints[1], ints[2]))
+                }
+                ([FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(i64, i64, i64)>(sym.ptr)(
+                        ints[0], ints[1], ints[2],
+                    );
+                    Value::Void
+                }
+                ([FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Float) => {
+                    Value::Float(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(i64, i64, i64) -> f64,
+                    >(sym.ptr)(ints[0], ints[1], ints[2]))
+                }
+                ([FfiType::Float, FfiType::Float, FfiType::Float], FfiType::Float) => {
+                    Value::Float(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(f64, f64, f64) -> f64,
+                    >(sym.ptr)(
+                        floats[0], floats[1], floats[2]
+                    ))
+                }
+                ([FfiType::Float, FfiType::Float, FfiType::Float], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(f64, f64, f64)>(sym.ptr)(
+                        floats[0], floats[1], floats[2],
+                    );
+                    Value::Void
+                }
+                ([FfiType::Int, FfiType::Float, FfiType::Float], FfiType::Float) => {
+                    Value::Float(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(i64, f64, f64) -> f64,
+                    >(sym.ptr)(ints[0], floats[1], floats[2]))
+                }
+                ([FfiType::OpaquePtr, FfiType::Int, FfiType::Int], FfiType::Int) => {
+                    Value::Int(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(*mut core::ffi::c_void, i64, i64) -> i64,
+                    >(sym.ptr)(ptrs[0], ints[1], ints[2]))
+                }
+                ([FfiType::OpaquePtr, FfiType::Int, FfiType::Int], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(*mut core::ffi::c_void, i64, i64)>(
+                        sym.ptr,
+                    )(ptrs[0], ints[1], ints[2]);
+                    Value::Void
+                }
+
+                // ---- RES-FFI-V3: Arity 4 ----
+                ([FfiType::Int, FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Int) => {
+                    Value::Int(std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(i64, i64, i64, i64) -> i64,
+                    >(sym.ptr)(
+                        ints[0], ints[1], ints[2], ints[3]
+                    ))
+                }
+                ([FfiType::Int, FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Void) => {
+                    std::mem::transmute::<*const (), extern "C" fn(i64, i64, i64, i64)>(sym.ptr)(
+                        ints[0], ints[1], ints[2], ints[3],
+                    );
+                    Value::Void
+                }
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
+                    FfiType::Float,
+                ) => Value::Float(std::mem::transmute::<
                     *const (),
-                    extern "C" fn(i64, i64, i64, i64) -> i64,
+                    extern "C" fn(f64, f64, f64, f64) -> f64,
                 >(sym.ptr)(
-                    ints[0], ints[1], ints[2], ints[3]
-                ))
-            }
-            ([FfiType::Int, FfiType::Int, FfiType::Int, FfiType::Int], FfiType::Void) => {
-                std::mem::transmute::<*const (), extern "C" fn(i64, i64, i64, i64)>(sym.ptr)(
-                    ints[0], ints[1], ints[2], ints[3],
-                );
-                Value::Void
-            }
-            (
-                [
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Float,
-            ) => Value::Float(std::mem::transmute::<
-                *const (),
-                extern "C" fn(f64, f64, f64, f64) -> f64,
-            >(sym.ptr)(
-                floats[0], floats[1], floats[2], floats[3]
-            )),
-            (
-                [
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Void,
-            ) => {
-                std::mem::transmute::<*const (), extern "C" fn(f64, f64, f64, f64)>(sym.ptr)(
-                    floats[0], floats[1], floats[2], floats[3],
-                );
-                Value::Void
-            }
+                    floats[0], floats[1], floats[2], floats[3]
+                )),
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
+                    FfiType::Void,
+                ) => {
+                    std::mem::transmute::<*const (), extern "C" fn(f64, f64, f64, f64)>(sym.ptr)(
+                        floats[0], floats[1], floats[2], floats[3],
+                    );
+                    Value::Void
+                }
 
-            // ---- RES-FFI-V3: Arity 5 ----
-            (
-                [
+                // ---- RES-FFI-V3: Arity 5 ----
+                (
+                    [
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                    ],
                     FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                ],
-                FfiType::Int,
-            ) => Value::Int(std::mem::transmute::<
-                *const (),
-                extern "C" fn(i64, i64, i64, i64, i64) -> i64,
-            >(sym.ptr)(
-                ints[0], ints[1], ints[2], ints[3], ints[4]
-            )),
-            (
-                [
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                ],
-                FfiType::Void,
-            ) => {
-                std::mem::transmute::<*const (), extern "C" fn(i64, i64, i64, i64, i64)>(sym.ptr)(
-                    ints[0], ints[1], ints[2], ints[3], ints[4],
-                );
-                Value::Void
-            }
-            (
-                [
+                ) => Value::Int(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn(i64, i64, i64, i64, i64) -> i64,
+                >(sym.ptr)(
+                    ints[0], ints[1], ints[2], ints[3], ints[4]
+                )),
+                (
+                    [
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                    ],
+                    FfiType::Void,
+                ) => {
+                    std::mem::transmute::<*const (), extern "C" fn(i64, i64, i64, i64, i64)>(
+                        sym.ptr,
+                    )(ints[0], ints[1], ints[2], ints[3], ints[4]);
+                    Value::Void
+                }
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
                     FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Float,
-            ) => Value::Float(std::mem::transmute::<
-                *const (),
-                extern "C" fn(f64, f64, f64, f64, f64) -> f64,
-            >(sym.ptr)(
-                floats[0], floats[1], floats[2], floats[3], floats[4]
-            )),
-            (
-                [
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Void,
-            ) => {
-                std::mem::transmute::<*const (), extern "C" fn(f64, f64, f64, f64, f64)>(sym.ptr)(
-                    floats[0], floats[1], floats[2], floats[3], floats[4],
-                );
-                Value::Void
-            }
+                ) => Value::Float(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn(f64, f64, f64, f64, f64) -> f64,
+                >(sym.ptr)(
+                    floats[0], floats[1], floats[2], floats[3], floats[4]
+                )),
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
+                    FfiType::Void,
+                ) => {
+                    std::mem::transmute::<*const (), extern "C" fn(f64, f64, f64, f64, f64)>(
+                        sym.ptr,
+                    )(floats[0], floats[1], floats[2], floats[3], floats[4]);
+                    Value::Void
+                }
 
-            // ---- RES-FFI-V3: Arity 6 ----
-            (
-                [
+                // ---- RES-FFI-V3: Arity 6 ----
+                (
+                    [
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                    ],
                     FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                ],
-                FfiType::Int,
-            ) => Value::Int(std::mem::transmute::<
-                *const (),
-                extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64,
-            >(sym.ptr)(
-                ints[0], ints[1], ints[2], ints[3], ints[4], ints[5]
-            )),
-            (
-                [
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                ],
-                FfiType::Void,
-            ) => {
-                std::mem::transmute::<*const (), extern "C" fn(i64, i64, i64, i64, i64, i64)>(
-                    sym.ptr,
-                )(ints[0], ints[1], ints[2], ints[3], ints[4], ints[5]);
-                Value::Void
-            }
-            (
-                [
+                ) => Value::Int(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64,
+                >(sym.ptr)(
+                    ints[0], ints[1], ints[2], ints[3], ints[4], ints[5]
+                )),
+                (
+                    [
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                    ],
+                    FfiType::Void,
+                ) => {
+                    std::mem::transmute::<*const (), extern "C" fn(i64, i64, i64, i64, i64, i64)>(
+                        sym.ptr,
+                    )(ints[0], ints[1], ints[2], ints[3], ints[4], ints[5]);
+                    Value::Void
+                }
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
                     FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Float,
-            ) => Value::Float(std::mem::transmute::<
-                *const (),
-                extern "C" fn(f64, f64, f64, f64, f64, f64) -> f64,
-            >(sym.ptr)(
-                floats[0], floats[1], floats[2], floats[3], floats[4], floats[5],
-            )),
-            (
-                [
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Void,
-            ) => {
-                std::mem::transmute::<*const (), extern "C" fn(f64, f64, f64, f64, f64, f64)>(
-                    sym.ptr,
-                )(
+                ) => Value::Float(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn(f64, f64, f64, f64, f64, f64) -> f64,
+                >(sym.ptr)(
                     floats[0], floats[1], floats[2], floats[3], floats[4], floats[5],
-                );
-                Value::Void
-            }
+                )),
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
+                    FfiType::Void,
+                ) => {
+                    std::mem::transmute::<*const (), extern "C" fn(f64, f64, f64, f64, f64, f64)>(
+                        sym.ptr,
+                    )(
+                        floats[0], floats[1], floats[2], floats[3], floats[4], floats[5],
+                    );
+                    Value::Void
+                }
 
-            // ---- RES-FFI-V3: Arity 7 ----
-            (
-                [
+                // ---- RES-FFI-V3: Arity 7 ----
+                (
+                    [
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                    ],
                     FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                ],
-                FfiType::Int,
-            ) => Value::Int(std::mem::transmute::<
-                *const (),
-                extern "C" fn(i64, i64, i64, i64, i64, i64, i64) -> i64,
-            >(sym.ptr)(
-                ints[0], ints[1], ints[2], ints[3], ints[4], ints[5], ints[6],
-            )),
-            (
-                [
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                ],
-                FfiType::Void,
-            ) => {
-                std::mem::transmute::<*const (), extern "C" fn(i64, i64, i64, i64, i64, i64, i64)>(
-                    sym.ptr,
-                )(
-                    ints[0], ints[1], ints[2], ints[3], ints[4], ints[5], ints[6],
-                );
-                Value::Void
-            }
-            (
-                [
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Float,
-            ) => Value::Float(std::mem::transmute::<
-                *const (),
-                extern "C" fn(f64, f64, f64, f64, f64, f64, f64) -> f64,
-            >(sym.ptr)(
-                floats[0], floats[1], floats[2], floats[3], floats[4], floats[5], floats[6],
-            )),
-            (
-                [
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Void,
-            ) => {
-                std::mem::transmute::<*const (), extern "C" fn(f64, f64, f64, f64, f64, f64, f64)>(
-                    sym.ptr,
-                )(
-                    floats[0], floats[1], floats[2], floats[3], floats[4], floats[5], floats[6],
-                );
-                Value::Void
-            }
-
-            // ---- RES-FFI-V3: Arity 8 ----
-            (
-                [
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                ],
-                FfiType::Int,
-            ) => Value::Int(std::mem::transmute::<
-                *const (),
-                extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
-            >(sym.ptr)(
-                ints[0], ints[1], ints[2], ints[3], ints[4], ints[5], ints[6], ints[7],
-            )),
-            (
-                [
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                    FfiType::Int,
-                ],
-                FfiType::Void,
-            ) => {
-                std::mem::transmute::<
+                ) => Value::Int(std::mem::transmute::<
                     *const (),
-                    extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64),
+                    extern "C" fn(i64, i64, i64, i64, i64, i64, i64) -> i64,
+                >(sym.ptr)(
+                    ints[0], ints[1], ints[2], ints[3], ints[4], ints[5], ints[6],
+                )),
+                (
+                    [
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                    ],
+                    FfiType::Void,
+                ) => {
+                    std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(i64, i64, i64, i64, i64, i64, i64),
+                    >(sym.ptr)(
+                        ints[0], ints[1], ints[2], ints[3], ints[4], ints[5], ints[6],
+                    );
+                    Value::Void
+                }
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
+                    FfiType::Float,
+                ) => Value::Float(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn(f64, f64, f64, f64, f64, f64, f64) -> f64,
+                >(sym.ptr)(
+                    floats[0], floats[1], floats[2], floats[3], floats[4], floats[5], floats[6],
+                )),
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
+                    FfiType::Void,
+                ) => {
+                    std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(f64, f64, f64, f64, f64, f64, f64),
+                    >(sym.ptr)(
+                        floats[0], floats[1], floats[2], floats[3], floats[4], floats[5], floats[6],
+                    );
+                    Value::Void
+                }
+
+                // ---- RES-FFI-V3: Arity 8 ----
+                (
+                    [
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                    ],
+                    FfiType::Int,
+                ) => Value::Int(std::mem::transmute::<
+                    *const (),
+                    extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
                 >(sym.ptr)(
                     ints[0], ints[1], ints[2], ints[3], ints[4], ints[5], ints[6], ints[7],
-                );
-                Value::Void
-            }
-            (
-                [
+                )),
+                (
+                    [
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                        FfiType::Int,
+                    ],
+                    FfiType::Void,
+                ) => {
+                    std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64),
+                    >(sym.ptr)(
+                        ints[0], ints[1], ints[2], ints[3], ints[4], ints[5], ints[6], ints[7],
+                    );
+                    Value::Void
+                }
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
                     FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Float,
-            ) => Value::Float(std::mem::transmute::<
-                *const (),
-                extern "C" fn(f64, f64, f64, f64, f64, f64, f64, f64) -> f64,
-            >(sym.ptr)(
-                floats[0], floats[1], floats[2], floats[3], floats[4], floats[5], floats[6],
-                floats[7],
-            )),
-            (
-                [
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                    FfiType::Float,
-                ],
-                FfiType::Void,
-            ) => {
-                std::mem::transmute::<
+                ) => Value::Float(std::mem::transmute::<
                     *const (),
-                    extern "C" fn(f64, f64, f64, f64, f64, f64, f64, f64),
+                    extern "C" fn(f64, f64, f64, f64, f64, f64, f64, f64) -> f64,
                 >(sym.ptr)(
                     floats[0], floats[1], floats[2], floats[3], floats[4], floats[5], floats[6],
                     floats[7],
-                );
-                Value::Void
-            }
+                )),
+                (
+                    [
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                        FfiType::Float,
+                    ],
+                    FfiType::Void,
+                ) => {
+                    std::mem::transmute::<
+                        *const (),
+                        extern "C" fn(f64, f64, f64, f64, f64, f64, f64, f64),
+                    >(sym.ptr)(
+                        floats[0], floats[1], floats[2], floats[3], floats[4], floats[5],
+                        floats[6], floats[7],
+                    );
+                    Value::Void
+                }
 
-            // ---- RES-FFI-V3: Mixed Int+Float patterns (arity 4) ----
-            // Common in physics/control: (Float, Float, Float, Int) -> Float
-            ([FfiType::Float, FfiType::Float, FfiType::Float, FfiType::Int], FfiType::Float) => {
-                Value::Float(std::mem::transmute::<
+                // ---- RES-FFI-V3: Mixed Int+Float patterns (arity 4) ----
+                // Common in physics/control: (Float, Float, Float, Int) -> Float
+                (
+                    [FfiType::Float, FfiType::Float, FfiType::Float, FfiType::Int],
+                    FfiType::Float,
+                ) => Value::Float(std::mem::transmute::<
                     *const (),
                     extern "C" fn(f64, f64, f64, i64) -> f64,
                 >(sym.ptr)(
                     floats[0], floats[1], floats[2], ints[3]
-                ))
-            }
-            ([FfiType::Int, FfiType::Float, FfiType::Float, FfiType::Float], FfiType::Float) => {
-                Value::Float(std::mem::transmute::<
+                )),
+                (
+                    [FfiType::Int, FfiType::Float, FfiType::Float, FfiType::Float],
+                    FfiType::Float,
+                ) => Value::Float(std::mem::transmute::<
                     *const (),
                     extern "C" fn(i64, f64, f64, f64) -> f64,
                 >(sym.ptr)(
                     ints[0], floats[1], floats[2], floats[3]
-                ))
-            }
+                )),
 
-            // Fallback.
-            _ => {
-                return Err(format!(
-                    "FFI: no trampoline for signature ({:?}) -> {:?} (extend dispatch_explicit)",
-                    params, ret
-                ));
+                // Fallback.
+                _ => {
+                    return Err(format!(
+                        "FFI: no trampoline for signature ({:?}) -> {:?} (extend dispatch_explicit)",
+                        params, ret
+                    ));
+                }
             }
         }
     };
@@ -905,7 +1056,7 @@ fn dispatch_struct_signatures(
     sym: &ForeignSymbol,
     params: &[FfiType],
     ret: &FfiType,
-    ints: &[i64; 8],
+    ints: &[i64; 16],
     struct_words: &[u64; 8],
 ) -> RResult<Option<Value>> {
     // Quick reject: nothing to do unless a struct is on either side.

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -242,12 +242,14 @@ enum Tok {
     #[token("catch")]
     Catch,
     // RES-330: quantifier keywords + range separator. Logos picks the
-    // longer-match `..` over `.` automatically so no priority hint
+    // longer-match `...` / `..` over `.` automatically so no priority hint
     // needed.
     #[token("forall")]
     Forall,
     #[token("exists")]
     Exists,
+    #[token("...")]
+    DotDotDot,
     #[token("..")]
     DotDot,
     // RES-343: `#[` opener for `#[cfg(...)]` attributes. Logos picks
@@ -599,6 +601,7 @@ fn convert(t: Tok) -> Token {
         Tok::Forall => Token::Forall,
         Tok::Exists => Token::Exists,
         Tok::DotDot => Token::DotDot,
+        Tok::DotDotDot => Token::DotDotDot,
         // RES-343: `#[` opener for cfg attributes.
         Tok::HashLBracket => Token::HashLeftBracket,
         // </EXTENSION_KEYWORDS>

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -292,6 +292,8 @@ enum Token {
     /// parser doesn't need look-ahead to disambiguate from a bare `#`.
     /// Closing `]` is an ordinary `RightBracket`.
     HashLeftBracket,
+    /// RES-316: `...` marker at the end of an `extern fn` parameter list.
+    DotDotDot,
     // </EXTENSION_TOKENS>
 
     // Literals
@@ -424,6 +426,7 @@ impl Token {
             Token::Forall => "`forall`".to_string(),
             Token::Exists => "`exists`".to_string(),
             Token::DotDot => "`..`".to_string(),
+            Token::DotDotDot => "`...`".to_string(),
             Token::Underscore => "`_`".to_string(),
             Token::Default => "`default`".to_string(),
             Token::Dot => "`.`".to_string(),
@@ -767,11 +770,17 @@ impl Lexer {
             // before the tokenizer can dispatch here — digit check
             // comes first in next_token's fall-through arm.
             // RES-330: peek for `..` so quantifier ranges (`forall i in
-            // 0..n`) lex as a single `DotDot` token.
+            // 0..n`) lex as a single `DotDot` token. `...` is the longer
+            // RES-316 extern-variadic marker.
             '.' => {
                 if self.peek_char() == '.' {
                     self.read_char(); // consume second `.`
-                    Token::DotDot
+                    if self.peek_char() == '.' {
+                        self.read_char(); // consume third `.`
+                        Token::DotDotDot
+                    } else {
+                        Token::DotDot
+                    }
                 } else {
                     Token::Dot
                 }
@@ -2027,6 +2036,8 @@ pub(crate) struct ExternDecl {
     pub(crate) ensures: Vec<Node>,
     /// `@trusted` — `ensures` is assumed, not checked.
     pub(crate) trusted: bool,
+    /// True for C variadic declarations written as `extern fn f(x: T, ...)`.
+    pub(crate) is_variadic: bool,
     /// FFI v1: span of the extern keyword / decl. Consumed by later tasks.
     #[allow(dead_code)]
     pub(crate) span: span::Span,
@@ -4670,7 +4681,7 @@ impl Parser {
         self.next_token(); // skip `(`
 
         // Parameter list — extern fn uses `name: Type` (not `Type name`).
-        let parameters = self.parse_extern_fn_parameters();
+        let (parameters, is_variadic) = self.parse_extern_fn_parameters();
 
         // Return type `-> T`. Required for extern fns.
         if !matches!(self.current_token, Token::Arrow) {
@@ -4739,6 +4750,7 @@ impl Parser {
             requires,
             ensures,
             trusted,
+            is_variadic,
             span: decl_span,
         })
     }
@@ -4753,13 +4765,30 @@ impl Parser {
     /// On entry `current_token` is the first token after `(` (i.e., the `(`
     /// has already been consumed by the caller). On exit `current_token` is
     /// the token after `)`.
-    fn parse_extern_fn_parameters(&mut self) -> Vec<(String, String)> {
+    fn parse_extern_fn_parameters(&mut self) -> (Vec<(String, String)>, bool) {
         let mut parameters = Vec::new();
+        let mut is_variadic = false;
 
         // Empty param list: `()`.
         if matches!(self.current_token, Token::RightParen) {
             self.next_token(); // skip `)`
-            return parameters;
+            return (parameters, is_variadic);
+        }
+
+        if matches!(self.current_token, Token::DotDotDot) {
+            is_variadic = true;
+            self.next_token();
+            if !matches!(self.current_token, Token::RightParen) {
+                let tok = self.current_token.clone();
+                self.record_error(format!(
+                    "`...` must be the last entry in an extern fn parameter list, got {}",
+                    tok
+                ));
+            }
+            if matches!(self.current_token, Token::RightParen) {
+                self.next_token();
+            }
+            return (parameters, is_variadic);
         }
 
         loop {
@@ -4799,6 +4828,18 @@ impl Parser {
             match &self.current_token {
                 Token::Comma => {
                     self.next_token(); // skip `,`
+                    if matches!(self.current_token, Token::DotDotDot) {
+                        is_variadic = true;
+                        self.next_token();
+                        if !matches!(self.current_token, Token::RightParen) {
+                            let tok = self.current_token.clone();
+                            self.record_error(format!(
+                                "`...` must be the last entry in an extern fn parameter list, got {}",
+                                tok
+                            ));
+                        }
+                        break;
+                    }
                 }
                 Token::RightParen => break,
                 other => {
@@ -4816,7 +4857,7 @@ impl Parser {
         if matches!(self.current_token, Token::RightParen) {
             self.next_token();
         }
-        parameters
+        (parameters, is_variadic)
     }
 
     fn parse_return_statement(&mut self) -> Node {
@@ -7117,6 +7158,7 @@ enum Value {
         requires: Vec<Node>,
         ensures: Vec<Node>,
         trusted: bool,
+        is_variadic: bool,
     },
     /// RES-215: an opaque C pointer received from (or bound for) an
     /// FFI call. Resilient source cannot dereference or inspect it;
@@ -12162,6 +12204,7 @@ impl Interpreter {
                 requires,
                 ensures,
                 trusted,
+                is_variadic,
             } => {
                 // RES-FFI-V3: bind every declared parameter name to its
                 // actual argument value so `requires` / `ensures`
@@ -12196,8 +12239,11 @@ impl Interpreter {
                         ));
                     }
                 }
-                // Dispatch through the trampoline.
-                let result = crate::ffi_trampolines::call_foreign(&symbol, &args)?;
+                let result = if is_variadic {
+                    crate::ffi_trampolines::call_foreign_variadic(&symbol, &args)?
+                } else {
+                    crate::ffi_trampolines::call_foreign(&symbol, &args)?
+                };
                 // Check postconditions.
                 if !ensures.is_empty() {
                     let mut post_interp = Interpreter {
@@ -13636,6 +13682,7 @@ fn execute_file(
                                     requires: d.requires.clone(),
                                     ensures: d.ensures.clone(),
                                     trusted: d.trusted,
+                                    is_variadic: d.is_variadic,
                                 },
                             );
                         }
@@ -25155,6 +25202,7 @@ mod ffi_integration_tests {
                                     requires: d.requires.clone(),
                                     ensures: d.ensures.clone(),
                                     trusted: d.trusted,
+                                    is_variadic: d.is_variadic,
                                 },
                             );
                         }

--- a/resilient/tests/ffi_variadic_integration.rs
+++ b/resilient/tests/ffi_variadic_integration.rs
@@ -1,0 +1,61 @@
+//! RES-316: end-to-end C variadic FFI smoke tests.
+
+#![cfg(all(feature = "ffi", any(target_os = "linux", target_os = "macos")))]
+
+use std::io::Write;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn resilient_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn next_seq() -> u64 {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    SEQ.fetch_add(1, Ordering::Relaxed)
+}
+
+fn run_resilient_src(src: &str) -> (String, String, i32) {
+    let tmp = std::env::temp_dir().join(format!(
+        "res_ffi_variadic_{}_{}.rs",
+        std::process::id(),
+        next_seq()
+    ));
+    {
+        let mut f = std::fs::File::create(&tmp).expect("create tmp file");
+        f.write_all(src.as_bytes()).expect("write tmp file");
+    }
+    let output = Command::new(resilient_bin())
+        .arg(&tmp)
+        .output()
+        .expect("failed to spawn resilient binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let code = output.status.code().unwrap_or(-1);
+    let _ = std::fs::remove_file(&tmp);
+    (stdout, stderr, code)
+}
+
+#[test]
+fn printf_accepts_two_variadic_ints() {
+    #[cfg(target_os = "macos")]
+    let libc = "libSystem.dylib";
+    #[cfg(target_os = "linux")]
+    let libc = "libc.so.6";
+
+    let src = format!(
+        r#"extern "{lib}" {{ fn c_printf(fmt: String, ...) -> Int = "printf"; }};
+fn main(int _d) {{
+    c_printf("ffi variadic %lld %lld\n", 7, 35);
+}}
+main(0);"#,
+        lib = libc
+    );
+
+    let (stdout, stderr, code) = run_resilient_src(&src);
+    assert_eq!(code, 0, "stdout={stdout} stderr={stderr}");
+    assert!(
+        stdout.contains("ffi variadic 7 35"),
+        "expected printf output, got stdout={stdout} stderr={stderr}"
+    );
+}


### PR DESCRIPTION
Closes #108

## Summary

- Adds `...` tokenization/parsing for `extern fn` parameter lists and carries an `is_variadic` flag through extern bindings.
- Routes variadic extern calls through a dedicated trampoline path for `printf`-style `String, ... -> Int` calls with up to 16 integer variadic slots.
- Rejects variadic externs in the bytecode compiler with a clean unsupported error because the VM foreign-call opcode is fixed-arity today.

## Test changes

- Adds `ffi_variadic_integration.rs`, which calls real libc `printf` with two variadic integer arguments and asserts captured stdout. No existing tests or golden files modified.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --features ffi printf_accepts_two_variadic_ints`
- [x] `cargo test --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --features ffi`
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings`
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --features ffi --all-targets -- -D warnings`