### PR TITLE
agent-scripts: fix guardrail cargo fmt invocation

### DIFF
--- a/agent-scripts/verify-scope.sh
+++ b/agent-scripts/verify-scope.sh
@@ -225,7 +225,10 @@ run_cargo() {
 }
 
 if (( SKIP_FMT == 0 )); then
-  run_cargo "cargo fmt --check" cargo fmt --all -- --check
+  # The repo has no top-level Cargo.toml, so `cargo fmt` from the
+  # repo root cannot find a manifest. Point it at the workspace
+  # crate the same way the clippy/test invocations below do.
+  run_cargo "cargo fmt --check" cargo fmt --manifest-path resilient/Cargo.toml --all -- --check
 fi
 if (( SKIP_CLIPPY == 0 )); then
   run_cargo "cargo clippy -D warnings" cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings


### PR DESCRIPTION
## Summary

\`agent-scripts/verify-scope.sh\` was invoking \`cargo fmt --all\` from the repo root. The repository has no top-level \`Cargo.toml\` (the workspace crate lives in \`resilient/\`), so \`cargo metadata\` couldn't find a manifest and rustfmt never ran — the guardrail surfaced a usage banner as if it were a format failure.

## Fix

Add \`--manifest-path resilient/Cargo.toml\` to the \`cargo fmt\` invocation, matching the existing clippy and test lines two and three below it.

## Impact

Tooling-only — no language or runtime change. Without this, every agent PR was blocked from the draft → ready transition by a guardrail bug rather than a real scope violation.

## Test plan

- [x] \`bash agent-scripts/verify-scope.sh\` reports \`PASS  cargo fmt --check\` on a clean main
- [x] \`agent-scripts/ready-or-bail.sh --dry-run\` produces \`Guardrail PASSED\` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)