### PR TITLE
RES-326: default parameter values — fn foo(x: Int, y: Int = 0)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -27,6 +27,10 @@
     "resilient/src/main.rs": {
       "branch": "res-393-parser-panic-empty-rhs",
       "claimed_at": "2026-04-27T00:34:11Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-118-default-params",
+      "claimed_at": "2026-04-28T01:31:32Z"
     }
   }
 }

--- a/resilient/examples/default_params.expected.txt
+++ b/resilient/examples/default_params.expected.txt
@@ -1,0 +1,6 @@
+Hello, World!
+Hi, Alice!
+15
+25
+6
+Program executed successfully

--- a/resilient/examples/default_params.rz
+++ b/resilient/examples/default_params.rz
@@ -1,0 +1,23 @@
+// RES-326 demo: default parameter values.
+//
+// A parameter with a default can be omitted at the call site. The
+// post-parse `default_params::lower_program` pass fills in the missing
+// trailing argument before the interpreter ever sees the call — so the
+// hot dispatch path is identical to a fully-explicit positional call.
+
+fn greet(String name, String greeting = "Hello") {
+    println(greeting + ", " + name + "!");
+}
+
+fn add(Int x, Int y = 10, Int z = 0) -> Int {
+    return x + y + z;
+}
+
+fn main() {
+    greet("World");
+    greet("Alice", greeting: "Hi");
+    println(add(5));
+    println(add(5, 20));
+    println(add(1, 2, 3));
+}
+main();

--- a/resilient/src/default_params.rs
+++ b/resilient/src/default_params.rs
@@ -1,0 +1,502 @@
+//! RES-326: default parameter values — `fn foo(x: Int, y: Int = 0)`.
+//!
+//! Default values for trailing parameters allow call sites to omit them.
+//! Resolution is a post-parse lowering pass over the AST: this module
+//! walks the program, collects every top-level `fn` signature together
+//! with its per-parameter default expressions, then rewrites every
+//! `CallExpression` whose callee is a known top-level fn by appending
+//! cloned defaults for any trailing arguments that were omitted.
+//!
+//! This keeps the hot interpreter path completely free of
+//! default-parameter awareness — the call site, after lowering, looks
+//! identical to a fully-explicit positional call.
+//!
+//! Resolution rules:
+//! - Only trailing parameters may be omitted at a call site.
+//! - If a call provides fewer arguments than the function has
+//!   parameters, the missing trailing slots must all have defaults.
+//! - Mixing positional omission with named args is handled by running
+//!   `named_args::lower_program` first (which is the existing ordering
+//!   in `crate::parse`).
+//!
+//! Accepted by `lower_program`; `check` is an MVP no-op.
+
+use crate::Node;
+use std::collections::HashMap;
+
+/// A function's default-value information: parallel to `parameters`.
+#[derive(Clone)]
+struct FnDefaults {
+    /// Number of parameters the function declares.
+    param_count: usize,
+    /// `defaults[i]` is the default expression for parameter `i`, or
+    /// `None` when that parameter has no default.
+    defaults: Vec<Option<Box<Node>>>,
+}
+
+/// Walk a parsed `Node::Program` and rewrite every `CallExpression`
+/// whose callee is a known top-level fn by filling in any missing
+/// trailing arguments with that fn's declared default expressions.
+///
+/// Runs after `named_args::lower_program` so the argument list is
+/// already in positional order when we get here.
+pub fn lower_program(program: &mut Node) {
+    let mut sigs: HashMap<String, FnDefaults> = HashMap::new();
+    collect_defaults(program, &mut sigs);
+    rewrite_calls(program, &sigs);
+}
+
+/// RES-326: type-check pass for default parameter values.
+/// MVP: all defaults are accepted — a future ticket may enforce that
+/// defaults are constant-foldable or otherwise restricted.
+pub fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+    Ok(())
+}
+
+fn collect_defaults(node: &Node, sigs: &mut HashMap<String, FnDefaults>) {
+    match node {
+        Node::Program(stmts) => {
+            for s in stmts {
+                collect_defaults(&s.node, sigs);
+            }
+        }
+        Node::Function {
+            name,
+            parameters,
+            defaults,
+            ..
+        } => {
+            sigs.insert(
+                name.clone(),
+                FnDefaults {
+                    param_count: parameters.len(),
+                    defaults: defaults.clone(),
+                },
+            );
+        }
+        Node::ImplBlock { methods, .. } => {
+            for m in methods {
+                if let Node::Function {
+                    name,
+                    parameters,
+                    defaults,
+                    ..
+                } = m
+                {
+                    sigs.insert(
+                        name.clone(),
+                        FnDefaults {
+                            param_count: parameters.len(),
+                            defaults: defaults.clone(),
+                        },
+                    );
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Post-order rewrite: visit children before rewriting the call at each
+/// node so nested calls have their defaults filled in first.
+fn rewrite_calls(node: &mut Node, sigs: &HashMap<String, FnDefaults>) {
+    match node {
+        Node::Program(stmts) => {
+            for s in stmts.iter_mut() {
+                rewrite_calls(&mut s.node, sigs);
+            }
+        }
+        Node::Block { stmts, .. } => {
+            for s in stmts.iter_mut() {
+                rewrite_calls(s, sigs);
+            }
+        }
+        Node::Function {
+            body,
+            requires,
+            ensures,
+            recovers_to,
+            ..
+        } => {
+            rewrite_calls(body, sigs);
+            for r in requires.iter_mut() {
+                rewrite_calls(r, sigs);
+            }
+            for e in ensures.iter_mut() {
+                rewrite_calls(e, sigs);
+            }
+            if let Some(rec) = recovers_to {
+                rewrite_calls(rec, sigs);
+            }
+        }
+        Node::FunctionLiteral {
+            body,
+            requires,
+            ensures,
+            recovers_to,
+            ..
+        } => {
+            rewrite_calls(body, sigs);
+            for r in requires.iter_mut() {
+                rewrite_calls(r, sigs);
+            }
+            for e in ensures.iter_mut() {
+                rewrite_calls(e, sigs);
+            }
+            if let Some(rec) = recovers_to {
+                rewrite_calls(rec, sigs);
+            }
+        }
+        Node::ImplBlock { methods, .. } => {
+            for m in methods.iter_mut() {
+                rewrite_calls(m, sigs);
+            }
+        }
+        Node::LetStatement { value, .. }
+        | Node::StaticLet { value, .. }
+        | Node::Const { value, .. }
+        | Node::Assignment { value, .. }
+        | Node::ExpressionStatement { expr: value, .. } => rewrite_calls(value, sigs),
+        Node::ReturnStatement { value: Some(v), .. } => {
+            rewrite_calls(v, sigs);
+        }
+        Node::ReturnStatement { value: None, .. } => {}
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            rewrite_calls(condition, sigs);
+            rewrite_calls(consequence, sigs);
+            if let Some(alt) = alternative {
+                rewrite_calls(alt, sigs);
+            }
+        }
+        Node::WhileStatement {
+            condition,
+            body,
+            invariants,
+            ..
+        } => {
+            rewrite_calls(condition, sigs);
+            rewrite_calls(body, sigs);
+            for inv in invariants.iter_mut() {
+                rewrite_calls(inv, sigs);
+            }
+        }
+        Node::ForInStatement {
+            iterable,
+            body,
+            invariants,
+            ..
+        } => {
+            rewrite_calls(iterable, sigs);
+            rewrite_calls(body, sigs);
+            for inv in invariants.iter_mut() {
+                rewrite_calls(inv, sigs);
+            }
+        }
+        Node::PrefixExpression { right, .. } => rewrite_calls(right, sigs),
+        Node::InfixExpression { left, right, .. } => {
+            rewrite_calls(left, sigs);
+            rewrite_calls(right, sigs);
+        }
+        Node::IndexExpression { target, index, .. } => {
+            rewrite_calls(target, sigs);
+            rewrite_calls(index, sigs);
+        }
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
+            rewrite_calls(target, sigs);
+            rewrite_calls(index, sigs);
+            rewrite_calls(value, sigs);
+        }
+        Node::FieldAccess { target, .. } => rewrite_calls(target, sigs),
+        Node::FieldAssignment { target, value, .. } => {
+            rewrite_calls(target, sigs);
+            rewrite_calls(value, sigs);
+        }
+        Node::ArrayLiteral { items, .. } => {
+            for it in items.iter_mut() {
+                rewrite_calls(it, sigs);
+            }
+        }
+        Node::MapLiteral { entries, .. } => {
+            for (k, v) in entries.iter_mut() {
+                rewrite_calls(k, sigs);
+                rewrite_calls(v, sigs);
+            }
+        }
+        Node::SetLiteral { items, .. } => {
+            for it in items.iter_mut() {
+                rewrite_calls(it, sigs);
+            }
+        }
+        Node::TryExpression { expr, .. } => rewrite_calls(expr, sigs),
+        Node::OptionalChain { object, access, .. } => {
+            rewrite_calls(object, sigs);
+            if let crate::ChainAccess::Method(_, args) = access {
+                for a in args.iter_mut() {
+                    rewrite_calls(a, sigs);
+                }
+            }
+        }
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
+            rewrite_calls(scrutinee, sigs);
+            for (_pat, guard, body) in arms.iter_mut() {
+                if let Some(g) = guard {
+                    rewrite_calls(g, sigs);
+                }
+                rewrite_calls(body, sigs);
+            }
+        }
+        Node::TryCatch { body, handlers, .. } => {
+            for s in body.iter_mut() {
+                rewrite_calls(s, sigs);
+            }
+            for (_v, handler_body) in handlers.iter_mut() {
+                for s in handler_body.iter_mut() {
+                    rewrite_calls(s, sigs);
+                }
+            }
+        }
+        Node::Quantifier { range, body, .. } => {
+            match range {
+                crate::quantifiers::QuantRange::Range { lo, hi } => {
+                    rewrite_calls(lo, sigs);
+                    rewrite_calls(hi, sigs);
+                }
+                crate::quantifiers::QuantRange::Iterable(expr) => rewrite_calls(expr, sigs),
+            }
+            rewrite_calls(body, sigs);
+        }
+        Node::Assert {
+            condition, message, ..
+        }
+        | Node::Assume {
+            condition, message, ..
+        } => {
+            rewrite_calls(condition, sigs);
+            if let Some(m) = message {
+                rewrite_calls(m, sigs);
+            }
+        }
+        Node::InvariantStatement { expr, .. } => rewrite_calls(expr, sigs),
+        Node::LiveBlock {
+            body, invariants, ..
+        } => {
+            rewrite_calls(body, sigs);
+            for inv in invariants.iter_mut() {
+                rewrite_calls(inv, sigs);
+            }
+        }
+        Node::StructLiteral { fields, .. } => {
+            for (_n, v) in fields.iter_mut() {
+                rewrite_calls(v, sigs);
+            }
+        }
+        // The hot path: if a call to a known top-level fn is missing
+        // trailing arguments and those positions have defaults, fill
+        // them in before the interpreter ever sees the call.
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
+            rewrite_calls(function, sigs);
+            for a in arguments.iter_mut() {
+                rewrite_calls(a, sigs);
+            }
+            let callee_name = if let Node::Identifier { name, .. } = function.as_ref() {
+                Some(name.clone())
+            } else {
+                None
+            };
+            if let Some(name) = callee_name
+                && let Some(sig) = sigs.get(&name)
+            {
+                let provided = arguments.len();
+                let total = sig.param_count;
+                if provided < total {
+                    // Append cloned defaults for each missing trailing slot.
+                    for i in provided..total {
+                        if let Some(default_expr) = &sig.defaults.get(i).and_then(|d| d.as_ref()) {
+                            arguments.push(*(*default_expr).clone());
+                        }
+                        // If there is no default for this slot, leave the
+                        // argument list short — the runtime will surface a
+                        // clean "missing argument" diagnostic.
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::span::Span;
+
+    fn int_lit(v: i64) -> Node {
+        Node::IntegerLiteral {
+            value: v,
+            span: Span::default(),
+        }
+    }
+
+    fn ident(name: &str) -> Node {
+        Node::Identifier {
+            name: name.to_string(),
+            span: Span::default(),
+        }
+    }
+
+    fn call(callee: &str, args: Vec<Node>) -> Node {
+        Node::CallExpression {
+            function: Box::new(ident(callee)),
+            arguments: args,
+            span: Span::default(),
+        }
+    }
+
+    fn make_fn(name: &str, param_count: usize, defaults: Vec<Option<Box<Node>>>) -> Node {
+        // Build a dummy parameter list of `(int, pN)` pairs.
+        let parameters: Vec<(String, String)> = (0..param_count)
+            .map(|i| ("int".to_string(), format!("p{}", i)))
+            .collect();
+        Node::Function {
+            name: name.to_string(),
+            parameters,
+            defaults,
+            body: Box::new(Node::Block {
+                stmts: Vec::new(),
+                span: Span::default(),
+            }),
+            requires: Vec::new(),
+            ensures: Vec::new(),
+            recovers_to: None,
+            return_type: None,
+            span: Span::default(),
+            pure: false,
+            effects: crate::EffectSet::io(),
+            type_params: Vec::new(),
+            fails: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn call_with_all_args_is_unchanged() {
+        let fn_decl = make_fn("add", 2, vec![None, None]);
+        let call_node = call("add", vec![int_lit(1), int_lit(2)]);
+        let mut prog = Node::Program(vec![
+            crate::span::Spanned {
+                node: fn_decl,
+                span: Span::default(),
+            },
+            crate::span::Spanned {
+                node: call_node,
+                span: Span::default(),
+            },
+        ]);
+        lower_program(&mut prog);
+        if let Node::Program(stmts) = &prog {
+            if let Node::CallExpression { arguments, .. } = &stmts[1].node {
+                assert_eq!(arguments.len(), 2, "should still have 2 args");
+            } else {
+                panic!("expected CallExpression");
+            }
+        }
+    }
+
+    #[test]
+    fn missing_arg_with_default_is_filled_in() {
+        // fn f(p0: int, p1: int = 42)
+        let fn_decl = make_fn("f", 2, vec![None, Some(Box::new(int_lit(42)))]);
+        let call_node = call("f", vec![int_lit(1)]);
+        let mut prog = Node::Program(vec![
+            crate::span::Spanned {
+                node: fn_decl,
+                span: Span::default(),
+            },
+            crate::span::Spanned {
+                node: call_node,
+                span: Span::default(),
+            },
+        ]);
+        lower_program(&mut prog);
+        if let Node::Program(stmts) = &prog {
+            if let Node::CallExpression { arguments, .. } = &stmts[1].node {
+                assert_eq!(arguments.len(), 2, "default should have been inserted");
+                match &arguments[1] {
+                    Node::IntegerLiteral { value, .. } => assert_eq!(*value, 42),
+                    other => panic!("expected IntegerLiteral(42), got {:?}", other),
+                }
+            } else {
+                panic!("expected CallExpression");
+            }
+        }
+    }
+
+    #[test]
+    fn two_missing_defaults_both_filled_in() {
+        // fn g(p0: int, p1: int = 10, p2: int = 20)
+        let fn_decl = make_fn(
+            "g",
+            3,
+            vec![
+                None,
+                Some(Box::new(int_lit(10))),
+                Some(Box::new(int_lit(20))),
+            ],
+        );
+        let call_node = call("g", vec![int_lit(1)]);
+        let mut prog = Node::Program(vec![
+            crate::span::Spanned {
+                node: fn_decl,
+                span: Span::default(),
+            },
+            crate::span::Spanned {
+                node: call_node,
+                span: Span::default(),
+            },
+        ]);
+        lower_program(&mut prog);
+        if let Node::Program(stmts) = &prog
+            && let Node::CallExpression { arguments, .. } = &stmts[1].node
+        {
+            assert_eq!(arguments.len(), 3);
+            match &arguments[1] {
+                Node::IntegerLiteral { value, .. } => assert_eq!(*value, 10),
+                other => panic!("expected 10, got {:?}", other),
+            }
+            match &arguments[2] {
+                Node::IntegerLiteral { value, .. } => assert_eq!(*value, 20),
+                other => panic!("expected 20, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_callee_call_is_left_unchanged() {
+        let call_node = call("unknown", vec![int_lit(5)]);
+        let mut prog = Node::Program(vec![crate::span::Spanned {
+            node: call_node,
+            span: Span::default(),
+        }]);
+        lower_program(&mut prog);
+        if let Node::Program(stmts) = &prog
+            && let Node::CallExpression { arguments, .. } = &stmts[0].node
+        {
+            assert_eq!(arguments.len(), 1);
+        }
+    }
+}

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -175,6 +175,10 @@ mod string_interp;
 // logic (eval and static check) lives in this module; the only core-
 // file changes are Token::Mod, Node::ModuleDecl, and the dispatch lines.
 mod modules;
+// RES-326: default parameter values — `fn foo(x: Int, y: Int = 0)`.
+// A post-parse lowering pass fills in omitted trailing arguments with
+// their declared default expressions before the interpreter runs.
+mod default_params;
 
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
@@ -1184,6 +1188,10 @@ impl Lexer {
 }
 
 /// RES-039: patterns for `match` arms.
+// The Literal variant carries a Node (intentionally large — it holds
+// arbitrary constant expressions from the source). The size difference
+// relative to leaf variants like Wildcard is by design.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 enum Pattern {
     /// Matches a literal int, float, string, or bool.
@@ -1398,6 +1406,11 @@ enum Node {
     Function {
         name: String,
         parameters: Vec<(String, String)>, // (type, name)
+        /// RES-326: parallel default-value expressions for each parameter.
+        /// `defaults[i] == None` means parameter `i` has no default.
+        /// Length always matches `parameters.len()`.
+        #[allow(dead_code)]
+        defaults: Vec<Option<Box<Node>>>,
         body: Box<Node>,
         /// RES-035: pre-condition clauses, checked on entry. Each is a
         /// boolean expression over the parameters.
@@ -2683,6 +2696,7 @@ impl Parser {
                 return Node::Function {
                     name,
                     parameters: Vec::new(),
+                    defaults: Vec::new(),
                     body: Box::new(Node::Block {
                         stmts: Vec::new(),
                         span: span::Span::default(),
@@ -2703,6 +2717,7 @@ impl Parser {
             return Node::Function {
                 name,
                 parameters: Vec::new(),
+                defaults: Vec::new(),
                 body: Box::new(body),
                 requires: Vec::new(),
                 ensures: Vec::new(),
@@ -2718,7 +2733,7 @@ impl Parser {
 
         self.next_token(); // Skip '('
 
-        let parameters = self.parse_function_parameters();
+        let (parameters, defaults) = self.parse_function_parameters();
 
         // RES-052: optional `-> TYPE` return type, BEFORE contracts.
         let return_type = self.parse_optional_return_type();
@@ -2756,6 +2771,7 @@ impl Parser {
                 return Node::Function {
                     name,
                     parameters,
+                    defaults,
                     body: Box::new(Node::Block {
                         stmts: Vec::new(),
                         span: span::Span::default(),
@@ -2778,6 +2794,7 @@ impl Parser {
         Node::Function {
             name,
             parameters,
+            defaults,
             body: Box::new(body),
             requires,
             ensures,
@@ -3107,7 +3124,8 @@ impl Parser {
                         self.next_token();
                         Vec::new()
                     } else {
-                        self.parse_function_parameters()
+                        let (p, _) = self.parse_function_parameters();
+                        p
                     };
                     let (requires, ensures, _) = self.parse_function_contracts();
                     if self.current_token != Token::LeftBrace {
@@ -3222,12 +3240,14 @@ impl Parser {
         }
 
         let mut parameters: Vec<(String, String)> = Vec::new();
+        let mut defaults: Vec<Option<Box<Node>>> = Vec::new();
         // Special-case the `self` first parameter: accept it bare
         // (no explicit type) and synthesize `(StructName, "self")`.
         if let Token::Identifier(name) = &self.current_token
             && name == "self"
         {
             parameters.push((struct_name.to_string(), "self".to_string()));
+            defaults.push(None); // `self` never has a default
             self.next_token(); // skip 'self'
             if self.current_token == Token::Comma {
                 self.next_token(); // skip ','
@@ -3236,8 +3256,9 @@ impl Parser {
 
         // Parse any remaining TYPE NAME params until the `)`.
         if self.current_token != Token::RightParen {
-            let rest = self.parse_function_parameters();
-            parameters.extend(rest);
+            let (rest_params, rest_defaults) = self.parse_function_parameters();
+            parameters.extend(rest_params);
+            defaults.extend(rest_defaults);
         } else {
             self.next_token(); // skip ')'
         }
@@ -3264,6 +3285,7 @@ impl Parser {
         Node::Function {
             name: mangled,
             parameters,
+            defaults,
             body: Box::new(body),
             requires,
             ensures,
@@ -3773,12 +3795,16 @@ impl Parser {
         out
     }
 
-    fn parse_function_parameters(&mut self) -> Vec<(String, String)> {
+    #[allow(clippy::type_complexity)]
+    fn parse_function_parameters(
+        &mut self,
+    ) -> (Vec<(String, String)>, Vec<Option<Box<Node>>>) {
         let mut parameters = Vec::new();
+        let mut defaults: Vec<Option<Box<Node>>> = Vec::new();
 
         if self.current_token == Token::RightParen {
             self.next_token(); // Skip ')'
-            return parameters;
+            return (parameters, defaults);
         }
 
         while self.current_token != Token::RightParen {
@@ -3800,8 +3826,25 @@ impl Parser {
             };
 
             parameters.push((param_type, param_name));
-
             self.next_token(); // Skip name
+
+            // RES-326: optional `= EXPR` default value for this parameter.
+            if self.current_token == Token::Assign {
+                self.next_token(); // Skip '='
+                let default_expr = self.parse_expression(0);
+                defaults.push(default_expr.map(Box::new));
+                // Consume the token that terminates the expression only when
+                // parse_expression leaves the cursor one token _before_ the
+                // delimiter. The existing call convention advances past the
+                // expression but not the following comma/paren.
+                if self.current_token == Token::Comma || self.current_token == Token::RightParen {
+                    // cursor is already on the delimiter — do nothing extra
+                } else {
+                    self.next_token();
+                }
+            } else {
+                defaults.push(None);
+            }
 
             if self.current_token == Token::Comma {
                 self.next_token(); // Skip ','
@@ -3817,7 +3860,7 @@ impl Parser {
         }
 
         self.next_token(); // Skip ')'
-        parameters
+        (parameters, defaults)
     }
 
     fn parse_block_statement(&mut self) -> Node {
@@ -6492,7 +6535,9 @@ impl Parser {
             };
         }
         self.next_token(); // skip '('
-        let parameters = self.parse_function_parameters();
+        // Defaults from anonymous fn literals are discarded — MVP only
+        // supports defaults on named top-level fns (Node::Function).
+        let (parameters, _defaults) = self.parse_function_parameters();
         let return_type = self.parse_optional_return_type();
         let (requires, ensures, recovers_to) = self.parse_function_contracts();
         if self.current_token != Token::LeftBrace {
@@ -12600,6 +12645,8 @@ fn start_repl() -> RustylineResult<()> {
                     eprintln!("\x1B[31mError: {}\x1B[0m", e);
                     continue;
                 }
+                // RES-326: fill in omitted trailing args with defaults.
+                crate::default_params::lower_program(&mut program);
 
                 // Run type checker if enabled
                 if type_check_enabled {
@@ -12830,6 +12877,10 @@ fn parse(src: &str) -> (Node, Vec<String>) {
     if let Err(e) = crate::named_args::lower_program(&mut program) {
         errs.push(e);
     }
+    // RES-326: fill in omitted trailing arguments with their declared
+    // default expressions. Runs after named-arg lowering so positional
+    // reordering has already happened before we count arguments.
+    crate::default_params::lower_program(&mut program);
     (program, errs)
 }
 
@@ -13578,6 +13629,10 @@ fn execute_file(
         eprintln!("\x1B[31mNamed-argument error: {}\x1B[0m", e);
         return Err(format!("Named argument resolution failed: {}", e));
     }
+    // RES-326: fill in omitted trailing arguments with declared
+    // defaults. Runs after named-arg lowering (positional ordering
+    // must be stable before we count provided args).
+    crate::default_params::lower_program(&mut program);
 
     // RES-391: syntactic non-aliasing check over reference-type
     // parameters. Runs unconditionally — a borrow-check violation is
@@ -15973,6 +16028,8 @@ mod tests {
         if let Err(e) = crate::named_args::lower_program(&mut program) {
             errs.push(e);
         }
+        // RES-326: same default-param lowering as the production driver.
+        crate::default_params::lower_program(&mut program);
         (program, errs)
     }
 

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -3796,9 +3796,7 @@ impl Parser {
     }
 
     #[allow(clippy::type_complexity)]
-    fn parse_function_parameters(
-        &mut self,
-    ) -> (Vec<(String, String)>, Vec<Option<Box<Node>>>) {
+    fn parse_function_parameters(&mut self) -> (Vec<(String, String)>, Vec<Option<Box<Node>>>) {
         let mut parameters = Vec::new();
         let mut defaults: Vec<Option<Box<Node>>> = Vec::new();
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1694,6 +1694,7 @@ impl TypeChecker {
                 crate::ranges::check(program, source_path)?;
                 crate::string_interp::check(program, source_path)?;
                 crate::modules::check(program, source_path)?;
+                crate::default_params::check(program, source_path)?;
                 // </EXTENSION_PASSES>
 
                 // RES-192: IO-effect inference. Binary lattice


### PR DESCRIPTION
## Summary

- Adds `defaults: Vec<Option<Box<Node>>>` field to `Node::Function` (parallel to `parameters`) — parser populates it when it sees `= expr` after a parameter name.
- New module `resilient/src/default_params.rs` implements a post-parse lowering pass that walks `CallExpression` nodes and fills in missing trailing arguments from declared defaults, before the interpreter runs.
- `default_params::lower_program` is called immediately after `named_args::lower_program` in all three entry points: the `parse()` helper, the REPL loop, and the file-mode driver.
- `default_params::check` is registered in the `<EXTENSION_PASSES>` block in `typechecker.rs` (MVP no-op; future ticket may enforce constant-foldability).
- Golden test: `resilient/examples/default_params.rz` / `.expected.txt` — covers omitting one default, omitting two defaults, using all positional, and mixing with named args.

Closes #118

## Test plan

- [ ] `cargo build --manifest-path resilient/Cargo.toml` — clean
- [ ] `cargo test --manifest-path resilient/Cargo.toml` — 1129+ tests pass, 0 failures
- [ ] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [ ] `cargo run -- resilient/examples/default_params.rz` output matches `.expected.txt`

## Notes

`Node::FunctionLiteral` is intentionally NOT extended with defaults — anonymous fn literals rarely need defaults and adding a new required field to that variant would break `free_vars.rs` tests that construct it exhaustively. Named functions (`Node::Function`) cover the entire acceptance criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)