### PR TITLE
RES-289: generic type parameters for user-defined functions

### DIFF
--- a/resilient/examples/generics.expected.txt
+++ b/resilient/examples/generics.expected.txt
@@ -1,0 +1,6 @@
+42
+hello
+true
+1
+b
+Program executed successfully

--- a/resilient/examples/generics.rz
+++ b/resilient/examples/generics.rz
@@ -1,0 +1,20 @@
+fn identity<T>(T x) -> T {
+    return x;
+}
+
+fn first<A, B>(A a, B b) -> A {
+    return a;
+}
+
+fn second<A, B>(A a, B b) -> B {
+    return b;
+}
+
+fn main() {
+    println(identity(42));
+    println(identity("hello"));
+    println(identity(true));
+    println(first(1, 2));
+    println(second("a", "b"));
+}
+main();

--- a/resilient/src/generics.rs
+++ b/resilient/src/generics.rs
@@ -1,0 +1,40 @@
+/// RES-289 (RES-81): generic type-parameter validation pass.
+///
+/// The interpreter is dynamically typed, so no monomorphisation is
+/// performed here. This pass only checks that the type-parameter list
+/// on each `fn<T, U> name(...)` declaration is syntactically valid and
+/// contains no duplicate names. Semantic checking (substitution,
+/// instantiation) is deferred to a future ticket.
+use crate::Node;
+
+/// Walk the top-level program and validate all generic function
+/// declarations.  Returns `Err` with a diagnostic string on the first
+/// violation.
+pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    let stmts = match program {
+        Node::Program(stmts) => stmts,
+        _ => return Ok(()),
+    };
+    for stmt in stmts {
+        check_node(&stmt.node)?;
+    }
+    Ok(())
+}
+
+fn check_node(node: &Node) -> Result<(), String> {
+    if let Node::Function {
+        name, type_params, ..
+    } = node
+    {
+        let mut seen = std::collections::HashSet::new();
+        for tp in type_params {
+            if !seen.insert(tp.as_str()) {
+                return Err(format!(
+                    "duplicate type parameter `{}` in function `{}`",
+                    tp, name
+                ));
+            }
+        }
+    }
+    Ok(())
+}

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -183,6 +183,11 @@ mod default_params;
 // debounce. All watch logic lives in this module; main.rs only adds the
 // `mod` declaration and the dispatch call just before `execute_file`.
 mod watch_mode;
+// RES-289 (RES-81): generic type parameters — `fn identity<T>(x: T) -> T`.
+// Parse-time support (Token::Less/Greater reuse, parse_optional_type_params,
+// Node::Function::type_params field) lives in main.rs; this module owns the
+// typechecker validation pass (duplicate type-param detection).
+mod generics;
 
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
@@ -2665,10 +2670,12 @@ impl Parser {
         let fn_span = self.span_at_current();
         self.next_token(); // Skip 'fn'
 
-        // RES-124 (RES-124a): optional `<T, U, ...>` generic
-        // parameter list between `fn` and the name. Empty when
-        // the fn is monomorphic (classic `fn name(...)`).
-        let type_params = self.parse_optional_type_params();
+        // RES-289 (RES-81): accept type params either before the name
+        // (`fn<T> name(...)` — legacy form kept for backward compat)
+        // or after the name (`fn name<T>(...)` — canonical new form).
+        // Both forms set the same `type_params` field; they cannot be
+        // combined in a single declaration.
+        let pre_name_type_params = self.parse_optional_type_params();
 
         let name = match &self.current_token {
             Token::Identifier(name) => name.clone(),
@@ -2681,6 +2688,19 @@ impl Parser {
         };
 
         self.next_token(); // Skip name
+
+        // Post-name form: `fn name<T, U>(...)`.  Only applied when the
+        // pre-name form produced no params so the two forms don't stack.
+        let post_name_type_params = if pre_name_type_params.is_empty() {
+            self.parse_optional_type_params()
+        } else {
+            Vec::new()
+        };
+        let type_params = if pre_name_type_params.is_empty() {
+            post_name_type_params
+        } else {
+            pre_name_type_params
+        };
 
         // Check if we have a left parenthesis as expected
         if self.current_token != Token::LeftParen {

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1695,6 +1695,7 @@ impl TypeChecker {
                 crate::string_interp::check(program, source_path)?;
                 crate::modules::check(program, source_path)?;
                 crate::default_params::check(program, source_path)?;
+                crate::generics::check(program, source_path)?;
                 // </EXTENSION_PASSES>
 
                 // RES-192: IO-effect inference. Binary lattice


### PR DESCRIPTION
## Summary

- Adds `fn name<T, U>(...)` syntax for declaring generic type parameters on functions
- The interpreter stays dynamically typed — type params are parsed and validated but not monomorphised
- Also accepts the pre-existing `fn<T> name(...)` legacy form to avoid breaking existing tests
- New `resilient/src/generics.rs` module with a duplicate-type-param validation pass wired into `<EXTENSION_PASSES>`
- Golden example `resilient/examples/generics.rz` / `generics.expected.txt` covers `identity<T>`, `first<A,B>`, `second<A,B>`

## Test plan

- [ ] `cargo test --manifest-path resilient/Cargo.toml` — all 1125+ tests pass
- [ ] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all --check` — clean
- [ ] Golden test `examples/generics.expected.txt` matches binary output
- [ ] Existing `single_type_param_parses`, `multiple_type_params_preserve_order`, and `type_params_coexist_*` unit tests still pass (both syntax forms work)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)