### PR TITLE
RES-310/311: fix parenthesized expressions and unary precedence

### DIFF
--- a/resilient/examples/paren_expr.expected.txt
+++ b/resilient/examples/paren_expr.expected.txt
@@ -1,0 +1,4 @@
+120
+2
+242
+Program executed successfully

--- a/resilient/examples/paren_expr.rz
+++ b/resilient/examples/paren_expr.rz
@@ -1,0 +1,11 @@
+// RES-310: parenthesized expressions in let bindings and expressions
+fn main() {
+    let x = 120;
+    let y = (x);
+    let z = (x / 60);
+    println(y);
+    println(z);
+    let w = (x + 1) * 2;
+    println(w);
+}
+main();

--- a/resilient/examples/unary_prec.expected.txt
+++ b/resilient/examples/unary_prec.expected.txt
@@ -1,0 +1,3 @@
+false
+false
+Program executed successfully

--- a/resilient/examples/unary_prec.rz
+++ b/resilient/examples/unary_prec.rz
@@ -1,0 +1,12 @@
+// RES-311: unary ! binds less tightly than field access
+struct R {
+    Bool ok
+}
+fn main() {
+    let r = new R { ok: true };
+    let a = !r.ok;
+    println(a);
+    let b = !r.ok;
+    println(b);
+}
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -5506,9 +5506,12 @@ impl Parser {
                 // advancing past it.
                 let op_span = self.span_at_current();
                 self.next_token();
-                // Prefix precedence is higher than any infix operator
-                // so `-1 + 2` parses as `(-1) + 2`, not `-(1 + 2)`.
-                let right = self.parse_expression(11)?;
+                // RES-311: precedence 10 (one below Dot/LeftParen=11) so
+                // that `!r.ok` parses as `!(r.ok)` — field access binds
+                // tighter than prefix `!` / unary `-`, matching Rust/C/Go.
+                // Arithmetic precedences (+9, *10) are still below 10 so
+                // `-1 + 2` stays `(-1) + 2`.
+                let right = self.parse_expression(10)?;
                 Some(Node::PrefixExpression {
                     operator: op.to_string(),
                     right: Box::new(right),
@@ -5518,6 +5521,10 @@ impl Parser {
             Token::LeftParen => {
                 self.next_token(); // Skip '('
                 let expr = self.parse_expression(0);
+                // RES-310: parse_expression leaves current_token on the
+                // last token it consumed; advance one more so we can
+                // check that the next token is the closing ')'.
+                self.next_token();
                 if self.current_token != Token::RightParen {
                     let tok = self.current_token.clone();
                     self.record_error(format!(


### PR DESCRIPTION
## Summary

- **RES-310**: `(expr)` in let bindings, struct fields, and `requires`/`ensures` clauses failed with *Expected ')' closing parenthesized expression, found identifier*. Root cause: `parse_expression` leaves `current_token` on the last consumed token; the `)` check was running too early. Fix: call `next_token()` once more before checking for `)`.

- **RES-311**: `!a.b` parsed as `(!a).b` instead of `!(a.b)`. Root cause: prefix `!`/`-` called `parse_expression(11)` which equals `Token::Dot`'s precedence — so the infix loop's `precedence < peek_precedence()` test (i.e. `11 < 11`) was `false`, preventing `.` from binding. Fix: lower to `parse_expression(10)` so field-access (11) beats prefix ops.

## Test plan
- [x] New golden `paren_expr.rz` exercises `(x)`, `(x/60)`, `(x+1)*2`
- [x] New golden `unary_prec.rz` exercises `!r.ok` returning `false`
- [x] All 1125+ existing tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean

Closes #310
Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)