### PR TITLE
RES-392b: Fix recovers_to examples — add main() invocation and golden sidecars

### DIFF
--- a/resilient/examples/recovers_to_final_state_only.expected.txt
+++ b/resilient/examples/recovers_to_final_state_only.expected.txt
@@ -1,0 +1,3 @@
+RES-392 MVP: recovers_to enforced at final state only
+6
+Program executed successfully

--- a/resilient/examples/recovers_to_final_state_only.rz
+++ b/resilient/examples/recovers_to_final_state_only.rz
@@ -12,3 +12,4 @@ fn main() {
   let result = increment_safe(5);
   println(result);
 }
+main();

--- a/resilient/examples/recovers_to_per_prefix.expected.txt
+++ b/resilient/examples/recovers_to_per_prefix.expected.txt
@@ -1,0 +1,3 @@
+RES-392b: recovers_to verified at every instruction boundary
+2
+Program executed successfully

--- a/resilient/examples/recovers_to_per_prefix.rz
+++ b/resilient/examples/recovers_to_per_prefix.rz
@@ -15,3 +15,4 @@ fn main() {
   println(value);
   assert(value >= 2);
 }
+main();


### PR DESCRIPTION
## Summary

Two follow-up fixes to the RES-392b example files merged in PR #345:

1. **Empty stdout bug.** Resilient does not auto-invoke `fn main()` — test programs must call `main();` explicitly (see e.g. `recovers_to_ok.rz`). Both new examples were missing the invocation, so they ran to completion with empty stdout.
2. **Missing golden sidecars.** CLAUDE.md requires `.expected.txt` golden files for new examples. Both files now have one, capturing the actual expected output.

## Verification

- [x] `cargo test --test examples_golden` passes locally
- [x] Both examples produce the documented stdout when run with `rz <file>`

Refs #212