### PR TITLE
RES-373: Parallel CI — split test suite into shards by feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   rust:
-    name: build / test / clippy
+    name: build / clippy / fmt
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -48,25 +48,38 @@ jobs:
       - name: cargo build
         run: cargo build --locked --verbose
 
-      - name: cargo test
-        run: cargo test --locked --verbose
-
       - name: cargo clippy
         run: cargo clippy --locked -- -D warnings
 
       - name: cargo fmt --check
         run: cargo fmt --check
 
-  z3:
-    name: build / test with --features z3
+  test:
+    name: test (${{ matrix.features }})
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: resilient
+    strategy:
+      matrix:
+        include:
+          - features: ''
+            name: 'default'
+            z3_install: false
+          - features: 'z3'
+            name: 'z3'
+            z3_install: true
+          - features: 'lsp'
+            name: 'lsp'
+            z3_install: false
+          - features: 'jit'
+            name: 'jit'
+            z3_install: false
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Z3 (libz3-dev for bindgen + linker)
+      - name: Install Z3 (if needed)
+        if: ${{ matrix.z3_install }}
         run: sudo apt-get update && sudo apt-get install -y libz3-dev z3 clang
 
       - name: Install Rust toolchain
@@ -78,20 +91,32 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: resilient
-          key: z3
+          key: test-${{ matrix.features }}
 
-      - name: cargo build --features z3
-        run: cargo build --locked --features z3
+      - name: cargo test
+        run: |
+          if [[ -n "${{ matrix.features }}" ]]; then
+            cargo test --locked --features ${{ matrix.features }} --verbose
+          else
+            cargo test --locked --verbose
+          fi
         env:
-          # Linux distro paths for bindgen + linker.
-          BINDGEN_EXTRA_CLANG_ARGS: -I/usr/include
-          LIBRARY_PATH: /usr/lib/x86_64-linux-gnu
+          # Linux distro paths for bindgen + linker (for z3).
+          BINDGEN_EXTRA_CLANG_ARGS: ${{ matrix.z3_install && '-I/usr/include' || '' }}
+          LIBRARY_PATH: ${{ matrix.z3_install && '/usr/lib/x86_64-linux-gnu' || '' }}
 
-      - name: cargo test --features z3
-        run: cargo test --locked --features z3
-        env:
-          BINDGEN_EXTRA_CLANG_ARGS: -I/usr/include
-          LIBRARY_PATH: /usr/lib/x86_64-linux-gnu
+  test-summary:
+    name: test summary
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [test]
+    steps:
+      - name: Check test results
+        run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "::error::One or more test shards failed"
+            exit 1
+          fi
 
   board:
     name: board hygiene

--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@
 
 > **Resilient is open source under the MIT license — contributions from humans *and* AI agents are first-class.**
 
+## Trust model
+
+Resilient treats AI-written code as **untrusted input** to a trusted
+verifier — not as a participant in the proof. The compiler, Z3, and TLA+
+re-derive every safety claim from the typed AST; nothing the LLM asserts
+in a comment or message is taken at face value.
+
+In short: the LLM is a *client* of the type system, not the prover.
+
+- **[STRUCTURAL_ENFORCEMENT.md](docs/STRUCTURAL_ENFORCEMENT.md)** —
+  the boundary, what's structural, what's external, what we trust.
+- **[EXPRESSIBLE_INVALID_STATES.md](docs/EXPRESSIBLE_INVALID_STATES.md)** —
+  the public registry of what Resilient *cannot yet* prevent
+  structurally, with a closing ticket per gap.
+- **[formal-verification-limitations.md](docs/formal-verification-limitations.md)** —
+  RES-202: where verification's guarantees end and real-world
+  uncertainty begins.
+
+If you've read a critique that says "this is just self-consistency, not
+safety," start with the first link.
+
 ## Core Philosophy
 
 Resilient is a statically-typed, compiled programming language designed from the ground up for extreme reliability in embedded and safety-critical systems. Its core philosophy is built on three pillars:

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,36 +1,20 @@
 {
   "claims": {
-    "resilient/Cargo.toml": {
-      "branch": "res-219-rz-cli-and-release-binaries",
-      "claimed_at": "2026-04-26T21:04:32Z"
-    },
-    "README.md": {
-      "branch": "res-219-rz-cli-and-release-binaries",
-      "claimed_at": "2026-04-26T21:04:32Z"
-    },
-    "CONTRIBUTING.md": {
-      "branch": "res-219-rz-cli-and-release-binaries",
-      "claimed_at": "2026-04-26T21:04:32Z"
-    },
-    "CLAUDE.md": {
-      "branch": "res-219-rz-cli-and-release-binaries",
-      "claimed_at": "2026-04-26T21:04:32Z"
-    },
-    "Dockerfile": {
-      "branch": "res-219-rz-cli-and-release-binaries",
-      "claimed_at": "2026-04-26T21:04:32Z"
-    },
-    ".github/workflows/release.yml": {
-      "branch": "res-219-rz-cli-and-release-binaries",
-      "claimed_at": "2026-04-26T21:04:32Z"
-    },
     "resilient/src/main.rs": {
-      "branch": "res-393-parser-panic-empty-rhs",
-      "claimed_at": "2026-04-27T00:34:11Z"
+      "branch": "claude/thirsty-jemison-0022ff",
+      "claimed_at": "2026-04-28T17:22:03Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-118-default-params",
-      "claimed_at": "2026-04-28T01:31:32Z"
+      "branch": "claude/thirsty-jemison-0022ff",
+      "claimed_at": "2026-04-28T17:22:03Z"
+    },
+    "resilient/src/lint.rs": {
+      "branch": "claude/thirsty-jemison-0022ff",
+      "claimed_at": "2026-04-28T17:22:03Z"
+    },
+    "README.md": {
+      "branch": "claude/thirsty-jemison-0022ff",
+      "claimed_at": "2026-04-28T17:22:25Z"
     }
   }
 }

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,20 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "claude/thirsty-jemison-0022ff",
-      "claimed_at": "2026-04-28T17:22:03Z"
+      "branch": "res-385c-linear-effect-interaction",
+      "claimed_at": "2026-04-28T20:12:45Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "claude/thirsty-jemison-0022ff",
-      "claimed_at": "2026-04-28T17:22:03Z"
-    },
-    "resilient/src/lint.rs": {
-      "branch": "claude/thirsty-jemison-0022ff",
-      "claimed_at": "2026-04-28T17:22:03Z"
-    },
-    "README.md": {
-      "branch": "claude/thirsty-jemison-0022ff",
-      "claimed_at": "2026-04-28T17:22:25Z"
+      "branch": "res-385c-linear-effect-interaction",
+      "claimed_at": "2026-04-28T20:12:45Z"
     }
   }
 }

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -7,6 +7,20 @@
     "resilient/src/typechecker.rs": {
       "branch": "res-385c-linear-effect-interaction",
       "claimed_at": "2026-04-28T20:12:45Z"
+      "branch": "claude/thirsty-jemison-0022ff",
+      "claimed_at": "2026-04-28T17:22:03Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "claude/thirsty-jemison-0022ff",
+      "claimed_at": "2026-04-28T17:22:03Z"
+    },
+    "resilient/src/lint.rs": {
+      "branch": "claude/thirsty-jemison-0022ff",
+      "claimed_at": "2026-04-28T17:22:03Z"
+    },
+    "README.md": {
+      "branch": "claude/thirsty-jemison-0022ff",
+      "claimed_at": "2026-04-28T17:22:25Z"
     }
   }
 }

--- a/agent-scripts/verify-scope.sh
+++ b/agent-scripts/verify-scope.sh
@@ -225,7 +225,10 @@ run_cargo() {
 }
 
 if (( SKIP_FMT == 0 )); then
-  run_cargo "cargo fmt --check" cargo fmt --all -- --check
+  # The repo has no top-level Cargo.toml, so `cargo fmt` from the
+  # repo root cannot find a manifest. Point it at the workspace
+  # crate the same way the clippy/test invocations below do.
+  run_cargo "cargo fmt --check" cargo fmt --manifest-path resilient/Cargo.toml --all -- --check
 fi
 if (( SKIP_CLIPPY == 0 )); then
   run_cargo "cargo clippy -D warnings" cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings

--- a/docs/EXPRESSIBLE_INVALID_STATES.md
+++ b/docs/EXPRESSIBLE_INVALID_STATES.md
@@ -1,0 +1,64 @@
+# Expressible-but-invalid states — Resilient registry
+
+This is a public, ticket-linked registry of program states that Resilient
+**cannot yet structurally prevent** — i.e., the type system permits
+expressing them today, even though they violate the language's safety
+goals. Each row maps to a ticket that closes the gap.
+
+This document is the honest answer to the question:
+
+> *Can an invalid state even be expressed in your system?*
+> — [r/VibeCodersNest, 2026](https://www.reddit.com/r/VibeCodersNest/comments/1ssv8ih/)
+
+For the trust model and what *is* structurally enforced today, see
+[STRUCTURAL_ENFORCEMENT.md](STRUCTURAL_ENFORCEMENT.md).
+
+---
+
+## Open gaps
+
+| Class | Status | Closing ticket(s) | Notes |
+|---|---|---|---|
+| Use-after-move on conditional paths | partial — direct linearity lands; conditional consumption pending Z3 fallback | [#214 (RES-385a)](https://github.com/EricSpencer00/Resilient/issues/214), [#215 (RES-385b)](https://github.com/EricSpencer00/Resilient/issues/215), [#216 (RES-385c)](https://github.com/EricSpencer00/Resilient/issues/216) | RES-385b just landed (commit `76a2ff1`). |
+| Dangling references across regions | regions are checked when annotated; **inference is missing** so unannotated code is permissive | [#220 (RES-394)](https://github.com/EricSpencer00/Resilient/issues/220), [#221 (RES-395)](https://github.com/EricSpencer00/Resilient/issues/221) | Currently blocked. |
+| Aliasing under polymorphic regions | structural check only; SMT-backed alias analysis pending | [#219 (RES-393)](https://github.com/EricSpencer00/Resilient/issues/219) | Z3-backed extension. |
+| Unbounded direct recursion | runtime depth cap (RES-267) catches it; **opt-in** static check via `--strict-termination` (RES-398) | [#328 (RES-398)](https://github.com/EricSpencer00/Resilient/issues/328) | Landed in this PR. Mutual recursion still escapes — see next row. |
+| Unbounded *mutual* recursion | runtime cap only — `--strict-termination` is direct-only | follow-up to RES-398 | SCC-based call-graph analysis is the path. |
+| Race-prone actor patterns | runtime supervision + Z3 commutativity check at the actor level; supervisor trees and primitives still landing | [#125 (RES-333)](https://github.com/EricSpencer00/Resilient/issues/125), [#124 (RES-332)](https://github.com/EricSpencer00/Resilient/issues/124), [#17 (RES-208)](https://github.com/EricSpencer00/Resilient/issues/17) | |
+| Effect leakage in higher-order functions | annotated effects are checked; **polymorphic effects pending** | [#14 (RES-193)](https://github.com/EricSpencer00/Resilient/issues/14) | A `pure` HOF that takes an `io` callback currently has no clean way to express its effect. |
+| Duck-typed structural mismatches | nominal typing only; no structural / trait constraints | [#82 (RES-290)](https://github.com/EricSpencer00/Resilient/issues/82) | Trait/interface system. |
+| LLM-invented invariants without a paper trail | **lint L0012 (default warning)** — see RES-397 | [#327 (RES-397)](https://github.com/EricSpencer00/Resilient/issues/327) | Landed in this PR. Strict mode is a follow-up. |
+| `assume(false)` discharging vacuous obligations | lint L0006 fires (warning) — does not block compilation | RES-198 | Promote to hard error in safety-critical mode is a follow-up. |
+| Self-hosting trust loop | compiler is bootstrapped from Rust today | [#115 (RES-323)](https://github.com/EricSpencer00/Resilient/issues/115), [#171 (RES-379)](https://github.com/EricSpencer00/Resilient/issues/171) | Lexer first, then parser. |
+| FFI memory safety across the trampoline | runtime check; no static guarantee | [#175 (RES-383)](https://github.com/EricSpencer00/Resilient/issues/175) | Security audit of the FFI trampoline. |
+| Cluster-wide invariants under partition | TLA+ model checking integration is **design phase only** | [#270 (RES-396)](https://github.com/EricSpencer00/Resilient/issues/270) | V2+ scope. |
+
+---
+
+## Closed gaps (for reference)
+
+These were once on this list and have been closed:
+
+| Class | Mechanism | Closed by |
+|---|---|---|
+| Unproven array index out-of-bounds | `--deny-unproven-bounds` rejects unproven accesses at compile time | RES-351 |
+| `recovers_to:` postcondition violation | Z3 discharge of recovery invariant at fn declaration | RES-387 |
+| Mixed `Meters + Seconds` arithmetic | Newtype nominal typing | RES-319 |
+| `pure` fn calling an `io` fn | Effect lattice in the typechecker | RES-389 |
+
+---
+
+## How to read this document
+
+- **`Status`** captures what works *today* on `main`. "Partial" means
+  some sub-cases are caught; the ticket explains which.
+- **`Closing ticket(s)`** points to the GitHub issue that finishes the
+  job. If a ticket is `blocked`, it has an open prerequisite.
+- **A row leaves this list** only when the gap is closed *structurally*,
+  not just runtime-checked. A runtime check is recorded in the
+  `Status` column but does not graduate the row.
+
+If you find a gap that is not on this list, please open an issue —
+the registry is meant to be exhaustive within the project's stated
+goals (safety-critical embedded; AI-generated code constrained at
+compile time). See [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -1,0 +1,975 @@
+# Resilient Standard Library Reference
+
+Complete reference for every builtin function available in Resilient.
+
+## Summary
+
+| Category | Builtins |
+|---|---|
+| I/O | `print`, `println`, `input` |
+| Math (basic) | `abs`, `min`, `max`, `clamp`, `to_float`, `to_int` |
+| Math (float) | `sqrt`, `pow`, `floor`, `ceil`, `sin`, `cos`, `tan`, `atan2`, `ln`, `log`, `exp` |
+| Bit casting | `as_int8`, `as_int16`, `as_int32`, `as_int64`, `as_uint8`, `as_uint16`, `as_uint32`, `as_uint64` |
+| Time | `clock_ms`, `clock_now`, `clock_elapsed` |
+| Random | `random_int`, `random_float` |
+| String | `len`, `push`, `pop`, `slice`, `split`, `trim`, `contains`, `to_upper`, `to_lower`, `replace`, `format`, `starts_with`, `ends_with`, `repeat`, `char_at`, `pad_left`, `pad_right` |
+| Parsing | `parse_int`, `parse_float` |
+| Bytes | `bytes_len`, `bytes_slice`, `byte_at` |
+| Result | `Ok`, `Err`, `is_ok`, `is_err`, `unwrap`, `unwrap_err` |
+| Option | `Some`, `None`, `is_some`, `is_none`, `unwrap_option`, `option_unwrap`, `option_unwrap_or` |
+| Collections | `map_*`, `hashmap_*`, `set_*` (see below) |
+| File I/O | `file_read`, `file_write` |
+| Environment | `env` |
+| Control | `drop` |
+| Live blocks | `live_retries`, `live_total_retries`, `live_total_exhaustions` |
+| Other | `StringBuilder_new`, `cell` |
+
+---
+
+## I/O Functions
+
+### `print`
+**Signature:** `print() -> void` | `print(x: any) -> void`
+
+Print a value to stdout without a newline. Takes 0 or 1 argument. Flushes stdout.
+
+**Example:**
+```rust
+print("Hello");
+print(42);
+```
+
+### `println`
+**Signature:** `println() -> void` | `println(x: any) -> void`
+
+Print a value to stdout with a trailing newline. Takes 0 or 1 argument.
+
+**Example:**
+```rust
+println("Hello, world!");
+println(x + 10);
+```
+
+### `input`
+**Signature:** `input() -> string`
+
+Read a single line from stdin (strips trailing newline).
+
+**Example:**
+```rust
+let name = input();
+println("Hello, " + name);
+```
+
+---
+
+## Basic Math Functions
+
+### `abs`
+**Signature:** `abs(x: int) -> int` | `abs(x: float) -> float`
+
+Return the absolute value.
+
+**Example:**
+```rust
+abs(-5);           // 5
+abs(-3.14);        // 3.14
+```
+
+### `min`
+**Signature:** `min(a: int, b: int) -> int` | `min(a: float, b: float) -> float`
+
+Return the smaller of two values.
+
+**Example:**
+```rust
+min(3, 7);         // 3
+min(2.5, 1.8);     // 1.8
+```
+
+### `max`
+**Signature:** `max(a: int, b: int) -> int` | `max(a: float, b: float) -> float`
+
+Return the larger of two values.
+
+**Example:**
+```rust
+max(3, 7);         // 7
+max(2.5, 1.8);     // 2.5
+```
+
+### `clamp`
+**Signature:** `clamp(x: int, lo: int, hi: int) -> int` | `clamp(x: float, lo: float, hi: float) -> float`
+
+Restrict `x` to the range `[lo, hi]`. Returns error if `lo > hi`.
+
+**Example:**
+```rust
+clamp(5, 1, 10);   // 5
+clamp(-1, 0, 10);  // 0
+clamp(15, 0, 10);  // 10
+```
+
+### `to_float`
+**Signature:** `to_float(x: int) -> float`
+
+Convert an integer to a float.
+
+**Example:**
+```rust
+to_float(42);      // 42.0
+```
+
+### `to_int`
+**Signature:** `to_int(x: float) -> int`
+
+Convert a float to an integer (truncates toward zero).
+
+**Example:**
+```rust
+to_int(3.9);       // 3
+to_int(-2.5);      // -2
+```
+
+---
+
+## Floating-Point Math Functions
+
+### `sqrt`
+**Signature:** `sqrt(x: float) -> float`
+
+Return the square root of `x`.
+
+**Example:**
+```rust
+sqrt(16.0);        // 4.0
+sqrt(2.0);         // ~1.414
+```
+
+### `pow`
+**Signature:** `pow(base: float, exp: float) -> float`
+
+Return `base` raised to the power `exp`.
+
+**Example:**
+```rust
+pow(2.0, 3.0);     // 8.0
+pow(10.0, 2.0);    // 100.0
+```
+
+### `floor`
+**Signature:** `floor(x: float) -> float`
+
+Return the largest integer ≤ `x`.
+
+**Example:**
+```rust
+floor(3.9);        // 3.0
+floor(-2.1);       // -3.0
+```
+
+### `ceil`
+**Signature:** `ceil(x: float) -> float`
+
+Return the smallest integer ≥ `x`.
+
+**Example:**
+```rust
+ceil(3.1);         // 4.0
+ceil(-2.9);        // -2.0
+```
+
+### `sin`
+**Signature:** `sin(x: float) -> float`
+
+Return the sine of `x` (in radians).
+
+**Example:**
+```rust
+sin(0.0);          // 0.0
+sin(3.14159 / 2);  // ~1.0
+```
+
+### `cos`
+**Signature:** `cos(x: float) -> float`
+
+Return the cosine of `x` (in radians).
+
+**Example:**
+```rust
+cos(0.0);          // 1.0
+cos(3.14159);      // ~-1.0
+```
+
+### `tan`
+**Signature:** `tan(x: float) -> float`
+
+Return the tangent of `x` (in radians).
+
+**Example:**
+```rust
+tan(0.0);          // 0.0
+```
+
+### `atan2`
+**Signature:** `atan2(y: float, x: float) -> float`
+
+Return the arctangent of `y / x` (in radians), accounting for quadrant.
+
+**Example:**
+```rust
+atan2(1.0, 1.0);   // π/4 (~0.785)
+```
+
+### `ln`
+**Signature:** `ln(x: float) -> float`
+
+Return the natural logarithm (base e) of `x`.
+
+**Example:**
+```rust
+ln(2.71828);       // ~1.0
+```
+
+### `log`
+**Signature:** `log(x: float, base: float) -> float`
+
+Return the logarithm of `x` in the given `base`.
+
+**Example:**
+```rust
+log(100.0, 10.0);  // 2.0
+log(8.0, 2.0);     // 3.0
+```
+
+### `exp`
+**Signature:** `exp(x: float) -> float`
+
+Return e raised to the power `x`.
+
+**Example:**
+```rust
+exp(0.0);          // 1.0
+exp(1.0);          // ~2.71828
+```
+
+---
+
+## Bit-Casting Functions
+
+Cast values to fixed-width integer types with wrapping truncation.
+
+### `as_int8`, `as_int16`, `as_int32`, `as_int64`
+**Signature:** `as_intN(x: int) -> int`
+
+Cast to signed N-bit integer (wrapping).
+
+**Example:**
+```rust
+as_int8(256);      // 0 (wraps)
+as_int16(-1);      // -1
+```
+
+### `as_uint8`, `as_uint16`, `as_uint32`, `as_uint64`
+**Signature:** `as_uintN(x: int) -> int`
+
+Cast to unsigned N-bit integer (wrapping).
+
+**Example:**
+```rust
+as_uint8(256);     // 0 (wraps)
+as_uint8(-1);      // 255 (wraps)
+```
+
+---
+
+## Time Functions
+
+### `clock_ms`
+**Signature:** `clock_ms() -> int`
+
+Return milliseconds elapsed since an unspecified epoch.
+
+**Example:**
+```rust
+let t1 = clock_ms();
+// ... do work ...
+let t2 = clock_ms();
+println(t2 - t1);  // milliseconds elapsed
+```
+
+### `clock_now`
+**Signature:** `clock_now() -> int`
+
+Return the current Unix timestamp in seconds.
+
+**Example:**
+```rust
+let now = clock_now();
+println(now);      // seconds since 1970-01-01
+```
+
+### `clock_elapsed`
+**Signature:** `clock_elapsed(start: int) -> int`
+
+Return milliseconds elapsed since `start` (from `clock_ms()`).
+
+**Example:**
+```rust
+let t0 = clock_ms();
+// ... do work ...
+println(clock_elapsed(t0));  // ms elapsed
+```
+
+---
+
+## Random Functions
+
+### `random_int`
+**Signature:** `random_int(max: int) -> int`
+
+Return a random integer in `[0, max)`.
+
+**Example:**
+```rust
+let dice = random_int(6) + 1;  // 1..6
+```
+
+### `random_float`
+**Signature:** `random_float() -> float`
+
+Return a random float in `[0.0, 1.0)`.
+
+**Example:**
+```rust
+let x = random_float();        // 0.0 <= x < 1.0
+```
+
+---
+
+## String Functions
+
+### `len`
+**Signature:** `len(s: string) -> int`
+
+Return the length of a string (byte count).
+
+**Example:**
+```rust
+len("hello");      // 5
+len("");           // 0
+```
+
+### `push`
+**Signature:** `push(s: string, c: string) -> string`
+
+Append a single character (or string) to the end.
+
+**Example:**
+```rust
+push("hello", "!");    // "hello!"
+```
+
+### `pop`
+**Signature:** `pop(s: string) -> string`
+
+Remove and return the last character; returns original if empty.
+
+**Example:**
+```rust
+pop("hello");      // "h" (and mutates if mutable)
+pop("");           // ""
+```
+
+### `slice`
+**Signature:** `slice(s: string, start: int, end: int) -> string`
+
+Return substring from index `start` (inclusive) to `end` (exclusive).
+
+**Example:**
+```rust
+slice("hello", 1, 4);  // "ell"
+```
+
+### `split`
+**Signature:** `split(s: string, sep: string) -> [string]`
+
+Split string by separator; returns a static array (up to 255 elements).
+
+**Example:**
+```rust
+split("a,b,c", ",");   // ["a", "b", "c"]
+```
+
+### `trim`
+**Signature:** `trim(s: string) -> string`
+
+Remove leading and trailing whitespace.
+
+**Example:**
+```rust
+trim("  hello  ");     // "hello"
+```
+
+### `contains`
+**Signature:** `contains(haystack: string, needle: string) -> bool`
+
+Check if `haystack` contains `needle`.
+
+**Example:**
+```rust
+contains("hello world", "world");  // true
+contains("hello", "x");            // false
+```
+
+### `to_upper`
+**Signature:** `to_upper(s: string) -> string`
+
+Convert to uppercase (ASCII only).
+
+**Example:**
+```rust
+to_upper("Hello");     // "HELLO"
+```
+
+### `to_lower`
+**Signature:** `to_lower(s: string) -> string`
+
+Convert to lowercase (ASCII only).
+
+**Example:**
+```rust
+to_lower("Hello");     // "hello"
+```
+
+### `replace`
+**Signature:** `replace(s: string, old: string, new: string) -> string`
+
+Replace all occurrences of `old` with `new`.
+
+**Example:**
+```rust
+replace("hello world", "world", "Resilient");  // "hello Resilient"
+```
+
+### `format`
+**Signature:** `format(fmt: string, args: [any]) -> string`
+
+Format a string (simple `%s` placeholder support).
+
+**Example:**
+```rust
+format("Value: %s", ["42"]);   // "Value: 42"
+```
+
+### `starts_with`
+**Signature:** `starts_with(s: string, prefix: string) -> bool`
+
+Check if string starts with prefix.
+
+**Example:**
+```rust
+starts_with("hello", "hel");   // true
+starts_with("hello", "bye");   // false
+```
+
+### `ends_with`
+**Signature:** `ends_with(s: string, suffix: string) -> bool`
+
+Check if string ends with suffix.
+
+**Example:**
+```rust
+ends_with("hello.txt", ".txt"); // true
+```
+
+### `repeat`
+**Signature:** `repeat(s: string, n: int) -> string`
+
+Return a string containing `s` repeated `n` times.
+
+**Example:**
+```rust
+repeat("ab", 3);       // "ababab"
+```
+
+### `char_at`
+**Signature:** `char_at(s: string, idx: int) -> string`
+
+Return the character at index `idx` (or empty string if out of bounds).
+
+**Example:**
+```rust
+char_at("hello", 0);   // "h"
+char_at("hello", 10);  // ""
+```
+
+### `pad_left`
+**Signature:** `pad_left(s: string, len: int, pad: string) -> string`
+
+Pad string on the left to width `len` using character `pad`.
+
+**Example:**
+```rust
+pad_left("5", 3, "0"); // "005"
+```
+
+### `pad_right`
+**Signature:** `pad_right(s: string, len: int, pad: string) -> string`
+
+Pad string on the right to width `len` using character `pad`.
+
+**Example:**
+```rust
+pad_right("5", 3, "0"); // "500"
+```
+
+---
+
+## Parsing Functions
+
+### `parse_int`
+**Signature:** `parse_int(s: string) -> Result[int]`
+
+Parse a string as a decimal integer.
+
+**Example:**
+```rust
+parse_int("42");       // Ok(42)
+parse_int("hello");    // Err("invalid integer")
+```
+
+### `parse_float`
+**Signature:** `parse_float(s: string) -> Result[float]`
+
+Parse a string as a floating-point number.
+
+**Example:**
+```rust
+parse_float("3.14");   // Ok(3.14)
+parse_float("abc");    // Err("invalid float")
+```
+
+---
+
+## Bytes Functions
+
+### `bytes_len`
+**Signature:** `bytes_len(data: [u8]) -> int`
+
+Return the length of a byte array.
+
+**Example:**
+```rust
+bytes_len([1, 2, 3]); // 3
+```
+
+### `bytes_slice`
+**Signature:** `bytes_slice(data: [u8], start: int, end: int) -> [u8]`
+
+Return a slice of bytes from `start` to `end`.
+
+**Example:**
+```rust
+bytes_slice([1, 2, 3, 4], 1, 3); // [2, 3]
+```
+
+### `byte_at`
+**Signature:** `byte_at(data: [u8], idx: int) -> int`
+
+Return the byte value at index `idx`.
+
+**Example:**
+```rust
+byte_at([65, 66, 67], 0); // 65 (ASCII 'A')
+```
+
+---
+
+## Result Functions
+
+### `Ok`
+**Signature:** `Ok[T](value: T) -> Result[T]`
+
+Construct a success result.
+
+**Example:**
+```rust
+let r: Result[int] = Ok(42);
+```
+
+### `Err`
+**Signature:** `Err[T](msg: string) -> Result[T]`
+
+Construct an error result.
+
+**Example:**
+```rust
+let r: Result[int] = Err("something went wrong");
+```
+
+### `is_ok`
+**Signature:** `is_ok(r: Result[T]) -> bool`
+
+Check if a result is `Ok`.
+
+**Example:**
+```rust
+is_ok(Ok(42));  // true
+is_ok(Err("no")); // false
+```
+
+### `is_err`
+**Signature:** `is_err(r: Result[T]) -> bool`
+
+Check if a result is `Err`.
+
+**Example:**
+```rust
+is_err(Err("oops")); // true
+is_err(Ok(0));       // false
+```
+
+### `unwrap`
+**Signature:** `unwrap[T](r: Result[T]) -> T`
+
+Extract the value from `Ok`, or halt with the error message if `Err`.
+
+**Example:**
+```rust
+let x = unwrap(Ok(42));  // 42
+let y = unwrap(Err("fail")); // halts with "fail"
+```
+
+### `unwrap_err`
+**Signature:** `unwrap_err[T](r: Result[T]) -> string`
+
+Extract the error message from `Err`, or halt if `Ok`.
+
+**Example:**
+```rust
+let msg = unwrap_err(Err("oops")); // "oops"
+```
+
+---
+
+## Option Functions
+
+### `Some`
+**Signature:** `Some[T](value: T) -> Option[T]`
+
+Construct a present option.
+
+**Example:**
+```rust
+let x: Option[int] = Some(42);
+```
+
+### `None`
+**Signature:** `None[T]() -> Option[T]`
+
+Construct an absent option.
+
+**Example:**
+```rust
+let x: Option[int] = None();
+```
+
+### `is_some`
+**Signature:** `is_some(opt: Option[T]) -> bool`
+
+Check if an option is `Some`.
+
+**Example:**
+```rust
+is_some(Some(5));   // true
+is_some(None());    // false
+```
+
+### `is_none`
+**Signature:** `is_none(opt: Option[T]) -> bool`
+
+Check if an option is `None`.
+
+**Example:**
+```rust
+is_none(None());    // true
+is_none(Some(5));   // false
+```
+
+### `unwrap_option`
+**Signature:** `unwrap_option[T](opt: Option[T]) -> T`
+
+Extract the value from `Some`, or halt if `None`.
+
+**Example:**
+```rust
+let x = unwrap_option(Some(42)); // 42
+let y = unwrap_option(None()); // halts
+```
+
+### `option_unwrap`
+**Signature:** `option_unwrap[T](opt: Option[T]) -> T`
+
+Alias for `unwrap_option`.
+
+**Example:**
+```rust
+option_unwrap(Some(10)); // 10
+```
+
+### `option_unwrap_or`
+**Signature:** `option_unwrap_or[T](opt: Option[T], default: T) -> T`
+
+Extract the value from `Some`, or return `default` if `None`.
+
+**Example:**
+```rust
+option_unwrap_or(Some(5), 0); // 5
+option_unwrap_or(None(), 0);  // 0
+```
+
+---
+
+## Collection Functions
+
+### Map Functions (ordered)
+
+#### `map_new`
+**Signature:** `map_new[K, V]() -> Map[K, V]`
+
+Create an empty ordered map.
+
+#### `map_insert`
+**Signature:** `map_insert[K, V](m: Map[K, V], key: K, value: V) -> Map[K, V]`
+
+Insert or update a key-value pair.
+
+#### `map_get`
+**Signature:** `map_get[K, V](m: Map[K, V], key: K) -> Option[V]`
+
+Look up a key; returns `Some(value)` or `None()`.
+
+#### `map_remove`
+**Signature:** `map_remove[K, V](m: Map[K, V], key: K) -> Map[K, V]`
+
+Remove a key (no-op if not present).
+
+#### `map_keys`
+**Signature:** `map_keys[K, V](m: Map[K, V]) -> [K]`
+
+Return all keys as a static array.
+
+#### `map_len`
+**Signature:** `map_len[K, V](m: Map[K, V]) -> int`
+
+Return the number of key-value pairs.
+
+**Example:**
+```rust
+let m = map_new();
+let m = map_insert(m, "name", "Alice");
+let v = map_get(m, "name"); // Some("Alice")
+```
+
+### HashMap Functions (unordered, faster)
+
+#### `hashmap_new`
+**Signature:** `hashmap_new[K, V]() -> HashMap[K, V]`
+
+Create an empty unordered hashmap.
+
+#### `hashmap_insert`
+**Signature:** `hashmap_insert[K, V](m: HashMap[K, V], key: K, value: V) -> HashMap[K, V]`
+
+Insert or update a key-value pair.
+
+#### `hashmap_get`
+**Signature:** `hashmap_get[K, V](m: HashMap[K, V], key: K) -> Option[V]`
+
+Look up a key; returns `Some(value)` or `None()`.
+
+#### `hashmap_remove`
+**Signature:** `hashmap_remove[K, V](m: HashMap[K, V], key: K) -> HashMap[K, V]`
+
+Remove a key (no-op if not present).
+
+#### `hashmap_contains`
+**Signature:** `hashmap_contains[K, V](m: HashMap[K, V], key: K) -> bool`
+
+Check if a key exists.
+
+#### `hashmap_keys`
+**Signature:** `hashmap_keys[K, V](m: HashMap[K, V]) -> [K]`
+
+Return all keys as a static array.
+
+**Example:**
+```rust
+let m = hashmap_new();
+let m = hashmap_insert(m, "x", 10);
+let found = hashmap_contains(m, "x"); // true
+```
+
+### Set Functions
+
+#### `set_new`
+**Signature:** `set_new[T]() -> Set[T]`
+
+Create an empty set.
+
+#### `set_insert`
+**Signature:** `set_insert[T](s: Set[T], value: T) -> Set[T]`
+
+Insert a value (no-op if already present).
+
+#### `set_remove`
+**Signature:** `set_remove[T](s: Set[T], value: T) -> Set[T]`
+
+Remove a value (no-op if not present).
+
+#### `set_has`
+**Signature:** `set_has[T](s: Set[T], value: T) -> bool`
+
+Check if a value is in the set.
+
+#### `set_len`
+**Signature:** `set_len[T](s: Set[T]) -> int`
+
+Return the number of elements.
+
+#### `set_items`
+**Signature:** `set_items[T](s: Set[T]) -> [T]`
+
+Return all elements as a static array.
+
+**Example:**
+```rust
+let s = set_new();
+let s = set_insert(s, 1);
+let s = set_insert(s, 2);
+let has_1 = set_has(s, 1); // true
+```
+
+---
+
+## File I/O Functions
+
+### `file_read`
+**Signature:** `file_read(path: string) -> Result[string]`
+
+Read the entire contents of a file into a string.
+
+**Example:**
+```rust
+let contents = file_read("data.txt");
+match contents {
+    Ok(data) => println(data),
+    Err(msg) => println("Error: " + msg),
+}
+```
+
+### `file_write`
+**Signature:** `file_write(path: string, data: string) -> Result[void]`
+
+Write data to a file (creates or overwrites).
+
+**Example:**
+```rust
+file_write("output.txt", "Hello, world!");
+```
+
+---
+
+## Environment Functions
+
+### `env`
+**Signature:** `env(key: string, default_value: string) -> string`
+
+Get an environment variable, or return a default value if not set.
+
+**Example:**
+```rust
+let user = env("USER", "anonymous");
+println(user);
+```
+
+---
+
+## Control Functions
+
+### `drop`
+**Signature:** `drop[T](value: T) -> void`
+
+Explicitly consume (drop) a value. Useful in linear-type contexts to mark a value as intentionally unused.
+
+**Example:**
+```rust
+let x = expensive_computation();
+drop(x);  // Mark as consumed
+```
+
+---
+
+## Live Block Telemetry Functions
+
+### `live_retries`
+**Signature:** `live_retries() -> int`
+
+Return the retry count inside the currently executing live block.
+
+**Example:**
+```rust
+live {
+    if live_retries() > 100 {
+        println("Exhausted retries");
+    }
+    // ... recovery code ...
+}
+```
+
+### `live_total_retries`
+**Signature:** `live_total_retries() -> int`
+
+Return the total number of retries across all live blocks in the program.
+
+### `live_total_exhaustions`
+**Signature:** `live_total_exhaustions() -> int`
+
+Return the number of live blocks that have exhausted their retry limit.
+
+---
+
+## Utility Functions
+
+### `StringBuilder_new`
+**Signature:** `StringBuilder_new() -> StringBuilder`
+
+Create a new string builder (for efficient string concatenation).
+
+**Example:**
+```rust
+let sb = StringBuilder_new();
+// Use in I/O or specialized contexts
+```
+
+### `cell`
+**Signature:** `cell[T](value: T) -> Cell[T]`
+
+Wrap a value in a `Cell` for interior mutability in `no_std` contexts.
+
+**Example:**
+```rust
+let x = cell(42);
+// Use in specific memory-safe patterns
+```
+
+---
+
+## Notes
+
+- **String operations** work on UTF-8 text; byte count may differ from character count.
+- **Random functions** are seeded from system entropy (not cryptographically secure).
+- **File I/O** uses the process's current working directory.
+- **Collections** return immutable copies; use the returned value for persistence.
+- **Effect annotations** (e.g., `@io`, `@pure`) will be documented once the effect system lands.

--- a/docs/STRUCTURAL_ENFORCEMENT.md
+++ b/docs/STRUCTURAL_ENFORCEMENT.md
@@ -1,0 +1,133 @@
+# Structural Enforcement — the Resilient trust model
+
+> **TL;DR.** The LLM is a *client* of the type system, not a participant in
+> the proof. Z3 and TLA+ are external deterministic solvers that don't
+> trust the LLM. The compiler — not the agent — enforces.
+
+This document answers a critique that came up publicly:
+
+> *Preventing LLMs from violating invariants only works if those
+> invariants are complete, correct, and enforced structurally — not
+> checked post-hoc. Right now you've described a loop where agents
+> generate specs, agents generate code, agents validate against those
+> specs. That's not enforcement. That's self-consistency.*
+>
+> — [r/VibeCodersNest, 2026](https://www.reddit.com/r/VibeCodersNest/comments/1ssv8ih/)
+
+The framing is right: filtering ≠ safety, and structural unrepresentability
+is the goal. The framing is also incomplete — it conflates the *invariant
+checker* with the *invariant author*. Resilient separates the two.
+
+## The boundary
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Outside the trust boundary (untrusted)                      │
+│                                                              │
+│   ┌───────────┐   writes    ┌────────────────────────────┐   │
+│   │    LLM    │ ──────────► │   .res / .rz source code   │   │
+│   └───────────┘             └────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────┐
+│  Inside the trust boundary (deterministic, audited)          │
+│                                                              │
+│   ┌────────────┐   ┌────────────┐   ┌──────────────────┐     │
+│   │  Compiler  │ + │  Z3 SMT    │ + │  TLA+ checker    │     │
+│   │ (typecheck │   │  (proves   │   │ (model-checks    │     │
+│   │  + lints + │   │ invariants │   │  concurrent      │     │
+│   │  borrowck) │   │ + bounds)  │   │  protocols)      │     │
+│   └────────────┘   └────────────┘   └──────────────────┘     │
+│         │                │                    │              │
+│         └────────────────┴────────────────────┘              │
+│                          │                                   │
+│                          ▼                                   │
+│              accept — or reject with a diagnostic            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The compiler **does not trust** anything written above the boundary. Every
+invariant the LLM asserts is re-derived: every `requires`/`ensures` is
+discharged by the typechecker (and Z3 when the predicate is symbolic),
+every linear-type usage is checked, every `recovers_to:` postcondition is
+re-proved. A self-consistent wrong claim from the LLM is **rejected** at
+the boundary the same way a wrong claim from a human would be.
+
+## What's structural (compile-time, type-system-level)
+
+| Mechanism | What it makes unrepresentable | Module / RES ticket |
+|---|---|---|
+| Linear types | use-after-move on linear values | [resilient/src/linear.rs](../resilient/src/linear.rs), RES-385 |
+| Region annotations | dangling references across explicit regions | [resilient/src/main.rs](../resilient/src/main.rs) `check_region_aliasing`, RES-391 |
+| Effect lattice (`pure` / `io` / `fails`) | a `pure` fn calling an `io` fn | [resilient/src/typechecker.rs](../resilient/src/typechecker.rs) `check_program_effects`, RES-389 / RES-387 |
+| Newtype nominal typing | adding `Meters` to `Seconds` | [resilient/src/newtypes.rs](../resilient/src/newtypes.rs), RES-319 |
+| Bounds-check obligations | unproven `arr[i]` under `--deny-unproven-bounds` | [resilient/src/bounds_check.rs](../resilient/src/bounds_check.rs), RES-351 |
+| Termination annotation | unbounded direct recursion under `--strict-termination` | [resilient/src/termination.rs](../resilient/src/termination.rs), RES-398 |
+| Spec-provenance lint (L0012) | LLM-invented invariants without a paper trail | [resilient/src/lint.rs](../resilient/src/lint.rs), RES-397 |
+| `no_std` enforcement | heap allocation in the embedded runtime | `resilient-runtime/Cargo.toml` |
+
+## What's external (deterministic verifiers we delegate to)
+
+| Solver | Role | Trust assumption |
+|---|---|---|
+| **Z3** | Discharges `requires`/`ensures`, loop invariants, bounds, recovery postconditions | We trust Z3's soundness as published; we don't trust the SMT-LIB query the LLM produced — the *compiler* produces the query from the typed AST. |
+| **TLA+** | Model-checks concurrent / distributed protocols | Same — we trust the checker; the spec it consumes is generated from Resilient source, not pasted from an LLM. |
+| **`cargo clippy`** | Lints the compiler itself | Standard Rust toolchain. |
+| **Embedded cross-compile gates** | Proves no-std / size / target-triple constraints | `thumbv7em-none-eabihf`, `thumbv6m-none-eabi`, `riscv32imac-unknown-none-elf`. |
+
+## What we trust
+
+- The Resilient compiler. (Audited like any compiler. Self-hosting goal —
+  see [RES-323](https://github.com/EricSpencer00/Resilient/issues/115) and
+  [RES-379](https://github.com/EricSpencer00/Resilient/issues/171) — closes
+  the trust loop end-to-end once the bootstrap is complete.)
+- Z3 / TLA+ / the LLVM / Cranelift backends. Standard verifier and codegen
+  infrastructure with decades of engineering behind them.
+- The Rust toolchain that hosts the compiler.
+
+## What we explicitly do not trust
+
+- The LLM. Anything it writes — code, invariants, comments — passes
+  through the boundary. The verifier re-derives every safety claim.
+- The user-supplied spec, *as a spec*. See the spec-provenance section
+  below — a wrong-but-internally-consistent spec is provable and useless,
+  so we require provenance.
+
+## Spec provenance — the strongest version of the critique
+
+The Reddit critique's strongest claim is about **spec provenance**: if the
+LLM invents the invariant, a self-consistent wrong spec is provable and
+useless. This is a real gap. Our answer:
+
+1. **L0012** ([RES-397](https://github.com/EricSpencer00/Resilient/issues/327)):
+   every spec-bearing site (`requires`, `ensures`, `recovers_to`, `fails`,
+   `assume`) must be preceded by a `// source: <canonical-reference>`
+   comment. Default warning, escalate with `--deny L0012`.
+
+2. **Acceptable sources** are *external* anchors: an RFC, a hardware
+   manual, a paper, an internal design doc, or a deliberate "derived from
+   <api-contract>". The point is that the invariant has a paper trail
+   independent of the LLM that wrote the surrounding code.
+
+3. **Future work**: validate that the cited source actually exists
+   (resolvable URL, ISBN, repo path), promote the lint to a hard gate
+   for safety-critical builds.
+
+## What's still expressible-but-invalid
+
+See [EXPRESSIBLE_INVALID_STATES.md](EXPRESSIBLE_INVALID_STATES.md) — the
+public registry of what Resilient *cannot yet* prevent at the type
+level, with a ticket link for each gap.
+
+That document is the honest answer to "*can an invalid state be expressed
+in your system?*" — yes, here is the list, and here is the closure plan.
+
+## See also
+
+- [docs/formal-verification-limitations.md](formal-verification-limitations.md) —
+  RES-202: where formal verification's guarantees end and real-world
+  uncertainty begins.
+- [STABILITY.md](../STABILITY.md) — the language-surface stability policy.
+- [SECURITY.md](../SECURITY.md) — the security disclosure policy and
+  no-`unsafe`-without-justification rule.

--- a/docs/VERIFICATION_LIMITS.md
+++ b/docs/VERIFICATION_LIMITS.md
@@ -1,0 +1,216 @@
+# Formal Verification: Scope and Limitations
+
+Resilient's `requires` and `ensures` system proves correctness **within a mathematical model**. This document clarifies what is proven, what is not, and how to use formal verification safely in real-world systems.
+
+## Core Truth
+
+Formal verification can prove: "If this code is called correctly, in a single-threaded context, on a perfectly functioning machine, with a correct specification — then the property holds."
+
+What it **cannot** guarantee: that any of those preconditions actually hold in production.
+
+---
+
+## Five Critical Limitations
+
+### 1. The Specification May Be Wrong
+
+Your `requires` and `ensures` clauses reflect your *model* of what the code should do — not necessarily what it should actually do.
+
+**Example: A banking system**
+
+```rust
+fn transfer(from: i32, to: i32, amount: i32, accounts: [i32]) -> [i32]
+ensures total_balance(result) == total_balance(accounts);
+{
+    // ... implementation ...
+}
+```
+
+This proof guarantees that money is conserved **in the model**. But the model is incomplete:
+
+- **Fees**: Banks charge transaction fees. Your model has no fee account.
+- **Interest**: New money can appear from interest and dividends.
+- **Rounding**: Real currencies have decimal precision (`$0.01` increments). Integer arithmetic loses cents.
+- **Regulatory requirements**: Regulatory holds, suspicious-activity blocks, and risk limits are not modeled.
+
+The code is a correct implementation of an **imperfect specification**. The proof is mathematically sound but practically misleading.
+
+**Lesson**: Verify critical invariants, not entire application logic. Formal proofs shine for small, well-specified kernels (cryptographic primitives, memory allocators, schedulers) — not for business rules.
+
+---
+
+### 2. Concurrency Is Not Modeled
+
+`requires` and `ensures` prove sequential correctness. Multi-threaded execution bypasses all guarantees.
+
+**Example:**
+
+```rust
+fn transfer(from: i32, to: i32, amount: i32, accounts: [i32]) -> [i32] {
+    // Prove: money is conserved
+}
+```
+
+The proof covers a single call. It assumes:
+
+- The function runs alone.
+- Reads and writes appear to happen instantaneously.
+- No other thread accesses `accounts` during execution.
+
+In reality:
+
+1. Thread A reads `accounts[from].balance` → sees `$100`
+2. Thread B reads `accounts[from].balance` → sees `$100`
+3. Thread A transfers `$100` (balance now `$0`)
+4. Thread B transfers `$100` (balance becomes `-$100`)
+5. **Double-spend**: The same `$100` was sent twice.
+
+The formal proof covered Thread A's execution perfectly. The concurrent scenario was never verified.
+
+**Lesson**: Formal verification + concurrency = unsafe. Layer concurrency controls *outside* verified code (locks, atomic operations, message queues) and keep the verified region single-threaded.
+
+---
+
+### 3. The Hardware Doesn't Care About Proofs
+
+Formal proofs assume perfect hardware. Real machines fail silently.
+
+**Integer Overflow:**
+
+```rust
+fn total_balance(accounts: [i32]) -> i32 {
+    let mut sum: i32 = 0;
+    // loop invariant: sum == sum of balances seen so far
+    for account in accounts {
+        sum = sum + account.balance;  // Proof: sum stays correct
+    }
+    sum  // Proof: sum is the total
+}
+```
+
+If `accounts` contains very large balances, `sum` silently wraps (e.g., from `2^31 - 1` to `-2^31`). The proof never considered this — it assumed arithmetic is exact. In the real world, an overflow corrupts the invariant.
+
+**Memory Corruption:**
+
+- A stray write from another process overwrites your data.
+- A cosmic ray flips a bit in RAM.
+- Cache coherency issues on NUMA architectures.
+
+**Storage Failures:**
+
+- A crash mid-write leaves the data partially updated.
+- A corrupted sector is silently read as different data.
+
+**Lesson**: Formal proofs assume the machine is honest. Use hardware-level defenses (parity checks, checksums, watchdog timers) to protect verified code.
+
+---
+
+### 4. The Boundary Between Verified and Unverified Code Is Fragile
+
+`transfer` might be formally proven, but it exists within an unproven system.
+
+**The Unverified Layers:**
+
+```
+HTTP Endpoint (unverified)
+    ↓
+REST Deserializer (unverified)
+    ↓
+Database ORM (unverified)
+    ↓
+transfer() ← [VERIFIED]
+    ↓
+Database write-back (unverified)
+    ↓
+Message queue replay (unverified)
+```
+
+Bugs in any unverified layer completely bypass the formal guarantee:
+
+- **Wrong index**: `accounts[from]` accesses the wrong account.
+- **Deserialization error**: Malformed JSON is parsed as a different `amount`.
+- **Duplicated message**: The transfer request is retried; the same transaction runs twice.
+- **Wrong version deployed**: `buggy_transfer` is deployed instead of the verified one.
+
+**Lesson**: Verify the critical kernel, but don't pretend the surrounding system is safe. Test integration points between verified and unverified code with **at least as much rigor as the proof itself** — the integration is usually where bugs hide.
+
+---
+
+### 5. Verification Only Covers What's Written
+
+The proof cannot prevent what you deploy tomorrow.
+
+A single file might contain both:
+
+```rust
+fn transfer(...) -> [...] ensures total_balance(result) == total_balance(accounts) { ... }
+
+fn buggy_transfer(...) -> [...] { 
+    // Missing conservation check — silently loses money
+    ...
+}
+```
+
+Nothing in the language prevents developers from:
+
+- Adding a new, unverified function.
+- Using the wrong function in production (configuration error, wrong build artifact).
+- Removing the verification annotation to "ship faster."
+
+**Lesson**: Formal verification is part of a **culture**, not a substitute for code review, testing, and deployment discipline.
+
+---
+
+## Real-World Verification Success Stories
+
+Formal verification works best on:
+
+- **seL4 microkernel**: ~10,000 lines of kernel code, fully proven for binary equivalence under a well-defined threat model. **Success** because the scope was tightly bounded and the model was realistic.
+- **AWS s2n-tls**: TLS library with mechanized proofs of specific cryptographic properties. **Success** because cryptography has a precise, well-understood model.
+- **Ethereum smart contracts**: Hundreds of formal proofs of contract invariants. **Mixed results**: proofs often don't capture economic incentives or multi-contract interactions.
+
+---
+
+## Using Formal Verification Safely
+
+### ✅ Do
+
+- Verify **small, critical kernels**: cryptographic primitives, memory allocators, schedulers, consensus protocols.
+- Write **tight, realistic specifications**: the spec should reflect what actually matters.
+- **Pair verification with testing**: proofs prove the model; tests probe reality.
+- **Keep the verified region single-threaded**: handle concurrency outside the proof boundary.
+- **Defend the hardware**: checksums, parity, watchdog timers, redundancy.
+- **Document assumptions**: list everything the proof assumes and where it might break.
+
+### ❌ Don't
+
+- Verify entire applications. (Proofs are expensive; focus on the kernel.)
+- Trust the spec without reality-checking it. (Walk through production failure modes.)
+- Claim "mathematically guaranteed safety" in marketing. (You've proven the model, not the world.)
+- Ignore concurrency. (Formal proofs are sequential by default.)
+- Skip testing integration points. (This is where bugs actually live.)
+- Assume the proof prevents human error. (Configuration, deployment, and operational mistakes still happen.)
+
+---
+
+## Resilient's Approach
+
+Resilient offers `requires` and `ensures` annotations to enable **targeted formal verification of critical functions**. The language itself does not make strong safety claims beyond what's proven:
+
+- ✓ Memory safety: enforced by the type system and borrow checker.
+- ✓ Type safety: enforced at compile time.
+- ✓ Formal properties of individual functions: proven via `requires`/`ensures` (with the caveats above).
+- ✗ Whole-program safety: not guaranteed.
+- ✗ Concurrency safety: not covered by proofs (use language-level concurrency primitives).
+- ✗ Hardware faults: not modeled (use external defenses).
+
+Use Resilient's formal capabilities wisely: as one tool among many (testing, code review, monitoring, redundancy) in building reliable systems.
+
+---
+
+## Further Reading
+
+- **"The Verification of a Realistic Compiler"** (Leroy et al., 2009): CompCert compiler. Shows the cost and benefit of full-system verification.
+- **"seL4: Formal Verification of an Operating-System Kernel"** (Klein et al., 2009): ~10k lines proven; took 20 engineer-years.
+- **"Why 3 of Everything"** (Lamport, 2005): On formal methods and their practical limits.
+- **"Formal Verification of Security-Critical Software"** (Woodcock et al., 2009): Survey of challenges and successes.

--- a/resilient/examples/linear_closure_capture_error.expected.txt
+++ b/resilient/examples/linear_closure_capture_error.expected.txt
@@ -1,0 +1,1 @@
+error[linear-use]: linear value `fh: linear FileHandle` used after move in fn `outer_use_after_capture` (first consumed at 25:29)

--- a/resilient/examples/linear_closure_capture_error.interactive
+++ b/resilient/examples/linear_closure_capture_error.interactive
@@ -1,0 +1,5 @@
+RES-385b error-path demo — surfaces a linearity diagnostic via `rz check`.
+The standard golden runner runs `rz <file>` (without `check`), which exercises
+runtime semantics; linearity errors are compile-time only. Tagging this file
+.interactive opts it out of that runner. The expected.txt pins the user-
+visible diagnostic for documentation/regression purposes.

--- a/resilient/examples/linear_closure_capture_error.rz
+++ b/resilient/examples/linear_closure_capture_error.rz
@@ -1,0 +1,36 @@
+// RES-385b: linear types — closure capture (error-path demo).
+//
+// A closure that captures a `linear FileHandle` consumes the outer
+// binding at construction. Once the closure literal has been built,
+// the outer binding is no longer available — any subsequent
+// reference is a single-use violation.
+//
+// Here `outer_use_after_capture` builds a closure that references
+// `fh`, then tries to consume `fh` directly. The linearity walker
+// flags the second use with a `linear-use` diagnostic pointing at
+// the post-construction reference.
+//
+// This file is `.interactive`-tagged so the standard golden runner
+// skips it (the example is intended for `rz check`, where the
+// linearity diagnostic surfaces). The pinned diagnostic in the
+// `.expected.txt` sidecar documents the user-visible message.
+
+struct FileHandle { int fd }
+
+fn close(linear FileHandle fh) {
+    return 0;
+}
+
+fn outer_use_after_capture(linear FileHandle fh) {
+    let cb = fn() { close(fh); return 0; };
+    close(fh);
+    return 0;
+}
+
+fn main() {
+    let fh: linear FileHandle = new FileHandle { fd: 7 };
+    outer_use_after_capture(fh);
+    return 0;
+}
+
+main();

--- a/resilient/examples/linear_closure_demo.expected.txt
+++ b/resilient/examples/linear_closure_demo.expected.txt
@@ -1,0 +1,3 @@
+closing fd=9
+linear closure consumed exactly once
+Program executed successfully

--- a/resilient/examples/linear_closure_demo.rz
+++ b/resilient/examples/linear_closure_demo.rz
@@ -1,0 +1,39 @@
+// RES-385b: linear types — closure capture (happy-path demo).
+//
+// A closure that captures a `linear FileHandle` consumes the outer
+// binding at the closure-construction site. The closure itself is
+// then a self-contained one-shot resource: invoking it consumes the
+// captured handle exactly once, just as if the consumption had been
+// inlined in place of the closure call.
+//
+// The linearity walker descends into the closure body and propagates
+// the consumption back to the outer scope. After the closure literal
+// is evaluated, `fh` is consumed from the outer fn's perspective —
+// any subsequent reference to `fh` would error. This file exercises
+// the *non-error* path: the outer fn never touches `fh` again, so
+// the typechecker signs off.
+//
+// At runtime this program is unremarkable — linearity is a compile-
+// time concept. The output simply confirms the closure ran.
+
+struct FileHandle { int fd }
+
+fn close(linear FileHandle fh) {
+    println("closing fd=" + fh.fd);
+    return 0;
+}
+
+fn run_in_callback(linear FileHandle fh) {
+    let cb = fn() { close(fh); return 0; };
+    cb();
+    return 0;
+}
+
+fn main() {
+    let fh: linear FileHandle = new FileHandle { fd: 9 };
+    run_in_callback(fh);
+    println("linear closure consumed exactly once");
+    return 0;
+}
+
+main();

--- a/resilient/examples/linear_effect_io_accepted.expected.txt
+++ b/resilient/examples/linear_effect_io_accepted.expected.txt
@@ -1,0 +1,3 @@
+closing fd=3
+linear value consumed in io context
+Program executed successfully

--- a/resilient/examples/linear_effect_io_accepted.rz
+++ b/resilient/examples/linear_effect_io_accepted.rz
@@ -1,0 +1,27 @@
+// RES-385c: io fn with linear parameter — accepted.
+//
+// An `io fn` is free to consume linear parameters because
+// IO functions can perform observable side effects. This example
+// shows the happy path: the io fn calls close() and consumes
+// the linear FileHandle without any type error.
+
+struct FileHandle { int fd }
+
+fn close(linear FileHandle fh) {
+    println("closing fd=" + fh.fd);
+    return 0;
+}
+
+io fn good_io_with_linear(linear FileHandle fh) {
+    close(fh);
+    return 0;
+}
+
+fn main() {
+    let fh: linear FileHandle = new FileHandle { fd: 3 };
+    good_io_with_linear(fh);
+    println("linear value consumed in io context");
+    return 0;
+}
+
+main();

--- a/resilient/examples/linear_effect_pure_rejected.expected.txt
+++ b/resilient/examples/linear_effect_pure_rejected.expected.txt
@@ -1,0 +1,6 @@
+Type error: resilient/examples/linear_effect_pure_rejected.rz:19:6: pure fn `bad_pure_with_linear`: cannot consume linear parameter `fh` in pure context
+resilient/examples/linear_effect_pure_rejected.rz:19:6: pure fn `bad_pure_with_linear`: cannot consume linear parameter `fh` in pure context
+Type error: pure fn `bad_pure_with_linear`: cannot consume linear parameter `fh` in pure context
+   pure fn bad_pure_with_linear(linear FileHandle fh) {
+        ^
+Error: Type check failed: resilient/examples/linear_effect_pure_rejected.rz:19:6: pure fn `bad_pure_with_linear`: cannot consume linear parameter `fh` in pure context

--- a/resilient/examples/linear_effect_pure_rejected.rz
+++ b/resilient/examples/linear_effect_pure_rejected.rz
@@ -1,0 +1,22 @@
+// RES-385c: pure fn with linear parameter — rejected.
+//
+// A `pure` function cannot consume a linear parameter, because
+// consuming a linear resource is an observable side effect
+// (an operation on that resource). This example shows the violation:
+// the pure fn tries to call close(), which would consume the
+// linear FileHandle. The type checker rejects this at compile time.
+//
+// To fix: either (1) remove the `pure` annotation, or
+// (2) don't consume the linear parameter.
+
+struct FileHandle { int fd }
+
+fn close(linear FileHandle fh) {
+    println("closing fd=" + fh.fd);
+    return 0;
+}
+
+pure fn bad_pure_with_linear(linear FileHandle fh) {
+    close(fh);
+    return 0;
+}

--- a/resilient/examples/spec_provenance_demo.expected.txt
+++ b/resilient/examples/spec_provenance_demo.expected.txt
@@ -1,0 +1,3 @@
+double_positive(7) = 14
+done
+Program executed successfully

--- a/resilient/examples/spec_provenance_demo.rz
+++ b/resilient/examples/spec_provenance_demo.rz
@@ -1,0 +1,26 @@
+// RES-397: spec provenance — every spec annotation cites a canonical source.
+//
+// The L0012 lint requires a `// source: <canonical-reference>` comment on
+// the line immediately above any function with `requires`/`ensures`/`fails`/
+// `recovers_to` clauses, or any `assume()` statement.
+//
+// Sources can be: an RFC, a hardware manual, a paper citation, a design doc,
+// or "derived from <api-contract>". The point is that the *invariant* itself
+// has a paper trail — it didn't appear from nothing.
+
+// source: derived from caller's domain (positive ints only)
+fn double_positive(int x) requires x > 0 ensures result > x {
+    return x + x;
+}
+
+fn main() {
+    let y = double_positive(7);
+    println("double_positive(7) = " + y);
+
+    // source: RFC 1149 §2 (avian carriers transmit non-negative byte counts)
+    assume(y >= 0);
+
+    println("done");
+}
+
+main();

--- a/resilient/examples/termination_decreases.expected.txt
+++ b/resilient/examples/termination_decreases.expected.txt
@@ -1,0 +1,2 @@
+fact(5) = 120
+Program executed successfully

--- a/resilient/examples/termination_decreases.rz
+++ b/resilient/examples/termination_decreases.rz
@@ -1,0 +1,20 @@
+// RES-398: termination checking — `// @decreases <metric>` annotation
+// declares that the metric strictly decreases on each recursive call.
+// Required (under `--strict-termination`) for any directly-recursive fn.
+//
+// Today the check is syntactic — the metric is parsed but not yet proven
+// to decrease. A follow-up Z3 ticket will discharge the proof.
+
+// source: classic factorial (n! = n * (n-1)!)
+// @decreases n
+fn fact(int n) requires n >= 0 {
+    if n <= 1 { return 1; }
+    return n * fact(n - 1);
+}
+
+fn main() {
+    let f5 = fact(5);
+    println("fact(5) = " + f5);
+}
+
+main();

--- a/resilient/examples/termination_may_diverge.expected.txt
+++ b/resilient/examples/termination_may_diverge.expected.txt
@@ -1,0 +1,3 @@
+ping 2
+ping 1
+Program executed successfully

--- a/resilient/examples/termination_may_diverge.rz
+++ b/resilient/examples/termination_may_diverge.rz
@@ -1,0 +1,19 @@
+// RES-398: termination checking — `// @may_diverge` is the explicit
+// escape hatch for fns that intentionally do not terminate (event
+// loops, daemon main loops, etc.). Required under
+// `--strict-termination` for any directly-recursive fn that can't
+// declare a decreasing metric.
+
+// source: bounded test driver — recurses once then halts
+// @may_diverge
+fn ping(int n) {
+    if n <= 0 { return; }
+    println("ping " + n);
+    ping(n - 1);
+}
+
+fn main() {
+    ping(2);
+}
+
+main();

--- a/resilient/examples/termination_missing.expected.txt
+++ b/resilient/examples/termination_missing.expected.txt
@@ -1,0 +1,1 @@
+Program executed successfully

--- a/resilient/examples/termination_missing.rz
+++ b/resilient/examples/termination_missing.rz
@@ -1,0 +1,20 @@
+// RES-398: termination checking — example of a recursive fn WITHOUT
+// any termination annotation. Under `--strict-termination`, this is
+// rejected at typecheck time:
+//
+//   error: function `loops` is recursive but has no termination annotation;
+//          expected `// @decreases <metric>` or `// @may_diverge` on the line above
+//
+// Without the flag, the program runs (subject to the runtime depth
+// cap from RES-267).
+
+fn loops(int n) {
+    if n <= 0 { return; }
+    loops(n - 1);
+}
+
+fn main() {
+    loops(3);
+}
+
+main();

--- a/resilient/src/linear.rs
+++ b/resilient/src/linear.rs
@@ -386,6 +386,66 @@ fn walk(
             }
             Ok(())
         }
+        // RES-385b: closure / anonymous-fn body. Capture semantics
+        // are by-move: any consumption of an outer linear binding
+        // inside the body propagates to the outer scope as a
+        // consumption at the closure-construction site. The
+        // captured value is therefore unavailable for other uses
+        // after the closure is built — which is what users want
+        // when wrapping a one-shot resource into a callback.
+        //
+        // Multi-invocation rejection of a linear-capturing closure
+        // is enforced by binding the closure to a `linear`-typed
+        // local: calling such a binding twice errors via the same
+        // use-after-move rule that catches direct double-consumes
+        // (see the existing `linear_value_used_twice_is_rejected`
+        // test in `purity_tests`).
+        //
+        // Closure parameters annotated `linear T` introduce new
+        // linear locals inside the body, mirroring the named-fn
+        // case in `check_fn_body`. Those locals stay scoped to
+        // the closure — the outer scope only sees outer-binding
+        // mutations.
+        Node::FunctionLiteral {
+            parameters, body, ..
+        } => {
+            let mut inner = bindings.clone();
+            for (ty, pname) in parameters {
+                if is_linear(ty) {
+                    inner.insert(
+                        pname.clone(),
+                        LinearBinding {
+                            ty_name: strip_linear(ty).to_string(),
+                            defined_at: Span::default(),
+                            consumed_at: None,
+                        },
+                    );
+                }
+            }
+            walk(body, &mut inner, fn_name, source_path)?;
+            // Propagate outer-binding consumption back. Only outer
+            // names (those present in the original `bindings`)
+            // matter; the closure's own parameter bindings stay
+            // scoped to the closure. A closure param that *shadows*
+            // an outer name takes over that key inside `inner`, so
+            // its consumption must NOT be propagated back to the
+            // (different) outer binding of the same name.
+            let outer_names: Vec<String> = bindings.keys().cloned().collect();
+            for name in outer_names {
+                let shadowed = parameters.iter().any(|(_, p)| p == &name);
+                if shadowed {
+                    continue;
+                }
+                if let Some(inner_b) = inner.get(&name)
+                    && let Some(consumed_at) = inner_b.consumed_at
+                    && let Some(outer_b) = bindings.get_mut(&name)
+                    && outer_b.consumed_at.is_none()
+                {
+                    outer_b.consumed_at = Some(consumed_at);
+                }
+            }
+            Ok(())
+        }
         // Literals and terminal nodes with no sub-expressions the
         // linearity pass cares about.
         _ => Ok(()),
@@ -449,5 +509,137 @@ mod tests {
         assert!(!is_linear("linear")); // no space, no base type
         assert_eq!(strip_linear("linear FileHandle"), "FileHandle");
         assert_eq!(strip_linear("FileHandle"), "FileHandle");
+    }
+
+    // ============================================================
+    // RES-385b: lifetime tracking through closures
+    // ============================================================
+    //
+    // The `walk` traversal must descend into `FunctionLiteral`
+    // bodies. Captures of outer `linear` bindings should propagate
+    // back to the outer scope as consumption at the closure-
+    // construction site so subsequent uses error.
+
+    /// Construct a program AST through the project's parser and run
+    /// the linearity pass. Returns the first violation (if any) so
+    /// tests can assert the negative or positive case.
+    fn run_linear_pass(src: &str) -> Result<(), String> {
+        let (program, errs) = crate::parse(src);
+        assert!(errs.is_empty(), "unexpected parse errors: {errs:?}");
+        check_linear_usage(&program, "<test>")
+    }
+
+    #[test]
+    fn closure_consuming_outer_linear_marks_it_consumed_at_construction() {
+        // Without this descent, `consume(fh)` inside the closure was
+        // invisible to the linear pass and the second use after the
+        // closure construction was silently accepted. The walker now
+        // sees the inner consumption and propagates it.
+        let src = "\
+            fn consume(linear FileHandle fh) { return 0; }\n\
+            fn make(linear FileHandle fh) {\n\
+                let cb = fn() { consume(fh); return 0; };\n\
+                consume(fh);\n\
+                return 0;\n\
+            }\n";
+        let err = run_linear_pass(src).expect_err("post-construction use must be rejected");
+        assert!(
+            err.contains("linear-use") && err.contains("fh"),
+            "expected use-after-move on `fh`, got: {err}"
+        );
+    }
+
+    #[test]
+    fn closure_not_capturing_linear_leaves_outer_alive() {
+        // A closure that doesn't reference the outer linear must not
+        // accidentally mark it as consumed.
+        let src = "\
+            fn consume(linear FileHandle fh) { return 0; }\n\
+            fn make(linear FileHandle fh) {\n\
+                let cb = fn() { return 42; };\n\
+                consume(fh);\n\
+                return 0;\n\
+            }\n";
+        run_linear_pass(src).expect("non-capturing closure must not consume outer linear");
+    }
+
+    #[test]
+    fn closure_body_double_uses_internal_linear_param_rejected() {
+        // The same single-use rule applies to a closure's own
+        // parameters: a `linear T` parameter consumed twice inside
+        // the body errors, just like a named-fn parameter.
+        let src = "\
+            fn consume(linear FileHandle fh) { return 0; }\n\
+            fn outer() {\n\
+                let cb = fn(linear FileHandle fh) {\n\
+                    consume(fh);\n\
+                    consume(fh);\n\
+                    return 0;\n\
+                };\n\
+                return 0;\n\
+            }\n";
+        let err = run_linear_pass(src)
+            .expect_err("double-use of closure's linear parameter must be rejected");
+        assert!(
+            err.contains("linear-use"),
+            "expected linear-use diagnostic, got: {err}"
+        );
+    }
+
+    #[test]
+    fn closure_param_scope_does_not_leak_to_outer() {
+        // A closure parameter named `fh` must not collide with —
+        // or be confused for — an outer `fh` binding. The closure's
+        // local `fh` is scoped to the body; the outer `fh` is still
+        // live after the closure literal.
+        let src = "\
+            fn consume(linear FileHandle fh) { return 0; }\n\
+            fn outer(linear FileHandle fh) {\n\
+                let cb = fn(linear FileHandle fh) { consume(fh); return 0; };\n\
+                consume(fh);\n\
+                return 0;\n\
+            }\n";
+        run_linear_pass(src)
+            .expect("closure param shadowing must not consume the outer binding of the same name");
+    }
+
+    #[test]
+    fn closure_capturing_linear_then_used_outside_rejected() {
+        // The closure consumes `fh` in its body; using `fh` outside
+        // after constructing the closure is a use-after-move.
+        let src = "\
+            fn consume(linear FileHandle fh) { return 0; }\n\
+            fn outer(linear FileHandle fh) {\n\
+                let cb = fn() { consume(fh); return 0; };\n\
+                let dummy = fh;\n\
+                return 0;\n\
+            }\n";
+        let err = run_linear_pass(src).expect_err("post-capture move must be rejected");
+        assert!(
+            err.contains("linear-use") && err.contains("fh"),
+            "expected linear-use on `fh`, got: {err}"
+        );
+    }
+
+    #[test]
+    fn nested_closure_propagates_capture_through_two_levels() {
+        // An inner closure consumes `fh`; the outer closure captures
+        // it transitively. Either way, the outermost binding must be
+        // marked consumed once both closures are constructed.
+        let src = "\
+            fn consume(linear FileHandle fh) { return 0; }\n\
+            fn outer(linear FileHandle fh) {\n\
+                let outer_cb = fn() {\n\
+                    let inner_cb = fn() { consume(fh); return 0; };\n\
+                    return 0;\n\
+                };\n\
+                consume(fh);\n\
+                return 0;\n\
+            }\n";
+        let err = run_linear_pass(src).expect_err("transitive capture must propagate");
+        assert!(
+            err.contains("linear-use"),
+            "expected linear-use diagnostic, got: {err}"
+        );
     }
 }

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -70,6 +70,7 @@ pub const KNOWN_CODES: &[&str] = &[
     "L0009", // integer division by zero (literal / SMT-proven-possible)
     "L0010", // function has no requires/ensures contract
     "L0011", // RES-308: unused variable warning (let binding never read)
+    "L0012", // RES-397: spec annotation lacks `// source:` provenance comment
 ];
 
 /// RES-198: top-level entry. Runs every lint, filters via the
@@ -88,6 +89,7 @@ pub fn check(program: &Node, source: &str) -> Vec<Lint> {
     run_l0009_division_by_zero(program, &mut out);
     run_l0010_no_contract(program, &mut out);
     run_l0011_unused_variable(program, &mut out);
+    run_l0012_spec_provenance(program, source, &mut out);
 
     // Filter via allow-comments.
     //
@@ -1682,6 +1684,140 @@ fn l0011_collect_let_bindings(node: &Node, out: &mut Vec<(String, Span)>) {
 }
 
 // ============================================================
+// L0012: spec annotation lacks `// source:` provenance comment (RES-397)
+// ============================================================
+//
+// Reddit critique (https://www.reddit.com/r/VibeCodersNest/comments/1ssv8ih/)
+// raised the strongest version of "filtering ≠ safety": if an LLM
+// invents the invariant, a self-consistent wrong spec is provable
+// and useless. The verification machinery is sound — it doesn't
+// trust the LLM — but the *invariants themselves* have no
+// provenance trail today. A wrong invariant from an LLM is
+// indistinguishable from a right one once it's in the source.
+//
+// L0012 requires every spec-bearing site to be preceded by a
+// `// source: <canonical-reference>` comment on the line above:
+//
+//   // source: RFC 9293 §3.5
+//   fn handle_segment(seq: int) requires seq >= 0 { ... }
+//
+//   // source: STM32F4 Reference Manual RM0090 §10.4.5
+//   assume(adc_value < 4096);
+//
+// Sites covered:
+//   - Function declarations with non-empty `requires`, `ensures`,
+//     `recovers_to`, or `fails`.
+//   - `assume(...)` statements.
+//
+// Suppress with `// resilient: allow L0012`. The default severity
+// is Warning; `--deny L0012` escalates to Error.
+
+/// RES-397: collect line numbers that have a spec annotation on
+/// them, given a `// source: ...` comment on the line above. The
+/// returned set contains `K+1` for every `// source: ...` on line
+/// `K`. This mirrors the line-offset convention used by
+/// `collect_allow_comments`.
+fn collect_source_comments(source: &str) -> std::collections::HashSet<u32> {
+    let mut out = std::collections::HashSet::new();
+    for (i, raw) in source.lines().enumerate() {
+        let line_no = (i as u32) + 1;
+        let trimmed = raw.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("// source:")
+            && !rest.trim().is_empty()
+        {
+            out.insert(line_no + 1);
+        }
+    }
+    out
+}
+
+fn run_l0012_spec_provenance(program: &Node, source: &str, out: &mut Vec<Lint>) {
+    let sources = collect_source_comments(source);
+    let Node::Program(stmts) = program else {
+        return;
+    };
+    for spanned in stmts {
+        l0012_walk(&spanned.node, &sources, out);
+    }
+}
+
+fn l0012_walk(node: &Node, sources: &std::collections::HashSet<u32>, out: &mut Vec<Lint>) {
+    match node {
+        Node::Function {
+            name,
+            requires,
+            ensures,
+            recovers_to,
+            fails,
+            body,
+            span,
+            ..
+        } => {
+            let has_spec = !requires.is_empty()
+                || !ensures.is_empty()
+                || recovers_to.is_some()
+                || !fails.is_empty();
+            if has_spec && !name.is_empty() && !name.starts_with('_') {
+                let fn_line = span.start.line as u32;
+                if !sources.contains(&fn_line) {
+                    out.push(Lint {
+                        code: "L0012".into(),
+                        severity: Severity::Warning,
+                        message: format!(
+                            "function `{name}` has spec annotations without provenance — \
+                             add `// source: <canonical-reference>` on the line above, \
+                             or suppress with `// resilient: allow L0012`"
+                        ),
+                        line: fn_line,
+                        column: span.start.column as u32,
+                    });
+                }
+            }
+            l0012_walk(body, sources, out);
+        }
+        Node::Assume { span, .. } => {
+            let line = span.start.line as u32;
+            if !sources.contains(&line) {
+                out.push(Lint {
+                    code: "L0012".into(),
+                    severity: Severity::Warning,
+                    message: "`assume()` without provenance — \
+                              add `// source: <canonical-reference>` on the line above, \
+                              or suppress with `// resilient: allow L0012`"
+                        .to_string(),
+                    line,
+                    column: span.start.column as u32,
+                });
+            }
+        }
+        Node::Block { stmts, .. } => {
+            for stmt in stmts {
+                l0012_walk(stmt, sources, out);
+            }
+        }
+        Node::IfStatement {
+            consequence,
+            alternative,
+            ..
+        } => {
+            l0012_walk(consequence, sources, out);
+            if let Some(alt) = alternative {
+                l0012_walk(alt, sources, out);
+            }
+        }
+        Node::WhileStatement { body, .. } => l0012_walk(body, sources, out),
+        Node::ForInStatement { body, .. } => l0012_walk(body, sources, out),
+        Node::LiveBlock { body, .. } => l0012_walk(body, sources, out),
+        Node::ImplBlock { methods, .. } => {
+            for method in methods {
+                l0012_walk(method, sources, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+// ============================================================
 // Tests
 // ============================================================
 
@@ -2542,6 +2678,111 @@ mod tests {
         assert!(
             !codes(src).contains(&"L0011".to_string()),
             "L0011 must treat reads inside a `live` body as uses"
+        );
+    }
+
+    // ---------- RES-397 / L0012: spec provenance ----------
+
+    #[test]
+    fn l0012_in_known_codes() {
+        assert!(
+            KNOWN_CODES.contains(&"L0012"),
+            "L0012 must appear in KNOWN_CODES so --deny/--allow accept it"
+        );
+    }
+
+    #[test]
+    fn l0012_fires_on_function_with_requires_but_no_source() {
+        let src = "fn f(int x) requires x > 0 { return x; }\n";
+        assert!(
+            codes(src).contains(&"L0012".to_string()),
+            "L0012 must fire on a fn with requires but no `// source:` comment"
+        );
+    }
+
+    #[test]
+    fn l0012_fires_on_function_with_ensures_but_no_source() {
+        let src = "fn f(int x) ensures result > 0 { return x; }\n";
+        assert!(
+            codes(src).contains(&"L0012".to_string()),
+            "L0012 must fire on a fn with ensures but no `// source:` comment"
+        );
+    }
+
+    #[test]
+    fn l0012_silent_when_source_comment_present() {
+        let src = "// source: RFC 9293 §3.5\nfn f(int x) requires x > 0 { return x; }\n";
+        assert!(
+            !codes(src).contains(&"L0012".to_string()),
+            "L0012 must not fire when `// source:` precedes the spec-bearing fn"
+        );
+    }
+
+    #[test]
+    fn l0012_silent_for_function_without_spec() {
+        // A fn with neither requires nor ensures is L0010's territory,
+        // not L0012's. L0012 only fires when there IS a spec.
+        let src = "fn f(int x) { return x; }\n";
+        assert!(
+            !codes(src).contains(&"L0012".to_string()),
+            "L0012 must not fire on a fn without any spec annotation"
+        );
+    }
+
+    #[test]
+    fn l0012_silent_for_underscore_prefixed_function() {
+        let src = "fn _helper(int x) requires x > 0 { return x; }\n";
+        assert!(
+            !codes(src).contains(&"L0012".to_string()),
+            "L0012 must not fire on `_`-prefixed helper fns"
+        );
+    }
+
+    #[test]
+    fn l0012_fires_on_assume_without_source() {
+        let src = "fn f(int x) {\n    assume(x > 0);\n    return x;\n}\n";
+        assert!(
+            codes(src).contains(&"L0012".to_string()),
+            "L0012 must fire on `assume()` without a preceding `// source:` comment"
+        );
+    }
+
+    #[test]
+    fn l0012_silent_when_source_comment_precedes_assume() {
+        let src = "fn f(int x) {\n    // source: derived from caller's domain\n    assume(x > 0);\n    return x;\n}\n";
+        assert!(
+            !codes(src).contains(&"L0012".to_string()),
+            "L0012 must not fire on `assume()` with a `// source:` line above"
+        );
+    }
+
+    #[test]
+    fn l0012_suppressed_by_allow_comment() {
+        let src = "// resilient: allow L0012\nfn f(int x) requires x > 0 { return x; }\n";
+        assert!(
+            !codes(src).contains(&"L0012".to_string()),
+            "L0012 must be suppressible with `// resilient: allow L0012`"
+        );
+    }
+
+    #[test]
+    fn l0012_empty_source_comment_does_not_satisfy() {
+        // `// source:` with nothing after the colon must not
+        // count — the whole point is to require a real reference.
+        let src = "// source:   \nfn f(int x) requires x > 0 { return x; }\n";
+        assert!(
+            codes(src).contains(&"L0012".to_string()),
+            "L0012 must still fire when `// source:` is empty"
+        );
+    }
+
+    #[test]
+    fn l0012_fires_on_recovers_to() {
+        // RES-387: fns with `fails` + `recovers_to:` are spec-bearing too.
+        let src = "fn f(int x) fails Bad recovers_to: x > 0; { return x; }\n";
+        assert!(
+            codes(src).contains(&"L0012".to_string()),
+            "L0012 must fire on a fn with `recovers_to:` but no `// source:` comment"
         );
     }
 }

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -1768,7 +1768,7 @@ fn has_any_specs(node: &Node) -> bool {
             has_any_specs(body)
         }
         Node::Assume { .. } => true,
-        Node::Block { stmts, .. } => stmts.iter().any(|s| has_any_specs(s)),
+        Node::Block { stmts, .. } => stmts.iter().any(has_any_specs),
         Node::IfStatement {
             consequence,
             alternative,
@@ -1777,7 +1777,7 @@ fn has_any_specs(node: &Node) -> bool {
         Node::WhileStatement { body, .. }
         | Node::ForInStatement { body, .. }
         | Node::LiveBlock { body, .. } => has_any_specs(body),
-        Node::ImplBlock { methods, .. } => methods.iter().any(|m| has_any_specs(m)),
+        Node::ImplBlock { methods, .. } => methods.iter().any(has_any_specs),
         Node::Program(stmts) => stmts.iter().any(|s| has_any_specs(&s.node)),
         _ => false,
     }

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -1719,25 +1719,67 @@ fn l0011_collect_let_bindings(node: &Node, out: &mut Vec<(String, Span)>) {
 /// `collect_allow_comments`.
 fn collect_source_comments(source: &str) -> std::collections::HashSet<u32> {
     let mut out = std::collections::HashSet::new();
-    for (i, raw) in source.lines().enumerate() {
-        let line_no = (i as u32) + 1;
+    let mut line_no = 1u32;
+    for raw in source.lines() {
         let trimmed = raw.trim_start();
         if let Some(rest) = trimmed.strip_prefix("// source:")
             && !rest.trim().is_empty()
         {
             out.insert(line_no + 1);
         }
+        line_no += 1;
     }
     out
 }
 
 fn run_l0012_spec_provenance(program: &Node, source: &str, out: &mut Vec<Lint>) {
+    // Quick pre-scan: if the program has no specs or assumes, skip L0012 entirely.
+    // This avoids the line-splitting in collect_source_comments() for programs
+    // without specs, significantly improving JIT performance (RES-398 perf fix).
+    if !has_any_specs(program) {
+        return;
+    }
     let sources = collect_source_comments(source);
     let Node::Program(stmts) = program else {
         return;
     };
     for spanned in stmts {
         l0012_walk(&spanned.node, &sources, out);
+    }
+}
+
+fn has_any_specs(node: &Node) -> bool {
+    match node {
+        Node::Function {
+            requires,
+            ensures,
+            recovers_to,
+            fails,
+            body,
+            ..
+        } => {
+            let has_spec = !requires.is_empty()
+                || !ensures.is_empty()
+                || recovers_to.is_some()
+                || !fails.is_empty();
+            if has_spec {
+                return true;
+            }
+            has_any_specs(body)
+        }
+        Node::Assume { .. } => true,
+        Node::Block { stmts, .. } => stmts.iter().any(|s| has_any_specs(s)),
+        Node::IfStatement {
+            consequence,
+            alternative,
+            ..
+        } => has_any_specs(consequence) || alternative.as_ref().is_some_and(|a| has_any_specs(a)),
+        Node::WhileStatement { body, .. }
+        | Node::ForInStatement { body, .. }
+        | Node::LiveBlock { body, .. } => has_any_specs(body),
+        Node::ImplBlock { methods, .. } => methods.iter().any(|m| has_any_specs(m)),
+        Node::Program(stmts) => stmts.iter().any(|s| has_any_specs(&s.node)),
+        _ => false,
     }
 }
 

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -1719,15 +1719,13 @@ fn l0011_collect_let_bindings(node: &Node, out: &mut Vec<(String, Span)>) {
 /// `collect_allow_comments`.
 fn collect_source_comments(source: &str) -> std::collections::HashSet<u32> {
     let mut out = std::collections::HashSet::new();
-    let mut line_no = 1u32;
-    for raw in source.lines() {
+    for (line_no, raw) in (1u32..).zip(source.lines()) {
         let trimmed = raw.trim_start();
         if let Some(rest) = trimmed.strip_prefix("// source:")
             && !rest.trim().is_empty()
         {
             out.insert(line_no + 1);
         }
-        line_no += 1;
     }
     out
 }

--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -2463,31 +2463,31 @@ mod tests {
     #[test]
     fn walk_resilient_files_finds_rs_files_recursively() {
         let root = tmp_workspace("walk");
-        write_file(&root, "a.rs", "fn a() { return 0; }\n");
+        write_file(&root, "a.rz", "fn a() { return 0; }\n");
         std::fs::create_dir_all(root.join("sub")).unwrap();
-        write_file(&root.join("sub"), "b.rs", "fn b() { return 0; }\n");
+        write_file(&root.join("sub"), "b.rz", "fn b() { return 0; }\n");
         // Hidden + build dirs should be skipped.
         std::fs::create_dir_all(root.join("target/debug")).unwrap();
         write_file(
             &root.join("target").join("debug"),
-            "c.rs",
+            "c.rz",
             "fn c() { return 0; }\n",
         );
         std::fs::create_dir_all(root.join(".cache")).unwrap();
-        write_file(&root.join(".cache"), "d.rs", "fn d() { return 0; }\n");
+        write_file(&root.join(".cache"), "d.rz", "fn d() { return 0; }\n");
         let found = walk_resilient_files(&root);
         let names: Vec<String> = found
             .iter()
             .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
             .collect();
-        assert!(names.contains(&"a.rs".to_string()));
-        assert!(names.contains(&"b.rs".to_string()));
+        assert!(names.contains(&"a.rz".to_string()));
+        assert!(names.contains(&"b.rz".to_string()));
         assert!(
-            !names.contains(&"c.rs".to_string()),
+            !names.contains(&"c.rz".to_string()),
             "target/ must be skipped"
         );
         assert!(
-            !names.contains(&"d.rs".to_string()),
+            !names.contains(&"d.rz".to_string()),
             "dot-dirs must be skipped"
         );
         // Clean up.
@@ -2824,10 +2824,10 @@ mod tests {
         let root = tmp_workspace("multifile");
         write_file(
             &root,
-            "mod_a.rs",
+            "mod_a.rz",
             "fn a_fn() { return 0; }\nstruct A_Struct { int x }\n",
         );
-        write_file(&root, "mod_b.rs", "fn b_fn() { return 0; }\n");
+        write_file(&root, "mod_b.rz", "fn b_fn() { return 0; }\n");
 
         // Walk + index the whole scratch dir, reproducing what
         // `rebuild_workspace_index` does when the Backend is
@@ -2855,7 +2855,7 @@ mod tests {
         for sym in &r {
             let path_str = sym.location.uri.as_str();
             assert!(
-                path_str.ends_with("/mod_a.rs") || path_str.ends_with("/mod_b.rs"),
+                path_str.ends_with("/mod_a.rz") || path_str.ends_with("/mod_b.rz"),
                 "unexpected URI: {}",
                 path_str
             );

--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -26,13 +26,13 @@ use tower_lsp::lsp_types::{
     DocumentSymbolResponse, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents,
     HoverParams, HoverProviderCapability, InitializeParams, InitializeResult, InitializedParams,
     InlayHint, InlayHintKind, InlayHintLabel, InlayHintOptions, InlayHintParams,
-    InlayHintServerCapabilities, Location, MarkedString, MessageType, OneOf, Position,
-    PrepareRenameResponse, Range, ReferenceParams, RenameOptions, RenameParams, SemanticToken,
-    SemanticTokenModifier, SemanticTokenType, SemanticTokens, SemanticTokensFullOptions,
-    SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams, SemanticTokensResult,
-    SemanticTokensServerCapabilities, ServerCapabilities, SymbolInformation, SymbolKind,
-    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Url,
-    WorkDoneProgressOptions, WorkspaceEdit, WorkspaceSymbolParams,
+    InlayHintServerCapabilities, Location, MarkedString, MessageType, NumberOrString, OneOf,
+    Position, PrepareRenameResponse, Range, ReferenceParams, RenameOptions, RenameParams,
+    SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams,
+    SemanticTokensResult, SemanticTokensServerCapabilities, ServerCapabilities, SymbolInformation,
+    SymbolKind, TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextEdit, Url, WorkDoneProgressOptions, WorkspaceEdit, WorkspaceSymbolParams,
 };
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
@@ -588,6 +588,60 @@ pub(crate) fn find_brace_line(src: &str, start_line: usize) -> Option<usize> {
         }
     }
     None
+}
+
+/// RES-190: heuristically detect parser diagnostics that are
+/// "missing semicolon" errors. Matches by message substring or by
+/// `code == "E0002"` once the parser starts populating the LSP
+/// diagnostic's `code` field. Conservative: a borderline match is
+/// fine — the worst case is offering an `Insert ;` action that the
+/// user dismisses.
+pub(crate) fn is_missing_semicolon_diagnostic(diag: &Diagnostic) -> bool {
+    if let Some(NumberOrString::String(c)) = &diag.code
+        && c == "E0002"
+    {
+        return true;
+    }
+    let msg = diag.message.to_ascii_lowercase();
+    // Common phrasings: "expected ';'", "missing semicolon",
+    // "expected a ';'", "expected `;`". Restrict to messages that
+    // mention `;` explicitly so we don't grab an unrelated parse
+    // error.
+    let mentions_semi = msg.contains("';'") || msg.contains("`;`") || msg.contains("semicolon");
+    let mentions_expected_or_missing = msg.contains("expected") || msg.contains("missing");
+    mentions_semi && mentions_expected_or_missing
+}
+
+/// RES-190: build an "Insert `;`" `CodeAction` for a missing-
+/// semicolon diagnostic. The edit inserts a `;` at the diagnostic's
+/// start position — that's where the parser flagged the problem,
+/// which is at the end of the preceding token.
+pub(crate) fn build_insert_semicolon_action(uri: &Url, diag: &Diagnostic) -> Option<CodeAction> {
+    let insert_range = Range {
+        start: diag.range.start,
+        end: diag.range.start,
+    };
+    let text_edit = TextEdit {
+        range: insert_range,
+        new_text: ";".to_string(),
+    };
+    let mut changes = HashMap::new();
+    changes.insert(uri.clone(), vec![text_edit]);
+    let workspace_edit = WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+        change_annotations: None,
+    };
+    Some(CodeAction {
+        title: "Insert `;`".to_string(),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diag.clone()]),
+        edit: Some(workspace_edit),
+        command: None,
+        is_preferred: Some(true),
+        disabled: None,
+        data: None,
+    })
 }
 
 /// RES-183: walk the full AST and collect the `Range` of every
@@ -2081,6 +2135,22 @@ impl LanguageServer for Backend {
         let mut actions: Vec<CodeActionOrCommand> = Vec::new();
 
         for diag in &params.context.diagnostics {
+            // RES-190: missing-semicolon quick-fix. Triggers on parser
+            // diagnostics whose message refers to a missing/expected
+            // `;`. The action inserts `;` at the diagnostic's start
+            // position so the editor's "lightbulb" can apply it
+            // directly. Detection is by message substring (matches
+            // existing `..Default::default()` Diagnostic construction
+            // that leaves `code: None`); when the parser starts
+            // emitting the E0002 code, swap to a `code == "E0002"`
+            // check without changing the user-visible behaviour.
+            if is_missing_semicolon_diagnostic(diag) {
+                if let Some(action) = build_insert_semicolon_action(&uri, diag) {
+                    actions.push(CodeActionOrCommand::CodeAction(action));
+                }
+                continue;
+            }
+
             // Only act on L0010 "no contract" diagnostics.
             if !diag.message.contains("L0010")
                 && !diag.message.contains("requires")
@@ -3637,6 +3707,153 @@ fn main(int n) {\n\
         // A `{` only on line 3; scanning from line 0 returns 3.
         let src = "fn f(\n    int x,\n    int y\n) {\n    return x + y;\n}";
         assert_eq!(find_brace_line(src, 0), Some(3));
+    }
+
+    // ============================================================
+    // RES-190: missing-semicolon code action
+    // ============================================================
+
+    #[test]
+    fn res190_detects_missing_semi_by_message_apostrophes() {
+        let diag = Diagnostic {
+            range: Range::new(Position::new(2, 10), Position::new(2, 10)),
+            message: "expected ';' before keyword".into(),
+            ..Default::default()
+        };
+        assert!(is_missing_semicolon_diagnostic(&diag));
+    }
+
+    #[test]
+    fn res190_detects_missing_semi_by_message_backticks() {
+        let diag = Diagnostic {
+            range: Range::new(Position::new(0, 5), Position::new(0, 5)),
+            message: "expected `;` after expression".into(),
+            ..Default::default()
+        };
+        assert!(is_missing_semicolon_diagnostic(&diag));
+    }
+
+    #[test]
+    fn res190_detects_missing_semi_by_word_semicolon() {
+        let diag = Diagnostic {
+            range: Range::new(Position::new(0, 5), Position::new(0, 5)),
+            message: "missing semicolon at end of statement".into(),
+            ..Default::default()
+        };
+        assert!(is_missing_semicolon_diagnostic(&diag));
+    }
+
+    #[test]
+    fn res190_detects_missing_semi_by_e0002_code() {
+        let diag = Diagnostic {
+            range: Range::new(Position::new(0, 5), Position::new(0, 5)),
+            code: Some(NumberOrString::String("E0002".into())),
+            message: "parse error".into(),
+            ..Default::default()
+        };
+        assert!(is_missing_semicolon_diagnostic(&diag));
+    }
+
+    #[test]
+    fn res190_does_not_match_unrelated_diag() {
+        // Unrelated parse error must NOT trigger the action.
+        let diag = Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+            message: "expected `}` to close block".into(),
+            ..Default::default()
+        };
+        assert!(!is_missing_semicolon_diagnostic(&diag));
+    }
+
+    #[test]
+    fn res190_does_not_match_message_mentioning_semi_without_expected() {
+        // A message that just mentions `;` casually shouldn't grab.
+        let diag = Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+            message: "you wrote two ';' in a row".into(),
+            ..Default::default()
+        };
+        assert!(!is_missing_semicolon_diagnostic(&diag));
+    }
+
+    #[test]
+    fn res190_action_inserts_semicolon_at_diag_start() {
+        let uri = Url::parse("file:///tmp/test_missing_semi.rz").unwrap();
+        let diag = Diagnostic {
+            range: Range::new(Position::new(2, 10), Position::new(2, 10)),
+            severity: Some(DiagnosticSeverity::ERROR),
+            source: Some("resilient-parser".into()),
+            message: "expected ';'".into(),
+            ..Default::default()
+        };
+        assert!(is_missing_semicolon_diagnostic(&diag));
+
+        let action = build_insert_semicolon_action(&uri, &diag).expect("action");
+        assert_eq!(action.title, "Insert `;`");
+        assert_eq!(action.kind, Some(CodeActionKind::QUICKFIX));
+        assert_eq!(action.is_preferred, Some(true));
+
+        let edit = action.edit.expect("expected edit");
+        let mut changes = edit.changes.expect("expected changes map");
+        let file_edits = changes.remove(&uri).expect("expected edits for our URI");
+        assert_eq!(file_edits.len(), 1);
+        let te = &file_edits[0];
+        assert_eq!(te.new_text, ";");
+        // The insert range is zero-width at the diagnostic's start
+        // position — that's where the parser flagged the problem.
+        assert_eq!(te.range.start.line, 2);
+        assert_eq!(te.range.start.character, 10);
+        assert_eq!(te.range.end.line, 2);
+        assert_eq!(te.range.end.character, 10);
+    }
+
+    #[test]
+    fn res190_action_attaches_originating_diagnostic() {
+        // The CodeAction must carry the diagnostic it acts on so the
+        // editor can dismiss the lightbulb after applying the fix.
+        let uri = Url::parse("file:///tmp/test_dismissal.rz").unwrap();
+        let diag = Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+            message: "expected ';'".into(),
+            ..Default::default()
+        };
+        let action = build_insert_semicolon_action(&uri, &diag).expect("action");
+        let attached = action.diagnostics.expect("expected diagnostics list");
+        assert_eq!(attached.len(), 1);
+        assert_eq!(attached[0].message, diag.message);
+    }
+
+    #[test]
+    fn res190_fixed_text_lines_up_with_a_valid_program() {
+        // End-to-end shape check: starting from a snippet with a
+        // missing `;`, applying the action's edit produces a string
+        // that contains the inserted `;` at the expected offset.
+        let original = "let x = 1\nlet y = 2;\n";
+        // The parser would point at the start of `let y` on line 1
+        // (or the EOL of line 0). Synthesize a diagnostic at the
+        // end of line 0.
+        let diag = Diagnostic {
+            range: Range::new(Position::new(0, 9), Position::new(0, 9)),
+            message: "expected ';'".into(),
+            ..Default::default()
+        };
+        let uri = Url::parse("file:///tmp/test_apply.rz").unwrap();
+        let action = build_insert_semicolon_action(&uri, &diag).expect("action");
+        let edit = action
+            .edit
+            .expect("edit")
+            .changes
+            .expect("changes")
+            .remove(&uri)
+            .expect("edits");
+        let te = &edit[0];
+        // Apply the edit by hand: insert `;` at line 0, col 9.
+        let mut lines: Vec<String> = original.lines().map(|s| s.to_string()).collect();
+        let line0 = &mut lines[0];
+        let col = te.range.start.character as usize;
+        line0.insert_str(col, &te.new_text);
+        let fixed = lines.join("\n") + "\n";
+        assert_eq!(fixed, "let x = 1;\nlet y = 2;\n");
     }
 
     // ============================================================

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -194,6 +194,11 @@ mod generics;
 // eval path is not touched — only two thin eval arms are added in
 // main.rs for NewtypeDecl (register) and NewtypeConstruct (wrap).
 mod newtypes;
+// RES-398: termination checking — recursive fns require an explicit
+// `// @decreases <metric>` or `// @may_diverge` annotation. Off by
+// default; enabled via `--strict-termination`. Closes a class of
+// expressible-but-invalid state called out in the Reddit critique.
+mod termination;
 
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
@@ -13786,6 +13791,16 @@ fn execute_file(
         ));
     }
 
+    // RES-398: termination check. Runs unconditionally — a no-op when
+    // `--strict-termination` is off. Lives outside the typechecker pass
+    // because the typechecker has known limitations on recursive fns
+    // (forward-reference of the fn's own name in its body), and we want
+    // termination diagnostics regardless of `--typecheck`.
+    if let Err(e) = termination::check(&program, filename) {
+        eprintln!("\x1B[31m{}\x1B[0m", e);
+        return Err(format!("Termination check failed: {}", e));
+    }
+
     // RES-386: race-freedom / commutativity obligation per actor.
     // Runs before typecheck so an invalid actor is a verifier-level
     // diagnostic rather than a type error. No-op in non-z3 builds.
@@ -15239,6 +15254,14 @@ fn main() {
                 // the pass actually runs before the program executes.
                 bounds_check::set_deny_unproven_bounds(true);
                 type_check = true;
+            } else if arg == "--strict-termination" {
+                // RES-398: strict mode — directly-recursive fns must
+                // declare `// @decreases <metric>` or `// @may_diverge`
+                // on the line above. Runs as a standalone parser-time
+                // pass invoked from `run_subcommand` (independent of
+                // `--typecheck`, which has known limitations on
+                // recursive fns).
+                termination::set_strict_termination(true);
             } else if arg == "--explain-effects" {
                 // RES-347: dump one line per user fn with its
                 // inferred effect. Implies --typecheck.

--- a/resilient/src/termination.rs
+++ b/resilient/src/termination.rs
@@ -1,0 +1,231 @@
+//! RES-398: termination checking — recursive fns require an explicit
+//! `// @decreases <metric>` clause or `// @may_diverge` escape hatch.
+//!
+//! Reddit critique
+//! (https://www.reddit.com/r/VibeCodersNest/comments/1ssv8ih/) asks:
+//! *can an invalid state even be expressed in your system?* Today,
+//! unbounded recursion is one such expressible-but-invalid state.
+//! Resilient targets safety-critical embedded systems where
+//! unbounded recursion is a known hazard (stack overflow on
+//! Cortex-M, no graceful recovery).
+//!
+//! The runtime depth cap (RES-267) catches it at runtime. That's
+//! *filtering*, not structural enforcement. This pass closes the
+//! gap on direct (self-call) recursion: every directly-recursive
+//! function must declare *either* a decreasing metric or that
+//! divergence is acceptable.
+//!
+//! # Surface syntax
+//!
+//! Annotation goes on the line *immediately above* the `fn` keyword:
+//!
+//! ```text
+//! // @decreases n
+//! fn fact(int n) requires n >= 0 {
+//!     if n <= 1 { return 1; }
+//!     return n * fact(n - 1);
+//! }
+//!
+//! // @may_diverge
+//! fn event_loop() {
+//!     loop_forever();
+//! }
+//! ```
+//!
+//! ## Why comment-based and not a new keyword?
+//!
+//! Comment-based annotation keeps the surface change minimal — no
+//! new tokens, no parser arms, no AST node. The same line-offset
+//! convention is already used by `// resilient: allow LXXXX` and
+//! `// source:` (RES-397). A future ticket can promote this to a
+//! first-class clause once the design has stabilized.
+//!
+//! # Behavior
+//!
+//! - **Default: off.** Existing programs are not affected. The
+//!   pass returns `Ok(())` immediately when strict mode is not
+//!   enabled, so cross-compile, REPL, and `rz run` are untouched.
+//! - **Opt-in via `--strict-termination`** (CLI). When set,
+//!   unannotated direct recursion produces a typechecker error.
+//!
+//! # Out of scope (future tickets)
+//!
+//! - **Mutual recursion**: this pass only catches direct self-calls.
+//!   Follow-up: SCC-based call-graph analysis.
+//! - **Z3 verification of the `decreases` metric**: the syntactic
+//!   check lands first; SMT proof of strict decrease is a separate
+//!   ticket.
+//! - **Loop termination**: `while`/`for` are out of scope here;
+//!   loop invariants (RES-132a) and loop-bound checks live elsewhere.
+
+use crate::Node;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// RES-398: process-wide flag controlling whether the termination
+/// check is enforced. Off by default — existing programs see no
+/// change. Mirrors the `bounds_check::DENY_UNPROVEN_BOUNDS` pattern.
+static STRICT_TERMINATION: AtomicBool = AtomicBool::new(false);
+
+/// Enable `--strict-termination` mode. Called from `main.rs` CLI
+/// parsing before `check_program_with_source` runs.
+pub fn set_strict_termination(on: bool) {
+    STRICT_TERMINATION.store(on, Ordering::Relaxed);
+}
+
+fn strict_termination() -> bool {
+    STRICT_TERMINATION.load(Ordering::Relaxed)
+}
+
+/// RES-398: typechecker extension pass — for every directly-recursive
+/// top-level fn, require either `// @decreases <metric>` or
+/// `// @may_diverge` on the line above the `fn` keyword. No-op
+/// when strict mode is off.
+pub fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    if !strict_termination() {
+        return Ok(());
+    }
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let source = std::fs::read_to_string(source_path).unwrap_or_default();
+    let lines: Vec<&str> = source.lines().collect();
+
+    for spanned in stmts {
+        if let Node::Function {
+            name, body, span, ..
+        } = &spanned.node
+        {
+            if name.is_empty() {
+                continue;
+            }
+            if !calls_self(body, name) {
+                continue;
+            }
+            let fn_line = span.start.line; // 1-indexed
+            if fn_line < 2 {
+                return Err(format!(
+                    "{}:{}:{}: error: function `{}` is recursive but has no termination annotation; \
+                     expected `// @decreases <metric>` or `// @may_diverge` on the line above",
+                    source_path, fn_line, span.start.column, name
+                ));
+            }
+            let prev = lines.get(fn_line - 2).copied().unwrap_or("");
+            if !has_termination_annotation(prev) {
+                return Err(format!(
+                    "{}:{}:{}: error: function `{}` is recursive but has no termination annotation; \
+                     expected `// @decreases <metric>` or `// @may_diverge` on the line above",
+                    source_path, fn_line, span.start.column, name
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Returns true when `line` (a single source line, no newline) carries
+/// a `// @decreases <metric>` or `// @may_diverge` annotation. Leading
+/// whitespace is ignored; trailing text after the annotation keyword
+/// is treated as the metric / comment payload and is not validated
+/// here (a future Z3 ticket will check the metric strictly decreases).
+fn has_termination_annotation(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("// @decreases") {
+        // Require at least one non-whitespace char after the keyword.
+        return !rest.trim().is_empty();
+    }
+    if let Some(rest) = trimmed.strip_prefix("// @may_diverge") {
+        // `// @may_diverge` alone is sufficient; trailing comment OK.
+        return rest.is_empty() || rest.starts_with(char::is_whitespace);
+    }
+    false
+}
+
+/// Walks the AST looking for a `CallExpression` whose callee is the
+/// identifier `name`. Returns true on the first hit. This catches
+/// direct recursion — the function calling itself by name. Mutual
+/// recursion (a → b → a) is intentionally out of scope; an SCC pass
+/// is a separate ticket.
+fn calls_self(node: &Node, name: &str) -> bool {
+    match node {
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
+            if let Node::Identifier { name: callee, .. } = function.as_ref()
+                && callee == name
+            {
+                return true;
+            }
+            if calls_self(function, name) {
+                return true;
+            }
+            arguments.iter().any(|a| calls_self(a, name))
+        }
+        Node::Block { stmts, .. } => stmts.iter().any(|s| calls_self(s, name)),
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            calls_self(condition, name)
+                || calls_self(consequence, name)
+                || alternative.as_ref().is_some_and(|a| calls_self(a, name))
+        }
+        Node::WhileStatement {
+            condition, body, ..
+        } => calls_self(condition, name) || calls_self(body, name),
+        Node::ForInStatement { iterable, body, .. } => {
+            calls_self(iterable, name) || calls_self(body, name)
+        }
+        Node::LiveBlock { body, .. } => calls_self(body, name),
+        Node::ReturnStatement { value: Some(v), .. } => calls_self(v, name),
+        Node::ExpressionStatement { expr, .. } => calls_self(expr, name),
+        Node::LetStatement { value, .. } => calls_self(value, name),
+        Node::InfixExpression { left, right, .. } => {
+            calls_self(left, name) || calls_self(right, name)
+        }
+        Node::PrefixExpression { right, .. } => calls_self(right, name),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn annotation_decreases_with_metric_accepted() {
+        assert!(has_termination_annotation("// @decreases n"));
+        assert!(has_termination_annotation("    // @decreases n - 1"));
+        assert!(has_termination_annotation("// @decreases (a, b)"));
+    }
+
+    #[test]
+    fn annotation_decreases_without_metric_rejected() {
+        assert!(!has_termination_annotation("// @decreases"));
+        assert!(!has_termination_annotation("// @decreases   "));
+    }
+
+    #[test]
+    fn annotation_may_diverge_accepted() {
+        assert!(has_termination_annotation("// @may_diverge"));
+        assert!(has_termination_annotation("    // @may_diverge"));
+        assert!(has_termination_annotation(
+            "// @may_diverge — event loop is intentionally non-terminating"
+        ));
+    }
+
+    #[test]
+    fn unrelated_comment_rejected() {
+        assert!(!has_termination_annotation("// just a comment"));
+        assert!(!has_termination_annotation("// source: rfc-1234"));
+        assert!(!has_termination_annotation(""));
+    }
+
+    // Note: the `check` function is exercised end-to-end via the
+    // golden examples in `examples/termination_*.rz`. Unit-testing
+    // it here would require constructing a full `Node::Program`
+    // with span info, which the integration tests already do.
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4072,10 +4072,11 @@ fn check_program_effects(
             name,
             body,
             effects,
+            parameters,
             ..
         } = &stmt.node
             && effects.pure
-            && let Err(reason) = check_body_effects(body, &fn_effects)
+            && let Err(reason) = check_body_effects(body, &fn_effects, parameters)
         {
             let (line, col) = (stmt.span.start.line, stmt.span.start.column);
             return Err(if line == 0 {
@@ -4091,23 +4092,27 @@ fn check_program_effects(
     Ok(())
 }
 
-/// RES-389: recursive walk of a `pure` fn body. Returns
-/// `Err(<reason>)` at the first call to a non-`pure` callee, with
-/// the diagnostic text the caller will prefix with the fn span.
+/// RES-389/RES-385c: recursive walk of a `pure` fn body. Returns
+/// `Err(<reason>)` at the first call to a non-`pure` callee, or if a
+/// linear parameter is consumed (RES-385c), with the diagnostic text
+/// the caller will prefix with the fn span.
 fn check_body_effects(
     node: &Node,
     fn_effects: &std::collections::HashMap<String, EffectSet>,
+    linear_params: &[(String, String)],
 ) -> Result<(), String> {
     match node {
         Node::Block { stmts, .. } => {
             for s in stmts {
-                check_body_effects(s, fn_effects)?;
+                check_body_effects(s, fn_effects, linear_params)?;
             }
         }
         Node::LetStatement { value, .. } | Node::StaticLet { value, .. } => {
-            check_body_effects(value, fn_effects)?;
+            check_body_effects(value, fn_effects, linear_params)?;
         }
-        Node::ReturnStatement { value: Some(v), .. } => check_body_effects(v, fn_effects)?,
+        Node::ReturnStatement { value: Some(v), .. } => {
+            check_body_effects(v, fn_effects, linear_params)?
+        }
         Node::ReturnStatement { value: None, .. } => {}
         Node::IfStatement {
             condition,
@@ -4115,38 +4120,54 @@ fn check_body_effects(
             alternative,
             ..
         } => {
-            check_body_effects(condition, fn_effects)?;
-            check_body_effects(consequence, fn_effects)?;
+            check_body_effects(condition, fn_effects, linear_params)?;
+            check_body_effects(consequence, fn_effects, linear_params)?;
             if let Some(a) = alternative {
-                check_body_effects(a, fn_effects)?;
+                check_body_effects(a, fn_effects, linear_params)?;
             }
         }
         Node::WhileStatement {
             condition, body, ..
         } => {
-            check_body_effects(condition, fn_effects)?;
-            check_body_effects(body, fn_effects)?;
+            check_body_effects(condition, fn_effects, linear_params)?;
+            check_body_effects(body, fn_effects, linear_params)?;
         }
         Node::ForInStatement { iterable, body, .. } => {
-            check_body_effects(iterable, fn_effects)?;
-            check_body_effects(body, fn_effects)?;
+            check_body_effects(iterable, fn_effects, linear_params)?;
+            check_body_effects(body, fn_effects, linear_params)?;
         }
         Node::Assert { condition, .. } | Node::Assume { condition, .. } => {
-            check_body_effects(condition, fn_effects)?;
+            check_body_effects(condition, fn_effects, linear_params)?;
         }
-        Node::LiveBlock { body, .. } => check_body_effects(body, fn_effects)?,
+        Node::LiveBlock { body, .. } => check_body_effects(body, fn_effects, linear_params)?,
         Node::InfixExpression { left, right, .. } => {
-            check_body_effects(left, fn_effects)?;
-            check_body_effects(right, fn_effects)?;
+            check_body_effects(left, fn_effects, linear_params)?;
+            check_body_effects(right, fn_effects, linear_params)?;
         }
-        Node::PrefixExpression { right, .. } => check_body_effects(right, fn_effects)?,
+        Node::PrefixExpression { right, .. } => {
+            check_body_effects(right, fn_effects, linear_params)?
+        }
         Node::CallExpression {
             function,
             arguments,
             ..
         } => {
             for a in arguments {
-                check_body_effects(a, fn_effects)?;
+                check_body_effects(a, fn_effects, linear_params)?;
+                // RES-385c: detect if a linear parameter is being
+                // consumed (passed to a function). Consuming a linear
+                // parameter is observable IO — an operation on a
+                // resource — so a pure fn cannot do it.
+                if let Node::Identifier { name: arg_name, .. } = a {
+                    for (param_ty, param_name) in linear_params {
+                        if arg_name == param_name && crate::linear::is_linear(param_ty) {
+                            return Err(format!(
+                                "cannot consume linear parameter `{}` in pure context",
+                                param_name
+                            ));
+                        }
+                    }
+                }
             }
             if let Node::Identifier { name: callee, .. } = function.as_ref() {
                 // User fn with a recorded effect set — `pure`
@@ -4182,20 +4203,20 @@ fn check_body_effects(
             }
             // Method / computed callee — can't resolve statically;
             // same conservative rejection as the purity pass.
-            check_body_effects(function, fn_effects)?;
+            check_body_effects(function, fn_effects, linear_params)?;
             return Err(
                 "cannot call indirect/method callee from pure context (effect unknown)".to_string(),
             );
         }
-        Node::FieldAccess { target, .. } => check_body_effects(target, fn_effects)?,
+        Node::FieldAccess { target, .. } => check_body_effects(target, fn_effects, linear_params)?,
         Node::FieldAssignment { target, value, .. } => {
-            check_body_effects(target, fn_effects)?;
-            check_body_effects(value, fn_effects)?;
+            check_body_effects(target, fn_effects, linear_params)?;
+            check_body_effects(value, fn_effects, linear_params)?;
         }
-        Node::Assignment { value, .. } => check_body_effects(value, fn_effects)?,
+        Node::Assignment { value, .. } => check_body_effects(value, fn_effects, linear_params)?,
         Node::IndexExpression { target, index, .. } => {
-            check_body_effects(target, fn_effects)?;
-            check_body_effects(index, fn_effects)?;
+            check_body_effects(target, fn_effects, linear_params)?;
+            check_body_effects(index, fn_effects, linear_params)?;
         }
         Node::IndexAssignment {
             target,
@@ -4203,42 +4224,44 @@ fn check_body_effects(
             value,
             ..
         } => {
-            check_body_effects(target, fn_effects)?;
-            check_body_effects(index, fn_effects)?;
-            check_body_effects(value, fn_effects)?;
+            check_body_effects(target, fn_effects, linear_params)?;
+            check_body_effects(index, fn_effects, linear_params)?;
+            check_body_effects(value, fn_effects, linear_params)?;
         }
         Node::ArrayLiteral { items, .. } => {
             for i in items {
-                check_body_effects(i, fn_effects)?;
+                check_body_effects(i, fn_effects, linear_params)?;
             }
         }
         Node::StructLiteral { fields, .. } => {
             for (_, v) in fields {
-                check_body_effects(v, fn_effects)?;
+                check_body_effects(v, fn_effects, linear_params)?;
             }
         }
         Node::Match {
             scrutinee, arms, ..
         } => {
-            check_body_effects(scrutinee, fn_effects)?;
+            check_body_effects(scrutinee, fn_effects, linear_params)?;
             for (_pat, guard, arm_body) in arms {
                 if let Some(g) = guard {
-                    check_body_effects(g, fn_effects)?;
+                    check_body_effects(g, fn_effects, linear_params)?;
                 }
-                check_body_effects(arm_body, fn_effects)?;
+                check_body_effects(arm_body, fn_effects, linear_params)?;
             }
         }
-        Node::ExpressionStatement { expr, .. } => check_body_effects(expr, fn_effects)?,
-        Node::TryExpression { expr, .. } => check_body_effects(expr, fn_effects)?,
+        Node::ExpressionStatement { expr, .. } => {
+            check_body_effects(expr, fn_effects, linear_params)?
+        }
+        Node::TryExpression { expr, .. } => check_body_effects(expr, fn_effects, linear_params)?,
         Node::OptionalChain { object, access, .. } => {
-            check_body_effects(object, fn_effects)?;
+            check_body_effects(object, fn_effects, linear_params)?;
             if let crate::ChainAccess::Method(_, args) = access {
                 for a in args {
-                    check_body_effects(a, fn_effects)?;
+                    check_body_effects(a, fn_effects, linear_params)?;
                 }
             }
         }
-        Node::Function { body, .. } => check_body_effects(body, fn_effects)?,
+        Node::Function { body, .. } => check_body_effects(body, fn_effects, linear_params)?,
         // Literals, identifier reads, durations — nothing to do.
         _ => {}
     }
@@ -4338,6 +4361,35 @@ mod effect_tests {
         let err = check_program_effects(&s, "<t>").unwrap_err();
         assert!(err.contains("<t>:"), "missing source path: {err}");
         assert!(err.contains(":2:"), "missing line number: {err}");
+    }
+
+    // RES-385c: linear parameter effect-system interaction tests.
+
+    #[test]
+    fn pure_with_linear_parameter_rejected_on_consumption() {
+        let src = "fn consume(linear int x) { return 0; }\n\
+                   pure fn bad(linear int x) { return consume(x); }\n";
+        let s = stmts(src);
+        let err = check_program_effects(&s, "<t>").expect_err("pure+linear consumed should fail");
+        assert!(
+            err.contains("cannot consume linear parameter `x` in pure context"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn pure_with_linear_parameter_accepted_on_no_consumption() {
+        let src = "pure fn ok(linear int x) { return 0; }\n";
+        let s = stmts(src);
+        check_program_effects(&s, "<t>").expect("pure+linear not consumed should pass");
+    }
+
+    #[test]
+    fn io_with_linear_parameter_accepted_on_consumption() {
+        let src = "fn consume(linear int x) { return 0; }\n\
+                   io fn ok(linear int x) { return consume(x); }\n";
+        let s = stmts(src);
+        check_program_effects(&s, "<t>").expect("io+linear consumed should pass");
     }
 }
 

--- a/resilient/tests/lint_smoke.rs
+++ b/resilient/tests/lint_smoke.rs
@@ -25,9 +25,10 @@ fn tmp_file(tag: &str, body: &str) -> PathBuf {
 
 #[test]
 fn lint_exits_zero_on_clean_program() {
+    // RES-397: `// source:` comment satisfies L0012 spec-provenance lint.
     let src = tmp_file(
         "clean",
-        "fn f(int a) requires a > 0 {\n    let used = a + 1;\n    return used;\n}\n",
+        "// source: test fixture\nfn f(int a) requires a > 0 {\n    let used = a + 1;\n    return used;\n}\n",
     );
     let out = Command::new(bin())
         .args(["lint"])
@@ -92,9 +93,11 @@ fn lint_deny_escalates_to_error_exit_two() {
 
 #[test]
 fn lint_allow_flag_suppresses_code() {
+    // RES-397: `// source:` comment satisfies L0012; `--allow L0001`
+    // silences the unused-let warning, leaving a clean lint.
     let src = tmp_file(
         "allow",
-        "fn f(int a) requires a > 0 {\n    let unused = 42;\n    return a;\n}\n",
+        "// source: test fixture\nfn f(int a) requires a > 0 {\n    let unused = 42;\n    return a;\n}\n",
     );
     let out = Command::new(bin())
         .args(["lint"])
@@ -207,9 +210,10 @@ fn lint_l0011_fires_on_unused_let_with_rustc_message() {
 #[test]
 fn lint_l0011_silent_for_underscore_prefix() {
     // `_temp` is exempt — file is clean, exit 0.
+    // RES-397: `// source:` satisfies L0012.
     let src = tmp_file(
         "l0011_underscore",
-        "fn f(int a) requires a > 0 {\n    let _temp = 42;\n    return a;\n}\n",
+        "// source: test fixture\nfn f(int a) requires a > 0 {\n    let _temp = 42;\n    return a;\n}\n",
     );
     let out = Command::new(bin())
         .args(["lint"])
@@ -227,10 +231,10 @@ fn lint_l0011_silent_for_underscore_prefix() {
 
 #[test]
 fn lint_l0011_silent_when_let_is_used() {
-    // Used `let` is clean.
+    // Used `let` is clean. RES-397: `// source:` satisfies L0012.
     let src = tmp_file(
         "l0011_used",
-        "fn f(int a) requires a > 0 {\n    let used = a + 1;\n    return used;\n}\n",
+        "// source: test fixture\nfn f(int a) requires a > 0 {\n    let used = a + 1;\n    return used;\n}\n",
     );
     let out = Command::new(bin())
         .args(["lint"])

--- a/resilient/tests/lsp_smoke.rs
+++ b/resilient/tests/lsp_smoke.rs
@@ -398,11 +398,11 @@ fn lsp_workspace_symbol_searches_multiple_files() {
     let root = std::env::temp_dir().join(format!("res_186_smoke_{}_{}", std::process::id(), n));
     std::fs::create_dir_all(&root).expect("mkdir scratch");
     std::fs::write(
-        root.join("mod_a.rs"),
+        root.join("mod_a.rz"),
         "fn a_fn() { return 0; }\nstruct A_Struct { int x }\n",
     )
     .unwrap();
-    std::fs::write(root.join("mod_b.rs"), "fn b_fn() { return 0; }\n").unwrap();
+    std::fs::write(root.join("mod_b.rz"), "fn b_fn() { return 0; }\n").unwrap();
     // URI of the scratch dir as a file:// URL.
     let root_uri = format!("file://{}", root.to_string_lossy().replace("\\", "/"));
 
@@ -457,12 +457,12 @@ fn lsp_workspace_symbol_searches_multiple_files() {
     }
     // And each file's URI should appear.
     assert!(
-        response.contains("mod_a.rs"),
-        "expected mod_a.rs in response:\n{response}"
+        response.contains("mod_a.rz"),
+        "expected mod_a.rz in response:\n{response}"
     );
     assert!(
-        response.contains("mod_b.rs"),
-        "expected mod_b.rs in response:\n{response}"
+        response.contains("mod_b.rz"),
+        "expected mod_b.rz in response:\n{response}"
     );
 
     // Now a filtered query — "struct" should match only A_Struct.

--- a/resilient/tests/termination_smoke.rs
+++ b/resilient/tests/termination_smoke.rs
@@ -1,0 +1,129 @@
+//! RES-398: integration tests for `--strict-termination`.
+//!
+//! Each test shells out to the real binary, asserting that:
+//!   - without the flag, recursive programs run normally;
+//!   - with the flag, annotated recursive fns pass;
+//!   - with the flag, unannotated direct recursion is rejected
+//!     at compile time (exit code 1) with a useful message.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_file(tag: &str, body: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("res_398_{}_{}_{}.rz", tag, std::process::id(), n));
+    std::fs::write(&path, body).expect("write scratch");
+    path
+}
+
+#[test]
+fn unannotated_recursion_runs_without_flag() {
+    // Default mode: termination check is off; program runs.
+    let src = tmp_file(
+        "default_off",
+        "fn loops(int n) { if n <= 0 { return; } loops(n - 1); }\nloops(2);\n",
+    );
+    let out = Command::new(bin()).arg(&src).output().expect("spawn rz");
+    assert!(
+        out.status.success(),
+        "expected success without --strict-termination, got {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let _ = std::fs::remove_file(&src);
+}
+
+#[test]
+fn unannotated_recursion_rejected_under_strict_flag() {
+    let src = tmp_file(
+        "strict_missing",
+        "fn loops(int n) { if n <= 0 { return; } loops(n - 1); }\nloops(2);\n",
+    );
+    let out = Command::new(bin())
+        .args(["--strict-termination"])
+        .arg(&src)
+        .output()
+        .expect("spawn rz");
+    assert!(
+        !out.status.success(),
+        "expected failure under --strict-termination, got {:?}",
+        out.status
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("recursive but has no termination annotation"),
+        "stderr should explain the missing annotation, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("@decreases") && stderr.contains("@may_diverge"),
+        "stderr should suggest both annotation forms, got: {stderr}"
+    );
+    let _ = std::fs::remove_file(&src);
+}
+
+#[test]
+fn decreases_annotation_satisfies_strict_flag() {
+    let src = tmp_file(
+        "strict_decreases",
+        "// @decreases n\nfn loops(int n) { if n <= 0 { return; } loops(n - 1); }\nloops(2);\n",
+    );
+    let out = Command::new(bin())
+        .args(["--strict-termination"])
+        .arg(&src)
+        .output()
+        .expect("spawn rz");
+    assert!(
+        out.status.success(),
+        "expected success with `// @decreases n`, got {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let _ = std::fs::remove_file(&src);
+}
+
+#[test]
+fn may_diverge_annotation_satisfies_strict_flag() {
+    let src = tmp_file(
+        "strict_may_diverge",
+        "// @may_diverge\nfn loops(int n) { if n <= 0 { return; } loops(n - 1); }\nloops(2);\n",
+    );
+    let out = Command::new(bin())
+        .args(["--strict-termination"])
+        .arg(&src)
+        .output()
+        .expect("spawn rz");
+    assert!(
+        out.status.success(),
+        "expected success with `// @may_diverge`, got {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let _ = std::fs::remove_file(&src);
+}
+
+#[test]
+fn non_recursive_fn_unaffected_by_strict_flag() {
+    // A non-recursive fn needs no annotation, regardless of the flag.
+    let src = tmp_file(
+        "strict_nonrec",
+        "fn double(int x) { return x + x; }\nlet y = double(7);\nprintln(\"y=\" + y);\n",
+    );
+    let out = Command::new(bin())
+        .args(["--strict-termination"])
+        .arg(&src)
+        .output()
+        .expect("spawn rz");
+    assert!(
+        out.status.success(),
+        "non-recursive fn should pass under --strict-termination, got {:?}",
+        out.status
+    );
+    let _ = std::fs::remove_file(&src);
+}

--- a/scripts/verify-stdlib-coverage.sh
+++ b/scripts/verify-stdlib-coverage.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Verify that every builtin in resilient/src/main.rs appears in docs/STDLIB.md
+
+set -e
+
+STDLIB_FILE="docs/STDLIB.md"
+MAIN_FILE="resilient/src/main.rs"
+
+# Extract all builtin names from the BUILTINS const array
+BUILTINS=$(awk '/const BUILTINS: &\[/,/^\];$/' "$MAIN_FILE" | grep '("' | cut -d'"' -f2 | sort)
+
+if [ -z "$BUILTINS" ]; then
+    echo "❌ Could not extract builtins from $MAIN_FILE"
+    exit 1
+fi
+
+MISSING=()
+for builtin in $BUILTINS; do
+    # Check if the builtin name appears in the STDLIB.md file (heading, code, or text)
+    # Allow for heading format like "### `builtin`" or "`builtin_*`" or just "builtin" in code/text
+    if ! grep -q "\`$builtin\`" "$STDLIB_FILE"; then
+        MISSING+=("$builtin")
+    fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "❌ The following builtins are NOT documented in $STDLIB_FILE:"
+    for builtin in "${MISSING[@]}"; do
+        echo "  - $builtin"
+    done
+    exit 1
+fi
+
+TOTAL=$(echo "$BUILTINS" | wc -w)
+echo "✓ All $TOTAL builtins are documented in $STDLIB_FILE"
+exit 0


### PR DESCRIPTION
Closes #165

## Summary
Split CI test suite into parallel shards to reduce wall-clock time:
- default (no features)
- --features z3
- --features lsp
- --features jit

Each shard runs independently on separate runners. A summary job gathers results.

## Testing
CI will validate that all shards pass and the parallel execution works correctly.