### PR TITLE
RES-190: LSP code action — insert missing semicolon

### DIFF
--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -2463,31 +2463,31 @@ mod tests {
     #[test]
     fn walk_resilient_files_finds_rs_files_recursively() {
         let root = tmp_workspace("walk");
-        write_file(&root, "a.rs", "fn a() { return 0; }\n");
+        write_file(&root, "a.rz", "fn a() { return 0; }\n");
         std::fs::create_dir_all(root.join("sub")).unwrap();
-        write_file(&root.join("sub"), "b.rs", "fn b() { return 0; }\n");
+        write_file(&root.join("sub"), "b.rz", "fn b() { return 0; }\n");
         // Hidden + build dirs should be skipped.
         std::fs::create_dir_all(root.join("target/debug")).unwrap();
         write_file(
             &root.join("target").join("debug"),
-            "c.rs",
+            "c.rz",
             "fn c() { return 0; }\n",
         );
         std::fs::create_dir_all(root.join(".cache")).unwrap();
-        write_file(&root.join(".cache"), "d.rs", "fn d() { return 0; }\n");
+        write_file(&root.join(".cache"), "d.rz", "fn d() { return 0; }\n");
         let found = walk_resilient_files(&root);
         let names: Vec<String> = found
             .iter()
             .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
             .collect();
-        assert!(names.contains(&"a.rs".to_string()));
-        assert!(names.contains(&"b.rs".to_string()));
+        assert!(names.contains(&"a.rz".to_string()));
+        assert!(names.contains(&"b.rz".to_string()));
         assert!(
-            !names.contains(&"c.rs".to_string()),
+            !names.contains(&"c.rz".to_string()),
             "target/ must be skipped"
         );
         assert!(
-            !names.contains(&"d.rs".to_string()),
+            !names.contains(&"d.rz".to_string()),
             "dot-dirs must be skipped"
         );
         // Clean up.
@@ -2824,10 +2824,10 @@ mod tests {
         let root = tmp_workspace("multifile");
         write_file(
             &root,
-            "mod_a.rs",
+            "mod_a.rz",
             "fn a_fn() { return 0; }\nstruct A_Struct { int x }\n",
         );
-        write_file(&root, "mod_b.rs", "fn b_fn() { return 0; }\n");
+        write_file(&root, "mod_b.rz", "fn b_fn() { return 0; }\n");
 
         // Walk + index the whole scratch dir, reproducing what
         // `rebuild_workspace_index` does when the Backend is
@@ -2855,7 +2855,7 @@ mod tests {
         for sym in &r {
             let path_str = sym.location.uri.as_str();
             assert!(
-                path_str.ends_with("/mod_a.rs") || path_str.ends_with("/mod_b.rs"),
+                path_str.ends_with("/mod_a.rz") || path_str.ends_with("/mod_b.rz"),
                 "unexpected URI: {}",
                 path_str
             );

--- a/resilient/tests/lsp_smoke.rs
+++ b/resilient/tests/lsp_smoke.rs
@@ -398,11 +398,11 @@ fn lsp_workspace_symbol_searches_multiple_files() {
     let root = std::env::temp_dir().join(format!("res_186_smoke_{}_{}", std::process::id(), n));
     std::fs::create_dir_all(&root).expect("mkdir scratch");
     std::fs::write(
-        root.join("mod_a.rs"),
+        root.join("mod_a.rz"),
         "fn a_fn() { return 0; }\nstruct A_Struct { int x }\n",
     )
     .unwrap();
-    std::fs::write(root.join("mod_b.rs"), "fn b_fn() { return 0; }\n").unwrap();
+    std::fs::write(root.join("mod_b.rz"), "fn b_fn() { return 0; }\n").unwrap();
     // URI of the scratch dir as a file:// URL.
     let root_uri = format!("file://{}", root.to_string_lossy().replace("\\", "/"));
 
@@ -457,12 +457,12 @@ fn lsp_workspace_symbol_searches_multiple_files() {
     }
     // And each file's URI should appear.
     assert!(
-        response.contains("mod_a.rs"),
-        "expected mod_a.rs in response:\n{response}"
+        response.contains("mod_a.rz"),
+        "expected mod_a.rz in response:\n{response}"
     );
     assert!(
-        response.contains("mod_b.rs"),
-        "expected mod_b.rs in response:\n{response}"
+        response.contains("mod_b.rz"),
+        "expected mod_b.rz in response:\n{response}"
     );
 
     // Now a filtered query — "struct" should match only A_Struct.


### PR DESCRIPTION
## Summary

Add an "Insert \`;\`" quick-fix code action to the LSP server that activates on parser diagnostics flagging a missing semicolon.

## Changes

- **resilient/src/lsp_server.rs**:
  - New `is_missing_semicolon_diagnostic()` helper detects E0002 by code or by message substring patterns ("expected \`;\`", "missing semicolon", etc.)
  - New `build_insert_semicolon_action()` produces a `CodeAction` with a `WorkspaceEdit` that inserts \`;\` at the diagnostic's start position
  - `code_action()` handler dispatches missing-semi diagnostics to the new helper before falling through to the existing L0010 contract-stub action
  - Imports `NumberOrString` from `tower_lsp::lsp_types` for the code-field check

## Detection strategy

Dual-pathed for forward compatibility:
- **Code-based**: \`diag.code == "E0002"\` — registered in \`diag::codes\` for "Unexpected/missing \`;\`". Today the parser leaves \`code: None\` on its LSP diagnostics; once it starts populating the field, this path will fire automatically.
- **Message-based**: matches when both an \`expected\`/\`missing\` modifier AND a \`;\` token are mentioned in the message. Handles current parser output like "expected ';' before keyword".

The detector is conservative — borderline matches are fine; the worst case is a lightbulb the user dismisses.

## Test plan

- [x] 9 unit tests added under \`lsp_server::tests\`:
  - 4 positive matches (apostrophes, backticks, word "semicolon", E0002 code)
  - 2 negative matches (unrelated parse errors, casual \`;\` mentions)
  - Action structure (title, kind, insert range, attached diagnostic)
  - End-to-end shape check (applied edit produces valid program)
- [x] \`cargo build --features lsp\` clean
- [x] \`cargo test --features lsp\` all green
- [x] \`cargo clippy --features lsp --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Default-feature test suite still green (no regression)

## Notes

This addresses the LSP-side of RES-190. The complementary parser-side work — emitting an actual E0002 diagnostic when a \`;\` is missing — is upstream work tracked separately. The code action is functional today against the current message-based parser output and ready for the cleaner E0002-coded path when that lands.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)