### PR TITLE
RES-324: module namespaces — mod blocks

### DIFF
--- a/resilient/examples/module_namespaces.expected.txt
+++ b/resilient/examples/module_namespaces.expected.txt
@@ -1,0 +1,4 @@
+7
+42
+103
+Program executed successfully

--- a/resilient/examples/module_namespaces.rz
+++ b/resilient/examples/module_namespaces.rz
@@ -1,0 +1,15 @@
+mod math {
+    fn add(Int a, Int b) -> Int { return a + b; }
+    fn mul(Int a, Int b) -> Int { return a * b; }
+}
+
+mod utils {
+    fn add(Int a, Int b) -> Int { return a + b + 100; }
+}
+
+fn main() {
+    println(math::add(3, 4));
+    println(math::mul(6, 7));
+    println(utils::add(1, 2));
+}
+main();

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1165,6 +1165,9 @@ fn node_line(n: &Node) -> Option<u32> {
         Node::NamedArg { span, .. } => span.start.line as u32,
         // RES-221: interpolated string carries the opening quote's span.
         Node::InterpolatedString { span, .. } => span.start.line as u32,
+
+        // RES-324: module declaration; span at the `mod` keyword.
+        Node::ModuleDecl { span, .. } => span.start.line as u32,
     };
     if line == 0 { None } else { Some(line) }
 }

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -586,6 +586,18 @@ impl Formatter {
             }
             // FFI v1: extern blocks not yet formatted (Tasks 4-8).
             Node::Extern { .. } => {}
+            // RES-324: `mod name { ... }` namespace block.
+            Node::ModuleDecl { name, body, .. } => {
+                self.write(&format!("mod {} {{", name));
+                self.newline();
+                self.indent();
+                for s in body {
+                    self.fmt_stmt(s);
+                }
+                self.dedent();
+                self.write("}");
+                self.newline();
+            }
             // Anything else was an expression; dispatch to fmt_expr
             // and terminate with a semicolon so a bare expression
             // statement at top level still looks like a statement.
@@ -998,6 +1010,7 @@ impl Formatter {
             | Node::Extern { .. }
             | Node::LetDestructureStruct { .. }
             | Node::TryCatch { .. }
+            | Node::ModuleDecl { .. }
             | Node::Program(_) => {
                 self.fmt_stmt(node);
             }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -459,6 +459,13 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
         // doesn't bind a name; only the value expression introduces
         // free variables.
         Node::NamedArg { value, .. } => walk(value, bound, free),
+        // RES-324: walk module body declarations for free-variable
+        // analysis; the module name itself is not a free variable.
+        Node::ModuleDecl { body, .. } => {
+            for node in body {
+                walk(node, bound, free);
+            }
+        }
     }
 }
 

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -257,6 +257,9 @@ enum Tok {
     // no lone-`#` token in the logos surface anyway — only `#{` exists.
     #[token("#[")]
     HashLBracket,
+    // RES-324: `mod` keyword for namespace blocks.
+    #[token("mod")]
+    Mod,
     // </EXTENSION_TOKENS>
     #[token("true")]
     True,
@@ -604,6 +607,8 @@ fn convert(t: Tok) -> Token {
         Tok::DotDotDot => Token::DotDotDot,
         // RES-343: `#[` opener for cfg attributes.
         Tok::HashLBracket => Token::HashLeftBracket,
+        // RES-324: `mod` keyword for namespace blocks.
+        Tok::Mod => Token::Mod,
         // </EXTENSION_KEYWORDS>
         Tok::True => Token::BoolLiteral(true),
         Tok::False => Token::BoolLiteral(false),

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -171,6 +171,10 @@ mod named_args;
 // logic lives here; main.rs only adds a Node variant and two small
 // dispatch calls.
 mod string_interp;
+// RES-324: `mod name { ... }` inline namespace blocks. All namespace
+// logic (eval and static check) lives in this module; the only core-
+// file changes are Token::Mod, Node::ModuleDecl, and the dispatch lines.
+mod modules;
 
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
@@ -303,6 +307,8 @@ enum Token {
     HashLeftBracket,
     /// RES-316: `...` marker at the end of an `extern fn` parameter list.
     DotDotDot,
+    /// RES-324: `mod` keyword for inline namespace blocks.
+    Mod,
     // </EXTENSION_TOKENS>
 
     // Literals
@@ -436,6 +442,7 @@ impl Token {
             Token::Exists => "`exists`".to_string(),
             Token::DotDot => "`..`".to_string(),
             Token::DotDotDot => "`...`".to_string(),
+            Token::Mod => "`mod`".to_string(),
             Token::Underscore => "`_`".to_string(),
             Token::Default => "`default`".to_string(),
             Token::Dot => "`.`".to_string(),
@@ -889,6 +896,7 @@ impl Lexer {
                         "catch" => Token::Catch,
                         "forall" => Token::Forall,
                         "exists" => Token::Exists,
+                        "mod" => Token::Mod,
                         // </EXTENSION_KEYWORDS>
                         "_" => Token::Underscore,
                         // RES-163: `default` is a reserved alias
@@ -1995,6 +2003,13 @@ enum Node {
         #[allow(dead_code)]
         span: span::Span,
     },
+    /// RES-324: `mod name { decl* }` — inline namespace block.
+    ModuleDecl {
+        name: String,
+        body: Vec<Node>,
+        #[allow(dead_code)]
+        span: span::Span,
+    },
 }
 
 /// RES-386/RES-390: one `receive <name>()` handler inside an `actor` block.
@@ -2272,6 +2287,7 @@ impl Parser {
             Token::Let => Some(self.parse_let_statement()),
             Token::Static => Some(self.parse_static_let_statement()),
             Token::Const => Some(self.parse_const_statement()),
+            Token::Mod => Some(self.parse_module_decl()),
             Token::Return => Some(self.parse_return_statement()),
             Token::Live => Some(self.parse_live_block()),
             Token::Assert => Some(self.parse_assert()),
@@ -4131,6 +4147,44 @@ impl Parser {
             type_annot,
             span: stmt_span,
         }
+    }
+
+    /// RES-324: `mod name { decl* }` — inline namespace block.
+    ///
+    /// Entered with `current_token == Token::Mod`. Consumes through the
+    /// closing `}` and returns `Node::ModuleDecl`. The caller (`parse_program`
+    /// or `parse_block_statement`) advances one more token after the `}`.
+    fn parse_module_decl(&mut self) -> Node {
+        let span = self.span_at_current();
+        self.next_token(); // skip `mod`
+
+        let name = match &self.current_token {
+            Token::Identifier(n) => n.clone(),
+            _ => {
+                let tok = self.current_token.clone();
+                self.record_error(format!("Expected module name after 'mod', found {}", tok));
+                String::new()
+            }
+        };
+        self.next_token(); // skip name
+
+        if self.current_token != Token::LeftBrace {
+            let tok = self.current_token.clone();
+            self.record_error(format!(
+                "Expected '{{' after module name '{}', found {}",
+                name, tok
+            ));
+        }
+        // Delegate block-body parsing to the shared helper.
+        // parse_block_statement expects current_token == '{' and leaves
+        // current_token on '}' when it returns.
+        let block = self.parse_block_statement();
+        let body = match block {
+            Node::Block { stmts, .. } => stmts,
+            other => vec![other],
+        };
+
+        Node::ModuleDecl { name, body, span }
     }
 
     fn parse_let_statement(&mut self) -> Node {
@@ -11150,6 +11204,10 @@ impl Interpreter {
             // path. Delegate to a sibling so its locals don't
             // inflate this hot frame.
             Node::NamedArg { .. } => self.eval_stray_named_arg(node),
+            // RES-324: evaluate a `mod name { ... }` namespace block.
+            // Each contained declaration is registered under the
+            // prefixed key `"name::decl"` in the outer environment.
+            Node::ModuleDecl { name, body, .. } => crate::modules::eval_module(name, body, self),
         }
     }
 
@@ -11398,7 +11456,7 @@ impl Interpreter {
         // follows `main`.
         for statement in statements {
             match &statement.node {
-                Node::Function { .. } | Node::ImplBlock { .. } => {
+                Node::Function { .. } | Node::ImplBlock { .. } | Node::ModuleDecl { .. } => {
                     self.eval(&statement.node)
                         .map_err(|e| decorate_runtime_error(e, &statement.span))?;
                 }
@@ -11410,7 +11468,7 @@ impl Interpreter {
         for statement in statements {
             if matches!(
                 statement.node,
-                Node::Function { .. } | Node::ImplBlock { .. }
+                Node::Function { .. } | Node::ImplBlock { .. } | Node::ModuleDecl { .. }
             ) {
                 continue;
             }

--- a/resilient/src/modules.rs
+++ b/resilient/src/modules.rs
@@ -1,0 +1,74 @@
+//! RES-324: `mod name { ... }` inline namespace blocks.
+//!
+//! A `mod` block groups declarations under a namespace prefix. Every
+//! `fn` declared inside `mod math { ... }` is registered in the
+//! environment as `"math::fn_name"`. Call sites write `math::add(1, 2)`,
+//! which the parser already collapses into a flat
+//! `Node::Identifier { name: "math::add" }` via the `::` token path —
+//! so no extra runtime lookup machinery is needed.
+
+use crate::{Environment, Interpreter, Node, RResult, Value};
+
+/// Evaluate a `mod name { ... }` block.
+///
+/// Each `fn` in `body` is renamed to `"mod_name::fn_name"` before being
+/// registered in the outer environment, making the binding visible to
+/// subsequent call sites that use the `name::item` syntax.
+///
+/// Struct declarations inside the block are similarly prefixed.
+/// Other statements (helper `let` bindings, bare expressions) are
+/// evaluated in a temporary enclosed scope and do not pollute the outer
+/// environment.
+pub(crate) fn eval_module(
+    mod_name: &str,
+    body: &[Node],
+    interp: &mut Interpreter,
+) -> RResult<Value> {
+    for node in body {
+        match node {
+            Node::Function { name, .. } => {
+                let mut renamed = node.clone();
+                if let Node::Function {
+                    name: ref mut n, ..
+                } = renamed
+                {
+                    *n = format!("{}::{}", mod_name, name);
+                }
+                interp.eval(&renamed)?;
+            }
+            Node::StructDecl { name, .. } => {
+                let mut renamed = node.clone();
+                if let Node::StructDecl {
+                    name: ref mut n, ..
+                } = renamed
+                {
+                    *n = format!("{}::{}", mod_name, name);
+                }
+                interp.eval(&renamed)?;
+            }
+            Node::ImplBlock { .. } => {
+                // impl blocks inside modules are evaluated directly; their
+                // methods are already parser-mangled with the struct name
+                // and do not receive an extra namespace prefix here.
+                interp.eval(node)?;
+            }
+            _ => {
+                // For other statements evaluate them in a temporary child
+                // scope so they cannot clobber outer bindings.
+                let saved = interp.env.clone();
+                interp.env = Environment::new_enclosed(saved.clone());
+                let result = interp.eval(node);
+                interp.env = saved;
+                result?;
+            }
+        }
+    }
+    Ok(Value::Void)
+}
+
+/// Lightweight static pass — no-op for the MVP. Future extensions can
+/// enforce unique module names and verify that `name::item` references
+/// resolve to declared declarations.
+pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+    Ok(())
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1693,6 +1693,7 @@ impl TypeChecker {
                 crate::type_aliases::check(program, source_path)?;
                 crate::ranges::check(program, source_path)?;
                 crate::string_interp::check(program, source_path)?;
+                crate::modules::check(program, source_path)?;
                 // </EXTENSION_PASSES>
 
                 // RES-192: IO-effect inference. Binary lattice
@@ -3291,6 +3292,13 @@ impl TypeChecker {
             // a parser/internal bug; surface a clean error rather
             // than crashing the typechecker.
             Node::NamedArg { value, .. } => self.check_node(value),
+            // RES-324: module declaration — type-check each body node.
+            Node::ModuleDecl { body, .. } => {
+                for node in body {
+                    self.check_node(node)?;
+                }
+                Ok(Type::Void)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `mod name { ... }` inline namespace blocks to the Resilient language
- Functions declared inside a module are registered as `"name::fn"` in the environment
- Uses the existing `::` path-separator (already parsed by `parse_expression`) so `math::add(1, 2)` just works with no additional lookup machinery
- Follows the feature-isolation pattern: all logic in `src/modules.rs`, minimal touches to core files at extension points

## Changes

- `resilient/src/modules.rs` — new file: `eval_module` renames and registers declarations under the namespace prefix; no-op `check` pass
- `resilient/src/main.rs` — `Token::Mod`, `Node::ModuleDecl`, `parse_module_decl`, eval arm, hoisting pass, `mod modules;`
- `resilient/src/lexer_logos.rs` — `Token::Mod` in Logos lexer (parity with handwritten lexer)
- `resilient/src/typechecker.rs` — `crate::modules::check` call in `<EXTENSION_PASSES>`, `check_node` arm
- `resilient/src/compiler.rs` — `Node::ModuleDecl` span arm in `node_line` (exhaustive match)
- `resilient/src/formatter.rs` — `Node::ModuleDecl` in both `fmt_stmt` and `fmt_expr` (exhaustive match)
- `resilient/src/free_vars.rs` — `Node::ModuleDecl` arm in `walk` (exhaustive match)
- `resilient/examples/module_namespaces.rz` + `.expected.txt` — golden test

## Test plan

- [ ] `cargo build --manifest-path resilient/Cargo.toml` — passes
- [ ] `cargo test --manifest-path resilient/Cargo.toml` — 1125+ tests pass, 0 failed
- [ ] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --manifest-path resilient/Cargo.toml --check` — clean
- [ ] Golden test `module_namespaces.rz` produces `7\n42\n103\nProgram executed successfully`

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)