### PR TITLE
RES-160: Resilient playground — web-based live code editor and runner

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,0 +1,85 @@
+# RES-368: build and deploy the WASM playground to GitHub Pages.
+#
+# Runs on every push to main that touches the playground source or
+# the bundled examples; runs on pull-request as a build-and-size
+# check (no deploy). The deploy target is the repo's Pages site at
+# https://ericspencer00.github.io/Resilient/ — playground lives at
+# /playground/ underneath.
+
+name: playground
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "playground/**"
+      - "resilient/examples/**"
+      - ".github/workflows/playground.yml"
+  pull_request:
+    paths:
+      - "playground/**"
+      - "resilient/examples/**"
+      - ".github/workflows/playground.yml"
+
+# `pages` writes; `id-token: write` is required for the official
+# `actions/deploy-pages@v4` flow.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Serialize deploys: a queued push and an in-flight push both
+# targeting `main` should not race. Cancel the in-flight if a newer
+# one arrives.
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install rust toolchain (with wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: install wasm-pack
+        run: |
+          if ! command -v wasm-pack >/dev/null 2>&1; then
+            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          fi
+
+      - name: cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            playground/target
+          key: ${{ runner.os }}-playground-${{ hashFiles('playground/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-playground-
+
+      - name: build playground (release, size-checked)
+        run: |
+          bash playground/build.sh --check-size
+
+      - name: upload artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: playground/dist
+
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts produced by `playground/build.sh` and `wasm-pack`.
+target/
+dist/
+pkg/
+Cargo.lock

--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "resilient-playground"
+version = "0.1.0"
+edition = "2024"
+description = "RES-368: WASM-targeted scaffold for the Resilient web playground."
+authors = ["Eric Spencer"]
+publish = false
+
+# `cdylib` is required for `wasm-bindgen` to produce a `.wasm` artifact
+# that `wasm-pack` can bundle for the browser. `rlib` keeps `cargo test`
+# (native) usable from this directory.
+[lib]
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+
+[dependencies]
+# RES-368: bridge between Rust and JavaScript. `web-sys` is intentionally
+# absent — the JS side owns DOM, the Rust side stays a pure source-in
+# /text-out function. Keeps the WASM blob small and the API testable
+# from native Rust without a browser.
+wasm-bindgen = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde-wasm-bindgen = "0.6"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# `js_sys::Date::now()` is the cheapest way to read a wall-clock in
+# the browser; pulling `web-sys::window().performance()` would require
+# threading an `Option` through the timing path for no precision win.
+js-sys = "0.3"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+# Ship-quality release profile: optimize for size, abort on panic.
+# `lto` is intentionally `"thin"` (not full LTO) so build time stays
+# under a minute on CI; the 2 MiB gzip target in `.github/workflows/
+# playground.yml` is comfortably reachable without full LTO.
+[profile.release]
+opt-level = "z"
+lto = "thin"
+codegen-units = 1
+panic = "abort"
+strip = true

--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -42,3 +42,20 @@ lto = "thin"
 codegen-units = 1
 panic = "abort"
 strip = true
+
+# wasm-pack runs `wasm-opt` as a post-build optimization pass. The
+# bundled wasm-opt rejects bulk-memory and other modern WASM proposals
+# unless explicitly enabled — but Rust's wasm32-unknown-unknown target
+# emits `memory.copy` / `memory.fill` (bulk-memory), `i32.extend8_s`
+# (sign-ext), and saturating float-to-int conversions by default. Match
+# the feature set Rust emits so wasm-opt accepts the binary.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = [
+    "-Oz",
+    "--enable-bulk-memory",
+    "--enable-nontrapping-float-to-int",
+    "--enable-sign-ext",
+    "--enable-mutable-globals",
+    "--enable-reference-types",
+    "--enable-multivalue",
+]

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,82 @@
+# Resilient Playground (RES-368)
+
+Static-site playground for trying Resilient in the browser. Built as a
+WASM module (`wasm-bindgen`) plus a thin HTML/JS shell. No server.
+
+```
+playground/
+├── Cargo.toml         WASM crate manifest (cdylib + rlib)
+├── src/lib.rs         compile_and_run(source, _input) -> JSON
+├── web/               static page (HTML + CSS + JS)
+├── build.sh           wasm-pack build + dist/ assembly + size gate
+└── dist/              produced by build.sh; deployed to Pages (gitignored)
+```
+
+## Status
+
+This is the **scaffold** PR for [#160 (RES-368)](https://github.com/EricSpencer00/Resilient/issues/160).
+The page round-trip works end to end: load → init WASM → run → render
+result. The interpreter integration is **stubbed** — `compile_and_run`
+echoes the source with a "scaffold" notice, so the deploy pipeline,
+size budget, and UI flow can be verified before the real interpreter
+lands. The page surfaces this with a yellow banner so a casual visitor
+is not misled.
+
+## What's blocking full integration
+
+The `resilient` crate is currently `[[bin]]`-only (see the comment at
+`resilient/Cargo.toml:138` and the `[[bin]] name = "rz"` block above
+it). To embed the tree-walker in WASM we need a `[lib]` target that
+re-exports at minimum the lexer, parser, type checker, and interpreter
+modules. That requires editing `resilient/src/main.rs` to extract
+module declarations into a sibling `lib.rs` — currently held by the
+`res-333-supervisor-fresh` file claim. Tracked as a follow-up.
+
+A second blocker: several unconditional dependencies in
+`resilient/Cargo.toml` use platform APIs that won't compile to
+`wasm32-unknown-unknown`:
+
+| Dep | Use | WASM-safe path |
+|---|---|---|
+| `notify` + `notify-debouncer-mini` | `--watch` mode | gate behind `#[cfg(not(target_arch = "wasm32"))]` |
+| `rustyline` | REPL | gate behind `#[cfg(not(target_arch = "wasm32"))]` |
+| `rand_core` (getrandom) | cert-key generation | activate the `js` feature on `wasm32` |
+
+The follow-up ticket for the lib refactor should fold these into
+either feature gates or `cfg`-gated compilation.
+
+## Local development
+
+```bash
+# one-time install
+cargo install wasm-pack
+
+# build (no size enforcement) and serve
+playground/build.sh
+python3 -m http.server -d playground/dist 8080
+```
+
+Then open http://localhost:8080 .
+
+## Production build
+
+```bash
+playground/build.sh --check-size
+```
+
+Runs through `wasm-pack build --release`, bakes
+`resilient/examples/*.{rz,res}` into `dist/examples.json`, and rejects
+any artifact whose gzipped `.wasm` exceeds 2 MiB. CI runs this same
+command on every PR that touches `playground/`.
+
+## Acceptance criteria status (#160)
+
+| Criterion | State |
+|---|---|
+| `wasm32-unknown-unknown` target added to CI | ✅ — `.github/workflows/playground.yml` |
+| `resilient` binary compiles to WASM via `wasm-bindgen` | 🟡 — scaffold uses a stand-alone `resilient-playground` crate with a stub interpreter; full integration pending the lib refactor described above |
+| HTML+JS page at `playground/index.html` with CodeMirror + run button | ✅ — `playground/web/index.html` |
+| Run → WASM → stdout in result pane | ✅ — round-trip works; output is a stub message until full integration |
+| Examples dropdown pre-loads `resilient/examples/` | ✅ — baked into `dist/examples.json` at build time |
+| GitHub Pages deploy on push to main | ✅ — `.github/workflows/playground.yml` deploy job |
+| Size gate ≤ 2 MiB gzip | ✅ — `playground/build.sh --check-size` |

--- a/playground/build.sh
+++ b/playground/build.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# RES-368: build the WASM playground for static hosting.
+#
+# Produces a self-contained `playground/dist/` directory:
+#   - index.html, style.css, main.js (copied from `playground/web/`)
+#   - pkg/ (wasm-bindgen output from `wasm-pack`)
+#   - examples.json (manifest of `resilient/examples/*.rz` and *.res
+#     files, baked at build time so the page does not need a server-
+#     side examples endpoint)
+#
+# Exit codes:
+#   0 — dist/ is built and within the size budget
+#   1 — wasm-pack missing
+#   2 — build failed
+#   3 — gzipped .wasm exceeds the size budget
+#
+# Usage:
+#   playground/build.sh               # build, no size enforcement
+#   playground/build.sh --check-size  # also enforce ≤ 2 MiB gzip
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DIST_DIR="$SCRIPT_DIR/dist"
+SIZE_LIMIT=$((2 * 1024 * 1024))
+
+CHECK_SIZE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check-size) CHECK_SIZE=1; shift ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v wasm-pack >/dev/null 2>&1; then
+  echo "error: wasm-pack not found on PATH; install with 'cargo install wasm-pack'" >&2
+  exit 1
+fi
+
+echo ">>> building WASM crate"
+cd "$SCRIPT_DIR"
+wasm-pack build \
+  --target web \
+  --release \
+  --out-dir "$DIST_DIR/pkg" \
+  --out-name resilient_playground
+
+echo ">>> copying static assets"
+cp "$SCRIPT_DIR/web/index.html" "$DIST_DIR/index.html"
+cp "$SCRIPT_DIR/web/style.css"  "$DIST_DIR/style.css"
+cp "$SCRIPT_DIR/web/main.js"    "$DIST_DIR/main.js"
+
+echo ">>> baking examples.json from resilient/examples/"
+python3 - "$REPO_ROOT" "$DIST_DIR/examples.json" <<'PYEOF'
+import json
+import os
+import sys
+
+repo_root = sys.argv[1]
+out_path = sys.argv[2]
+
+examples_dir = os.path.join(repo_root, "resilient", "examples")
+items = []
+for name in sorted(os.listdir(examples_dir)):
+    if not (name.endswith(".rz") or name.endswith(".res")):
+        continue
+    path = os.path.join(examples_dir, name)
+    try:
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+    except (UnicodeDecodeError, OSError):
+        continue
+    # Skip the very large examples — the dropdown is not the place
+    # to scroll a 500-line snippet. Keeps the manifest under a few
+    # hundred KB.
+    if len(source) > 16 * 1024:
+        continue
+    items.append({"name": name, "source": source})
+
+with open(out_path, "w", encoding="utf-8") as f:
+    json.dump(items, f, indent=2)
+print(f"baked {len(items)} examples into {out_path}")
+PYEOF
+
+if (( CHECK_SIZE )); then
+  echo ">>> checking gzipped .wasm size"
+  WASM_FILE="$DIST_DIR/pkg/resilient_playground_bg.wasm"
+  if [ ! -f "$WASM_FILE" ]; then
+    echo "error: expected wasm output at $WASM_FILE" >&2
+    exit 2
+  fi
+  GZIPPED=$(gzip -c "$WASM_FILE" | wc -c | tr -d ' ')
+  echo "    gzipped size: $GZIPPED bytes (limit: $SIZE_LIMIT bytes)"
+  if (( GZIPPED > SIZE_LIMIT )); then
+    echo "error: WASM artifact exceeds 2 MiB gzip budget" >&2
+    exit 3
+  fi
+fi
+
+echo ">>> dist/ ready: $DIST_DIR"

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -1,0 +1,145 @@
+// RES-368: WASM-bindgen entry point for the Resilient web playground.
+//
+// Exposes `compile_and_run(source) -> JSON` so the browser can drive
+// the language without going through a server. The playground is a
+// "demo, not a full toolchain" surface — JIT, FFI, Z3, file I/O, and
+// the watcher are intentionally absent (none compile to WASM today,
+// and the playground value is the language semantics, not the
+// supporting tooling).
+//
+// Status: scaffold. The interpreter integration is deferred until
+// `resilient/Cargo.toml` exposes a library target — currently it is
+// `[[bin]]`-only (see comment at `resilient/Cargo.toml:138`). Tracked
+// in the PR description for #160.
+
+#![allow(clippy::needless_pass_by_value)]
+
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+/// Result of running a source snippet. The browser-side JS turns this
+/// into the editor's output pane. Kept JSON-stable so the schema can
+/// extend (diagnostics, timing) without breaking the page.
+#[derive(Serialize)]
+struct RunResult {
+    /// Concatenated stdout from the run. May be empty on success
+    /// when the program produces no output.
+    stdout: String,
+    /// Concatenated stderr / diagnostics from the run. `None` when
+    /// the run succeeded; `Some(text)` carries the diagnostic block
+    /// the user should see.
+    stderr: Option<String>,
+    /// Process-style exit status. `0` for success, non-zero for any
+    /// diagnostic-producing failure.
+    exit_code: i32,
+    /// Wall-clock milliseconds the run took, for the result pane's
+    /// "ran in N ms" footer.
+    duration_ms: f64,
+    /// Build flavor — `"stub"` until the interpreter integration
+    /// lands, then `"tree-walker"`. Surfaces to the UI so the
+    /// "scaffold" banner can hide once the real interpreter is wired.
+    flavor: &'static str,
+}
+
+/// Run a Resilient source snippet and return a JSON `RunResult`.
+///
+/// `source` is the editor buffer; `_input` is reserved for future
+/// stdin-style input (e.g. when the playground grows examples that
+/// read user keystrokes).
+///
+/// Today this is a stub that echoes the program text and surfaces a
+/// "scaffold" notice, so the page round-trip (editor → wasm → output)
+/// is verifiable end-to-end before the interpreter integration lands.
+#[wasm_bindgen]
+pub fn compile_and_run(source: &str, _input: &str) -> JsValue {
+    let started = now_ms();
+    let result = run_inner(source);
+    let elapsed = (now_ms() - started).max(0.0);
+    let payload = RunResult {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exit_code: result.exit_code,
+        duration_ms: elapsed,
+        flavor: "stub",
+    };
+    serde_wasm_bindgen::to_value(&payload).unwrap_or(JsValue::NULL)
+}
+
+/// `compile_and_run` implementation, factored out so it can be
+/// exercised from native `cargo test` without touching `JsValue`.
+fn run_inner(source: &str) -> InnerResult {
+    if source.trim().is_empty() {
+        return InnerResult {
+            stdout: String::new(),
+            stderr: Some("error: empty program".to_owned()),
+            exit_code: 2,
+        };
+    }
+
+    let preview = source.lines().take(5).collect::<Vec<_>>().join("\n");
+    let stdout = format!(
+        "[playground scaffold — interpreter integration pending]\n\
+         received {} bytes; first {} line(s):\n\
+         {}\n",
+        source.len(),
+        source.lines().take(5).count(),
+        preview
+    );
+    InnerResult {
+        stdout,
+        stderr: None,
+        exit_code: 0,
+    }
+}
+
+struct InnerResult {
+    stdout: String,
+    stderr: Option<String>,
+    exit_code: i32,
+}
+
+/// Library version string (e.g. `"0.1.0-stub"`) so the page banner
+/// can pin a build to a known scaffold version when filing bugs.
+#[wasm_bindgen]
+pub fn playground_version() -> String {
+    format!("{}-stub", env!("CARGO_PKG_VERSION"))
+}
+
+/// Best-effort wall-clock millisecond timer. Uses
+/// `js_sys::Date::now()` in the browser and `std::time` natively so
+/// the same code path is exercised by `cargo test`.
+fn now_ms() -> f64 {
+    #[cfg(target_arch = "wasm32")]
+    {
+        js_sys::Date::now()
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs_f64() * 1000.0)
+            .unwrap_or(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_source_is_diagnosed() {
+        let r = run_inner("");
+        assert_eq!(r.exit_code, 2);
+        assert!(r.stderr.is_some());
+    }
+
+    #[test]
+    fn nonempty_source_is_echoed_with_scaffold_marker() {
+        let r = run_inner("fn main() { println(\"hi\"); }");
+        assert_eq!(r.exit_code, 0);
+        assert!(r.stderr.is_none());
+        assert!(r.stdout.contains("playground scaffold"));
+        assert!(r.stdout.contains("first 1 line(s)"));
+    }
+}

--- a/playground/web/index.html
+++ b/playground/web/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Resilient Playground</title>
+    <link rel="stylesheet" href="style.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/theme/idea.css"
+    />
+  </head>
+  <body>
+    <header>
+      <h1>Resilient Playground</h1>
+      <span class="banner" id="scaffold-banner" hidden>
+        scaffold build &mdash; interpreter integration pending
+      </span>
+      <nav>
+        <label for="example-select">Examples:</label>
+        <select id="example-select">
+          <option value="">&mdash; choose an example &mdash;</option>
+        </select>
+        <button id="run-btn" type="button">Run</button>
+        <button id="clear-btn" type="button">Clear output</button>
+        <a
+          href="https://github.com/EricSpencer00/Resilient"
+          target="_blank"
+          rel="noreferrer noopener"
+          class="github-link"
+          >Source &amp; docs &rarr;</a
+        >
+      </nav>
+    </header>
+
+    <main>
+      <section class="editor-pane" aria-label="Source editor">
+        <textarea id="editor"></textarea>
+      </section>
+      <section class="output-pane" aria-label="Program output">
+        <pre id="output"></pre>
+        <footer id="output-footer"></footer>
+      </section>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/mode/rust/rust.js"></script>
+    <script type="module" src="main.js"></script>
+  </body>
+</html>

--- a/playground/web/main.js
+++ b/playground/web/main.js
@@ -1,0 +1,152 @@
+// RES-368: browser-side glue for the Resilient WASM playground.
+//
+// Wires three things:
+//   1. CodeMirror editor in the left pane.
+//   2. Examples dropdown — populated from `examples.json` produced
+//      at build time (or a fallback list of known examples if the
+//      manifest is missing, which keeps the page useful when served
+//      directly from the `playground/web/` directory in dev).
+//   3. Run button — invokes `compile_and_run(source, "")` from the
+//      WASM module and renders the structured result into the
+//      output pane.
+
+import init, {
+  compile_and_run,
+  playground_version,
+} from "./pkg/resilient_playground.js";
+
+const EXAMPLES_FALLBACK = [
+  {
+    name: "hello.rz",
+    source:
+      'fn main() {\n    println("Hello, Resilient world!");\n}\nmain();\n',
+  },
+  {
+    name: "factorial.rz",
+    source:
+      "fn fact(int n) {\n    if n <= 1 { return 1; }\n    return n * fact(n - 1);\n}\nprintln(fact(7));\n",
+  },
+  {
+    name: "loop_invariant.rz",
+    source:
+      "fn sum_to(int n)\n  requires n >= 0\n  ensures result >= 0\n{\n    let total = 0;\n    let i = 0;\n    while i < n\n      invariant total >= 0\n      invariant i >= 0\n    {\n        total = total + i;\n        i = i + 1;\n    }\n    return total;\n}\nprintln(sum_to(10));\n",
+  },
+];
+
+const editorEl = document.getElementById("editor");
+const outputEl = document.getElementById("output");
+const footerEl = document.getElementById("output-footer");
+const runBtn = document.getElementById("run-btn");
+const clearBtn = document.getElementById("clear-btn");
+const select = document.getElementById("example-select");
+const banner = document.getElementById("scaffold-banner");
+
+editorEl.value = EXAMPLES_FALLBACK[0].source;
+
+const cm = CodeMirror.fromTextArea(editorEl, {
+  mode: "rust",
+  lineNumbers: true,
+  theme: "idea",
+  indentUnit: 4,
+  smartIndent: true,
+  autofocus: true,
+});
+
+let wasmReady = false;
+
+async function bootstrap() {
+  try {
+    await init();
+    wasmReady = true;
+    const v = playground_version();
+    if (v.endsWith("-stub")) {
+      banner.hidden = false;
+    }
+    footerEl.textContent = `playground ${v} ready`;
+    runBtn.disabled = false;
+  } catch (err) {
+    runBtn.disabled = true;
+    outputEl.classList.add("error");
+    outputEl.textContent =
+      "Failed to load WASM module:\n" +
+      (err && err.message ? err.message : String(err));
+    footerEl.textContent = "WASM init failed";
+  }
+}
+
+async function loadExamples() {
+  let manifest = null;
+  try {
+    const res = await fetch("./examples.json", { cache: "no-store" });
+    if (res.ok) manifest = await res.json();
+  } catch (_err) {
+    // fall through to fallback
+  }
+  const list = Array.isArray(manifest) && manifest.length ? manifest : EXAMPLES_FALLBACK;
+  for (const ex of list) {
+    const opt = document.createElement("option");
+    opt.value = ex.name;
+    opt.textContent = ex.name;
+    opt.dataset.source = ex.source;
+    select.appendChild(opt);
+  }
+}
+
+select.addEventListener("change", () => {
+  const opt = select.selectedOptions[0];
+  if (opt && opt.dataset.source) {
+    cm.setValue(opt.dataset.source);
+    cm.focus();
+  }
+});
+
+clearBtn.addEventListener("click", () => {
+  outputEl.textContent = "";
+  outputEl.classList.remove("error");
+  footerEl.textContent = "";
+});
+
+runBtn.addEventListener("click", async () => {
+  if (!wasmReady) return;
+  runBtn.disabled = true;
+  outputEl.classList.remove("error");
+  outputEl.textContent = "Running…";
+  footerEl.textContent = "";
+
+  // Yield to the event loop so the "Running…" placeholder paints
+  // before the (potentially blocking) WASM call. Stubs are fast,
+  // but the full interpreter will benefit from this once integrated.
+  await new Promise((r) => setTimeout(r, 0));
+
+  let result;
+  try {
+    result = compile_and_run(cm.getValue(), "");
+  } catch (err) {
+    outputEl.classList.add("error");
+    outputEl.textContent =
+      "WASM trapped while running:\n" +
+      (err && err.message ? err.message : String(err));
+    footerEl.textContent = "trap";
+    runBtn.disabled = false;
+    return;
+  }
+
+  const stdout = result?.stdout ?? "";
+  const stderr = result?.stderr ?? null;
+  const code = result?.exit_code ?? -1;
+  const ms = Math.max(0, Math.round(result?.duration_ms ?? 0));
+  const flavor = result?.flavor ?? "unknown";
+
+  if (stderr) {
+    outputEl.classList.add("error");
+    outputEl.textContent = stderr + (stdout ? "\n--\n" + stdout : "");
+  } else {
+    outputEl.textContent = stdout || "(no output)";
+  }
+  footerEl.textContent = `exit ${code} • ${ms} ms • ${flavor}`;
+  runBtn.disabled = false;
+});
+
+runBtn.disabled = true;
+loadExamples();
+bootstrap();

--- a/playground/web/style.css
+++ b/playground/web/style.css
@@ -1,0 +1,158 @@
+/* RES-368: minimum-viable styling for the WASM playground page.
+ * Two-column layout (editor / output) with a thin top bar.
+ * No framework — plain CSS keeps the page deployable as static
+ * assets with no build step beyond `wasm-pack`.
+ */
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f7f7f7;
+  color: #1a1a1a;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 1px solid #d0d0d0;
+  background: #ffffff;
+  flex: 0 0 auto;
+}
+
+header h1 {
+  font-size: 18px;
+  margin: 0;
+  font-weight: 600;
+}
+
+.banner {
+  font-size: 12px;
+  background: #fff7d6;
+  color: #6a4f00;
+  border: 1px solid #e6cf66;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+nav {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+nav label {
+  font-size: 13px;
+  color: #555;
+}
+
+nav select,
+nav button {
+  font: inherit;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid #c0c0c0;
+  background: #fff;
+  cursor: pointer;
+}
+
+nav select:focus,
+nav button:focus {
+  outline: 2px solid #4f8cff;
+  outline-offset: 1px;
+}
+
+#run-btn {
+  background: #2c7a2c;
+  color: #fff;
+  border-color: #2c7a2c;
+}
+
+#run-btn:hover {
+  background: #246124;
+}
+
+#run-btn:disabled {
+  background: #9ec19e;
+  border-color: #9ec19e;
+  cursor: wait;
+}
+
+.github-link {
+  font-size: 13px;
+  color: #4f8cff;
+  text-decoration: none;
+}
+
+.github-link:hover {
+  text-decoration: underline;
+}
+
+main {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 1px;
+  background: #d0d0d0;
+  min-height: 0;
+}
+
+.editor-pane,
+.output-pane {
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.CodeMirror {
+  flex: 1 1 auto;
+  height: auto;
+  font-family: "SF Mono", "Menlo", "Consolas", monospace;
+  font-size: 13px;
+}
+
+#output {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 12px 16px;
+  font-family: "SF Mono", "Menlo", "Consolas", monospace;
+  font-size: 13px;
+  white-space: pre-wrap;
+  overflow: auto;
+  background: #fafafa;
+}
+
+#output.error {
+  background: #fff0f0;
+  color: #8a1a1a;
+}
+
+#output-footer {
+  flex: 0 0 auto;
+  padding: 6px 16px;
+  border-top: 1px solid #e0e0e0;
+  font-size: 12px;
+  color: #777;
+  background: #fff;
+}
+
+@media (max-width: 800px) {
+  main {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+}


### PR DESCRIPTION
Closes #160.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-160-resilient-playground-web-based-live-code`
Worktree: `.claude/worktrees/res-160`

## Agent claims

(none inferred from issue)