### PR TITLE
RES-407: per-access bounds-check elision via assumption stack

### DIFF
--- a/resilient/examples/bounds_elision_dynamic.expected.txt
+++ b/resilient/examples/bounds_elision_dynamic.expected.txt
@@ -1,0 +1,2 @@
+300
+Program executed successfully

--- a/resilient/examples/bounds_elision_dynamic.rz
+++ b/resilient/examples/bounds_elision_dynamic.rz
@@ -1,0 +1,18 @@
+// RES-407: per-access bounds-check elision (unprovable case).
+//
+// `i` is a free function parameter, so the bounds-check pass cannot
+// discharge `0 <= i < len(xs)`. The compiler keeps the runtime
+// `LoadIndex` and the VM checks bounds on every access. Runtime
+// behaviour matches the proven case for in-range inputs; the
+// difference is the elision claim, not the result.
+fn pick(int i) -> int {
+    let xs = [100, 200, 300];
+    return xs[i];
+}
+
+fn main() {
+    let v = pick(2);
+    println(v);
+}
+
+main();

--- a/resilient/examples/bounds_elision_proven.expected.txt
+++ b/resilient/examples/bounds_elision_proven.expected.txt
@@ -1,0 +1,2 @@
+20
+Program executed successfully

--- a/resilient/examples/bounds_elision_proven.rz
+++ b/resilient/examples/bounds_elision_proven.rz
@@ -1,0 +1,14 @@
+// RES-407: per-access bounds-check elision (proven case).
+//
+// `xs` is a literal-length array and the index `1` is a literal in
+// range — the bounds-check pass discharges `0 <= 1 < 3` without Z3
+// and the bytecode compiler emits `LoadIndexUnchecked` instead of
+// `LoadIndex`. Runtime behaviour is identical; the elision is
+// observable via `--audit --typecheck`, see the smoke test.
+fn main() {
+    let xs = [10, 20, 30];
+    let y = xs[1];
+    println(y);
+}
+
+main();

--- a/resilient/src/bounds_check.rs
+++ b/resilient/src/bounds_check.rs
@@ -28,7 +28,7 @@
 
 use crate::Node;
 use crate::span::Span;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// RES-351: global flag set by the CLI when `--deny-unproven-bounds`
@@ -65,6 +65,13 @@ thread_local! {
     static STATS: std::cell::RefCell<BoundsStats> = const {
         std::cell::RefCell::new(BoundsStats { proven: 0, unproven: 0 })
     };
+    /// RES-407: spans of every index expression the pass discharged.
+    /// Read by the bytecode compiler to emit `LoadIndexUnchecked` for
+    /// the access — and by the `--audit` reporter to surface a per-site
+    /// elided/runtime breakdown. Per-thread so the parallel test
+    /// runner stays correct (the `TEST_LOCK` mutex serialises the few
+    /// tests that read this).
+    static PROVEN_SITES: std::cell::RefCell<HashSet<Span>> = std::cell::RefCell::new(HashSet::new());
 }
 
 /// Read the last-run counters. Tests use this to confirm the pass
@@ -74,14 +81,36 @@ pub fn last_stats() -> BoundsStats {
     STATS.with(|s| *s.borrow())
 }
 
-fn bump_proven() {
+/// RES-407: true if the index access at `span` was proven by the
+/// last `check_array_bounds` run. The bytecode compiler queries this
+/// to emit `Op::LoadIndexUnchecked` instead of the bounds-checked
+/// `Op::LoadIndex`. Returns `false` when the pass hasn't run (e.g.
+/// the user passed neither `--typecheck` nor `--deny-unproven-bounds`)
+/// — the runtime check then keeps every access safe.
+pub fn is_proven_site(span: Span) -> bool {
+    PROVEN_SITES.with(|s| s.borrow().contains(&span))
+}
+
+/// RES-407: snapshot of the proven access spans, sorted by source
+/// position for deterministic `--audit` output.
+pub fn proven_sites_sorted() -> Vec<Span> {
+    let mut out: Vec<Span> = PROVEN_SITES.with(|s| s.borrow().iter().copied().collect());
+    out.sort_by_key(|s| (s.start.line, s.start.column, s.start.offset));
+    out
+}
+
+fn mark_proven(span: Span) {
     STATS.with(|s| s.borrow_mut().proven += 1);
+    PROVEN_SITES.with(|s| {
+        s.borrow_mut().insert(span);
+    });
 }
 fn bump_unproven() {
     STATS.with(|s| s.borrow_mut().unproven += 1);
 }
 fn reset_stats() {
     STATS.with(|s| *s.borrow_mut() = BoundsStats::default());
+    PROVEN_SITES.with(|s| s.borrow_mut().clear());
 }
 
 /// Axioms accumulated while descending into a function body. Each
@@ -282,7 +311,7 @@ fn check_index(
         && let Some(len) = ctx.literal_len.get(name)
     {
         if *value >= 0 && *value < *len {
-            bump_proven();
+            mark_proven(span);
             return;
         } else {
             // Provably out of bounds at compile time — this is an
@@ -322,7 +351,7 @@ fn check_index(
 
     let goal = build_bounds_goal(&target_name, index);
     if let Some(true) = try_prove(&goal, &ctx.axioms) {
-        bump_proven();
+        mark_proven(span);
         return;
     }
 
@@ -494,5 +523,95 @@ fn get(int i) -> int {
         let r = check_array_bounds(&program, "<test>");
         set_deny_unproven_bounds(false);
         assert!(r.is_err(), "expected strict-mode error for unproven index");
+    }
+
+    // --- RES-407: proven-site tracking ---
+
+    #[test]
+    fn proven_literal_index_is_recorded_with_span() {
+        let _g = TEST_LOCK.lock().unwrap();
+        set_deny_unproven_bounds(false);
+        let src = r#"
+fn main() {
+    let xs = [10, 20, 30];
+    let y = xs[1];
+}
+main();
+"#;
+        let program = parse(src);
+        check_array_bounds(&program, "<test>").unwrap();
+        let sites = proven_sites_sorted();
+        assert_eq!(sites.len(), 1, "expected one proven site, got {:?}", sites);
+        // Span points at line 4 (`let y = xs[1];`) — line numbers are
+        // 1-indexed in the source above (with the leading newline,
+        // `fn main()` is line 2 → array literal line 3 → access line 4).
+        assert_eq!(sites[0].start.line, 4);
+    }
+
+    #[test]
+    fn unproven_index_is_not_recorded() {
+        let _g = TEST_LOCK.lock().unwrap();
+        set_deny_unproven_bounds(false);
+        let src = r#"
+fn get(int i) -> int {
+    let xs = [1, 2, 3];
+    return xs[i];
+}
+"#;
+        let program = parse(src);
+        check_array_bounds(&program, "<test>").unwrap();
+        let sites = proven_sites_sorted();
+        assert!(
+            sites.is_empty(),
+            "expected no proven sites for dynamic index, got {:?}",
+            sites
+        );
+    }
+
+    #[test]
+    fn proven_sites_reset_between_runs() {
+        let _g = TEST_LOCK.lock().unwrap();
+        set_deny_unproven_bounds(false);
+        let src1 = r#"
+fn main() {
+    let xs = [10, 20, 30];
+    let y = xs[0];
+}
+main();
+"#;
+        let program1 = parse(src1);
+        check_array_bounds(&program1, "<test>").unwrap();
+        assert_eq!(proven_sites_sorted().len(), 1);
+
+        // Second run with no proven sites must clear the previous one.
+        let src2 = r#"
+fn get(int i) -> int {
+    let xs = [1, 2, 3];
+    return xs[i];
+}
+"#;
+        let program2 = parse(src2);
+        check_array_bounds(&program2, "<test>").unwrap();
+        assert!(proven_sites_sorted().is_empty());
+    }
+
+    #[test]
+    fn is_proven_site_returns_correct_membership() {
+        let _g = TEST_LOCK.lock().unwrap();
+        set_deny_unproven_bounds(false);
+        let src = r#"
+fn main() {
+    let xs = [10, 20, 30];
+    let y = xs[1];
+}
+main();
+"#;
+        let program = parse(src);
+        check_array_bounds(&program, "<test>").unwrap();
+        let sites = proven_sites_sorted();
+        assert_eq!(sites.len(), 1);
+        assert!(is_proven_site(sites[0]));
+        // A made-up span that doesn't match any access should be false.
+        assert!(!is_proven_site(Span::default()));
     }
 }

--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -126,6 +126,15 @@ pub enum Op {
     /// failing index + length. Non-Array on the top of the stack
     /// surfaces as `VmError::TypeMismatch("LoadIndex")`.
     LoadIndex,
+    /// RES-407: variant of [`LoadIndex`] that skips the bounds check.
+    /// Emitted only when the typechecker's bounds-check pass
+    /// (`bounds_check::check_array_bounds`) discharged the obligation
+    /// `0 <= idx < len(arr)` for this exact source span. Type-check on
+    /// the operands stays — a non-int index or non-array target is
+    /// always a real bug, not something the verifier should be used to
+    /// suppress. With `--audit`, the driver reports the count of
+    /// elided sites alongside the bounds-check audit line.
+    LoadIndexUnchecked,
     /// RES-171a: pop a value `v`, pop an i64 index, pop a
     /// `Value::Array`, write `arr[idx] = v`, then push the
     /// modified array back. Compiler follows with a `StoreLocal(a)`

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1026,10 +1026,26 @@ fn compile_expr(
         // Nested targets (e.g. `a[i][j]`) fall out naturally because
         // `compile_expr(target)` recurses: each `IndexExpression` at
         // an inner position pushes a clone of the sub-array.
-        Node::IndexExpression { target, index, .. } => {
+        //
+        // RES-407: if the typechecker's bounds-check pass discharged
+        // `0 <= index < len(target)` at this exact source span, emit
+        // the `LoadIndexUnchecked` variant — the runtime check is
+        // redundant and the elision is what hot-loop embedded code
+        // wants. Falls back to the checked op when the pass hasn't
+        // run or didn't prove this site.
+        Node::IndexExpression {
+            target,
+            index,
+            span,
+        } => {
             compile_expr(target, chunk, locals, fn_index, ffi_index, line)?;
             compile_expr(index, chunk, locals, fn_index, ffi_index, line)?;
-            chunk.emit(Op::LoadIndex, line);
+            let op = if crate::bounds_check::is_proven_site(*span) {
+                Op::LoadIndexUnchecked
+            } else {
+                Op::LoadIndex
+            };
+            chunk.emit(op, line);
             Ok(())
         }
         // RES-335: `Name { f1: e1, f2: e2 }` struct literal. Lowered
@@ -1943,5 +1959,83 @@ mod tests {
         };
         let err = StructRegistry::from_program(&just_int).unwrap_err();
         assert!(matches!(err, CompileError::Unsupported(_)), "got {:?}", err);
+    }
+
+    // ---------- RES-407: bounds-check elision ----------
+
+    use std::sync::Mutex;
+    static BOUNDS_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Walk every chunk in `prog` (main + all user fns) and count
+    /// occurrences of `LoadIndex` and `LoadIndexUnchecked`.
+    fn count_load_index_ops(prog: &Program) -> (usize, usize) {
+        let chunks = std::iter::once(&prog.main).chain(prog.functions.iter().map(|f| &f.chunk));
+        let mut checked = 0usize;
+        let mut unchecked = 0usize;
+        for c in chunks {
+            for op in &c.code {
+                match op {
+                    Op::LoadIndex => checked += 1,
+                    Op::LoadIndexUnchecked => unchecked += 1,
+                    _ => {}
+                }
+            }
+        }
+        (checked, unchecked)
+    }
+
+    #[test]
+    fn res407_proven_literal_index_emits_unchecked_load() {
+        // `lock()` may poison if a sibling test panicked; recover the
+        // guard so this test doesn't transitively fail.
+        let _g = BOUNDS_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let src = r#"
+fn main() {
+    let xs = [10, 20, 30];
+    let y = xs[1];
+}
+main();
+"#;
+        let program = parse_one(src);
+        // Pass needs to run before compile so the proven-sites set is
+        // populated. The compiler reads it via thread-local.
+        crate::bounds_check::check_array_bounds(&program, "<test>").unwrap();
+        let prog = compile(&program).expect("compiles");
+        let (checked, unchecked) = count_load_index_ops(&prog);
+        assert_eq!(
+            unchecked, 1,
+            "expected one LoadIndexUnchecked for proven xs[1] (checked={})",
+            checked
+        );
+        assert_eq!(
+            checked, 0,
+            "expected no checked LoadIndex (unchecked={})",
+            unchecked
+        );
+    }
+
+    #[test]
+    fn res407_unprovable_index_keeps_checked_load() {
+        let _g = BOUNDS_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // `i` is a free parameter — bounds_check can't prove it.
+        let src = r#"
+fn get(int i) -> int {
+    let xs = [1, 2, 3];
+    return xs[i];
+}
+"#;
+        let program = parse_one(src);
+        crate::bounds_check::check_array_bounds(&program, "<test>").unwrap();
+        let prog = compile(&program).expect("compiles");
+        let (checked, unchecked) = count_load_index_ops(&prog);
+        assert_eq!(
+            unchecked, 0,
+            "expected no LoadIndexUnchecked for dynamic xs[i] (checked={})",
+            checked
+        );
+        assert!(
+            checked >= 1,
+            "expected at least one checked LoadIndex for dynamic xs[i]"
+        );
     }
 }

--- a/resilient/src/disasm.rs
+++ b/resilient/src/disasm.rs
@@ -181,6 +181,9 @@ fn write_op(
         // RES-171a: array-ops disasm.
         Op::MakeArray { len } => write!(out, "MakeArray {}", len)?,
         Op::LoadIndex => write!(out, "LoadIndex")?,
+        // RES-407: bounds-elided variant — emitted when the
+        // verifier discharged `0 <= idx < len(arr)` for the site.
+        Op::LoadIndexUnchecked => write!(out, "LoadIndexUnchecked")?,
         Op::StoreIndex => write!(out, "StoreIndex")?,
         // FFI v2.
         Op::CallForeign(idx) => write!(out, "CallForeign {idx:<6}")?,

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -14347,6 +14347,30 @@ fn print_verification_audit(stats: &typechecker::VerificationStats) {
         );
     }
 
+    // RES-407: bounds-check elision summary. Sourced from the
+    // bounds_check pass's thread-local stats. The counts are zero
+    // when the pass didn't run (no `--typecheck`), in which case we
+    // skip the section entirely so the audit stays tidy.
+    let bstats = bounds_check::last_stats();
+    let total_bounds = bstats.proven + bstats.unproven;
+    if total_bounds > 0 {
+        println!();
+        println!(
+            "  array-bounds elided (proven static):      \x1B[32m{} / {}\x1B[0m",
+            bstats.proven, total_bounds
+        );
+        println!(
+            "  array-bounds left for runtime check:      \x1B[33m{} / {}\x1B[0m",
+            bstats.unproven, total_bounds
+        );
+        for site in bounds_check::proven_sites_sorted() {
+            println!(
+                "    \x1B[32melided\x1B[0m at {}:{}",
+                site.start.line, site.start.column
+            );
+        }
+    }
+
     // RES-192: per-fn inferred effect set. Sorted so the output
     // is stable across runs; color green for pure, yellow for
     // IO. Skips the table entirely when no user fn was seen

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -741,6 +741,22 @@ fn run_inner(
                 }
                 stack.push(items[idx as usize].clone());
             }
+            // RES-407: emitted only when `bounds_check::check_array_bounds`
+            // discharged the bounds obligation for this site. Skips the
+            // bounds check; type checks on operands stay.
+            Op::LoadIndexUnchecked => {
+                let idx_val = stack.pop().ok_or(VmError::EmptyStack)?;
+                let arr_val = stack.pop().ok_or(VmError::EmptyStack)?;
+                let Value::Int(idx) = idx_val else {
+                    return Err(VmError::TypeMismatch("LoadIndexUnchecked (non-int index)"));
+                };
+                let Value::Array(items) = arr_val else {
+                    return Err(VmError::TypeMismatch(
+                        "LoadIndexUnchecked (non-array target)",
+                    ));
+                };
+                stack.push(items[idx as usize].clone());
+            }
             Op::StoreIndex => {
                 // Stack layout on entry (top → bottom):
                 //   [v, idx, arr, ...]
@@ -946,7 +962,7 @@ type Handler = fn(&mut VmState<'_>, Op) -> Result<Step, VmError>;
 /// `bytecode.rs`. The `op_to_index` table below pins the mapping; if a
 /// new opcode is added, both `OP_KIND_COUNT` and the dispatch table must
 /// grow together.
-const OP_KIND_COUNT: usize = 31;
+const OP_KIND_COUNT: usize = 32;
 
 /// Map an `Op` to its dispatch-table index. Keeping this explicit (rather
 /// than relying on `mem::discriminant` or transmute on the enum tag)
@@ -986,6 +1002,7 @@ fn op_to_index(op: Op) -> usize {
         Op::StoreIndex => 28,
         Op::CallForeign(_) => 29,
         Op::CallBuiltin { .. } => 30,
+        Op::LoadIndexUnchecked => OP_KIND_LOAD_INDEX_UNCHECKED,
         // Note: StructLiteral/GetField/SetField fall through to the
         // catch-all index below since they share their semantics with
         // the match path. Keep them grouped at the tail of the table.
@@ -995,10 +1012,11 @@ fn op_to_index(op: Op) -> usize {
     }
 }
 
-const OP_KIND_STRUCT_LITERAL: usize = 31;
-const OP_KIND_GET_FIELD: usize = 32;
-const OP_KIND_SET_FIELD: usize = 33;
-const HANDLER_TABLE_LEN: usize = 34;
+const OP_KIND_LOAD_INDEX_UNCHECKED: usize = 31;
+const OP_KIND_STRUCT_LITERAL: usize = 32;
+const OP_KIND_GET_FIELD: usize = 33;
+const OP_KIND_SET_FIELD: usize = 34;
+const HANDLER_TABLE_LEN: usize = 35;
 
 /// The dispatch table. Each entry is a handler keyed by the index
 /// returned from `op_to_index`. Built once at compile time.
@@ -1035,6 +1053,7 @@ static HANDLERS: [Handler; HANDLER_TABLE_LEN] = {
     table[28] = h_store_index;
     table[29] = h_call_foreign;
     table[30] = h_call_builtin;
+    table[OP_KIND_LOAD_INDEX_UNCHECKED] = h_load_index_unchecked;
     table[OP_KIND_STRUCT_LITERAL] = h_struct_literal;
     table[OP_KIND_GET_FIELD] = h_get_field;
     table[OP_KIND_SET_FIELD] = h_set_field;
@@ -1456,6 +1475,25 @@ fn h_load_index(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
             len: items.len(),
         });
     }
+    state.stack.push(items[idx as usize].clone());
+    Ok(Step::Continue)
+}
+
+/// RES-407: bounds-check-elided sibling of [`h_load_index`]. Type
+/// checks on operands are kept — the verifier rules out a stale
+/// in-range claim only on the index value, not on type confusion.
+#[inline(never)]
+fn h_load_index_unchecked(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
+    let idx_val = state.stack.pop().ok_or(VmError::EmptyStack)?;
+    let arr_val = state.stack.pop().ok_or(VmError::EmptyStack)?;
+    let Value::Int(idx) = idx_val else {
+        return Err(VmError::TypeMismatch("LoadIndexUnchecked (non-int index)"));
+    };
+    let Value::Array(items) = arr_val else {
+        return Err(VmError::TypeMismatch(
+            "LoadIndexUnchecked (non-array target)",
+        ));
+    };
     state.stack.push(items[idx as usize].clone());
     Ok(Step::Continue)
 }

--- a/resilient/tests/bounds_elision_smoke.rs
+++ b/resilient/tests/bounds_elision_smoke.rs
@@ -1,0 +1,79 @@
+//! RES-407: integration tests for per-access bounds-check elision.
+//!
+//! End-to-end checks that `--audit --typecheck` surfaces the
+//! `array-bounds elided` summary line for the proven example and
+//! does not surface it for the dynamic-index one.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn examples_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples")
+}
+
+fn audit_run(filename: &str) -> (String, String, bool) {
+    let ex = examples_dir().join(filename);
+    assert!(ex.exists(), "missing example: {}", ex.display());
+    let output = Command::new(bin())
+        .arg("--audit")
+        .arg("--typecheck")
+        .arg(&ex)
+        .output()
+        .expect("spawn resilient binary");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.success(),
+    )
+}
+
+#[test]
+fn audit_surfaces_elided_line_for_proven_index() {
+    let (stdout, stderr, ok) = audit_run("bounds_elision_proven.rz");
+    assert!(
+        ok,
+        "expected successful run; stdout:\n{}\nstderr:\n{}",
+        stdout, stderr
+    );
+    assert!(
+        stdout.contains("array-bounds elided"),
+        "expected `array-bounds elided` audit line; stdout:\n{}",
+        stdout
+    );
+    // The per-site line is colored, so the literal substring `elided at`
+    // is broken up by an ANSI reset. Match the structural line:col instead
+    // — `xs[1]` lives on line 10 of the example.
+    assert!(
+        stdout.contains("at 10:"),
+        "expected per-site `elided at L:C` line referencing line 10; stdout:\n{}",
+        stdout
+    );
+}
+
+#[test]
+fn audit_does_not_surface_elided_line_for_dynamic_index() {
+    let (stdout, stderr, ok) = audit_run("bounds_elision_dynamic.rz");
+    assert!(
+        ok,
+        "expected successful run; stdout:\n{}\nstderr:\n{}",
+        stdout, stderr
+    );
+    // The summary section is gated on at least one bounds visit; the
+    // dynamic example has exactly one (unproven) so the section
+    // shows up — but the proven count must be 0.
+    assert!(
+        stdout.contains("array-bounds elided (proven static):      \x1B[32m0 / 1\x1B[0m")
+            || stdout.contains("array-bounds elided (proven static):      0 / 1"),
+        "expected `0 / 1` proven count; stdout:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("elided at"),
+        "expected no per-site `elided at L:C` line for dynamic-index program; stdout:\n{}",
+        stdout
+    );
+}


### PR DESCRIPTION
## Summary

Builds directly on the RES-133b assumption stack and the RES-068 elision
infrastructure: each `arr[i]` access the verifier discharges
(`0 <= i < len(arr)`) is recorded by source span, and the bytecode compiler
emits a new `Op::LoadIndexUnchecked` in place of the checked `Op::LoadIndex`
for those sites. Real-time embedded code stops paying for the redundant
branch on every load.

## Pipeline

- `bounds_check::check_array_bounds` now records each proven access's
  `Span` in a thread-local `HashSet<Span>` on top of the existing per-run
  counters. The set resets at the top of every run.
- `bounds_check::is_proven_site(span) -> bool` is the compiler's query
  hook; `proven_sites_sorted()` snapshots for the `--audit` reporter.
- `compiler::compile_expr` for `Node::IndexExpression` queries the hook
  and emits `LoadIndexUnchecked` when proven, else `LoadIndex` (current
  behaviour).
- `vm.rs` adds `h_load_index_unchecked`: same operand-type checks as the
  checked variant, but skips the `idx < 0 || idx >= len` test.
- `disasm.rs` prints `LoadIndexUnchecked` so dumped chunks stay honest.
- `print_verification_audit` (`--audit`) gains a bounds section showing
  the proven/runtime count and a per-site `elided at L:C` line.

VM dispatch table grew by one slot — `OP_KIND_COUNT` 31 → 32,
`HANDLER_TABLE_LEN` 34 → 35.

## Tests

- `bounds_check::tests::proven_*` (4 new): span recording, reset between
  runs, `is_proven_site` membership.
- `compiler::tests::res407_*` (2 new): proven literal index → exactly one
  `LoadIndexUnchecked` and zero `LoadIndex`; dynamic param index → zero
  unchecked, at least one checked.
- `tests/bounds_elision_smoke.rs` (2 new): end-to-end `--audit
  --typecheck` runs — proven example surfaces the audit line; dynamic
  example shows `0 / 1` proven.
- Two golden examples (`bounds_elision_proven.rz`,
  `bounds_elision_dynamic.rz`) confirm runtime semantics are unchanged
  by elision.

## Verification

- `cargo test` — all suites green (1190+ tests).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

## Test changes

No existing tests were modified or weakened. All 1180+ pre-existing
tests pass unchanged.

Closes #370