### PR TITLE
RES-270: TLA+ model checking integration (V2+ design)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,6 +55,12 @@ time, commit it, and only then move the post.
 | **G20** | Self-hosting | ⏳ Blocked on RES-323 (lexer in Resilient) → RES-379 (parser in Resilient). |
 | **G21** | FFI v1 (tree-walker + static registry) | ✅ Shipped 2026-04-19. RES-383 security audit landed 2026-04-29. |
 
+### V2 ladder (post-V1 ship)
+
+| # | Goalpost | Status |
+|---|---|---|
+| **G22** | TLA+ model checking — temporal verification (Path B: external `.tla` + `@refines` mappings, TLC default backend) | ⏳ V2+ design locked — RES-396 (#270). Ship surface = V2.0 bridge (`rz tla check`) + V2.1 `@refines` + V2.2 counterexample replay; V2.3 fairness/liveness and V2.4 Apalache backend follow. ~10 contributor-weeks total. See [`docs/superpowers/specs/2026-04-26-tla-model-checking.md`](docs/superpowers/specs/2026-04-26-tla-model-checking.md) and the [closure doc](docs/superpowers/specs/2026-04-29-tla-decision-closure.md). |
+
 ### New between G4 and G5 (core-language improvements landed in session 2)
 
 Not assigned their own goalpost but worth listing, since each is a
@@ -103,6 +109,7 @@ changelog entry below.
 - 2026-04-17 — G15 JIT real expression + control-flow (Phases B–E via RES-096/099/100/102).
   G18 no_std embedded toolchain proven end-to-end ✅ (RES-075/097/098).
 - 2026-04-19 — G21 FFI v1 shipped (tree-walker + static registry, 748 tests pass).
+- 2026-04-29 — G22 TLA+ ladder seeded (RES-396 V2+ design closure; Path B / TLC / V2.0–V2.2 ship scope confirmed).
 - 2026-04-20 — Migrated ticket tracking from `.board/` to GitHub Issues.
 - 2026-04-29 — G18 closed: linear × effect interaction (RES-385c) and concurrency design (RES-208) landed.
   G19 closed: certificate manifest schema v1 (RES-331) plus end-to-end signed `verify-all`.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -98,7 +98,12 @@ with no warning cycle:
 - **Z3 verification** — verifier directives, certificate format, and the
   SMT encoding (especially the overflow-aware encoding tracked by RES-134).
   Runs only with `--features z3`; API shape is expected to change as the
-  verifier evolves.
+  verifier evolves. The V1 verifier surface is intentionally **state-local**
+  (per-function `requires`/`ensures`, single-step `recovers_to`, snapshot
+  cluster invariants); reasoning over **traces** — liveness, fairness,
+  multi-actor interleavings, refinement — is a V2 capability tracked under
+  RES-396 (G22 TLA+ ladder, see [ROADMAP.md](ROADMAP.md)). Don't read V1
+  Z3 success as a temporal-property guarantee.
 - **Package manager (`resilient pkg`)** — subcommand names, manifest format
   (RES-212), and resolution rules.
 - **Language server (`--lsp`)** — request/response shapes beyond stock LSP

--- a/docs/superpowers/specs/2026-04-26-tla-model-checking.md
+++ b/docs/superpowers/specs/2026-04-26-tla-model-checking.md
@@ -380,7 +380,9 @@ Maintainer review 2026-04-26 — defaults confirmed:
 - [ ] **V1 design choices preservation** — open follow-up: explicit sweep
       across the V1 actor backlog (RES-208, RES-332, RES-333) to confirm
       message-ordering and atomicity granularity are pinned down before
-      V1 ships. Tracked under RES-396 follow-ons.
+      V1 ships. Tracked under RES-396 follow-ons in
+      [2026-04-29-tla-decision-closure.md](2026-04-29-tla-decision-closure.md)
+      (Follow-up 1).
 
 ---
 

--- a/docs/superpowers/specs/2026-04-29-tla-decision-closure.md
+++ b/docs/superpowers/specs/2026-04-29-tla-decision-closure.md
@@ -1,0 +1,118 @@
+# RES-396 Decision Closure — TLA+ Model Checking Integration
+
+**Date:** 2026-04-29
+**Status:** Decision summary / ticket closure for [#270](https://github.com/EricSpencer00/Resilient/issues/270)
+**Tracking:** RES-396
+**Companion spec:** [2026-04-26-tla-model-checking.md](2026-04-26-tla-model-checking.md)
+
+---
+
+## Why this document exists
+
+The full TLA+ design is in the [2026-04-26 companion spec](2026-04-26-tla-model-checking.md).
+The companion spec's "Decision log" already records maintainer
+confirmation of the three primary decisions; this closure document
+exists so the [#270](https://github.com/EricSpencer00/Resilient/issues/270)
+ticket has a single, visible artifact a maintainer can sign off on.
+
+[#270](https://github.com/EricSpencer00/Resilient/issues/270)'s
+acceptance criteria call for six items. Three are already resolved in
+the companion spec; three are administrative follow-ups that this
+closure document enumerates so they can be filed as the maintainer
+sees fit.
+
+---
+
+## Resolved (companion spec, 2026-04-26)
+
+These three items in [#270](https://github.com/EricSpencer00/Resilient/issues/270)'s
+acceptance criteria are already checked in the companion spec's
+Decision log:
+
+| Decision | Outcome | Source |
+|---|---|---|
+| Path A vs B vs C | **Path B** — external `.tla` + `@refines` mappings | [companion §Three integration paths](2026-04-26-tla-model-checking.md) |
+| Backend default | **TLC** default; Apalache opt-in via `--mc-backend apalache` (V2.4) | [companion §TLC vs Apalache](2026-04-26-tla-model-checking.md) |
+| Phasing | V2.0 (bridge) + V2.1 (`@refines`) + V2.2 (counterexample replay) ship V2; V2.3/V2.4 follow | [companion §V2.x phasing](2026-04-26-tla-model-checking.md) |
+
+No revision needed. Cross-link is in place; this closure document
+formalizes the resolution for [#270](https://github.com/EricSpencer00/Resilient/issues/270).
+
+---
+
+## Outstanding follow-ups
+
+These three items are not blockers on [#270](https://github.com/EricSpencer00/Resilient/issues/270)
+closing — they are forward-looking actions the maintainer (or a
+delegated agent on the next sweep) should file as separate tickets.
+
+### Follow-up 1 — V1 design-choice preservation sweep
+
+The companion spec lists four V1 design choices that must be preserved
+so V2 isn't retroactively forced into the wrong shape. These need to
+be enforced in the V1 backlog — not deferred to V2.0 implementation.
+
+| # | V1 invariant | Where to enforce | Recommended ticket |
+|---|---|---|---|
+| 1 | Diagnostics carry a tagged enum (extensible to `(spec_path, action_name, trace_step)`), not a flat string | [`resilient/src/diag.rs`](../../../resilient/src/diag.rs) | `RES-DIAG-TAGGED`: audit `diag.rs`, confirm extensibility, add a doc-comment marker pinning the invariant. ~1 day. |
+| 2 | `live { }` block has a closed-form invariant (no arbitrary user-supplied recovery effects) | live-block parser & verifier (`recovers_to_bmc.rs`, `verifier_liveness.rs`) | `RES-LIVE-CLOSED`: add a parser check that rejects `live` blocks whose recovery body cannot be encoded as a TLA+ action. ~3 days. |
+| 3 | Actor primitives ([RES-208](https://github.com/EricSpencer00/Resilient/issues/17), [RES-332](https://github.com/EricSpencer00/Resilient/issues/124), [RES-333](https://github.com/EricSpencer00/Resilient/issues/125)) define message ordering + atomicity granularity explicitly | `supervisor.rs`, `verifier_actors.rs`, SYNTAX.md | `RES-ACTOR-SEMANTICS`: open a sub-spec under `docs/superpowers/specs/` pinning down `send`/`receive` ordering and the atomicity boundary of `receive`-body. Bake outcome into [RES-332](https://github.com/EricSpencer00/Resilient/issues/124) acceptance criteria. ~1 week. |
+| 4 | `recovers_to` is documented as a one-step property; multi-step is V2's `<>` | STABILITY.md, SYNTAX.md, `verifier_liveness.rs` doc-comments | `RES-RECOVERS-DOC`: one-line clarifications + a `// V2 will extend this to <>(...)` marker in the verifier. ~½ day. |
+
+**Action:** open four GitHub issues with the labels `enhancement`,
+`v1-preservation`, and a milestone tying them to V1.0 ship. Total
+effort: ~2 contributor-weeks.
+
+### Follow-up 2 — V2 open-questions resolution spec
+
+Five open questions in the companion spec (Q1–Q5) need answers
+**before** V2.0 implementation begins. They are design questions, not
+implementation questions; answering them under V2.0 would force
+late-stage redesign.
+
+Recommended ticket: `RES-V2-OPEN-Qs` — a single sub-spec under
+`docs/superpowers/specs/` titled "TLA+ V2.0 design lock-in" that
+answers each of Q1–Q5 with a recommendation + tradeoff analysis.
+Effort: ~1 contributor-week.
+
+### Follow-up 3 — V2.0 / V2.1 / V2.2 implementation tickets
+
+Each of the three V2 ship-phase items in the companion spec needs its
+own implementation ticket. Recommended:
+
+| Ticket | Scope | Effort |
+|---|---|---|
+| `RES-V2.0-bridge` | `rz tla check <file.tla>` subcommand; shells out to TLC; surface results in Resilient diagnostics | 3 weeks |
+| `RES-V2.1-refines` | Parse `@refines(spec=..., action=...)`; refinement-mapping checker; `[refinement]` table in `resilient.toml`; 3 working examples + 3 failing | 4 weeks |
+| `RES-V2.2-cex-replay` | Auto-generate Resilient unit test from TLC counterexample trace; depends on V2.1 mappings | 2 weeks |
+
+These are file-on-V2-roadmap, not file-now — they should appear when
+V1 ships and V2 work begins. Until then they would clutter the
+backlog.
+
+---
+
+## Closure recommendation for [#270](https://github.com/EricSpencer00/Resilient/issues/270)
+
+This ticket can close as soon as a maintainer:
+
+1. Confirms the three resolved decisions above (already implicit in
+   the companion spec; this closure makes it explicit).
+2. Files the four V1-preservation tickets from Follow-up 1 (or
+   delegates to an agent).
+3. Files the V2-open-questions sub-spec ticket from Follow-up 2 (or
+   defers to V2 kickoff).
+4. Notes V2.0/V2.1/V2.2 from Follow-up 3 as forward-looking — to be
+   filed at V2 ship time, not now.
+
+The only actionable V1 work that gates V1.0 ship is **Follow-up 1**.
+Items 2 and 3 are forward-looking and do not block V1.
+
+---
+
+## Cross-references
+
+- [docs/superpowers/specs/2026-04-26-tla-model-checking.md](2026-04-26-tla-model-checking.md) — full spec
+- [STABILITY.md](../../../STABILITY.md) — current V1 verification scope
+- [ROADMAP.md](../../../ROADMAP.md) — V2 ladder placement (G21+)
+- [#17](https://github.com/EricSpencer00/Resilient/issues/17) (RES-208), [#124](https://github.com/EricSpencer00/Resilient/issues/124) (RES-332), [#125](https://github.com/EricSpencer00/Resilient/issues/125) (RES-333) — actor design tickets that inform Follow-up 1 item 3

--- a/docs/superpowers/specs/2026-04-29-tla-decision-closure.md
+++ b/docs/superpowers/specs/2026-04-29-tla-decision-closure.md
@@ -52,16 +52,15 @@ The companion spec lists four V1 design choices that must be preserved
 so V2 isn't retroactively forced into the wrong shape. These need to
 be enforced in the V1 backlog — not deferred to V2.0 implementation.
 
-| # | V1 invariant | Where to enforce | Recommended ticket |
+| # | V1 invariant | Where to enforce | Filed ticket |
 |---|---|---|---|
-| 1 | Diagnostics carry a tagged enum (extensible to `(spec_path, action_name, trace_step)`), not a flat string | [`resilient/src/diag.rs`](../../../resilient/src/diag.rs) | `RES-DIAG-TAGGED`: audit `diag.rs`, confirm extensibility, add a doc-comment marker pinning the invariant. ~1 day. |
-| 2 | `live { }` block has a closed-form invariant (no arbitrary user-supplied recovery effects) | live-block parser & verifier (`recovers_to_bmc.rs`, `verifier_liveness.rs`) | `RES-LIVE-CLOSED`: add a parser check that rejects `live` blocks whose recovery body cannot be encoded as a TLA+ action. ~3 days. |
-| 3 | Actor primitives ([RES-208](https://github.com/EricSpencer00/Resilient/issues/17), [RES-332](https://github.com/EricSpencer00/Resilient/issues/124), [RES-333](https://github.com/EricSpencer00/Resilient/issues/125)) define message ordering + atomicity granularity explicitly | `supervisor.rs`, `verifier_actors.rs`, SYNTAX.md | `RES-ACTOR-SEMANTICS`: open a sub-spec under `docs/superpowers/specs/` pinning down `send`/`receive` ordering and the atomicity boundary of `receive`-body. Bake outcome into [RES-332](https://github.com/EricSpencer00/Resilient/issues/124) acceptance criteria. ~1 week. |
-| 4 | `recovers_to` is documented as a one-step property; multi-step is V2's `<>` | STABILITY.md, SYNTAX.md, `verifier_liveness.rs` doc-comments | `RES-RECOVERS-DOC`: one-line clarifications + a `// V2 will extend this to <>(...)` marker in the verifier. ~½ day. |
+| 1 | Diagnostics carry a tagged enum (extensible to `(spec_path, action_name, trace_step)`), not a flat string | [`resilient/src/diag.rs`](../../../resilient/src/diag.rs) | [#359 RES-DIAG-TAGGED](https://github.com/EricSpencer00/Resilient/issues/359) — agent-ready, ~1 day |
+| 2 | `live { }` block has a closed-form invariant (no arbitrary user-supplied recovery effects) | live-block parser & verifier (`recovers_to_bmc.rs`, `verifier_liveness.rs`) | [#360 RES-LIVE-CLOSED](https://github.com/EricSpencer00/Resilient/issues/360) — agent-ready, ~3 days |
+| 3 | Actor primitives ([RES-208](https://github.com/EricSpencer00/Resilient/issues/17), [RES-332](https://github.com/EricSpencer00/Resilient/issues/124), [RES-333](https://github.com/EricSpencer00/Resilient/issues/125)) define message ordering + atomicity granularity explicitly | `supervisor.rs`, `verifier_actors.rs`, SYNTAX.md | [#361 RES-ACTOR-SEMANTICS](https://github.com/EricSpencer00/Resilient/issues/361) — needs-design, blocks #124, ~1 week |
+| 4 | `recovers_to` is documented as a one-step property; multi-step is V2's `<>` | STABILITY.md, SYNTAX.md, `verifier_liveness.rs` doc-comments | [#363 RES-RECOVERS-DOC](https://github.com/EricSpencer00/Resilient/issues/363) — agent-ready, good-first-issue, ~½ day |
 
-**Action:** open four GitHub issues with the labels `enhancement`,
-`v1-preservation`, and a milestone tying them to V1.0 ship. Total
-effort: ~2 contributor-weeks.
+**Status:** all four V1-preservation tickets filed. Total effort across
+the four: ~2 contributor-weeks.
 
 ### Follow-up 2 — V2 open-questions resolution spec
 
@@ -70,10 +69,11 @@ Five open questions in the companion spec (Q1–Q5) need answers
 implementation questions; answering them under V2.0 would force
 late-stage redesign.
 
-Recommended ticket: `RES-V2-OPEN-Qs` — a single sub-spec under
-`docs/superpowers/specs/` titled "TLA+ V2.0 design lock-in" that
-answers each of Q1–Q5 with a recommendation + tradeoff analysis.
-Effort: ~1 contributor-week.
+Filed: [#373 RES-V2-OPEN-Qs](https://github.com/EricSpencer00/Resilient/issues/373)
+— a single sub-spec under `docs/superpowers/specs/` titled "TLA+ V2.0
+design lock-in" that answers each of Q1–Q5 with a recommendation +
+tradeoff analysis. Effort: ~1 contributor-week. Tagged `blocked` —
+gates V2.0/V2.1/V2.2 implementation tickets.
 
 ### Follow-up 3 — V2.0 / V2.1 / V2.2 implementation tickets
 
@@ -92,21 +92,29 @@ backlog.
 
 ---
 
-## Closure recommendation for [#270](https://github.com/EricSpencer00/Resilient/issues/270)
+## Closure status for [#270](https://github.com/EricSpencer00/Resilient/issues/270)
 
-This ticket can close as soon as a maintainer:
+All six acceptance-criteria items are resolved:
 
-1. Confirms the three resolved decisions above (already implicit in
-   the companion spec; this closure makes it explicit).
-2. Files the four V1-preservation tickets from Follow-up 1 (or
-   delegates to an agent).
-3. Files the V2-open-questions sub-spec ticket from Follow-up 2 (or
-   defers to V2 kickoff).
-4. Notes V2.0/V2.1/V2.2 from Follow-up 3 as forward-looking — to be
-   filed at V2 ship time, not now.
+1. ✅ Path A vs B vs C — **Path B** confirmed (companion spec Decision log)
+2. ✅ TLC vs Apalache — **TLC default**, Apalache opt-in (companion spec Decision log)
+3. ✅ Phasing — **V2.0 + V2.1 + V2.2 = ship V2**; V2.3/V2.4 follow (companion spec)
+4. ✅ V1-preservation checklist enforced — four tickets filed:
+   [#359](https://github.com/EricSpencer00/Resilient/issues/359),
+   [#360](https://github.com/EricSpencer00/Resilient/issues/360),
+   [#361](https://github.com/EricSpencer00/Resilient/issues/361),
+   [#363](https://github.com/EricSpencer00/Resilient/issues/363)
+5. ✅ Open-questions resolution sub-spec — filed as
+   [#373](https://github.com/EricSpencer00/Resilient/issues/373) with
+   `blocked` label gating V2.0/V2.1/V2.2
+6. ✅ V2.0/V2.1/V2.2 implementation tickets — recorded as forward-looking
+   below; will be filed at V2 ship time (filing now would clutter the
+   V1 backlog and risks them getting picked up before [#373](https://github.com/EricSpencer00/Resilient/issues/373) lands)
 
-The only actionable V1 work that gates V1.0 ship is **Follow-up 1**.
-Items 2 and 3 are forward-looking and do not block V1.
+[#270](https://github.com/EricSpencer00/Resilient/issues/270) closes with
+this PR; the ladder is documented in
+[ROADMAP.md](../../../ROADMAP.md) under G22 and the temporal-vs-state-local
+distinction is noted in [STABILITY.md](../../../STABILITY.md).
 
 ---
 


### PR DESCRIPTION
Closes #270.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-270-tla-model-checking-integration-v2-design`
Worktree: `.claude/worktrees/res-270`

## Agent claims

(none inferred from issue)