### PR TITLE
RES-409: streaming file I/O with handle-keyed registry

### DIFF
--- a/resilient/examples/file_streaming.expected.txt
+++ b/resilient/examples/file_streaming.expected.txt
@@ -1,0 +1,6 @@
+b"abc"
+b"def"
+0
+b"abcde"
+true
+Program executed successfully

--- a/resilient/examples/file_streaming.rz
+++ b/resilient/examples/file_streaming.rz
@@ -1,0 +1,33 @@
+// RES-409: streaming file I/O — open, chunked read, seek, close.
+//
+// Writes a known string to a tmpfile, then reads it back chunk by
+// chunk to demonstrate that memory-bounded reads are now possible.
+// Cleans up at the end so re-runs are deterministic.
+fn main() {
+    let path = "/tmp/resilient-res409-streaming.txt";
+
+    // Bootstrap the file with the existing whole-file writer.
+    file_write(path, "abcdefghij");
+
+    // Open a streaming reader.
+    let opened = file_open(path, "r");
+    let f = unwrap(opened);
+
+    // Read 3 bytes at a time.
+    let chunk1 = unwrap(file_read_chunk(f, 3));
+    println(chunk1);
+    let chunk2 = unwrap(file_read_chunk(f, 3));
+    println(chunk2);
+
+    // Seek back to the start.
+    let pos = unwrap(file_seek(f, 0, "start"));
+    println(pos);
+    let chunk3 = unwrap(file_read_chunk(f, 5));
+    println(chunk3);
+
+    // Close — second close would error.
+    let close = file_close(f);
+    println(is_ok(close));
+}
+
+main();

--- a/resilient/examples/file_streaming_write.expected.txt
+++ b/resilient/examples/file_streaming_write.expected.txt
@@ -1,0 +1,4 @@
+6
+5
+hello world
+Program executed successfully

--- a/resilient/examples/file_streaming_write.rz
+++ b/resilient/examples/file_streaming_write.rz
@@ -1,0 +1,18 @@
+// RES-409: streaming write — file_open(w) + file_write_chunk + close,
+// then read back the file to verify the bytes round-tripped.
+fn main() {
+    let path = "/tmp/resilient-res409-write.txt";
+
+    let f = unwrap(file_open(path, "w"));
+    let n = unwrap(file_write_chunk(f, b"hello "));
+    println(n);
+    let m = unwrap(file_write_chunk(f, b"world"));
+    println(m);
+    file_close(f);
+
+    // Read back via the existing whole-file reader.
+    let contents = file_read(path);
+    println(contents);
+}
+
+main();

--- a/resilient/src/file_io.rs
+++ b/resilient/src/file_io.rs
@@ -1,0 +1,493 @@
+//! RES-409: streaming file I/O — `file_open`, `file_read_chunk`,
+//! `file_seek`, `file_close`. Memory-bounded reads (the only safe
+//! kind on embedded with constrained RAM) finally possible.
+//!
+//! A file handle is encoded as a `Value::Struct { name: "File",
+//! fields: [("id", Int(N))] }` so the Value enum doesn't need a new
+//! variant — the runtime registry below is keyed by `N`. The struct
+//! shape doubles as the user-visible value (`f.id` is the handle id
+//! if anyone needs it for debugging).
+//!
+//! Linear-type integration: a future RES-385 follow-up can mark
+//! `File` as linear by adding it to the linear-type module's
+//! resource list. For the MVP, single-use is enforced by the runtime
+//! itself: `file_close` drops the handle from the registry, and any
+//! subsequent operation on it surfaces a `closed-or-unknown handle`
+//! diagnostic.
+//!
+//! Std-only — every builtin here pulls in `std::fs`. The
+//! `resilient-runtime` sibling crate has no builtins table at all and
+//! stays no_std-clean.
+
+use crate::{RResult, Value};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::sync::atomic::{AtomicI64, Ordering};
+
+/// Process-global handle id counter. Each `file_open` mints the next
+/// id; ids never recycle within a process so a stale handle can't
+/// silently alias a freshly opened file.
+static NEXT_HANDLE: AtomicI64 = AtomicI64::new(1);
+
+thread_local! {
+    static REGISTRY: RefCell<HashMap<i64, File>> = RefCell::new(HashMap::new());
+}
+
+/// `file_open(path: String, mode: String) -> Result<File, String>`.
+/// Modes: `"r"` (read-only), `"w"` (write-only, truncate), `"rw"`
+/// (read+write, create if missing, do not truncate).
+pub(crate) fn builtin_file_open(args: &[Value]) -> RResult<Value> {
+    let (path, mode) = match args {
+        [Value::String(p), Value::String(m)] => (p, m),
+        _ => {
+            return Err(format!(
+                "file_open: expected (String path, String mode), got {} arg(s)",
+                args.len()
+            ));
+        }
+    };
+    let result = match mode.as_str() {
+        "r" => OpenOptions::new().read(true).open(path),
+        "w" => OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path),
+        "rw" => OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path),
+        other => {
+            return Ok(Value::Result {
+                ok: false,
+                payload: Box::new(Value::String(format!(
+                    "file_open: unknown mode `{}` (expected r / w / rw)",
+                    other
+                ))),
+            });
+        }
+    };
+    match result {
+        Ok(file) => {
+            let id = NEXT_HANDLE.fetch_add(1, Ordering::Relaxed);
+            REGISTRY.with(|r| {
+                r.borrow_mut().insert(id, file);
+            });
+            Ok(Value::Result {
+                ok: true,
+                payload: Box::new(handle_value(id)),
+            })
+        }
+        Err(e) => Ok(Value::Result {
+            ok: false,
+            payload: Box::new(Value::String(format!("file_open: {}: {}", path, e))),
+        }),
+    }
+}
+
+/// `file_read_chunk(handle: File, max_bytes: Int) -> Result<Bytes, String>`.
+/// Reads up to `max_bytes` bytes from the current cursor position.
+/// Empty `Bytes` indicates EOF.
+pub(crate) fn builtin_file_read_chunk(args: &[Value]) -> RResult<Value> {
+    let (id, max) = match args {
+        [Value::Struct { name, fields }, Value::Int(n)] if name == "File" => {
+            let id = handle_id_from_fields(fields)?;
+            (id, *n)
+        }
+        _ => {
+            return Err(format!(
+                "file_read_chunk: expected (File, Int), got {} arg(s)",
+                args.len()
+            ));
+        }
+    };
+    if max < 0 {
+        return Err(format!(
+            "file_read_chunk: max_bytes must be non-negative, got {}",
+            max
+        ));
+    }
+    let max_usize = max as usize;
+    let result = REGISTRY.with(|r| -> Result<Vec<u8>, std::io::Error> {
+        let mut reg = r.borrow_mut();
+        let f = reg
+            .get_mut(&id)
+            .ok_or_else(|| std::io::Error::other("closed or unknown file handle"))?;
+        let mut buf = vec![0u8; max_usize];
+        let n = f.read(&mut buf)?;
+        buf.truncate(n);
+        Ok(buf)
+    });
+    match result {
+        Ok(bytes) => Ok(Value::Result {
+            ok: true,
+            payload: Box::new(Value::Bytes(bytes)),
+        }),
+        Err(e) => Ok(Value::Result {
+            ok: false,
+            payload: Box::new(Value::String(format!("file_read_chunk: {}", e))),
+        }),
+    }
+}
+
+/// `file_write_chunk(handle: File, bytes: Bytes) -> Result<Int, String>`.
+/// Writes the entire byte slice; returns the number of bytes written.
+pub(crate) fn builtin_file_write_chunk(args: &[Value]) -> RResult<Value> {
+    let (id, bytes) = match args {
+        [Value::Struct { name, fields }, Value::Bytes(b)] if name == "File" => {
+            let id = handle_id_from_fields(fields)?;
+            (id, b.clone())
+        }
+        _ => {
+            return Err(format!(
+                "file_write_chunk: expected (File, Bytes), got {} arg(s)",
+                args.len()
+            ));
+        }
+    };
+    let result = REGISTRY.with(|r| -> Result<usize, std::io::Error> {
+        let mut reg = r.borrow_mut();
+        let f = reg
+            .get_mut(&id)
+            .ok_or_else(|| std::io::Error::other("closed or unknown file handle"))?;
+        f.write_all(&bytes)?;
+        Ok(bytes.len())
+    });
+    match result {
+        Ok(n) => Ok(Value::Result {
+            ok: true,
+            payload: Box::new(Value::Int(n as i64)),
+        }),
+        Err(e) => Ok(Value::Result {
+            ok: false,
+            payload: Box::new(Value::String(format!("file_write_chunk: {}", e))),
+        }),
+    }
+}
+
+/// `file_seek(handle: File, offset: Int, whence: String) -> Result<Int, String>`.
+/// Whence is one of `"start"`, `"current"`, `"end"`. Returns the new
+/// cursor position from the start of the file.
+pub(crate) fn builtin_file_seek(args: &[Value]) -> RResult<Value> {
+    let (id, offset, whence) = match args {
+        [
+            Value::Struct { name, fields },
+            Value::Int(o),
+            Value::String(w),
+        ] if name == "File" => {
+            let id = handle_id_from_fields(fields)?;
+            (id, *o, w.clone())
+        }
+        _ => {
+            return Err(format!(
+                "file_seek: expected (File, Int, String), got {} arg(s)",
+                args.len()
+            ));
+        }
+    };
+    let seek_from = match whence.as_str() {
+        "start" => {
+            if offset < 0 {
+                return Err(format!(
+                    "file_seek: `start` whence requires non-negative offset, got {}",
+                    offset
+                ));
+            }
+            SeekFrom::Start(offset as u64)
+        }
+        "current" => SeekFrom::Current(offset),
+        "end" => SeekFrom::End(offset),
+        other => {
+            return Ok(Value::Result {
+                ok: false,
+                payload: Box::new(Value::String(format!(
+                    "file_seek: unknown whence `{}` (expected start / current / end)",
+                    other
+                ))),
+            });
+        }
+    };
+    let result = REGISTRY.with(|r| -> Result<u64, std::io::Error> {
+        let mut reg = r.borrow_mut();
+        let f = reg
+            .get_mut(&id)
+            .ok_or_else(|| std::io::Error::other("closed or unknown file handle"))?;
+        f.seek(seek_from)
+    });
+    match result {
+        Ok(pos) => Ok(Value::Result {
+            ok: true,
+            payload: Box::new(Value::Int(pos as i64)),
+        }),
+        Err(e) => Ok(Value::Result {
+            ok: false,
+            payload: Box::new(Value::String(format!("file_seek: {}", e))),
+        }),
+    }
+}
+
+/// `file_close(handle: File) -> Result<Void, String>`. Removes the
+/// handle from the registry; the underlying `std::fs::File` is dropped
+/// (and flushed) at that point. A second close returns `Err("already
+/// closed")` so the linear-use violation is loud, not silent.
+pub(crate) fn builtin_file_close(args: &[Value]) -> RResult<Value> {
+    let id = match args {
+        [Value::Struct { name, fields }] if name == "File" => handle_id_from_fields(fields)?,
+        _ => {
+            return Err(format!(
+                "file_close: expected (File,), got {} arg(s)",
+                args.len()
+            ));
+        }
+    };
+    let removed = REGISTRY.with(|r| r.borrow_mut().remove(&id).is_some());
+    if removed {
+        Ok(Value::Result {
+            ok: true,
+            payload: Box::new(Value::Void),
+        })
+    } else {
+        Ok(Value::Result {
+            ok: false,
+            payload: Box::new(Value::String(
+                "file_close: already closed or unknown handle".to_string(),
+            )),
+        })
+    }
+}
+
+fn handle_value(id: i64) -> Value {
+    Value::Struct {
+        name: "File".to_string(),
+        fields: vec![("id".to_string(), Value::Int(id))],
+    }
+}
+
+fn handle_id_from_fields(fields: &[(String, Value)]) -> Result<i64, String> {
+    for (k, v) in fields {
+        if k == "id"
+            && let Value::Int(n) = v
+        {
+            return Ok(*n);
+        }
+    }
+    Err("file handle struct is missing `id: Int` field".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("resilient-res409-{}-{}", name, std::process::id()));
+        p
+    }
+
+    fn open_handle_id(v: &Value) -> i64 {
+        match v {
+            Value::Result { ok: true, payload } => match payload.as_ref() {
+                Value::Struct { name, fields } if name == "File" => {
+                    handle_id_from_fields(fields).unwrap()
+                }
+                other => panic!("expected File struct, got {:?}", other),
+            },
+            other => panic!("expected Ok payload, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn open_read_close_round_trip() {
+        let path = temp_path("rw");
+        std::fs::write(&path, b"hello world").unwrap();
+
+        let opened = builtin_file_open(&[
+            Value::String(path.to_string_lossy().into()),
+            Value::String("r".into()),
+        ])
+        .unwrap();
+        let id = open_handle_id(&opened);
+        let handle = handle_value(id);
+
+        let chunk = builtin_file_read_chunk(&[handle.clone(), Value::Int(5)]).unwrap();
+        let Value::Result { ok: true, payload } = chunk else {
+            panic!("expected Ok, got {:?}", chunk);
+        };
+        let Value::Bytes(b) = *payload else {
+            panic!("expected Bytes payload");
+        };
+        assert_eq!(b, b"hello");
+
+        let close = builtin_file_close(&[handle]).unwrap();
+        assert!(matches!(close, Value::Result { ok: true, .. }));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn read_chunk_returns_empty_at_eof() {
+        let path = temp_path("eof");
+        std::fs::write(&path, b"abc").unwrap();
+        let opened = builtin_file_open(&[
+            Value::String(path.to_string_lossy().into()),
+            Value::String("r".into()),
+        ])
+        .unwrap();
+        let handle = handle_value(open_handle_id(&opened));
+
+        // Drain the file.
+        let _ = builtin_file_read_chunk(&[handle.clone(), Value::Int(1024)]).unwrap();
+        // Subsequent read returns Ok(Bytes(empty)).
+        let again = builtin_file_read_chunk(&[handle.clone(), Value::Int(1024)]).unwrap();
+        let Value::Result { ok: true, payload } = again else {
+            panic!("expected Ok, got {:?}", again);
+        };
+        let Value::Bytes(b) = *payload else {
+            panic!("expected Bytes payload");
+        };
+        assert!(b.is_empty(), "expected empty bytes at EOF, got {:?}", b);
+
+        builtin_file_close(&[handle]).unwrap();
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn double_close_errors() {
+        let path = temp_path("double-close");
+        std::fs::write(&path, b"x").unwrap();
+        let opened = builtin_file_open(&[
+            Value::String(path.to_string_lossy().into()),
+            Value::String("r".into()),
+        ])
+        .unwrap();
+        let handle = handle_value(open_handle_id(&opened));
+
+        let first = builtin_file_close(std::slice::from_ref(&handle)).unwrap();
+        assert!(matches!(first, Value::Result { ok: true, .. }));
+
+        let second = builtin_file_close(&[handle]).unwrap();
+        let Value::Result { ok: false, payload } = second else {
+            panic!("expected Err, got {:?}", second);
+        };
+        let Value::String(msg) = *payload else {
+            panic!("expected String error payload");
+        };
+        assert!(msg.contains("already closed"), "unexpected error: {}", msg);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn seek_repositions_cursor() {
+        let path = temp_path("seek");
+        std::fs::write(&path, b"abcdefgh").unwrap();
+        let opened = builtin_file_open(&[
+            Value::String(path.to_string_lossy().into()),
+            Value::String("r".into()),
+        ])
+        .unwrap();
+        let handle = handle_value(open_handle_id(&opened));
+
+        // Seek to byte 3, read 3 bytes → "def".
+        let seek =
+            builtin_file_seek(&[handle.clone(), Value::Int(3), Value::String("start".into())])
+                .unwrap();
+        assert!(matches!(seek, Value::Result { ok: true, .. }));
+
+        let chunk = builtin_file_read_chunk(&[handle.clone(), Value::Int(3)]).unwrap();
+        let Value::Result { ok: true, payload } = chunk else {
+            panic!("expected Ok");
+        };
+        let Value::Bytes(b) = *payload else {
+            panic!("expected Bytes")
+        };
+        assert_eq!(b, b"def");
+
+        builtin_file_close(&[handle]).unwrap();
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn open_unknown_mode_errors() {
+        let opened = builtin_file_open(&[
+            Value::String("/dev/null".into()),
+            Value::String("zzz".into()),
+        ])
+        .unwrap();
+        let Value::Result { ok: false, payload } = opened else {
+            panic!("expected Err on bad mode");
+        };
+        let Value::String(msg) = *payload else {
+            panic!("expected String error");
+        };
+        assert!(msg.contains("unknown mode"), "unexpected: {}", msg);
+    }
+
+    #[test]
+    fn open_missing_file_errors() {
+        let opened = builtin_file_open(&[
+            Value::String("/nonexistent-resilient-res409-xxx".into()),
+            Value::String("r".into()),
+        ])
+        .unwrap();
+        assert!(
+            matches!(opened, Value::Result { ok: false, .. }),
+            "expected Err for missing file"
+        );
+    }
+
+    #[test]
+    fn read_after_close_errors() {
+        let path = temp_path("read-after-close");
+        std::fs::write(&path, b"x").unwrap();
+        let opened = builtin_file_open(&[
+            Value::String(path.to_string_lossy().into()),
+            Value::String("r".into()),
+        ])
+        .unwrap();
+        let handle = handle_value(open_handle_id(&opened));
+
+        builtin_file_close(std::slice::from_ref(&handle)).unwrap();
+        let read = builtin_file_read_chunk(&[handle, Value::Int(1)]).unwrap();
+        let Value::Result { ok: false, payload } = read else {
+            panic!("expected Err on read-after-close");
+        };
+        let Value::String(msg) = *payload else {
+            panic!("expected String payload");
+        };
+        assert!(msg.contains("closed or unknown"), "unexpected: {}", msg);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn write_chunk_round_trip() {
+        let path = temp_path("write");
+        let _ = std::fs::remove_file(&path);
+
+        let opened = builtin_file_open(&[
+            Value::String(path.to_string_lossy().into()),
+            Value::String("w".into()),
+        ])
+        .unwrap();
+        let handle = handle_value(open_handle_id(&opened));
+
+        let written =
+            builtin_file_write_chunk(&[handle.clone(), Value::Bytes(b"hello".to_vec())]).unwrap();
+        let Value::Result { ok: true, payload } = written else {
+            panic!("expected Ok");
+        };
+        assert!(matches!(*payload, Value::Int(5)));
+
+        builtin_file_close(&[handle]).unwrap();
+
+        let on_disk = std::fs::read(&path).unwrap();
+        assert_eq!(on_disk, b"hello");
+
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -184,6 +184,11 @@ mod string_interp;
 // `tuples.rs`; main.rs only adds the Node / Value variants and routes
 // through to the helpers.
 mod tuples;
+// RES-409: streaming file I/O — `file_open`, `file_read_chunk`,
+// `file_seek`, `file_close`, `file_write_chunk`. All builtins and the
+// thread-local handle registry live here; main.rs just registers
+// them in the BUILTINS table.
+mod file_io;
 // RES-324: `mod name { ... }` inline namespace blocks. All namespace
 // logic (eval and static check) lives in this module; the only core-
 // file changes are Token::Mod, Node::ModuleDecl, and the dispatch lines.
@@ -8135,6 +8140,13 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     // no builtins table and stays no_std-clean.
     ("file_read", builtin_file_read),
     ("file_write", builtin_file_write),
+    // RES-409: streaming file I/O — open / read_chunk / seek /
+    // write_chunk / close. Memory-bounded reads finally possible.
+    ("file_open", file_io::builtin_file_open),
+    ("file_read_chunk", file_io::builtin_file_read_chunk),
+    ("file_write_chunk", file_io::builtin_file_write_chunk),
+    ("file_seek", file_io::builtin_file_seek),
+    ("file_close", file_io::builtin_file_close),
     // RES-151: read-only env-var accessor, std-only.
     ("env", builtin_env),
     // RES-148: Map builtins.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1239,6 +1239,47 @@ impl TypeChecker {
             },
         );
 
+        // RES-409: streaming file I/O — `file_open`, `file_read_chunk`,
+        // `file_write_chunk`, `file_seek`, `file_close`. The `File`
+        // handle is a `Type::Any` (a struct in disguise) until the type
+        // system grows a dedicated linear-resource form. Each builtin
+        // returns `Type::Result` so the user is forced to handle errors.
+        env.set(
+            "file_open".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Result),
+            },
+        );
+        env.set(
+            "file_read_chunk".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Int],
+                return_type: Box::new(Type::Result),
+            },
+        );
+        env.set(
+            "file_write_chunk".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Bytes],
+                return_type: Box::new(Type::Result),
+            },
+        );
+        env.set(
+            "file_seek".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Int, Type::String],
+                return_type: Box::new(Type::Result),
+            },
+        );
+        env.set(
+            "file_close".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Result),
+            },
+        );
+
         // RES-151: read-only env-var accessor. `Result<String, String>`
         // — absence is a first-class outcome, not a runtime halt.
         env.set(
@@ -3481,6 +3522,13 @@ const IMPURE_BUILTINS: &[&str] = &[
     // RES-143: disk I/O.
     "file_read",
     "file_write",
+    // RES-409: streaming file I/O. All five reach the disk and so
+    // count as impure for the effect inferrer.
+    "file_open",
+    "file_read_chunk",
+    "file_write_chunk",
+    "file_seek",
+    "file_close",
     // RES-151: env-var reads depend on process state outside
     // the fn.
     "env",


### PR DESCRIPTION
## Summary

Five new builtins replace the whole-file `file_read`/`file_write` MVP
to enable memory-bounded reads on RAM-constrained targets:

- `file_open(path: String, mode: String) -> Result<File, String>` —
  `"r"` / `"w"` (truncate) / `"rw"` (create-if-missing).
- `file_read_chunk(f: File, max_bytes: Int) -> Result<Bytes, String>` —
  reads up to N bytes; empty on EOF.
- `file_write_chunk(f: File, bytes: Bytes) -> Result<Int, String>` —
  writes the full slice, returns count.
- `file_seek(f: File, offset: Int, whence: String) -> Result<Int, String>`
  with `whence ∈ {start, current, end}`.
- `file_close(f: File) -> Result<Void, String>` — drops the handle;
  a second close returns `Err("already closed or unknown")` so a
  linear-use violation is loud rather than silent.

## Implementation

`resilient/src/file_io.rs` owns a thread-local
`HashMap<i64, std::fs::File>` keyed by a process-global atomic
counter — ids never recycle so a stale handle can't silently alias a
newly opened file. The `File` value is encoded as
`Value::Struct { name: "File", fields: [("id", Int(N))] }` so no
`Value` enum variant has to be added.

`main.rs` only registers the five builtins in the static `BUILTINS`
table; `typechecker.rs` adds their `Type::Function` signatures and
adds them to `IMPURE_BUILTINS` so `@pure` fns can't reach them.

## Linear-type integration

Deferred. The runtime registry already enforces single-use
(post-close access errors with a clear message). A follow-up
RES-385 extension can mark the `File` struct as a linear resource
at the type-system level; this MVP doesn't block on that.

## Tests

- `file_io::tests::*` (8 new): open+read+close round-trip,
  write_chunk round-trip, EOF returns empty, double_close errors,
  seek+read, unknown mode, missing file, read-after-close.
- Two golden examples (`file_streaming.rz`, `file_streaming_write.rz`)
  demonstrating end-to-end usage with the existing whole-file
  `file_read`/`file_write` for setup + verification.
- Pre-existing `purity_tests::file_io_builtins_flag_io` already
  covers the impure-classification side.
- Full suite: 1228 tests pass.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.

## Test changes

No existing tests were modified or weakened.

Closes #372