### PR TITLE
RES-312: link to companion Resilient-examples repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [**🧭 Philosophy**](https://ericspencer00.github.io/Resilient/philosophy) &nbsp;·&nbsp;
 [**⚡ Performance**](https://ericspencer00.github.io/Resilient/performance) &nbsp;·&nbsp;
 [**🧠 Memory Model**](https://ericspencer00.github.io/Resilient/memory-model) &nbsp;·&nbsp;
+[**🩺 Examples**](https://github.com/EricSpencer00/Resilient-examples) &nbsp;·&nbsp;
 [**🤝 Contributing**](CONTRIBUTING.md)
 
 </div>
@@ -192,6 +193,16 @@ rz --typecheck resilient/examples/sensor_monitor.rz
 # With verification audit (shows static-vs-runtime contract coverage)
 rz --audit resilient/examples/sensor_monitor.rz
 ```
+
+For full mission-critical project demos — pacemaker, infusion pump, ABS
+brake controller, traffic-light interlock, reactor coolant monitor, CAN
+bus parser — see the dedicated companion repo:
+
+➜ **[EricSpencer00/Resilient-examples](https://github.com/EricSpencer00/Resilient-examples)**
+
+Each project there is a small, runnable program with its own README
+explaining the safety property, the language features it exercises,
+and the limitations or follow-up tickets.
 
 ### Running the REPL
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,6 +127,28 @@ With `--features z3`, the `b != 0` precondition becomes a
 discharged proof obligation rather than a runtime check on
 every call.
 
+## Mission-critical example projects
+
+Reading the syntax page is one thing — seeing the language
+used end-to-end on the kind of system it was designed for is
+another. The companion repo
+[**EricSpencer00/Resilient-examples**](https://github.com/EricSpencer00/Resilient-examples)
+contains six full mission-critical demos:
+
+| # | Project | Headline features |
+|---|---|---|
+| 01 | pacemaker | `live invariant`, `recovers_to`, contract-checked decision logic |
+| 02 | infusion-pump | actor `always:`, cumulative-dose ceiling, `parse_int` Result chain |
+| 03 | abs-brake-controller | `forall i in lo..hi`, saturating `clamp`, per-wheel `ensures` |
+| 04 | traffic-light-interlock | `cluster_invariant` proves never-both-green |
+| 05 | reactor-coolant-monitor | actor envelope `[0, 250] kPa`, `live` over a sensor stream |
+| 06 | can-bus-parser | `bytes` literals, `Result` chain, `match` arm guards |
+
+Each project has its own README documenting the safety property
+under proof, the language features it exercises, and any
+compiler limitations. Run `./run_all.sh` from that repo to diff
+every program against its golden output.
+
 ## Pick a backend
 
 Resilient ships three execution backends. All accept the same

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,7 @@ Resilient is MIT-licensed. Contributions from humans and AI agents are equally w
 ## Where next?
 
 - **New here?** → [Getting Started](getting-started)
+- **Mission-critical example projects** → [Resilient-examples ↗](https://github.com/EricSpencer00/Resilient-examples) (pacemaker, infusion pump, ABS, traffic-light interlock, reactor monitor, CAN parser)
 - **Learn the syntax** → [Syntax Reference](syntax)
 - **Contracts and formal verification** → [Language Reference](language-reference)
 - **Embedded / bare-metal** → [no\_std runtime](no-std)


### PR DESCRIPTION
## Summary

Surface the new companion repo
[**EricSpencer00/Resilient-examples**](https://github.com/EricSpencer00/Resilient-examples)
from three docs entry points so visitors find the mission-critical
project demos without having to dig:

- `README.md` — adds a 🩺 Examples link to the header nav row and a
  paragraph in the "Running an example" section pointing at the new
  repo for full project demos (in-tree `resilient/examples/` stays
  feature-focused).
- `docs/index.md` — entry in the "Where next?" list.
- `docs/getting-started.md` — new "Mission-critical example projects"
  subsection between the `safe_div` tour and "Pick a backend",
  with the six-project catalogue table.

## What's in Resilient-examples

Six runnable mission-critical demos written against current `main`
of this repo:

| # | Project | Headline features |
|---|---|---|
| 01 | pacemaker | `live invariant`, `recovers_to`, contract-checked decision logic |
| 02 | infusion-pump | actor `always:`, cumulative-dose ceiling, `parse_int` Result chain |
| 03 | abs-brake-controller | `forall i in lo..hi`, saturating `clamp`, per-wheel `ensures` |
| 04 | traffic-light-interlock | `cluster_invariant` proves never-both-green |
| 05 | reactor-coolant-monitor | actor envelope `[0, 250] kPa`, `live` over a sensor stream |
| 06 | can-bus-parser | `bytes` literals, `Result` chain, `match` arm guards |

Each project ships a README + `*.expected.txt` golden output;
`run_all.sh` diffs every program against its golden and exits
non-zero on drift.

## Why a separate repo (rationale also in #312)

* In-tree `resilient/examples/` is feature-focused (one file per
  language feature). Resilient-examples is project-focused (one
  folder per realistic mission-critical scenario).
* Keeps the main repo's CI fast — full project demos that need
  Z3 enabled or that take >100 ms don't need to slow the inner loop.
* Lets the safety-critical narrative ("the language can build
  X, Y, Z") live somewhere other than in the language docs themselves.

## Findings while writing the examples

Two parser bugs surfaced and have been filed separately:

* [#310](https://github.com/EricSpencer00/Resilient/issues/310) —
  parens around expressions (`let y = (x / 60);`) fail in `let`,
  struct-literal fields, and `requires`/`ensures` clauses.
* [#311](https://github.com/EricSpencer00/Resilient/issues/311) —
  `!a.b` parses as `(!a).b` instead of `!(a.b)`; runtime error
  instead of a parse error.

The example programs use workarounds (hoisting subexpressions,
`x == false` instead of `!x`) so they run cleanly today.

## Test plan

- [x] `rz` runs all six example programs and matches the goldens
- [x] `run_all.sh` exits 0 (6/6 pass)
- [ ] Maintainer reviews the link placement in each docs page

Closes #312