### PR TITLE
docs: SEO landing pages for comparisons and standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 
 > **Resilient is open source under the MIT license — contributions from humans *and* AI agents are first-class.**
 
+Resilient is a statically-typed compiled language for **safety-critical embedded systems** — Z3-verified function contracts (`requires` / `ensures`) discharged at compile time, a `#![no_std]` runtime that cross-compiles to Cortex-M and RISC-V bare metal, and self-healing `live { }` blocks that recover from transient hardware faults. Compare it to [Rust embedded](https://ericspencer.us/Resilient/compare/rust-vs-resilient), [Ada / SPARK](https://ericspencer.us/Resilient/compare/ada-spark-vs-resilient), and [MISRA C](https://ericspencer.us/Resilient/compare/misra-c-vs-resilient), or read the [DO-178C](https://ericspencer.us/Resilient/standards/do-178c), [ISO 26262](https://ericspencer.us/Resilient/standards/iso-26262), and [IEC 62304](https://ericspencer.us/Resilient/standards/iec-62304) standards mappings.
+
 ## Trust model
 
 Resilient treats AI-written code as **untrusted input** to a trusted

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,10 +3,7 @@ description: Statically-typed compiled language for safety-critical embedded sys
 author: Eric Spencer
 lang: en
 
-# Open Graph / Twitter card defaults — picked up by jekyll-seo-tag.
-twitter:
-  username: EricSpencer00
-  card: summary_large_image
+# Open Graph defaults — picked up by jekyll-seo-tag.
 social:
   name: Resilient
   links:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,16 @@
 title: Resilient
-description: A programming language designed for extreme reliability in embedded and safety-critical systems.
+description: Statically-typed compiled language for safety-critical embedded systems. Z3-verified contracts, no_std runtime, self-healing live blocks for Cortex-M, RISC-V, and bare metal.
+author: Eric Spencer
+lang: en
+
+# Open Graph / Twitter card defaults — picked up by jekyll-seo-tag.
+twitter:
+  username: EricSpencer00
+  card: summary_large_image
+social:
+  name: Resilient
+  links:
+    - https://github.com/EricSpencer00/Resilient
 
 # The site is served at ericspencer.us/Resilient via GitHub Pages
 # using the custom domain set on the EricSpencer00 account.
@@ -51,6 +62,7 @@ color_scheme: light
 plugins:
   - jekyll-remote-theme
   - jekyll-seo-tag
+  - jekyll-sitemap
 
 # Don't ship benchmark CSV / Cargo lockfile if anyone drops one
 # in docs/ — Jekyll skips these by default but we name them

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -1,0 +1,48 @@
+---
+title: Compare
+nav_order: 16
+has_children: true
+permalink: /compare
+description: "How Resilient compares to Rust embedded, Ada/SPARK, and MISRA C for safety-critical embedded systems."
+---
+
+# How Resilient compares to other safety-critical languages
+{: .no_toc }
+
+Side-by-side technical comparisons for teams evaluating Resilient
+against established safety-critical toolchains.
+{: .fs-6 .fw-300 }
+
+---
+
+## Pick your starting point
+
+If you are already shipping safety-critical embedded code, you have
+an existing toolchain. The pages below frame Resilient honestly
+relative to what you already use — including where Resilient is
+*not* the right choice today.
+
+- **[Resilient vs Rust for embedded](compare/rust-vs-resilient)** —
+  for `embedded-rust` teams who want compile-time contract proofs,
+  not just memory safety.
+- **[Resilient vs Ada / SPARK](compare/ada-spark-vs-resilient)** —
+  for avionics, defense, and rail teams comparing two formally
+  verified embedded languages.
+- **[Resilient vs MISRA C](compare/misra-c-vs-resilient)** —
+  for automotive and industrial teams hitting the limits of MISRA
+  C:2012 conformance.
+
+## What gets compared
+
+Each page is structured the same way so you can scan them quickly:
+
+| Section | What you'll find |
+|---|---|
+| **Memory model** | Heap policy, `no_std` story, stack discipline. |
+| **Verification** | What's proven at compile time vs runtime. |
+| **Toolchain maturity** | Honest framing of certification readiness, ecosystem, hiring pool. |
+| **When to pick** | The decision rule we'd use ourselves. |
+
+For a deeper dive into Resilient's verifier and certificate
+emission, see the [Language Reference](../language-reference) and
+[Certification mapping](../certification).

--- a/docs/compare/ada-spark-vs-resilient.md
+++ b/docs/compare/ada-spark-vs-resilient.md
@@ -1,0 +1,127 @@
+---
+title: Resilient vs Ada / SPARK
+parent: Compare
+nav_order: 2
+permalink: /compare/ada-spark-vs-resilient
+description: "Resilient vs Ada/SPARK for safety-critical embedded systems — formal verification, contract proofs, and certifiability compared honestly for avionics, defense, and rail teams."
+---
+
+# Resilient vs Ada / SPARK
+{: .no_toc }
+
+Two formally-verified embedded languages, very different
+maturities. A side-by-side for teams in avionics, defense, rail,
+or industrial automation evaluating SPARK against Resilient.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Honest framing
+
+Ada has been used in DO-178B/C-certified avionics and rail
+control systems for over thirty years. SPARK 2014 is the
+verifiable subset, with a mature toolchain (GNATprove) and a
+demonstrated track record of high-DAL deployments.
+
+Resilient does not match SPARK on maturity, ecosystem, or
+certifiability today. It does match SPARK in one specific area:
+*proof obligations for function contracts discharged by an SMT
+solver at compile time*. Where it differs is in the rest of the
+language design — modern syntax, JIT-able semantics for dev-time
+iteration, and signed certificates as a first-class artifact.
+
+If you can use SPARK and your team already knows Ada, use SPARK.
+The rest of this page is for teams who can't, or whose criteria
+weight modern tooling over ecosystem maturity.
+
+## Side-by-side
+
+| Concern | SPARK 2014 | Resilient |
+|---|---|---|
+| Lineage | Ada subset, GNAT/GNATprove | Original language, Rust-implemented compiler |
+| Verifier | GNATprove (CVC4, Z3, Alt-Ergo) | Z3 in-tree, SMT-LIB2 certificates re-verifiable under any solver |
+| Contract syntax | `Pre =>`, `Post =>`, `Loop_Invariant` | `requires`, `ensures` (modern, terse) |
+| Memory model | Heap by default; SPARK subset constrains | Static-only heap by default; no `unsafe` |
+| Concurrency | Ravenscar / Jorvik profile | `live { }` supervised execution; concurrency primitives WIP |
+| Certificate emission | GNATprove proof reports | SMT-LIB2 + Ed25519-signed `cert.sig` + `manifest.json` |
+| `no_std` story | N/A — Ada has its own runtime model | First-class `#![no_std]` runtime crate |
+| Cross-compile | Ada cross-compilers, broad coverage | thumbv7em, thumbv6m, riscv32 |
+| Certification track record | DO-178B/C up to DAL A, ISO 26262 ASIL D | None — features map to objectives but tool not qualified |
+| Hiring pool | Small but stable (defense, avionics) | Effectively zero today |
+| License | GPL with exception (or commercial) | MIT |
+| Iteration speed | AdaCore commercial cadence | Open-source, ticket-by-ticket |
+
+## Where Resilient overlaps with SPARK
+
+- **Function contracts as proof obligations.** Both languages
+  treat `requires` / `ensures` (or `Pre` / `Post`) as obligations
+  the verifier discharges before the program is admitted. The
+  user-facing experience is similar.
+
+- **Static heap discipline.** SPARK forbids most heap
+  allocation by default, as does Resilient.
+
+- **Decidable subset by design.** Both languages choose
+  semantics that an SMT solver can decide for the common cases —
+  no exception machinery in the verified subset.
+
+## Where the two differ
+
+- **Re-verifiable certificates.** Resilient's SMT-LIB2 output
+  + Ed25519 signature is intended to make a third-party
+  re-verification trivial. SPARK's report is more deeply
+  integrated with GNATprove's evidence model. The Resilient
+  approach is lighter weight but has not been through a real
+  certification audit.
+
+- **Modern syntax surface.** Ada is verbose by design —
+  arguably an advantage for safety-critical readability.
+  Resilient is closer to Rust syntax. Pick whichever your team
+  reads more fluently.
+
+- **JIT-able semantics.** Resilient runs on a tree-walker, a
+  bytecode VM, or a Cranelift JIT. The same source executes
+  on a dev laptop or cross-compiles to bare metal. SPARK does
+  not have a comparable dev-time iteration story.
+
+- **License.** Resilient is MIT; AdaCore SPARK is dual-licensed
+  with a commercial offering for certified use. For a
+  research project or open-source product, Resilient is the
+  cheaper path.
+
+## When to pick SPARK
+
+- You're shipping a DAL A/B avionics product on a hard
+  timeline.
+- You're in defense, rail, or nuclear, where Ada/SPARK is the
+  default and your customers already accept it.
+- You need a qualified compiler today.
+- You have an Ada team already.
+
+## When to pick Resilient
+
+- You're starting a new safety-critical-adjacent project where
+  you can absorb research-language risk for compile-time
+  contract proofs.
+- You want re-verifiable certificates as an artifact in your
+  build pipeline.
+- You're comfortable with a smaller ecosystem and writing
+  your own glue.
+- You want a single language for dev-laptop iteration and
+  bare-metal deployment.
+
+---
+
+## See also
+
+- [Resilient vs Rust for embedded](rust-vs-resilient)
+- [Certification and Safety Standards](../certification)
+- [Language Reference](../language-reference) — contract syntax
+  and verifier behavior.

--- a/docs/compare/misra-c-vs-resilient.md
+++ b/docs/compare/misra-c-vs-resilient.md
@@ -1,0 +1,113 @@
+---
+title: Resilient vs MISRA C
+parent: Compare
+nav_order: 3
+permalink: /compare/misra-c-vs-resilient
+description: "Resilient vs MISRA C:2012 — compile-time bounds, divide-by-zero safety, and contract proofs as a modern alternative for automotive and industrial embedded teams."
+---
+
+# Resilient vs MISRA C:2012
+{: .no_toc }
+
+For automotive, industrial, and medical-device teams hitting
+the limits of MISRA C:2012 conformance and looking for a
+language where the rules are enforced by the compiler, not a
+linter.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Honest framing
+
+MISRA C is a coding standard layered on top of C — it does
+not change the language. Conformance is checked by static
+analyzers (Polyspace, LDRA, Coverity, PC-lint), and rule
+violations are flagged but not always prevented.
+
+Resilient is a *different language*. The MISRA-style rules
+that matter for safety — no implicit conversions, no `goto`,
+no recursion in some profiles, bounds checks, no
+divide-by-zero — are not rules layered on top. They are
+either prohibited by the type system or proven by the
+verifier. There is no "deviation" mechanism because there is
+no rule to deviate from.
+
+Migrating from MISRA C to Resilient is a rewrite. It is not a
+trivial decision. Most automotive teams will stay on MISRA C
+for the foreseeable future. This page exists for teams whose
+risk profile or product roadmap justifies a clean break.
+
+## Side-by-side
+
+| Concern | MISRA C:2012 | Resilient |
+|---|---|---|
+| Substrate | C99 / C11 + ruleset | Original language |
+| Rule enforcement | Static analyzer + manual review | Compiler errors, type system, Z3 proofs |
+| Implicit conversions | Discouraged (Rule 10.x) | Disallowed by language design |
+| `goto` | Restricted (Rule 15.x) | No `goto` in the language |
+| Recursion | Restricted in some profiles (Rule 17.2) | Restricted in the verified subset |
+| Pointer arithmetic | Restricted (Rule 18.x) | No raw pointer arithmetic |
+| Divide-by-zero | Manual review + analyzer | Compile-time linter (RES-133) |
+| Array bounds | Manual review + analyzer + runtime | Compile-time bounds checks from contracts |
+| Tool qualification | Some analyzers qualified per ISO 26262 | Not qualified |
+| Maturity | Industry standard since 1998 (MISRA C:1998) | Research-stage |
+| Hiring pool | Very large (automotive, industrial) | Effectively zero |
+| Re-use of existing C code | Yes (legacy continuity) | No — rewrite required |
+
+## Where Resilient earns its keep
+
+- **The rule is the language.** Where MISRA bans implicit
+  conversions, Resilient does not have implicit conversions
+  to ban. Where MISRA restricts pointer arithmetic, Resilient
+  does not expose it. The class of bugs MISRA tries to
+  prevent in C cannot be expressed in Resilient.
+
+- **Compile-time proofs of arithmetic safety.** RES-133 makes
+  divide-by-zero a compile-time error in trivial cases and a
+  Z3 obligation when contracts cover the divisor. MISRA C
+  treats this as Rule 1.3 / undefined behavior — flagged but
+  not prevented.
+
+- **No deviation mechanism needed.** MISRA conformance reports
+  list deviations. Resilient does not have rules to deviate
+  from in the same way — the verifier either discharges an
+  obligation or it doesn't.
+
+## When MISRA C is still the right call
+
+- **You have a working MISRA-conformant codebase.** Rewriting
+  is enormously expensive; the right move is usually to keep
+  MISRA C and improve the analyzer config.
+- **Your toolchain is locked by your customer.** Tier-1
+  automotive suppliers often have hard requirements on
+  toolchains, and MISRA C is what's accepted.
+- **You need certified compiler output today.** A qualified
+  C compiler exists; a qualified Resilient compiler does not.
+
+## When Resilient is worth evaluating
+
+- **You're starting a new product** where the legacy continuity
+  argument doesn't apply.
+- **You're already paying** for a static analyzer that catches
+  half the rule classes Resilient eliminates by design — and
+  the analyzer's false-positive rate is hurting velocity.
+- **Your risk profile justifies a research-language bet** —
+  research vehicle, internal tooling, or a clean-slate
+  greenfield product where the certification cost is years
+  away anyway.
+
+---
+
+## See also
+
+- [Resilient vs Rust for embedded](rust-vs-resilient)
+- [Resilient vs Ada / SPARK](ada-spark-vs-resilient)
+- [ISO 26262 mapping](../standards/iso-26262)
+- [Certification and Safety Standards](../certification)

--- a/docs/compare/rust-vs-resilient.md
+++ b/docs/compare/rust-vs-resilient.md
@@ -1,0 +1,122 @@
+---
+title: Resilient vs Rust (embedded)
+parent: Compare
+nav_order: 1
+permalink: /compare/rust-vs-resilient
+description: "Resilient vs Rust for embedded systems — compile-time contract proofs, no_std runtime, Z3-verified bounds and divide-by-zero safety. Honest comparison for embedded-rust teams."
+---
+
+# Resilient vs Rust for embedded systems
+{: .no_toc }
+
+A technical comparison for teams already shipping `embedded-rust`
+who are evaluating Resilient for tighter compile-time guarantees on
+safety-critical firmware.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Honest framing
+
+Rust is a mature, production language with one of the strongest
+embedded ecosystems of any modern language. Resilient is a young
+research language with a working compiler, JIT, and `no_std`
+runtime, but a fraction of Rust's ecosystem and zero certification
+history.
+
+If your decision criterion is "ship to a customer in the next 18
+months," Rust is the safer choice. If your criterion is "I want
+contract proofs at compile time, not just memory safety, and I can
+absorb a smaller ecosystem to get them," Resilient is worth
+evaluating.
+
+This page does not claim Resilient is better than Rust. It claims
+they make different trade-offs.
+
+## Side-by-side
+
+| Concern | Rust (embedded) | Resilient |
+|---|---|---|
+| Memory safety | Borrow checker — proven at compile time | Static-only heap, no `unsafe`, bounds-checked indexing — proven at compile time |
+| Functional contracts | None in core; opt-in via `kani`, `creusot`, `prusti` | First-class `requires` / `ensures`, discharged by Z3 at compile time |
+| Divide-by-zero | Runtime panic | Compile-time linter (RES-133) + Z3 proof obligation when contracts cover the divisor |
+| Array bounds | Runtime panic on out-of-bounds | Compile-time bounds check from `requires` clauses; runtime guard otherwise |
+| Self-healing | Manual `Result` plumbing | `live { }` blocks restore last-known-good state on transient fault |
+| Certificates | None native | Re-verifiable SMT-LIB2 certificates, Ed25519-signed |
+| `no_std` story | Mature; cargo + crates.io | `resilient-runtime` crate; Cortex-M4F demo passes; smaller ecosystem |
+| Cross-compile targets | thumbv7em, thumbv6m, thumbv8m, riscv32, esp32, … | thumbv7em-none-eabihf, thumbv6m-none-eabi, riscv32imac-unknown-none-elf |
+| Standards mapping | DO-178C qualification underway via Ferrous Systems / Ferrocene | No qualification dossier; features map to objectives but tool not qualified |
+| LSP / editor tooling | rust-analyzer (industry-leading) | `rz --lsp` — diagnostics + hover + goto-def, smaller surface |
+| Hiring pool | Large and growing | Tiny (research-stage language) |
+
+## Where Resilient earns its keep
+
+- **Function contracts as proof obligations.** A Rust panic that
+  would crash a flight controller is, in Resilient, a Z3 obligation
+  resolved at compile time when the surrounding contracts admit
+  it. The compiler tells you which assertions became proofs and
+  which remained runtime guards. See the [contract proofs example](../language-reference#contracts).
+
+- **Re-verifiable certificates.** Resilient's
+  `--emit-certificate` writes SMT-LIB2 files that an auditor
+  re-runs under their own Z3. This breaks the circular trust
+  problem — the auditor does not have to trust the Resilient
+  binary to accept the proof. Rust has no equivalent in-tree.
+
+- **Divide-by-zero and bounds at compile time.** RES-133 surfaces
+  trivially-wrong arithmetic at compile time. The same surface
+  in Rust panics at runtime unless you reach for `kani` or
+  similar third-party tools.
+
+- **`live { }` for transient faults.** Sensor-noise or
+  cosmic-ray-bit-flip recovery without manual `Result`-plumbing
+  on every operation. Read [live block semantics](../live-block-semantics).
+
+## Where Rust is the right call today
+
+- **You need to ship now.** Rust embedded has battle-tested HAL
+  crates, RTOS bindings (`embassy`, `RTIC`), and a hiring pool.
+  Resilient does not.
+
+- **You need certified toolchain output.** Ferrocene is on a
+  certification path; Resilient is not.
+
+- **You depend on a specific HAL.** If your board's vendor ships
+  a Rust HAL, that's where the path of least resistance lives.
+
+- **You need a large team.** Recruiting Rust embedded engineers
+  is hard but possible. Recruiting Resilient engineers is, at
+  time of writing, not a thing.
+
+## When to pick Resilient
+
+Pick Resilient if **all** of the following are true:
+
+1. You are working on safety-critical or research code where
+   compile-time contract proofs would meaningfully reduce risk.
+2. You can absorb a smaller ecosystem and the cost of writing
+   your own integration glue.
+3. You're willing to file issues against a young compiler.
+4. You're not on a hard ship deadline that requires a mature HAL.
+
+If any of those four are false, ship Rust today and watch
+Resilient for the next 12–24 months.
+
+---
+
+## See also
+
+- [Resilient vs Ada / SPARK](ada-spark-vs-resilient) —
+  for the formally-verified-language comparison.
+- [Resilient vs MISRA C](misra-c-vs-resilient) —
+  for teams migrating from C.
+- [Certification and Safety Standards](../certification) —
+  what Resilient contributes to DO-178C / ISO 26262 / IEC 61508.
+- [no_std Runtime](../no-std) — the embedded story in detail.

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,6 +123,29 @@ Tree-walking interpreter for fast iteration → bytecode VM (~12×) → Cranelif
 | Language Server (LSP) | ✅ opt-in | `rz --lsp` (build with `--features lsp`) |
 | `#![no_std]` runtime | ✅ stable | `resilient-runtime/` crate |
 
+## How Resilient compares
+
+If you're evaluating Resilient against an existing safety-critical
+toolchain, start with the side-by-side comparisons:
+
+- **[Resilient vs Rust for embedded](compare/rust-vs-resilient)** —
+  for teams already using `embedded-rust` and looking for sharper
+  compile-time guarantees.
+- **[Resilient vs Ada / SPARK](compare/ada-spark-vs-resilient)** —
+  for teams in defense, avionics, or rail evaluating a modern
+  formally-verified alternative.
+- **[Resilient vs MISRA C](compare/misra-c-vs-resilient)** —
+  for automotive and industrial teams reaching the limits of MISRA C:2012.
+
+## Standards mapping
+
+Resilient is not a certified tool, but its features map directly to
+specific objectives in the major safety standards:
+
+- **[DO-178C (avionics)](standards/do-178c)** — objective-by-objective mapping
+- **[ISO 26262 (automotive ASIL D)](standards/iso-26262)** — objective-by-objective mapping
+- **[IEC 62304 (medical devices)](standards/iec-62304)** — class C software mapping
+
 ## Open source
 
 Resilient is MIT-licensed. Contributions from humans and AI agents are equally welcome — work is tracked in [GitHub Issues](https://github.com/EricSpencer00/Resilient/issues), and `cargo test` is the acceptance gate.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -1,0 +1,45 @@
+---
+title: Standards
+nav_order: 17
+has_children: true
+permalink: /standards
+description: "How Resilient maps to safety standards: DO-178C avionics, ISO 26262 automotive, IEC 62304 medical devices, IEC 61508 industrial."
+---
+
+# Resilient and safety standards
+{: .no_toc }
+
+Resilient is not a certified tool, but its features map directly
+to specific objectives in the major safety standards. These pages
+list the mappings, honestly, with the gaps called out.
+{: .fs-6 .fw-300 }
+
+---
+
+## Per-standard mappings
+
+- **[DO-178C (Airborne Software)](standards/do-178c)** —
+  for civil avionics applicants targeting DAL A–E.
+- **[ISO 26262 (Road Vehicles)](standards/iso-26262)** —
+  for automotive teams targeting ASIL A–D.
+- **[IEC 62304 (Medical Device Software)](standards/iec-62304)** —
+  for medical device teams targeting Class A / B / C software.
+
+## What Resilient is not
+
+Resilient is **not** a certified tool. No tool qualification
+dossier exists. No certification body has audited the compiler.
+Claiming otherwise would mislead a safety engineer into
+building on a foundation that hasn't been laid.
+
+What Resilient *is* is a language designed with certifiability
+as a first-order concern. Its features — function contracts,
+SMT-LIB2 certificates, Ed25519-signed manifests, static-only
+heap, ASCII-only identifiers, deterministic execution — were
+chosen knowing that downstream users may eventually defend
+the software to a DER, functional safety manager, or IEC 61508
+assessor.
+
+For the full per-objective mapping that consolidates all four
+standards on a single page, see
+[Certification and Safety Standards](../certification).

--- a/docs/standards/do-178c.md
+++ b/docs/standards/do-178c.md
@@ -1,0 +1,101 @@
+---
+title: DO-178C (Avionics)
+parent: Standards
+nav_order: 1
+permalink: /standards/do-178c
+description: "Resilient and DO-178C — how the language's contract proofs, SMT-LIB2 certificates, and signed manifests map to Annex A objectives for airborne software."
+---
+
+# Resilient and DO-178C (Airborne Software)
+{: .no_toc }
+
+DO-178C governs software in certified civil aircraft. This page
+lists the Annex A objectives where Resilient features
+contribute evidence, and the gaps that remain the integrator's
+responsibility.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Honest framing
+
+Resilient is **not** DO-178C compliant and **not** a qualified
+tool. No DER has audited the compiler. No PSAC, SDP, SVP, or
+SQAP for Resilient itself exists.
+
+What follows is the realistic path for an applicant who chooses
+Resilient: the language reduces evidence burden on specific
+Annex A objectives, but tool qualification per DO-330 (TQL-1
+through TQL-5) is required before Resilient artifacts can be
+used as primary verification evidence in a certified product.
+Until that work is done, Resilient acts as an **input artifact
+generator** to a qualified process the applicant runs.
+
+## Annex A objectives Resilient contributes to
+
+The following list is non-exhaustive — these are the objectives
+where the mapping is direct.
+
+- **A-5 (Verify software architecture).** Function contracts
+  (`requires` / `ensures`) express architectural invariants
+  directly in source. When Z3 discharges them, the
+  architectural property is proven for all inputs in the
+  contract's domain — stronger than test-based architectural
+  verification.
+
+- **A-6 (Verify source code).** SMT-LIB2 certificates emitted
+  by `--emit-certificate` are re-verifiable under stock Z3.
+  This breaks the circular trust problem: an auditor does not
+  need to trust the Resilient binary to accept the proof —
+  they re-run the `.smt2` file under their own solver and
+  confirm `unsat`. Per-cert `sha256` in `manifest.json` plus
+  the `cert.sig` Ed25519 signature give tamper-evidence from
+  the point of emission onward.
+
+- **A-7 (Verify software requirements).** `requires` /
+  `ensures` clauses tied to a function provide traceable
+  mappings from low-level requirements to code, with source
+  locations.
+
+- **A-3 / A-4 (Verify high-level / low-level requirements).**
+  When contracts mirror requirements, the verifier's
+  discharge is direct evidence of requirements satisfaction
+  for the discharged subset.
+
+- **Robustness testing scaffolding.** Contracts that *cannot*
+  be discharged at compile time become typed runtime asserts
+  that act as instrumented oracles for robustness testing.
+
+## Gaps the integrator still owns
+
+- **Tool qualification (DO-330).** Without it, Resilient's
+  output is not primary evidence. This is multi-year work and
+  has not started.
+- **Hardware/software interaction (DO-178C §6.4.3).**
+  Resilient's runtime is not yet integrated with a certified
+  RTOS in a documented way.
+- **Configuration management (A-8).** Standard SCM applies;
+  Resilient does not change this.
+- **Quality assurance (A-9).** Standard SQA applies.
+- **Liaison process (A-10).** Standard, unchanged.
+
+## What to read next
+
+- [Full DO-178C / ISO 26262 / IEC 61508 mapping](../certification) —
+  the consolidated, in-depth version of this page.
+- [Language Reference — contracts](../language-reference#contracts)
+- [Certificates](../tooling) — emission, signing, re-verification.
+
+## See also
+
+- [ISO 26262 mapping](iso-26262)
+- [IEC 62304 mapping](iec-62304)
+- [Resilient vs Ada / SPARK](../compare/ada-spark-vs-resilient) —
+  for teams comparing two formally-verified options for avionics.

--- a/docs/standards/iec-62304.md
+++ b/docs/standards/iec-62304.md
@@ -1,0 +1,103 @@
+---
+title: IEC 62304 (Medical Devices)
+parent: Standards
+nav_order: 3
+permalink: /standards/iec-62304
+description: "Resilient and IEC 62304 — contract-driven verification and re-verifiable certificates mapped to medical device software classes A, B, and C."
+---
+
+# Resilient and IEC 62304 (Medical Device Software)
+{: .no_toc }
+
+IEC 62304 governs the software lifecycle for medical devices.
+This page lists where Resilient features contribute evidence
+across software safety classes A, B, and C, and the gaps that
+remain the manufacturer's responsibility.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Honest framing
+
+Resilient is **not** IEC 62304 compliant and **not** a
+validated software tool under IEC 62304:2006/AMD 1:2015. No
+medical device has shipped on Resilient.
+
+The mapping below is the realistic path for a team evaluating
+Resilient: the language contributes to specific clauses, but
+software validation under §5.1.4 / §8.1.1 must be performed
+before Resilient artifacts can be used as primary evidence on
+a regulated device.
+
+## Clauses Resilient contributes to
+
+- **§5.5 (Software unit implementation and verification).**
+  Contract-driven verification at the unit level — `requires`
+  / `ensures` discharged by Z3 — provides primary evidence
+  of unit-level property satisfaction.
+
+- **§5.6 (Software integration and integration testing).**
+  Contracts that cannot be discharged at compile time become
+  typed runtime asserts that act as oracles during
+  integration testing.
+
+- **§5.7 (Software system testing).** Re-verifiable SMT-LIB2
+  certificates from `--emit-certificate` provide artifacts
+  the manufacturer can re-execute under their own Z3 to
+  confirm property satisfaction.
+
+- **§7 (Software risk management).** The language's
+  no-`unsafe` discipline, static-only heap, and bounds-checked
+  indexing eliminate whole hazard classes by construction —
+  reducing the risk-management burden for memory-corruption
+  hazards.
+
+- **§8 (Software configuration management).** Per-cert
+  `sha256` hashes in `manifest.json` and the Ed25519
+  `cert.sig` give tamper-evidence on verification artifacts.
+
+## Class-specific notes
+
+- **Class A (no injury or damage to health possible).**
+  Resilient's compile-time checks already exceed what Class A
+  requires.
+
+- **Class B (non-serious injury possible).** Contract-driven
+  verification provides strong evidence for hazard mitigation
+  in the unit-level subset that the verifier discharges.
+
+- **Class C (death or serious injury possible).** Software
+  validation under §5.1.4 is mandatory. Resilient artifacts
+  are supplementary evidence until validation is performed
+  by the manufacturer.
+
+## Gaps the manufacturer still owns
+
+- **Software validation per §5.1.4.** Not started — the
+  manufacturer must validate the toolchain in their
+  environment.
+- **Risk analysis (ISO 14971).** Unaffected by language
+  choice.
+- **Software-of-Unknown-Provenance (SOUP) classification of
+  the Resilient compiler.** As an open-source tool without a
+  validation history, the compiler itself is SOUP and must
+  be evaluated per §5.3.3 / §8.1.2.
+- **Post-market surveillance.** Standard, unchanged.
+
+## What to read next
+
+- [Full DO-178C / ISO 26262 / IEC 61508 mapping](../certification)
+- [Language Reference — contracts](../language-reference#contracts)
+- [Certificates and signed manifests](../tooling)
+
+## See also
+
+- [DO-178C mapping](do-178c)
+- [ISO 26262 mapping](iso-26262)

--- a/docs/standards/iso-26262.md
+++ b/docs/standards/iso-26262.md
@@ -1,0 +1,105 @@
+---
+title: ISO 26262 (Automotive)
+parent: Standards
+nav_order: 2
+permalink: /standards/iso-26262
+description: "Resilient and ISO 26262 — how contract proofs, certificates, and signed manifests map to Part 6 software-development objectives across ASIL A–D for road vehicles."
+---
+
+# Resilient and ISO 26262 (Road Vehicles)
+{: .no_toc }
+
+ISO 26262 governs functional safety for road vehicle E/E
+systems. This page lists the Part 6 (software development)
+objectives where Resilient features contribute evidence, and
+the gaps that remain the integrator's responsibility across
+ASIL A–D.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Honest framing
+
+Resilient is **not** ISO 26262 compliant and **not** an ISO
+26262-qualified software tool. No "Confidence in Software
+Tool" (TCL/TD) classification has been performed for the
+compiler. No ASIL-D project has shipped on Resilient.
+
+The mapping below is the realistic path for a team that
+chooses to evaluate Resilient: the language reduces evidence
+burden on specific Part 6 objectives, but tool confidence
+classification per ISO 26262-8:2018 §11 must be completed
+before Resilient artifacts can be used as primary verification
+evidence on an ASIL-rated item.
+
+## Part 6 objectives Resilient contributes to
+
+- **§7.4.5 (Software architectural design — verification).**
+  Function contracts capture architectural invariants
+  directly in source. When the verifier discharges them, the
+  invariant is proven for all inputs in the contract's
+  domain.
+
+- **§8.4 (Software unit design and implementation).** The
+  language's restrictions — no implicit conversions, no raw
+  pointer arithmetic, no `goto`, static-only heap — eliminate
+  whole classes of MISRA-C-style defects by construction.
+
+- **§9.4 (Software unit verification).** SMT-LIB2
+  certificates re-verifiable under stock Z3 act as primary
+  evidence of unit-level property satisfaction (subject to
+  tool qualification).
+
+- **§10.4 (Software integration and verification).** Contracts
+  that cannot be discharged at compile time become typed
+  runtime asserts that act as instrumented oracles for
+  integration testing.
+
+- **Coding guidelines (Annex A, MISRA C:2012).** Most of the
+  rule classes MISRA C imposes on C are eliminated by
+  Resilient's type system rather than enforced by linter.
+  See [Resilient vs MISRA C](../compare/misra-c-vs-resilient).
+
+## ASIL-specific notes
+
+- **ASIL A / B.** The pre-qualification Resilient features
+  contribute to objectives most clearly: contract-driven
+  verification, deterministic execution, and certificate
+  re-verification.
+
+- **ASIL C / D.** Tool qualification is mandatory. Until the
+  Resilient compiler completes a TCL/TD classification,
+  Resilient output is supplementary evidence, not primary.
+
+## Gaps the integrator still owns
+
+- **Tool confidence (ISO 26262-8:2018 §11).** Not started.
+- **Item-level safety analysis (HARA, FTA, FMEA).**
+  Unaffected by language choice.
+- **Hardware-software interaction.** No certified RTOS
+  integration documented.
+- **Configuration management (Part 8 §7).** Standard SCM
+  applies.
+- **Verification of software safety mechanisms.** Resilient's
+  `live { }` blocks are a *language* mechanism, not a
+  certified safety mechanism — system-level analysis still
+  required.
+
+## What to read next
+
+- [Full DO-178C / ISO 26262 / IEC 61508 mapping](../certification)
+- [Resilient vs MISRA C](../compare/misra-c-vs-resilient) —
+  for automotive teams currently on MISRA C:2012.
+- [Language Reference — contracts](../language-reference#contracts)
+
+## See also
+
+- [DO-178C mapping](do-178c)
+- [IEC 62304 mapping](iec-62304)


### PR DESCRIPTION
## Summary

Executes the SEO keyword plan for Resilient — adds high-intent landing pages targeting embedded engineers, formal-methods teams, and safety-cert engineers evaluating Resilient against existing toolchains.

## What's new

**Comparison pages** (Tier C — biggest organic upside; "X vs Y" queries convert because the searcher is in evaluation mode):
- [/compare/rust-vs-resilient](docs/compare/rust-vs-resilient.md) — for `embedded-rust` teams
- [/compare/ada-spark-vs-resilient](docs/compare/ada-spark-vs-resilient.md) — for avionics, defense, rail
- [/compare/misra-c-vs-resilient](docs/compare/misra-c-vs-resilient.md) — for automotive and industrial teams

Each page is honest about Resilient's current maturity and explicitly tells the reader when *not* to pick Resilient. No marketing-style overclaiming.

**Standards mapping pages** (Tier D — high-value B2B; aerospace/auto/med-device buyers):
- [/standards/do-178c](docs/standards/do-178c.md) — Annex A objectives + gaps
- [/standards/iso-26262](docs/standards/iso-26262.md) — Part 6 objectives + ASIL notes
- [/standards/iec-62304](docs/standards/iec-62304.md) — software-class A/B/C mapping

These cross-link to the existing consolidated `certification.md` rather than duplicating its content.

**Infra and metadata:**
- `docs/_config.yml` — site description rewritten with target keywords; `jekyll-sitemap` plugin added (auto-generates `sitemap.xml` for search engines); Twitter card + social defaults for OG previews
- `docs/index.md` — adds "How Resilient compares" + "Standards mapping" sections linking to the new pages
- `README.md` — intro paragraph surfaces target keywords near top with cross-links

**Repo metadata** (already pushed via `gh repo edit` before this PR):
- Description updated to lead with "Statically-typed compiled language for safety-critical embedded systems — Z3-verified contracts, no_std runtime, self-healing live blocks. Ships to Cortex-M, RISC-V, and bare metal."
- Topics added: `embedded`, `safety-critical`, `embedded-systems`, `no-std`, `cortex-m`, `smt`, `z3`, `embedded-rust`, `real-time`, `self-healing`

## Test plan

- [x] All new YAML front matter validates (`python3 yaml.safe_load`)
- [x] No conflicts with existing `nav_order` values (used 16, 17 for top-level)
- [ ] GH Pages build succeeds after merge (local Jekyll build blocked by pre-existing Ruby 3.4 SCSS encoding issue, unrelated to these changes)
- [ ] Live site renders the new pages at the documented permalinks
- [ ] `sitemap.xml` is generated and includes the new pages
- [ ] `jekyll-seo-tag` produces correct `<meta name=description>` tags

## What's intentionally not in this PR

- Blog setup (Tier E — long-tail problem/solution content)
- New homepage URL / canonical site under `resilient-lang.dev` (out of scope)
- Outreach (HN, Lobsters, awesome-* lists) — coordinated by maintainer
- IEC 61508 standards page — covered by existing `certification.md`; can add a dedicated landing later if traffic warrants

## Test changes

None. No tests were modified.