### PR TITLE
RES-221: string interpolation {expr} inside double-quoted strings

### DIFF
--- a/resilient/examples/interpolation.expected.txt
+++ b/resilient/examples/interpolation.expected.txt
@@ -1,0 +1,4 @@
+Hello, World!
+Hello, Alice!
+The answer is 42.
+Program executed successfully

--- a/resilient/examples/interpolation.rz
+++ b/resilient/examples/interpolation.rz
@@ -1,0 +1,12 @@
+fn greet(string name) -> string {
+    return "Hello, {name}!";
+}
+fn main() {
+    let name = "World";
+    println("Hello, {name}!");
+    println(greet("Alice"));
+    let x = 6;
+    let y = 7;
+    println("The answer is {x * y}.");
+}
+main();

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1163,6 +1163,8 @@ fn node_line(n: &Node) -> Option<u32> {
 
         // RES-325: NamedArg carries the span of its `name:` label.
         Node::NamedArg { span, .. } => span.start.line as u32,
+        // RES-221: interpolated string carries the opening quote's span.
+        Node::InterpolatedString { span, .. } => span.start.line as u32,
     };
     if line == 0 { None } else { Some(line) }
 }

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -951,6 +951,25 @@ impl Formatter {
                 }
                 self.fmt_expr(hi);
             }
+            // RES-221: re-emit the interpolated string literal by
+            // reconstructing each part. Literal text is escaped like an
+            // ordinary string; expressions are wrapped back in `{...}`.
+            Node::InterpolatedString { parts, .. } => {
+                self.write("\"");
+                for part in parts {
+                    match part {
+                        crate::string_interp::StringPart::Literal(s) => {
+                            self.write(&escape_string(s));
+                        }
+                        crate::string_interp::StringPart::Expr(expr) => {
+                            self.write("{");
+                            self.fmt_expr(expr);
+                            self.write("}");
+                        }
+                    }
+                }
+                self.write("\"");
+            }
             // Statement-shaped nodes that ended up in expression
             // position: degrade gracefully to their statement form.
             Node::Block { .. }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -91,6 +91,14 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
         | Node::BytesLiteral { .. }
         | Node::BooleanLiteral { .. }
         | Node::DurationLiteral { .. } => {}
+        // RES-221: walk each Expr part; literals have no free variables.
+        Node::InterpolatedString { parts, .. } => {
+            for part in parts {
+                if let crate::string_interp::StringPart::Expr(expr) = part {
+                    walk(expr, bound, free);
+                }
+            }
+        }
 
         // ---- Top-level shape ----
         Node::Program(stmts) => {

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -167,6 +167,11 @@ mod cfg_attr;
 // must follow positional, no duplicates) lives next to the parser.
 mod named_args;
 
+// RES-221: string interpolation — `"text {expr} more"`. All feature
+// logic lives here; main.rs only adds a Node variant and two small
+// dispatch calls.
+mod string_interp;
+
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
 
@@ -1979,6 +1984,14 @@ enum Node {
     NamedArg {
         name: String,
         value: Box<Node>,
+        #[allow(dead_code)]
+        span: span::Span,
+    },
+    /// RES-221: string interpolation — `"text {expr} more"`.
+    /// Parsed from a `StringLiteral` token whose raw value contains `{`.
+    /// Each `StringPart::Expr` is evaluated at runtime and spliced in.
+    InterpolatedString {
+        parts: Vec<crate::string_interp::StringPart>,
         #[allow(dead_code)]
         span: span::Span,
     },
@@ -5558,6 +5571,25 @@ impl Parser {
             // append-only and conflict-resistant.
             Token::Forall | Token::Exists => crate::quantifiers::parse_quantifier(self),
             _ => None,
+        };
+
+        // RES-221: upgrade a plain StringLiteral that contains `{` into
+        // an InterpolatedString node. Done here — after the outer match
+        // releases the borrow on `self.current_token` — so we can call
+        // `self.record_error` on parse failure without borrow conflicts.
+        left_expr = match left_expr {
+            Some(Node::StringLiteral { ref value, span }) if value.contains('{') => {
+                let raw = value.clone();
+                match crate::string_interp::parse_parts(&raw) {
+                    Ok(Some(parts)) => Some(Node::InterpolatedString { parts, span }),
+                    Ok(None) => Some(Node::StringLiteral { value: raw, span }),
+                    Err(e) => {
+                        self.record_error(format!("string interpolation error: {}", e));
+                        Some(Node::StringLiteral { value: raw, span })
+                    }
+                }
+            }
+            other => other,
         };
 
         // Parse infix expressions
@@ -10588,6 +10620,11 @@ impl Interpreter {
             Node::IntegerLiteral { value, .. } => Ok(Value::Int(*value)),
             Node::FloatLiteral { value, .. } => Ok(Value::Float(*value)),
             Node::StringLiteral { value, .. } => Ok(Value::String(value.clone())),
+            // RES-221: evaluate each part of an interpolated string and
+            // concatenate into a single String value.
+            Node::InterpolatedString { parts, .. } => {
+                crate::string_interp::eval_interp(self, parts)
+            }
             Node::BytesLiteral { value, .. } => Ok(Value::Bytes(value.clone())),
             Node::BooleanLiteral { value, .. } => Ok(Value::Bool(*value)),
             Node::PrefixExpression {

--- a/resilient/src/string_interp.rs
+++ b/resilient/src/string_interp.rs
@@ -1,0 +1,251 @@
+//! RES-221: string interpolation — `"text {expr} more"`.
+//!
+//! Syntax: any double-quoted string containing `{...}` segments is
+//! an interpolated string. The expression inside `{...}` is evaluated
+//! at runtime and spliced in as text.
+//!
+//! - `\{` produces a literal `{` (escape, no interpolation).
+//! - `{{` is a parse-time error; the escape form `\{` should be used.
+//! - Nesting `{...{...}...}` is not supported; the first `}` closes.
+//!
+//! This module owns:
+//! - [`StringPart`]: the parts of a parsed interpolated string.
+//! - [`parse_parts`]: splits a raw string value into literal/expr parts.
+//! - [`eval_interp`]: evaluates an `InterpolatedString` node at runtime.
+//! - [`check`]: top-level pass (no-op; parse-time errors are sufficient).
+
+use crate::{Interpreter, Lexer, Node, Parser, RResult, Value};
+
+// ---------- AST helpers ----------
+
+/// One segment of an interpolated string.
+#[derive(Debug, Clone)]
+pub enum StringPart {
+    /// A run of literal characters (no interpolation needed).
+    Literal(String),
+    /// A Resilient expression to be evaluated and stringified.
+    Expr(Box<Node>),
+}
+
+// ---------- Parser ----------
+
+/// Walk `raw` (the string literal's inner text, without surrounding
+/// quotes) and split it into [`StringPart`]s.
+///
+/// Returns `None` when no `{` is present — callers may keep the
+/// string as a plain `Node::StringLiteral` in that case.
+/// Returns `Err` when a `{` is found but the sub-expression cannot be
+/// parsed or the syntax is otherwise malformed.
+pub(crate) fn parse_parts(raw: &str) -> Result<Option<Vec<StringPart>>, String> {
+    if !raw.contains('{') {
+        return Ok(None);
+    }
+
+    let mut parts: Vec<StringPart> = Vec::new();
+    let mut literal_buf = String::new();
+    let mut chars = raw.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            // `\{` — escaped brace, emit literal `{`.
+            '\\' if chars.peek() == Some(&'{') => {
+                chars.next();
+                literal_buf.push('{');
+            }
+            '{' => {
+                // Opening brace — everything up to `}` is a sub-expression.
+                if chars.peek() == Some(&'{') {
+                    return Err("nested braces are not allowed in string interpolation; \
+                         escape `{` as `\\{`"
+                        .to_string());
+                }
+
+                // Flush the pending literal fragment.
+                if !literal_buf.is_empty() {
+                    parts.push(StringPart::Literal(literal_buf.clone()));
+                    literal_buf.clear();
+                }
+
+                // Collect source up to the matching `}`.
+                let mut expr_src = String::new();
+                let mut found_close = false;
+                for inner in chars.by_ref() {
+                    if inner == '}' {
+                        found_close = true;
+                        break;
+                    }
+                    expr_src.push(inner);
+                }
+                if !found_close {
+                    return Err("unterminated interpolation: `{` has no matching `}`".to_string());
+                }
+                if expr_src.trim().is_empty() {
+                    return Err("empty interpolation `{}` is not allowed".to_string());
+                }
+
+                // Parse the sub-expression using the main parser.
+                let lexer = Lexer::new(expr_src.clone());
+                let mut sub_parser = Parser::new(lexer);
+                let expr_node = match sub_parser.parse_expression(0) {
+                    Some(n) if sub_parser.errors.is_empty() => n,
+                    Some(_) => {
+                        return Err(format!(
+                            "syntax error in string interpolation `{{{}}}`{}",
+                            expr_src,
+                            if let Some(e) = sub_parser.errors.first() {
+                                format!(": {}", e)
+                            } else {
+                                String::new()
+                            }
+                        ));
+                    }
+                    None => {
+                        return Err(format!(
+                            "could not parse expression in string interpolation `{{{}}}`",
+                            expr_src
+                        ));
+                    }
+                };
+
+                parts.push(StringPart::Expr(Box::new(expr_node)));
+            }
+            other => literal_buf.push(other),
+        }
+    }
+
+    // Flush any trailing literal.
+    if !literal_buf.is_empty() {
+        parts.push(StringPart::Literal(literal_buf));
+    }
+
+    Ok(Some(parts))
+}
+
+// ---------- Evaluator ----------
+
+/// Evaluate an `InterpolatedString` node. Each part is either copied
+/// directly into the output string or evaluated and converted to its
+/// string representation.
+pub(crate) fn eval_interp(interp: &mut Interpreter, parts: &[StringPart]) -> RResult<Value> {
+    let mut out = String::new();
+    for part in parts {
+        match part {
+            StringPart::Literal(s) => out.push_str(s),
+            StringPart::Expr(expr) => {
+                let val = interp.eval(expr)?;
+                out.push_str(&value_to_string(val));
+            }
+        }
+    }
+    Ok(Value::String(out))
+}
+
+/// Convert a [`Value`] to its plain text form for string interpolation.
+///
+/// Strings yield their raw contents (no surrounding quotes).
+/// Integers, floats, and booleans convert via `Display`.
+/// All other values (arrays, structs, maps, etc.) use the `Display`
+/// implementation of `Value`, which matches what `println` would show.
+fn value_to_string(v: Value) -> String {
+    match v {
+        Value::String(s) => s,
+        Value::Int(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        other => format!("{}", other),
+    }
+}
+
+// ---------- Type-check pass ----------
+
+/// RES-221: top-level type-check pass for interpolated strings.
+///
+/// Parse-time validation (unterminated braces, empty interpolations,
+/// syntax errors in sub-expressions) is already handled in
+/// [`parse_parts`], so this pass is a no-op today. The extension-pass
+/// slot is kept for future work (e.g. type-checking interpolated
+/// sub-expressions against `String`-compatible types).
+pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+    Ok(())
+}
+
+// ---------- Tests ----------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn interp_eval(src: &str) -> String {
+        let lexer = crate::Lexer::new(src.to_string());
+        let mut parser = crate::Parser::new(lexer);
+        let program = parser.parse_program();
+        assert!(
+            parser.errors.is_empty(),
+            "parse errors: {:?}",
+            parser.errors
+        );
+        let mut interp = crate::Interpreter::new();
+        match interp.eval(&program) {
+            Ok(Value::String(s)) => s,
+            Ok(other) => format!("{}", other),
+            Err(e) => panic!("eval error: {}", e),
+        }
+    }
+
+    #[test]
+    fn no_braces_returns_none() {
+        assert!(parse_parts("hello world").unwrap().is_none());
+    }
+
+    #[test]
+    fn escaped_brace_is_literal() {
+        let parts = parse_parts("a\\{b").unwrap().expect("should have parts");
+        assert_eq!(parts.len(), 1);
+        assert!(matches!(&parts[0], StringPart::Literal(s) if s == "a{b"));
+    }
+
+    #[test]
+    fn nested_braces_error() {
+        assert!(parse_parts("{{x}}").is_err());
+    }
+
+    #[test]
+    fn empty_interpolation_error() {
+        assert!(parse_parts("a{}b").is_err());
+    }
+
+    #[test]
+    fn unterminated_interpolation_error() {
+        assert!(parse_parts("a{b").is_err());
+    }
+
+    #[test]
+    fn simple_variable_interp() {
+        let src = r#"
+let name = "World";
+"Hello, {name}!"
+"#;
+        assert_eq!(interp_eval(src), "Hello, World!");
+    }
+
+    #[test]
+    fn arithmetic_in_interp() {
+        let src = r#"
+let x = 6;
+let y = 7;
+"The answer is {x * y}."
+"#;
+        assert_eq!(interp_eval(src), "The answer is 42.");
+    }
+
+    #[test]
+    fn literal_prefix_and_suffix() {
+        let parts = parse_parts("Hello, {name}!")
+            .unwrap()
+            .expect("should have parts");
+        assert_eq!(parts.len(), 3);
+        assert!(matches!(&parts[0], StringPart::Literal(s) if s == "Hello, "));
+        assert!(matches!(&parts[1], StringPart::Expr(_)));
+        assert!(matches!(&parts[2], StringPart::Literal(s) if s == "!"));
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1692,6 +1692,7 @@ impl TypeChecker {
                 crate::verifier_loop_invariants::verify_and_capture(self, program);
                 crate::type_aliases::check(program, source_path)?;
                 crate::ranges::check(program, source_path)?;
+                crate::string_interp::check(program, source_path)?;
                 // </EXTENSION_PASSES>
 
                 // RES-192: IO-effect inference. Binary lattice
@@ -2963,6 +2964,8 @@ impl TypeChecker {
             Node::IntegerLiteral { .. } => Ok(Type::Int),
             Node::FloatLiteral { .. } => Ok(Type::Float),
             Node::StringLiteral { .. } => Ok(Type::String),
+            // RES-221: interpolated strings always produce a String value.
+            Node::InterpolatedString { .. } => Ok(Type::String),
             Node::BytesLiteral { .. } => Ok(Type::Bytes),
             Node::BooleanLiteral { .. } => Ok(Type::Bool),
 


### PR DESCRIPTION
## Summary

- Adds `"Hello, {name}!"` string interpolation syntax to Resilient
- Expressions inside `{...}` are evaluated at runtime and spliced into the string as text
- `\{` escapes to a literal `{`; `{{` is a parse-time error with a clear diagnostic

## Implementation

- `resilient/src/string_interp.rs` (new): `StringPart` enum, `parse_parts`, `eval_interp`, no-op `check` pass
- `main.rs`: `mod string_interp`, `Node::InterpolatedString` variant, post-match string upgrade, `eval` arm
- `typechecker.rs`: `InterpolatedString → Type::String` in `check_node`; `<EXTENSION_PASSES>` call
- `compiler.rs`, `formatter.rs`, `free_vars.rs`: exhaustive-match arms for the new node
- Golden test: `examples/interpolation.rz` + `examples/interpolation.expected.txt`

## Test plan

- [x] `cargo test` — 1133+ tests pass, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Golden test `interpolation.rz` produces correct output
- [x] Unit tests in `string_interp::tests` cover: no-brace passthrough, escaped brace, nested-brace error, empty-interpolation error, unterminated error, variable interp, arithmetic interp

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)