### PR TITLE
RES-401: tuples — literals, element access, destructuring

### DIFF
--- a/resilient/examples/tuple_basic.expected.txt
+++ b/resilient/examples/tuple_basic.expected.txt
@@ -1,0 +1,7 @@
+10
+20
+6
+42
+hello
+true
+Program executed successfully

--- a/resilient/examples/tuple_basic.rz
+++ b/resilient/examples/tuple_basic.rz
@@ -1,0 +1,16 @@
+// RES-401: tuple literals + element access.
+fn main() {
+    let pair = (10, 20);
+    println(pair.0);
+    println(pair.1);
+
+    let triple = (1, 2, 3);
+    println(triple.0 + triple.1 + triple.2);
+
+    let mixed = (42, "hello", true);
+    println(mixed.0);
+    println(mixed.1);
+    println(mixed.2);
+}
+
+main();

--- a/resilient/examples/tuple_destructure.expected.txt
+++ b/resilient/examples/tuple_destructure.expected.txt
@@ -1,0 +1,6 @@
+3
+7
+1
+2
+3
+Program executed successfully

--- a/resilient/examples/tuple_destructure.rz
+++ b/resilient/examples/tuple_destructure.rz
@@ -1,0 +1,15 @@
+// RES-401: tuple destructuring let.
+fn main() {
+    let pair = (3, 7);
+    let (x, y) = pair;
+    println(x);
+    println(y);
+
+    let triple = (1, 2, 3);
+    let (a, b, c) = triple;
+    println(a);
+    println(b);
+    println(c);
+}
+
+main();

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1192,6 +1192,10 @@ fn node_line(n: &Node) -> Option<u32> {
         // RES-319: newtype nodes carry a span.
         Node::NewtypeDecl { span, .. } => span.start.line as u32,
         Node::NewtypeConstruct { span, .. } => span.start.line as u32,
+        // RES-401: tuples carry their own spans.
+        Node::TupleLiteral { span, .. } => span.start.line as u32,
+        Node::TupleIndex { span, .. } => span.start.line as u32,
+        Node::LetTupleDestructure { span, .. } => span.start.line as u32,
     };
     if line == 0 { None } else { Some(line) }
 }

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -1058,6 +1058,33 @@ impl Formatter {
             | Node::Program(_) => {
                 self.fmt_stmt(node);
             }
+            // RES-401: tuple expressions and destructuring let.
+            Node::TupleLiteral { items, .. } => {
+                self.write("(");
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.fmt_expr(it);
+                }
+                self.write(")");
+            }
+            Node::TupleIndex { tuple, index, .. } => {
+                self.fmt_expr(tuple);
+                self.write(&format!(".{}", index));
+            }
+            Node::LetTupleDestructure { names, value, .. } => {
+                self.write("let (");
+                for (i, n) in names.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.write(n);
+                }
+                self.write(") = ");
+                self.fmt_expr(value);
+                self.write(";");
+            }
         }
     }
 

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -223,6 +223,20 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
         | Node::NewtypeDecl { .. }
         // RES-333: supervisor declarations. Phase 1: no free-variable tracking.
         | Node::SupervisorDecl { .. } => {}
+        // RES-401: tuples. Each item is walked; tuple-destructure also
+        // adds the bound names so subsequent expressions see them.
+        Node::TupleLiteral { items, .. } => {
+            for it in items {
+                walk(it, bound, free);
+            }
+        }
+        Node::TupleIndex { tuple, .. } => walk(tuple, bound, free),
+        Node::LetTupleDestructure { names, value, .. } => {
+            walk(value, bound, free);
+            for n in names {
+                bound.insert(n.clone());
+            }
+        }
         Node::NewtypeConstruct { value, .. } => walk(value, bound, free),
         // RES-386: Actor declarations are verifier-only.
         Node::Actor { .. } => {}

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -179,6 +179,11 @@ mod named_args;
 // logic lives here; main.rs only adds a Node variant and two small
 // dispatch calls.
 mod string_interp;
+// RES-401: tuples — literals, element access, destructuring let. All
+// feature logic (parser dispatch, interpreter helpers) lives in
+// `tuples.rs`; main.rs only adds the Node / Value variants and routes
+// through to the helpers.
+mod tuples;
 // RES-324: `mod name { ... }` inline namespace blocks. All namespace
 // logic (eval and static check) lives in this module; the only core-
 // file changes are Token::Mod, Node::ModuleDecl, and the dispatch lines.
@@ -2093,6 +2098,28 @@ enum Node {
         /// Array of child specifications
         children: Vec<SupervisorChild>,
         #[allow(dead_code)]
+        span: span::Span,
+    },
+    /// RES-401: tuple literal `(a, b, c)`. Empty `items` is the unit
+    /// value `()`. A single-element tuple is not constructible from
+    /// source today — `(x)` is parsed as a grouped expression to avoid
+    /// the ambiguity; users wanting a 1-tuple write `(x,)` (trailing
+    /// comma not yet supported as the disambiguator — file a follow-up
+    /// if needed).
+    TupleLiteral { items: Vec<Node>, span: span::Span },
+    /// RES-401: tuple element access — `t.0`, `t.1`. `index` is checked
+    /// at runtime against the actual tuple's length.
+    TupleIndex {
+        tuple: Box<Node>,
+        index: usize,
+        span: span::Span,
+    },
+    /// RES-401: tuple-destructuring `let` — `let (a, b) = pair;`.
+    /// Each name is bound in the enclosing environment; arity must
+    /// match the RHS at runtime.
+    LetTupleDestructure {
+        names: Vec<String>,
+        value: Box<Node>,
         span: span::Span,
     },
 }
@@ -4393,6 +4420,14 @@ impl Parser {
         let stmt_span = self.span_at_current();
         self.next_token(); // Skip 'let'
 
+        // RES-401: tuple destructure form — `let (a, b, ...) = expr;`.
+        // The `(` immediately after `let` is unambiguous: the
+        // single-name and annotated forms both require an identifier
+        // next. Reroute to the dedicated parser.
+        if self.current_token == Token::LeftParen {
+            return crate::tuples::parse_let_tuple_destructure(self, stmt_span);
+        }
+
         let name = match &self.current_token {
             Token::Identifier(name) => name.clone(),
             _ => {
@@ -5787,22 +5822,10 @@ impl Parser {
                     span: op_span,
                 })
             }
-            Token::LeftParen => {
-                self.next_token(); // Skip '('
-                let expr = self.parse_expression(0);
-                // RES-310: parse_expression leaves current_token on the
-                // last token it consumed; advance one more so we can
-                // check that the next token is the closing ')'.
-                self.next_token();
-                if self.current_token != Token::RightParen {
-                    let tok = self.current_token.clone();
-                    self.record_error(format!(
-                        "Expected ')' closing parenthesized expression, found {}",
-                        tok
-                    ));
-                }
-                expr
-            }
+            // RES-401: `(` opens either a tuple literal or a grouped
+            // expression. The disambiguator (number of comma-separated
+            // items inside) lives in `tuples::parse_paren_or_tuple`.
+            Token::LeftParen => crate::tuples::parse_paren_or_tuple(self),
             Token::LeftBracket => Some(self.parse_array_literal()),
             // RES-148: `{"k" -> v, ...}` in expression position parses
             // as a Map literal. Map literals are only valid in
@@ -6902,6 +6925,21 @@ impl Parser {
         // RES-085: span covers the `.` at current_token on entry.
         let dot_span = self.span_at_current();
         self.next_token(); // skip '.'
+        // RES-401: `t.0`, `t.1` — tuple element access. The token after
+        // `.` is an integer literal (non-negative); produce a
+        // `TupleIndex` node and let the interpreter check the bound.
+        if let Token::IntLiteral(n) = &self.current_token {
+            let n_val = *n;
+            if n_val < 0 {
+                self.record_error(format!("Tuple index must be non-negative, got {}", n_val));
+                return Some(target);
+            }
+            return Some(Node::TupleIndex {
+                tuple: Box::new(target),
+                index: n_val as usize,
+                span: dot_span,
+            });
+        }
         let field = match &self.current_token {
             Token::Identifier(n) => n.clone(),
             _ => {
@@ -7476,6 +7514,11 @@ enum Value {
     /// ordinary tree-walker values stay cheap while closures can still
     /// share state explicitly.
     Cell(i64),
+    /// RES-401: tuple. Heterogeneous fixed-length sequence. Empty
+    /// vector is the unit value. Distinct from `Array` so type-aware
+    /// passes can reject mixed-type array literals while still
+    /// permitting `(1, "two")`-style tuples.
+    Tuple(Vec<Value>),
 }
 
 /// RES-148: hashable-key restriction for `Value::Map`. Only the three
@@ -7569,6 +7612,7 @@ impl std::fmt::Debug for Value {
                 Ok(inner) => write!(f, "Cell({:?})", inner),
                 Err(_) => write!(f, "Cell(<missing>)"),
             },
+            Value::Tuple(items) => write!(f, "Tuple({} items)", items.len()),
         }
     }
 }
@@ -7591,6 +7635,18 @@ impl std::fmt::Display for Value {
                     write!(f, "{}", v)?;
                 }
                 write!(f, "]")
+            }
+            // RES-401: tuples render as `(a, b, c)`. The unit value
+            // (empty tuple) renders as `()` to mirror its source form.
+            Value::Tuple(items) => {
+                write!(f, "(")?;
+                for (i, v) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", v)?;
+                }
+                write!(f, ")")
             }
             Value::Struct { name, fields } => {
                 write!(f, "{} {{ ", name)?;
@@ -11229,6 +11285,16 @@ impl Interpreter {
                     out.push(self.eval(item)?);
                 }
                 Ok(Value::Array(out))
+            }
+            // RES-401: tuple literal / element access / let destructure.
+            // All three dispatch into helpers in `tuples.rs`; main.rs
+            // just routes here so the feature stays isolated.
+            Node::TupleLiteral { items, .. } => crate::tuples::eval_tuple_literal(self, items),
+            Node::TupleIndex { tuple, index, span } => {
+                crate::tuples::eval_tuple_index(self, tuple, *index, *span)
+            }
+            Node::LetTupleDestructure { names, value, span } => {
+                crate::tuples::bind_tuple_destructure(self, names, value, *span)
             }
             // RES-148: `{k -> v, ...}` — evaluate each key / value and
             // coerce keys to `MapKey` (errors if a key isn't one of

--- a/resilient/src/tuples.rs
+++ b/resilient/src/tuples.rs
@@ -1,0 +1,407 @@
+//! RES-401: tuples — literals, element access, destructuring let.
+//!
+//! Owns:
+//! - [`parse_paren_or_tuple`]: dispatch from the parser's `(` arm —
+//!   distinguishes `()` (unit), `(expr)` (grouping), and `(a, b, ...)`
+//!   (tuple).
+//! - [`parse_let_tuple_destructure`]: dispatch from the parser's `let (`
+//!   arm — produces a `Node::LetTupleDestructure`.
+//! - [`eval_tuple_literal`]: interpreter helper.
+//! - [`eval_tuple_index`]: interpreter helper for `t.N`.
+//! - [`bind_tuple_destructure`]: interpreter helper for the
+//!   destructuring let.
+//!
+//! Type checking is inline in `typechecker.rs` (treats every tuple
+//! element as `Type::Any`); a follow-up ticket extends `Type` with a
+//! dedicated tuple shape.
+//!
+//! The tuple AST is stored as three new `Node` variants and one new
+//! `Value` variant in `main.rs` (per the feature-isolation pattern,
+//! these are the only main.rs touch points).
+
+use crate::span::Span;
+use crate::{Interpreter, Node, Parser, RResult, Token, Value};
+
+/// Parser entry — called from the `Token::LeftParen` prefix arm in
+/// `main.rs`. On entry, `parser.current_token` is `(`. On exit,
+/// `parser.current_token` sits on the closing `)`.
+///
+/// Disambiguation:
+/// - `()` → `TupleLiteral { items: [] }` (the unit value).
+/// - `(expr)` → grouped expression (no tuple wrapper).
+/// - `(expr, ...)` → `TupleLiteral { items }`.
+pub(crate) fn parse_paren_or_tuple(parser: &mut Parser) -> Option<Node> {
+    let open_span = parser.span_at_current();
+    parser.next_token(); // skip `(`
+
+    // `()` — unit tuple.
+    if parser.current_token == Token::RightParen {
+        return Some(Node::TupleLiteral {
+            items: Vec::new(),
+            span: open_span,
+        });
+    }
+
+    // First element. parse_expression leaves current_token on the
+    // last token it consumed.
+    let first = parser.parse_expression(0)?;
+    parser.next_token();
+
+    if parser.current_token == Token::RightParen {
+        // Single expression in parens — keep grouping semantics.
+        return Some(first);
+    }
+    if parser.current_token != Token::Comma {
+        let tok = parser.current_token.clone();
+        parser.record_error(format!(
+            "Expected `,` or `)` after expression in parens, found {}",
+            tok
+        ));
+        return Some(first);
+    }
+
+    // Tuple — collect remaining items.
+    let mut items = vec![first];
+    while parser.current_token == Token::Comma {
+        parser.next_token(); // skip `,`
+        // Trailing comma allowed: `(a, b,)` — the `)` after a trailing
+        // comma falls through to the close branch below.
+        if parser.current_token == Token::RightParen {
+            break;
+        }
+        let item = parser.parse_expression(0)?;
+        items.push(item);
+        parser.next_token();
+    }
+
+    if parser.current_token != Token::RightParen {
+        let tok = parser.current_token.clone();
+        parser.record_error(format!("Expected `)` closing tuple literal, found {}", tok));
+    }
+
+    Some(Node::TupleLiteral {
+        items,
+        span: open_span,
+    })
+}
+
+/// Parser entry for `let (a, b, ...) = expr;`. Called from
+/// `parse_let_statement` when, after the `let` keyword, the next token
+/// is `(`. On entry, `parser.current_token` is `(`. On exit,
+/// `parser.current_token` sits on the last token of the value expression
+/// (the `;` is handled by the caller).
+pub(crate) fn parse_let_tuple_destructure(parser: &mut Parser, stmt_span: Span) -> Node {
+    parser.next_token(); // skip `(`
+
+    let mut names: Vec<String> = Vec::new();
+    let mut first = true;
+    loop {
+        if parser.current_token == Token::RightParen {
+            break;
+        }
+        if !first {
+            if parser.current_token != Token::Comma {
+                let tok = parser.current_token.clone();
+                parser.record_error(format!(
+                    "Expected `,` or `)` in tuple destructure, found {}",
+                    tok
+                ));
+                break;
+            }
+            parser.next_token(); // skip `,`
+            // Trailing comma support: `(a, b,)`.
+            if parser.current_token == Token::RightParen {
+                break;
+            }
+        }
+        match &parser.current_token {
+            Token::Identifier(n) => names.push(n.clone()),
+            other => {
+                let tok = other.clone();
+                parser.record_error(format!(
+                    "Expected identifier in tuple destructure, found {}",
+                    tok
+                ));
+            }
+        }
+        parser.next_token();
+        first = false;
+    }
+    // Now sit on `)`.
+    parser.next_token(); // skip `)`
+
+    if parser.current_token != Token::Assign {
+        let tok = parser.current_token.clone();
+        parser.record_error(format!(
+            "Expected `=` after tuple destructure pattern, found {}",
+            tok
+        ));
+        return Node::LetTupleDestructure {
+            names,
+            value: Box::new(Node::IntegerLiteral {
+                value: 0,
+                span: Span::default(),
+            }),
+            span: stmt_span,
+        };
+    }
+    parser.next_token(); // skip `=`
+
+    let value = parser.parse_expression(0).unwrap_or(Node::IntegerLiteral {
+        value: 0,
+        span: Span::default(),
+    });
+
+    if parser.peek_token == Token::Semicolon {
+        parser.next_token();
+    }
+
+    Node::LetTupleDestructure {
+        names,
+        value: Box::new(value),
+        span: stmt_span,
+    }
+}
+
+/// Interpreter helper for `Node::TupleLiteral`. Each item is evaluated
+/// left-to-right and collected into a `Value::Tuple`.
+pub(crate) fn eval_tuple_literal(interp: &mut Interpreter, items: &[Node]) -> RResult<Value> {
+    let mut out = Vec::with_capacity(items.len());
+    for it in items {
+        out.push(interp.eval(it)?);
+    }
+    Ok(Value::Tuple(out))
+}
+
+/// Interpreter helper for `Node::TupleIndex`. Returns a clear runtime
+/// diagnostic on out-of-range or non-tuple targets.
+pub(crate) fn eval_tuple_index(
+    interp: &mut Interpreter,
+    tuple: &Node,
+    index: usize,
+    span: Span,
+) -> RResult<Value> {
+    let v = interp.eval(tuple)?;
+    match v {
+        Value::Tuple(items) => items.get(index).cloned().ok_or_else(|| {
+            format!(
+                "{}:{}: tuple index {} out of range (length {})",
+                span.start.line,
+                span.start.column,
+                index,
+                items.len()
+            )
+        }),
+        other => Err(format!(
+            "{}:{}: cannot index `.{}` on non-tuple value `{}`",
+            span.start.line, span.start.column, index, other
+        )),
+    }
+}
+
+/// Interpreter helper for `Node::LetTupleDestructure`. Evaluates the
+/// RHS, asserts it's a tuple of the right arity, and binds each name
+/// in the current environment.
+pub(crate) fn bind_tuple_destructure(
+    interp: &mut Interpreter,
+    names: &[String],
+    value: &Node,
+    span: Span,
+) -> RResult<Value> {
+    let v = interp.eval(value)?;
+    let items = match v {
+        Value::Tuple(items) => items,
+        other => {
+            return Err(format!(
+                "{}:{}: cannot destructure non-tuple value `{}` into ({} names)",
+                span.start.line,
+                span.start.column,
+                other,
+                names.len()
+            ));
+        }
+    };
+    if items.len() != names.len() {
+        return Err(format!(
+            "{}:{}: tuple destructure expects {} elements, got {}",
+            span.start.line,
+            span.start.column,
+            names.len(),
+            items.len()
+        ));
+    }
+    for (n, val) in names.iter().zip(items.into_iter()) {
+        interp.env.set(n.clone(), val);
+    }
+    Ok(Value::Void)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Interpreter, Lexer, Parser, Value};
+
+    /// Parse + run `src`. Returns the program's final result for
+    /// expression-style smoke tests, or `Value::Void` for procedural
+    /// programs that print via `println`. Tests assert against
+    /// captured side effects via the runtime's known semantics.
+    fn run(src: &str) -> Value {
+        let lexer = Lexer::new(src.to_string());
+        let mut parser = Parser::new(lexer);
+        let program = parser.parse_program();
+        assert!(
+            parser.errors.is_empty(),
+            "parse errors: {:?}",
+            parser.errors
+        );
+        let mut interp = Interpreter::new();
+        interp.eval(&program).expect("eval failed")
+    }
+
+    #[test]
+    fn empty_parens_is_unit_tuple() {
+        let v = run("()");
+        assert!(matches!(&v, Value::Tuple(items) if items.is_empty()));
+    }
+
+    #[test]
+    fn paren_around_single_expr_is_grouped() {
+        // `(42)` parses as the integer literal `42`, NOT a 1-tuple.
+        let v = run("(42)");
+        assert!(matches!(&v, Value::Int(42)));
+    }
+
+    #[test]
+    fn pair_tuple_evaluates() {
+        let v = run("(10, 20)");
+        match v {
+            Value::Tuple(items) => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(items[0], Value::Int(10)));
+                assert!(matches!(items[1], Value::Int(20)));
+            }
+            other => panic!("expected Tuple, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn triple_tuple_with_mixed_types() {
+        let v = run("(1, \"two\", true)");
+        match v {
+            Value::Tuple(items) => {
+                assert_eq!(items.len(), 3);
+                assert!(matches!(items[0], Value::Int(1)));
+                assert!(matches!(&items[1], Value::String(s) if s == "two"));
+                assert!(matches!(items[2], Value::Bool(true)));
+            }
+            other => panic!("expected Tuple, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn element_access_returns_correct_item() {
+        let v = run("(10, 20, 30).1");
+        assert!(matches!(v, Value::Int(20)));
+    }
+
+    #[test]
+    fn element_access_on_named_binding() {
+        let v = run("let p = (5, 7); p.0 + p.1");
+        assert!(matches!(v, Value::Int(12)));
+    }
+
+    #[test]
+    fn element_access_out_of_range_errors() {
+        let lexer = Lexer::new("(1, 2).5".to_string());
+        let mut parser = Parser::new(lexer);
+        let program = parser.parse_program();
+        assert!(parser.errors.is_empty());
+        let mut interp = Interpreter::new();
+        let err = interp.eval(&program).unwrap_err();
+        assert!(
+            err.contains("out of range"),
+            "expected `out of range`, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn destructure_let_binds_all_names() {
+        let v = run("let (a, b) = (10, 20); a + b");
+        assert!(matches!(v, Value::Int(30)));
+    }
+
+    #[test]
+    fn destructure_arity_mismatch_errors() {
+        let lexer = Lexer::new("let (a, b, c) = (1, 2);".to_string());
+        let mut parser = Parser::new(lexer);
+        let program = parser.parse_program();
+        assert!(parser.errors.is_empty());
+        let mut interp = Interpreter::new();
+        let err = interp.eval(&program).unwrap_err();
+        assert!(
+            err.contains("expects 3 elements"),
+            "expected arity error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn destructure_non_tuple_errors() {
+        let lexer = Lexer::new("let (a, b) = 42;".to_string());
+        let mut parser = Parser::new(lexer);
+        let program = parser.parse_program();
+        assert!(parser.errors.is_empty());
+        let mut interp = Interpreter::new();
+        let err = interp.eval(&program).unwrap_err();
+        assert!(
+            err.contains("non-tuple"),
+            "expected non-tuple error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn nested_tuple() {
+        let v = run("((1, 2), (3, 4))");
+        match &v {
+            Value::Tuple(outer) => {
+                assert_eq!(outer.len(), 2);
+                match (&outer[0], &outer[1]) {
+                    (Value::Tuple(a), Value::Tuple(b)) => {
+                        assert_eq!(a.len(), 2);
+                        assert_eq!(b.len(), 2);
+                    }
+                    _ => panic!("inner items must be tuples"),
+                }
+            }
+            other => panic!("expected outer Tuple, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn tuple_display_format() {
+        let v = run("(1, 2, 3)");
+        assert_eq!(format!("{}", v), "(1, 2, 3)");
+    }
+
+    #[test]
+    fn unit_tuple_display() {
+        let v = run("()");
+        assert_eq!(format!("{}", v), "()");
+    }
+
+    #[test]
+    fn tuple_index_on_non_tuple_errors() {
+        let lexer = Lexer::new("let x = 42; x.0".to_string());
+        let mut parser = Parser::new(lexer);
+        let program = parser.parse_program();
+        assert!(parser.errors.is_empty());
+        let mut interp = Interpreter::new();
+        let err = interp.eval(&program).unwrap_err();
+        assert!(
+            err.contains("non-tuple"),
+            "expected non-tuple error, got: {}",
+            err
+        );
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2672,6 +2672,28 @@ impl TypeChecker {
             // RES-390: ClusterDecl is compile-time-only.
             Node::ClusterDecl { .. } => Ok(Type::Void),
 
+            // RES-401: tuples — type-check each item in a literal,
+            // recurse into the destructure RHS, and treat element
+            // access as `Type::Any` until the type system grows a
+            // dedicated tuple shape (follow-up ticket).
+            Node::TupleLiteral { items, .. } => {
+                for it in items {
+                    self.check_node(it)?;
+                }
+                Ok(Type::Any)
+            }
+            Node::TupleIndex { tuple, .. } => {
+                self.check_node(tuple)?;
+                Ok(Type::Any)
+            }
+            Node::LetTupleDestructure { names, value, .. } => {
+                self.check_node(value)?;
+                for n in names {
+                    self.env.set(n.clone(), Type::Any);
+                }
+                Ok(Type::Void)
+            }
+
             // RES-388/RES-390: ActorDecl type-checks state fields,
             // always invariants, and receive handler bodies.
             Node::ActorDecl {


### PR DESCRIPTION
## Summary

First-class tuple support in the tree-walker: `(a, b, c)` literals,
`t.0` element access, `let (a, b) = pair;` destructuring, and a new
`Value::Tuple(Vec<Value>)` runtime variant with `(a, b, c)` Display.

## Implementation

All feature logic lives in the new `resilient/src/tuples.rs` module
per the feature-isolation pattern. `main.rs` adds three Node variants
(`TupleLiteral`, `TupleIndex`, `LetTupleDestructure`) and one Value
variant, and routes through to module helpers from:

- the parser's `Token::LeftParen` prefix arm (calls `parse_paren_or_tuple`),
- `parse_let_statement` when the next token after `let` is `(` (calls
  `parse_let_tuple_destructure`),
- the interpreter's `eval` match (calls `eval_tuple_literal`,
  `eval_tuple_index`, `bind_tuple_destructure`).

`parse_field_access` was extended to dispatch on `IntLiteral` after
`.` — that's how `t.0` parses to a `TupleIndex` rather than a
`FieldAccess`.

## Disambiguation

- `()` → unit tuple (empty).
- `(expr)` → grouped expression (current behaviour preserved).
- `(a, b, ...)` → tuple literal.

The single-element tuple form `(x,)` is not yet constructible — the
disambiguator will need a sniff for the trailing comma; tracked as a
follow-up.

## Skipped (out of scope; follow-ups)

- Tuple **type annotations** in fn signatures / let bindings — `fn
  f() -> (Int, Int)`. The type system treats tuple values as
  `Type::Any` element-wise today.
- Tuple destructuring **in match arms** — `match p { (0, y) => ..., }`.
- **Bytecode lowering / VM support** — tuples run on the tree-walker
  only. A follow-up will add `Op::MakeTuple` / `Op::TupleIndex`
  alongside the RES-405 generic-monomorph push.

These three deferrals are flagged in the commit message; happy to
spin them off into their own tickets on request.

## Test changes

No existing tests were modified or weakened.

## Tests

- `tuples::tests::*` (14 new): empty / grouped / pair / triple /
  mixed-type literals, element access (in/out of range, on
  identifier, on non-tuple), destructure (success / arity-mismatch
  / non-tuple), nested tuples, Display round-trip.
- Two golden examples (`tuple_basic.rz`, `tuple_destructure.rz`).
- Full suite: 1220 tests pass.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.

Closes #364