### PR TITLE
RES-133b: extend L0009 divide-by-zero linter with leading assume axioms

### DIFF
--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -1184,18 +1184,31 @@ fn run_l0009_division_by_zero(program: &Node, out: &mut Vec<Lint>) {
     for spanned in stmts {
         match &spanned.node {
             Node::Function { body, requires, .. } => {
-                l0009_check_body(body, requires, out);
+                let axioms = combine_axioms(requires, body);
+                l0009_check_body(body, &axioms, out);
             }
             Node::ImplBlock { methods, .. } => {
                 for method in methods {
                     if let Node::Function { body, requires, .. } = method {
-                        l0009_check_body(body, requires, out);
+                        let axioms = combine_axioms(requires, body);
+                        l0009_check_body(body, &axioms, out);
                     }
                 }
             }
             _ => {}
         }
     }
+}
+
+/// RES-133b: combine the function's `requires` clauses with the
+/// leading `assume(P)` predicates from the body. The result is the
+/// axiom set the divide-by-zero prover sees — assumes at the start
+/// of a fn body are valid axioms because they're runtime-checked
+/// before any expression evaluates.
+fn combine_axioms(requires: &[Node], body: &Node) -> Vec<Node> {
+    let mut axioms: Vec<Node> = requires.to_vec();
+    axioms.extend(crate::assume_axioms::collect_leading_assume_axioms(body));
+    axioms
 }
 
 /// RES-350: walk one fn body, flagging divisions by zero. The


### PR DESCRIPTION
## Summary

Builds on PRs #352 and #353. The L0009 divide-by-zero linter already admits `requires` clauses as Z3 axioms; this extends that axiom set with the leading `assume(P)` predicates from the function body, reusing the helper landed in PR #352.

## Use case

```
fn safe_div(int a, int b) -> int {
    assume(b != 0);   // hardware-guaranteed non-zero
    return a / b;     // ← L0009 no longer fires
}
```

## Verification

- [x] All existing tests still pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Refs #7