### PR TITLE
RES-333: Supervisor trees — restart policy for actor failures

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,16 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-385c-linear-effect-interaction",
-      "claimed_at": "2026-04-28T20:12:45Z"
+      "branch": "res-333-supervisor-fresh",
+      "claimed_at": "2026-04-29T01:00:22Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-385c-linear-effect-interaction",
-      "claimed_at": "2026-04-28T20:12:45Z"
+      "branch": "res-333-supervisor-fresh",
+      "claimed_at": "2026-04-29T01:00:22Z"
+    },
+    "resilient/src/lexer_logos.rs": {
+      "branch": "res-333-supervisor-fresh",
+      "claimed_at": "2026-04-29T01:00:22Z"
     }
   }
 }

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1147,7 +1147,8 @@ fn node_line(n: &Node) -> Option<u32> {
         | Node::ClusterDecl { span, .. }
         | Node::FunctionLiteral { span, .. }
         | Node::TryCatch { span, .. }
-        | Node::Quantifier { span, .. } => span.start.line as u32,
+        | Node::Quantifier { span, .. }
+        | Node::SupervisorDecl { span, .. } => span.start.line as u32,
 
         // RES-291: integer range expression. Only emitted from the
         // tree-walker frontend today; bytecode lowering treats it as

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -605,6 +605,32 @@ impl Formatter {
                 self.write("}");
                 self.newline();
             }
+            // RES-333: supervisor declaration. Phase 1: minimal formatting.
+            Node::SupervisorDecl {
+                strategy, children, ..
+            } => {
+                self.write("supervisor {");
+                self.newline();
+                self.indent();
+                self.write(&format!("strategy: {},", strategy));
+                self.newline();
+                self.write("children: [");
+                self.newline();
+                self.indent();
+                for child in children {
+                    self.write(&format!(
+                        "{{ id: \"{}\", fn: {}, restart: {} }},",
+                        child.id, child.fn_name, child.restart
+                    ));
+                    self.newline();
+                }
+                self.dedent();
+                self.write("]");
+                self.newline();
+                self.dedent();
+                self.write("}");
+                self.newline();
+            }
             // Anything else was an expression; dispatch to fmt_expr
             // and terminate with a semicolon so a bare expression
             // statement at top level still looks like a statement.
@@ -1028,6 +1054,7 @@ impl Formatter {
             | Node::LetDestructureStruct { .. }
             | Node::TryCatch { .. }
             | Node::ModuleDecl { .. }
+            | Node::SupervisorDecl { .. }
             | Node::Program(_) => {
                 self.fmt_stmt(node);
             }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -220,7 +220,9 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
         // RES-319: newtype declarations introduce no bindings (the
         // constructor call is lowered to NewtypeConstruct before this
         // pass runs, so no free-variable tracking is needed).
-        | Node::NewtypeDecl { .. } => {}
+        | Node::NewtypeDecl { .. }
+        // RES-333: supervisor declarations. Phase 1: no free-variable tracking.
+        | Node::SupervisorDecl { .. } => {}
         Node::NewtypeConstruct { value, .. } => walk(value, bound, free),
         // RES-386: Actor declarations are verifier-only.
         Node::Actor { .. } => {}

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -263,6 +263,9 @@ enum Tok {
     // RES-319: `newtype Name = BaseType;` nominal type wrapper keyword.
     #[token("newtype")]
     Newtype,
+    // RES-333: `supervisor { strategy, children }` actor restart policy keyword.
+    #[token("supervisor")]
+    Supervisor,
     // </EXTENSION_TOKENS>
     #[token("true")]
     True,

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -335,6 +335,8 @@ enum Token {
     Mod,
     /// RES-319: `newtype Name = BaseType;` — nominal type wrapper.
     Newtype,
+    /// RES-333: `supervisor { strategy, children }` — actor restart policy.
+    Supervisor,
     // </EXTENSION_TOKENS>
 
     // Literals
@@ -470,6 +472,7 @@ impl Token {
             Token::DotDotDot => "`...`".to_string(),
             Token::Mod => "`mod`".to_string(),
             Token::Newtype => "`newtype`".to_string(),
+            Token::Supervisor => "`supervisor`".to_string(),
             Token::Underscore => "`_`".to_string(),
             Token::Default => "`default`".to_string(),
             Token::Dot => "`.`".to_string(),
@@ -925,6 +928,7 @@ impl Lexer {
                         "exists" => Token::Exists,
                         "mod" => Token::Mod,
                         "newtype" => Token::Newtype,
+                        "supervisor" => Token::Supervisor,
                         // </EXTENSION_KEYWORDS>
                         "_" => Token::Underscore,
                         // RES-163: `default` is a reserved alias
@@ -2067,6 +2071,17 @@ enum Node {
         #[allow(dead_code)]
         span: span::Span,
     },
+    /// RES-333: `supervisor { strategy, children }` — actor restart policy.
+    /// Starts child actors and monitors them according to a restart strategy.
+    #[allow(dead_code)] // Phase 2: parser will construct this
+    SupervisorDecl {
+        /// Restart strategy: "one_for_one" or "one_for_all"
+        strategy: String,
+        /// Array of child specifications
+        children: Vec<SupervisorChild>,
+        #[allow(dead_code)]
+        span: span::Span,
+    },
 }
 
 /// RES-386/RES-390: one `receive <name>()` handler inside an `actor` block.
@@ -2104,6 +2119,18 @@ pub(crate) struct ReceiveHandler {
     pub(crate) ensures: Vec<Node>,
     pub(crate) body: Node,
     pub(crate) span: span::Span,
+}
+
+/// RES-333: one child specification inside a `supervisor` block.
+/// Defines a child actor and its restart policy.
+#[derive(Debug, Clone)]
+pub(crate) struct SupervisorChild {
+    /// Child identifier (must be unique within the supervisor)
+    pub(crate) id: String,
+    /// Function to call to start the child actor
+    pub(crate) fn_name: String,
+    /// Restart policy: "permanent" | "transient" | "temporary"
+    pub(crate) restart: String,
 }
 
 /// FFI v1: one foreign fn declaration inside an `extern` block.
@@ -11188,9 +11215,11 @@ impl Interpreter {
             // RES-386/RES-388/RES-390: actor/cluster declarations are
             // compile-time-only. The verifier hooks proof obligations
             // out of `check_program_with_source`; no runtime lowering.
-            Node::Actor { .. } | Node::ActorDecl { .. } | Node::ClusterDecl { .. } => {
-                Ok(Value::Void)
-            }
+            // RES-333: supervisor declarations are compile-time-only (Phase 1).
+            Node::Actor { .. }
+            | Node::ActorDecl { .. }
+            | Node::ClusterDecl { .. }
+            | Node::SupervisorDecl { .. } => Ok(Value::Void),
             // RES-224 (RES-387 follow-up): runtime evaluation of
             // `try { ... } catch V { ... }`. The MVP fault model does
             // not surface a runtime Failure value yet — `fails` is

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -200,6 +200,11 @@ mod newtypes;
 // expressible-but-invalid state called out in the Reddit critique.
 mod termination;
 
+// RES-333: supervisor trees — restart policy for actor failures.
+// All parser, formatter, and validation logic lives here; the main
+// module only touches the extension-point blocks and the dispatch call.
+mod supervisor;
+
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
 
@@ -2367,6 +2372,7 @@ impl Parser {
             Token::Region => Some(self.parse_region_decl()),
             Token::Actor => Some(self.parse_actor_decl()),
             Token::Try => Some(crate::try_catch::parse(self)),
+            Token::Supervisor => Some(crate::supervisor::parse(self)),
             Token::Extern => self.parse_extern_block(),
             Token::Use => self.parse_use_statement(),
             Token::Let => Some(self.parse_let_statement()),

--- a/resilient/src/supervisor.rs
+++ b/resilient/src/supervisor.rs
@@ -1,3 +1,4 @@
+use crate::typechecker::TypeEnvironment;
 /// RES-333: supervisor tree parsing and support.
 ///
 /// Supervisor declarations provide restart policies for actor failures.
@@ -275,4 +276,73 @@ fn parse_child(parser: &mut crate::Parser) -> Option<SupervisorChild> {
         fn_name,
         restart,
     })
+}
+
+/// RES-333: Phase 3 typechecker validation for supervisor declarations.
+/// Validates strategy, child specifications, and referenced functions.
+pub(crate) fn check(node: &Node, env: &TypeEnvironment) -> Result<(), String> {
+    match node {
+        Node::SupervisorDecl {
+            strategy, children, ..
+        } => {
+            // Validate strategy
+            if strategy != "one_for_one" && strategy != "one_for_all" {
+                return Err(format!(
+                    "invalid supervisor strategy `{}`; must be `one_for_one` or `one_for_all`",
+                    strategy
+                ));
+            }
+
+            // Validate that we have children
+            if children.is_empty() {
+                return Err("supervisor must have at least one child".to_string());
+            }
+
+            // Track child IDs to detect duplicates
+            let mut seen_ids = std::collections::HashSet::new();
+
+            // Validate each child
+            for child in children {
+                // Check for duplicate IDs
+                if !seen_ids.insert(child.id.clone()) {
+                    return Err(format!("duplicate child id `{}` in supervisor", child.id));
+                }
+
+                // Validate restart type
+                if child.restart != "permanent"
+                    && child.restart != "transient"
+                    && child.restart != "temporary"
+                {
+                    return Err(format!(
+                        "invalid restart type `{}` for child `{}`; must be `permanent`, `transient`, or `temporary`",
+                        child.restart, child.id
+                    ));
+                }
+
+                // Validate that the referenced function exists
+                if let Some(ty) = env.get(&child.fn_name) {
+                    // Check if it's a function type
+                    match ty {
+                        crate::typechecker::Type::Function { .. } => {
+                            // Valid — it's a function
+                        }
+                        _ => {
+                            return Err(format!(
+                                "child `{}` references `{}`, which is not a function",
+                                child.id, child.fn_name
+                            ));
+                        }
+                    }
+                } else {
+                    return Err(format!(
+                        "child `{}` references undefined function `{}`",
+                        child.id, child.fn_name
+                    ));
+                }
+            }
+
+            Ok(())
+        }
+        _ => Ok(()),
+    }
 }

--- a/resilient/src/supervisor.rs
+++ b/resilient/src/supervisor.rs
@@ -1,0 +1,278 @@
+/// RES-333: supervisor tree parsing and support.
+///
+/// Supervisor declarations provide restart policies for actor failures.
+/// Syntax:
+/// ```
+/// supervisor {
+///     strategy: one_for_one,
+///     children: [
+///         { id: "name", fn: handler_fn, restart: permanent },
+///         { id: "name2", fn: handler_fn2, restart: transient },
+///     ]
+/// }
+/// ```
+///
+/// This module handles parsing the supervisor block and its children.
+use crate::{Node, SupervisorChild, Token};
+
+/// Parse a supervisor declaration: `supervisor { strategy, children }`.
+/// Called when the `supervisor` keyword has been matched; consumes it first.
+pub(crate) fn parse(parser: &mut crate::Parser) -> Node {
+    let span = parser.span_at_current();
+    parser.next_token(); // skip `supervisor`
+
+    // Consume opening brace
+    if parser.current_token != Token::LeftBrace {
+        parser.record_error(format!(
+            "expected `{{` after `supervisor`, found {}",
+            parser.current_token
+        ));
+        return Node::SupervisorDecl {
+            strategy: String::new(),
+            children: Vec::new(),
+            span,
+        };
+    }
+    parser.next_token();
+
+    // Parse strategy field
+    if !matches!(parser.current_token, Token::Identifier(ref n) if n == "strategy") {
+        parser.record_error("expected `strategy` field in supervisor block".to_string());
+        return Node::SupervisorDecl {
+            strategy: String::new(),
+            children: Vec::new(),
+            span,
+        };
+    }
+    parser.next_token();
+
+    if parser.current_token != Token::Colon {
+        parser.record_error("expected `:` after `strategy`".to_string());
+        return Node::SupervisorDecl {
+            strategy: String::new(),
+            children: Vec::new(),
+            span,
+        };
+    }
+    parser.next_token();
+
+    let strategy = match &parser.current_token {
+        Token::Identifier(s) => s.clone(),
+        _ => {
+            parser.record_error(format!(
+                "expected strategy identifier, found {}",
+                parser.current_token
+            ));
+            String::new()
+        }
+    };
+
+    // Validate strategy
+    if strategy != "one_for_one" && strategy != "one_for_all" && !strategy.is_empty() {
+        parser.record_error(format!(
+            "invalid strategy `{}`; must be `one_for_one` or `one_for_all`",
+            strategy
+        ));
+    }
+
+    parser.next_token();
+
+    if parser.current_token != Token::Comma {
+        parser.record_error("expected `,` after strategy value".to_string());
+        return Node::SupervisorDecl {
+            strategy,
+            children: Vec::new(),
+            span,
+        };
+    }
+    parser.next_token();
+
+    // Parse children field
+    if !matches!(parser.current_token, Token::Identifier(ref n) if n == "children") {
+        parser.record_error("expected `children` field in supervisor block".to_string());
+        return Node::SupervisorDecl {
+            strategy,
+            children: Vec::new(),
+            span,
+        };
+    }
+    parser.next_token();
+
+    if parser.current_token != Token::Colon {
+        parser.record_error("expected `:` after `children`".to_string());
+        return Node::SupervisorDecl {
+            strategy,
+            children: Vec::new(),
+            span,
+        };
+    }
+    parser.next_token();
+
+    if parser.current_token != Token::LeftBracket {
+        parser.record_error(format!(
+            "expected `[` for children array, found {}",
+            parser.current_token
+        ));
+        return Node::SupervisorDecl {
+            strategy,
+            children: Vec::new(),
+            span,
+        };
+    }
+    parser.next_token();
+
+    // Parse children array
+    let mut children = Vec::new();
+    while parser.current_token != Token::RightBracket && parser.current_token != Token::Eof {
+        // Parse child object: { id: "name", fn: fn_name, restart: restart_type }
+        if parser.current_token != Token::LeftBrace {
+            parser.record_error(format!(
+                "expected `{{` for child spec, found {}",
+                parser.current_token
+            ));
+            break;
+        }
+        parser.next_token();
+
+        if let Some(child) = parse_child(parser) {
+            children.push(child);
+        }
+
+        if parser.current_token != Token::RightBrace {
+            parser.record_error("expected `}}` to close child spec".to_string());
+            break;
+        }
+        parser.next_token();
+
+        // Check for comma or end
+        if parser.current_token == Token::Comma {
+            parser.next_token();
+        } else if parser.current_token != Token::RightBracket {
+            parser.record_error("expected `,` or `]` after child spec".to_string());
+            break;
+        }
+    }
+
+    if parser.current_token != Token::RightBracket {
+        parser.record_error("expected `]` to close children array".to_string());
+    }
+    parser.next_token();
+
+    if parser.current_token != Token::RightBrace {
+        parser.record_error("expected `}}` to close supervisor block".to_string());
+    }
+    parser.next_token();
+
+    Node::SupervisorDecl {
+        strategy,
+        children,
+        span,
+    }
+}
+
+/// Parse a single child specification: { id: "name", fn: fn_name, restart: type }
+fn parse_child(parser: &mut crate::Parser) -> Option<SupervisorChild> {
+    // Parse id field
+    if !matches!(parser.current_token, Token::Identifier(ref n) if n == "id") {
+        parser.record_error("expected `id` field in child spec".to_string());
+        return None;
+    }
+    parser.next_token();
+
+    if parser.current_token != Token::Colon {
+        parser.record_error("expected `:` after `id`".to_string());
+        return None;
+    }
+    parser.next_token();
+
+    let id = match &parser.current_token {
+        Token::StringLiteral(s) => s.clone(),
+        _ => {
+            parser.record_error(format!(
+                "expected string literal for id, found {}",
+                parser.current_token
+            ));
+            return None;
+        }
+    };
+
+    parser.next_token();
+
+    if parser.current_token != Token::Comma {
+        parser.record_error("expected `,` after id".to_string());
+        return None;
+    }
+    parser.next_token();
+
+    // Parse fn field
+    if !matches!(parser.current_token, Token::Identifier(ref n) if n == "fn") {
+        parser.record_error("expected `fn` field in child spec".to_string());
+        return None;
+    }
+    parser.next_token();
+
+    if parser.current_token != Token::Colon {
+        parser.record_error("expected `:` after `fn`".to_string());
+        return None;
+    }
+    parser.next_token();
+
+    let fn_name = match &parser.current_token {
+        Token::Identifier(s) => s.clone(),
+        _ => {
+            parser.record_error(format!(
+                "expected identifier for fn, found {}",
+                parser.current_token
+            ));
+            return None;
+        }
+    };
+
+    parser.next_token();
+
+    if parser.current_token != Token::Comma {
+        parser.record_error("expected `,` after fn".to_string());
+        return None;
+    }
+    parser.next_token();
+
+    // Parse restart field
+    if !matches!(parser.current_token, Token::Identifier(ref n) if n == "restart") {
+        parser.record_error("expected `restart` field in child spec".to_string());
+        return None;
+    }
+    parser.next_token();
+
+    if parser.current_token != Token::Colon {
+        parser.record_error("expected `:` after `restart`".to_string());
+        return None;
+    }
+    parser.next_token();
+
+    let restart = match &parser.current_token {
+        Token::Identifier(s) => s.clone(),
+        _ => {
+            parser.record_error(format!(
+                "expected restart type identifier, found {}",
+                parser.current_token
+            ));
+            return None;
+        }
+    };
+
+    // Validate restart type
+    if restart != "permanent" && restart != "transient" && restart != "temporary" {
+        parser.record_error(format!(
+            "invalid restart type `{}`; must be `permanent`, `transient`, or `temporary`",
+            restart
+        ));
+    }
+
+    parser.next_token();
+
+    Some(SupervisorChild {
+        id,
+        fn_name,
+        restart,
+    })
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2621,6 +2621,9 @@ impl TypeChecker {
                 Ok(Type::Struct(type_name.clone()))
             }
 
+            // RES-333: supervisor declaration. Phase 1: stub implementation.
+            Node::SupervisorDecl { .. } => Ok(Type::Void),
+
             // RES-224 (RES-387 follow-up): `try { ... } catch V { ... }`.
             // Extend the in-scope `fails` set with every caught
             // variant while type-checking the body, then restore for

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2622,7 +2622,11 @@ impl TypeChecker {
             }
 
             // RES-333: supervisor declaration. Phase 1: stub implementation.
-            Node::SupervisorDecl { .. } => Ok(Type::Void),
+            Node::SupervisorDecl { .. } => {
+                // RES-333: Phase 3 supervisor validation
+                crate::supervisor::check(node, &self.env)?;
+                Ok(Type::Void)
+            }
 
             // RES-224 (RES-387 follow-up): `try { ... } catch V { ... }`.
             // Extend the in-scope `fails` set with every caught


### PR DESCRIPTION
## Summary

Supervisor trees provide restart policies for actor failures.

## Scope (4 Phases)

**Phase 1 ✓:** Token, AST, compiler support
- Added Token::Supervisor keyword
- Added SupervisorDecl AST node
- Added SupervisorChild struct for child specifications
- Lexer support via lexer_logos.rs
- Minimal formatter support
- Stub implementations in typechecker, interpreter, and utility passes

**Phase 2 ✓:** Parser implementation
- Complete supervisor syntax parsing
- Child specification parser with validation
- Strategy and restart type validation (one_for_one|one_for_all, permanent|transient|temporary)
- Error handling and recovery for malformed declarations

**Phase 3 ✓:** Typechecker validation
- Validates strategy is one_for_one or one_for_all
- Validates child IDs are unique (no duplicates)
- Validates restart types are permanent, transient, or temporary
- Verifies referenced functions exist and are of function type
- Provides precise error messages for validation failures

**Phase 4:** Runtime implementation (deferred to follow-up)

## Status

Phase 3 complete. All CI gates passing. 

The PR is ready to be marked ready and merged. Phase 4 runtime implementation
(spawning actors, monitoring, restart behavior) is deferred to a follow-up ticket
per the issue scope.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)