### PR TITLE
RES-133b: extend bounds-check axioms with leading assume() predicates

### DIFF
--- a/resilient/src/bounds_check.rs
+++ b/resilient/src/bounds_check.rs
@@ -129,6 +129,11 @@ fn walk_toplevel(node: &Node, source_path: &str, errors: &mut Vec<String>) {
         for r in requires {
             ctx.axioms.push(r.clone());
         }
+        // RES-133b: leading `assume(P)` predicates are also axioms.
+        // The runtime check halts before any indexing in the body if
+        // they are violated, so the bounds prover may use them.
+        ctx.axioms
+            .extend(crate::assume_axioms::collect_leading_assume_axioms(body));
         walk_node(body, &ctx, source_path, errors);
     } else if let Node::ImplBlock { methods, .. } = node {
         for m in methods {


### PR DESCRIPTION
## Summary

Builds on PR #352. The bounds prover (`resilient/src/bounds_check.rs`) already admits `requires` clauses as Z3 axioms when discharging `0 <= i < len(arr)`. This PR extends it to also admit leading `assume(P)` predicates from the function body.

## Use case

Users can now surface non-derivable invariants (e.g. a hardware-ensured array length) and have the static bounds prover use them:

```
fn read_sensor_buffer(int idx) -> int {
    assume(idx < 256);    // hardware guarantee, not derivable from types
    return SENSOR_BUF[idx];  // ← bounds prover uses the assume
}
```

## Verification

- [x] All existing tests still pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Reuses the helper from PR #352 — same soundness boundary (leading-only)

Refs #7