### PR TITLE
RES-133b: admit leading assume() predicates as recovers_to axioms (MVP)

### DIFF
--- a/resilient/examples/assume_recovers_to.expected.txt
+++ b/resilient/examples/assume_recovers_to.expected.txt
@@ -1,0 +1,2 @@
+6
+Program executed successfully

--- a/resilient/examples/assume_recovers_to.rz
+++ b/resilient/examples/assume_recovers_to.rz
@@ -1,0 +1,20 @@
+// RES-133b: leading assume() predicates are admitted as axioms
+// when the verifier discharges `recovers_to`.
+//
+// Without RES-133b, this fn's recovers_to would not be discharged
+// statically because the verifier doesn't know that x >= 0 by the
+// time we reach the body. The runtime check would still be there.
+//
+// With RES-133b, the leading `assume(x >= 0)` is added to the axiom
+// set, and the verifier proves `result >= 0` from `x >= 0`.
+
+fn safe_increment(int x) fails IOError recovers_to: result >= 0 {
+    assume(x >= 0);
+    return x + 1;
+}
+
+fn main() {
+    let n = safe_increment(5);
+    println(n);
+}
+main();

--- a/resilient/src/assume_axioms.rs
+++ b/resilient/src/assume_axioms.rs
@@ -1,0 +1,146 @@
+// RES-133b: collect top-level `assume(P)` predicates from a function
+// body so the verifier can admit them as axioms when discharging
+// `ensures` / `recovers_to` obligations.
+//
+// **Soundness boundary (MVP).** Only `assume`s that occur *before
+// any control-flow* in the top-level Block are collected. An
+// `assume` inside an `if`, `while`, `for`, `match`, or after a
+// `return` is ignored — admitting those as universal axioms would
+// be unsound for the postcondition (a never-taken branch's
+// `assume(false)` would let us prove anything).
+//
+// This is intentionally conservative; a fuller per-block scoping
+// pass is RES-133's longer-term goal. This MVP handles the common
+// case: `assume`s at the start of a function describing what the
+// runtime check ensures we entered the body with.
+
+use crate::Node;
+
+/// Walk the leading prefix of a function body's top-level Block
+/// and collect each `assume(P)` predicate. Stops at the first
+/// statement that introduces control-flow or an early exit.
+///
+/// Returns conditions in source order. Caller appends them to the
+/// `requires` axiom set when invoking the Z3 prover.
+pub(crate) fn collect_leading_assume_axioms(body: &Node) -> Vec<Node> {
+    let mut out = Vec::new();
+    let stmts = match body {
+        Node::Block { stmts, .. } => stmts,
+        _ => return out,
+    };
+
+    for stmt in stmts {
+        match stmt {
+            // `assume(P)` — admit P as an axiom.
+            Node::Assume { condition, .. } => {
+                out.push((**condition).clone());
+            }
+            // `let x = expr;` — does not introduce control flow;
+            // the binding is irrelevant to the assume axioms.
+            Node::LetStatement { .. } => {}
+            // `assert(P)` — runtime-checked; we could admit it but
+            // assert is a *check*, not an *assumption*. Skip; users
+            // who want it admitted should use `assume`.
+            Node::Assert { .. } => {}
+            // Anything else introduces control flow or is a real
+            // statement; stop collecting to stay sound.
+            _ => break,
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Node;
+    use crate::span::Span;
+
+    fn ident(name: &str) -> Node {
+        Node::Identifier {
+            name: name.to_string(),
+            span: Span::default(),
+        }
+    }
+
+    fn block(stmts: Vec<Node>) -> Node {
+        Node::Block {
+            stmts,
+            span: Span::default(),
+        }
+    }
+
+    fn assume_stmt(name: &str) -> Node {
+        Node::Assume {
+            condition: Box::new(ident(name)),
+            message: None,
+            span: Span::default(),
+        }
+    }
+
+    fn assert_stmt(name: &str) -> Node {
+        Node::Assert {
+            condition: Box::new(ident(name)),
+            message: None,
+            span: Span::default(),
+        }
+    }
+
+    #[test]
+    fn empty_body_returns_empty() {
+        let body = block(vec![]);
+        assert_eq!(collect_leading_assume_axioms(&body).len(), 0);
+    }
+
+    #[test]
+    fn collects_leading_assumes() {
+        let body = block(vec![assume_stmt("x"), assume_stmt("y")]);
+        let axioms = collect_leading_assume_axioms(&body);
+        assert_eq!(axioms.len(), 2);
+    }
+
+    #[test]
+    fn assert_does_not_block_collection() {
+        // assert is a check, not control flow; collection continues past it.
+        // But we don't admit asserts as axioms.
+        let body = block(vec![assume_stmt("a"), assert_stmt("b"), assume_stmt("c")]);
+        let axioms = collect_leading_assume_axioms(&body);
+        assert_eq!(axioms.len(), 2);
+    }
+
+    #[test]
+    fn let_does_not_block_collection() {
+        let body = block(vec![
+            assume_stmt("a"),
+            Node::LetStatement {
+                name: "x".into(),
+                value: Box::new(ident("v")),
+                type_annot: None,
+                span: Span::default(),
+            },
+            assume_stmt("b"),
+        ]);
+        let axioms = collect_leading_assume_axioms(&body);
+        assert_eq!(axioms.len(), 2);
+    }
+
+    #[test]
+    fn return_stops_collection() {
+        let body = block(vec![
+            assume_stmt("a"),
+            Node::ReturnStatement {
+                value: None,
+                span: Span::default(),
+            },
+            assume_stmt("b"),
+        ]);
+        let axioms = collect_leading_assume_axioms(&body);
+        assert_eq!(axioms.len(), 1);
+    }
+
+    #[test]
+    fn non_block_body_returns_empty() {
+        let body = ident("x");
+        assert_eq!(collect_leading_assume_axioms(&body).len(), 0);
+    }
+}

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -100,6 +100,10 @@ mod linear;
 // Extends RES-392 (final-state only) with verification that recovers_to
 // holds from any instruction boundary in the function.
 mod recovers_to_bmc;
+// RES-133b: collect leading `assume(P)` predicates from a function body
+// for admission as Z3 axioms when discharging `ensures` / `recovers_to`.
+// MVP scope: top-of-function assumes only (sound — see module docs).
+mod assume_axioms;
 // RES-351: array bounds — static Z3 proof of `0 <= i < len(arr)`
 // at every index site, with an optional strict `--deny-unproven-bounds`
 // mode for safety-critical embedded builds.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1993,7 +1993,12 @@ impl TypeChecker {
                     // after the precondition has been checked, so
                     // the solver is allowed to assume them when
                     // discharging the recovery invariant.
-                    let axioms: Vec<Node> = requires.clone();
+                    // RES-133b: also admit leading `assume(P)` predicates
+                    // from the function body. They are runtime-checked
+                    // before any control flow, so by the time recovers_to
+                    // is evaluated they hold.
+                    let mut axioms: Vec<Node> = requires.clone();
+                    axioms.extend(crate::assume_axioms::collect_leading_assume_axioms(body));
 
                     let mut verdict = fold_const_bool(clause, &no_bindings);
                     let mut cx: Option<String> = None;


### PR DESCRIPTION
## Summary

Partial implementation of RES-133b: the verifier now admits leading `assume(P)` predicates from a function body as Z3 axioms when discharging the `recovers_to` invariant.

## Soundness boundary (MVP)

Only `assume`s that occur **before any control-flow** in the top-level Block of the function body are collected. An `assume` inside an `if`, `while`, `for`, `match`, or after a `return` is **intentionally ignored** — admitting those as universal axioms would be unsound (a never-taken branch's `assume(false)` would let us prove anything).

This handles the common case: `assume`s at the start of a function describing what the runtime check ensures we entered the body with.

A fuller per-block scoping pass (the full RES-133b acceptance criteria) is deferred — the issue body itself splits this into three subtickets, and this MVP covers the most useful slice without the deep typechecker plumbing the full version requires.

## Changes

- New module `resilient/src/assume_axioms.rs` with helper `collect_leading_assume_axioms(body)`
- 6 unit tests covering empty body, leading collection, assert/let passthrough, return stop, non-block body
- `typechecker.rs` recovers_to discharge path extends the requires axiom set with the leading assumes
- Example `resilient/examples/assume_recovers_to.rz` with golden sidecar

## Verification

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] All 1180+ existing tests still pass
- [x] 6 new unit tests pass
- [x] Example produces expected output

Refs #7