### PR TITLE
RES-363: document recovers_to as one-step; flag V2 multi-step extension

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -103,7 +103,10 @@ with no warning cycle:
   cluster invariants); reasoning over **traces** — liveness, fairness,
   multi-actor interleavings, refinement — is a V2 capability tracked under
   RES-396 (G22 TLA+ ladder, see [ROADMAP.md](ROADMAP.md)). Don't read V1
-  Z3 success as a temporal-property guarantee.
+  Z3 success as a temporal-property guarantee. Note: `recovers_to` is a
+  single-transition postcondition — it does not provide an eventually-holds
+  guarantee; multi-step recovery operators are a V2 capability tracked under
+  RES-396.
 - **Package manager (`resilient pkg`)** — subcommand names, manifest format
   (RES-212), and resolution rules.
 - **Language server (`--lsp`)** — request/response shapes beyond stock LSP

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -90,6 +90,24 @@ typechecker rejects with a clean `return type mismatch — declared
 required** — inferring them from call-site usage is a worse DX
 (errors fire at callers, not at the definition).
 
+### Function Contracts
+
+Functions can declare contracts using `requires`, `ensures`, and `recovers_to`:
+
+```rust
+fn safe_divide(int a, int b)
+    requires b != 0
+    ensures  result >= 0
+    recovers_to: result > 0
+{ return a / b; }
+```
+
+- `requires` — pre-condition checked before the function executes
+- `ensures` — post-condition checked after successful return
+- `recovers_to` — recovery postcondition (V1: single-step property; see RES-396 for V2's multi-step `<>` operator)
+
+All three clauses are checked at runtime and discharged by the Z3 verifier when `--features z3` is enabled. `recovers_to` is a **single-transition** postcondition — it asserts a property of the final state after recovery, not a guarantee of eventual reachability. Multi-step recovery operators are a V2 capability tracked under [RES-396](https://github.com/EricSpencer00/Resilient/issues/270); do not read `recovers_to` as providing temporal guarantees.
+
 ## Lexical: identifiers
 
 Identifiers match `[A-Za-z_][A-Za-z0-9_]*` — **ASCII only**. Non-

--- a/resilient/examples/live_closed_form_fail_ffi.rz
+++ b/resilient/examples/live_closed_form_fail_ffi.rz
@@ -1,0 +1,30 @@
+// RES-360: Live block with opaque FFI in recovery (FAIL - V2)
+// This example demonstrates code that should be REJECTED by V2's
+// closed-form constraint checker (RES-360). It calls an opaque FFI
+// function (malloc) inside the recovery body, which V2 TLA+ cannot model.
+//
+// V1 behavior: Emits warning but runs without error.
+// V2 behavior: Typechecker will reject with error[live-closed]: opaque FFI
+// call in recovery body cannot be modeled as a TLA+ action.
+
+extern "libc.so.6" {
+    fn malloc(size: Int) -> Int;
+}
+
+fn dangerous_recover(int size) -> int {
+    live {
+        // This FFI call in the recovery body violates the closed-form
+        // invariant: V2 TLA+ cannot reason about malloc's side effects
+        // (heap modification, allocation failure, etc.).
+        let ptr = malloc(size);
+        assume(ptr != 0);
+        return ptr;
+    }
+}
+
+fn main() {
+    let result = dangerous_recover(256);
+    println(result);
+}
+
+main();

--- a/resilient/examples/live_closed_form_fail_recursion.rz
+++ b/resilient/examples/live_closed_form_fail_recursion.rz
@@ -1,0 +1,29 @@
+// RES-360: Live block with direct recursion (FAIL - V2)
+// This example demonstrates code that should be REJECTED by V2's
+// closed-form constraint checker (RES-360). It recursively calls itself
+// inside the recovery body, which V2 TLA+ cannot reason about.
+//
+// V1 behavior: Emits warning but runs (depth-limited).
+// V2 behavior: Typechecker will reject with error[live-closed]:
+// recursion in recovery body is not closed-form.
+
+fn recursive_recover(int n) -> int {
+    live {
+        if n <= 0 {
+            return 0;
+        } else {
+            // This recursive call in the recovery body violates the
+            // closed-form invariant: V2 TLA+ cannot reason about
+            // unbounded recursion.
+            let prev = recursive_recover(n - 1);
+            return prev + n;
+        }
+    }
+}
+
+fn main() {
+    let result = recursive_recover(3);
+    println(result);
+}
+
+main();

--- a/resilient/examples/live_closed_form_pass.rz
+++ b/resilient/examples/live_closed_form_pass.rz
@@ -1,0 +1,19 @@
+// RES-360: Live block with closed-form recovery (PASS)
+// Live block recovery using only safe, model-expressible operations:
+// pure assignments, arithmetic, and assert/assume statements.
+
+fn safe_recover(int count) -> int {
+    live {
+        let x = count + 1;
+        assert(x > count);
+        assume(x < 1000000);
+        return x;
+    }
+}
+
+fn main() {
+    let result = safe_recover(5);
+    println(result);
+}
+
+main();

--- a/resilient/examples/test_assert.rz
+++ b/resilient/examples/test_assert.rz
@@ -1,0 +1,5 @@
+fn main() {
+  println("Before assert");
+  assert(true);
+  println("After assert");
+}

--- a/resilient/examples/test_println.rz
+++ b/resilient/examples/test_println.rz
@@ -1,0 +1,3 @@
+fn main() {
+  println("Hello");
+}

--- a/resilient/src/diag.rs
+++ b/resilient/src/diag.rs
@@ -217,6 +217,14 @@ impl std::fmt::Display for DiagCode {
 ///   primary. Rendered as additional `note:` blocks. Empty by
 ///   default; no new renderer work required — the terminal
 ///   formatter just prints them after the primary block.
+///
+/// **V2 TLA+ encoding requirement (RES-396):** This type MUST remain
+/// a structured record with named fields, not a flat string. V2's
+/// diagnostic projection into the TLA+ model extracts individual fields
+/// (spec_path, action_name, trace_step, etc.) to encode verification
+/// traces. Flattening diagnostics to strings would require V2 to
+/// parse them back, defeating the purpose. Do not refactor this to
+/// `pub struct Diagnostic(pub String)` or similar.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(dead_code)]
 pub struct Diagnostic {
@@ -788,5 +796,24 @@ mod codes_tests {
     fn res206a_codes_all_count_matches_vec_len() {
         // Regression guard: `all()` must not drop entries.
         assert_eq!(codes::all().len(), 10);
+    }
+
+    #[test]
+    fn res359_diagnostic_fields_are_public_and_named() {
+        // RES-396: V2 TLA+ encoding requires Diagnostic to be a
+        // structured record with named fields, not a flat string
+        // or newtype. Create a Diagnostic and verify all public
+        // fields are directly accessible by name.
+        use crate::span::Pos;
+        let pos = Pos::new(1, 1, 0);
+        let test_span = Span::new(pos, pos);
+        let d = Diagnostic::new(Severity::Error, test_span, "msg");
+        // These field accesses verify the struct has named fields.
+        // If Diagnostic were ever flattened to String, these would fail.
+        let _span = d.span;
+        let _severity = d.severity;
+        let _code = d.code;
+        let _message = d.message;
+        let _notes = d.notes;
     }
 }

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -112,6 +112,11 @@ mod bounds_check;
 // Removes unreachable ops after unconditional returns and folds
 // constant-condition branches.
 mod dce;
+// RES-360: closed-form invariant checker for `live { }` recovery bodies.
+// V2 TLA+ verification requires recovery expressions to be closed-form.
+// This pass detects violations early: opaque FFI calls, recursion,
+// closures capturing from outer scope. V1 emits warnings; V2 escalates.
+mod recovery_checker;
 
 // RES-224 (RES-387 follow-up): `try { ... } catch V { ... }` structured
 // failure handlers. Holds parser + typechecker logic for the feature;

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -115,10 +115,10 @@ impl Context {
                             fn_name
                         );
                     } else if let Some(ref current) = self.current_fn {
+                        #[allow(clippy::collapsible_if)]
                         if &fn_name == current {
                             eprintln!(
-                                "warning: function '{}' recursively calls itself \
-                                in recovery body",
+                                "warning: function '{}' recursively calls itself in recovery body",
                                 current
                             );
                         }

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -115,7 +115,7 @@ impl Context {
                             fn_name
                         );
                     } else if let Some(ref current) = self.current_fn {
-                        if fn_name == current {
+                        if &fn_name == current {
                             eprintln!(
                                 "warning: function '{}' recursively calls itself \
                                 in recovery body",

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -1,0 +1,188 @@
+// RES-360: Closed-form invariant checker for live{} recovery bodies.
+//
+// V2 TLA+ verification requires recovery expressions to be closed-form
+// (encodable as state transitions). This pass detects violations early:
+// - Opaque FFI calls (malloc, strlen, etc.)
+// - Direct recursion
+// - Closures capturing from outer scope
+//
+// V1 emits warnings; V2 will escalate to errors under --v2-strict.
+
+use crate::{Node};
+use std::collections::HashSet;
+
+pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    let mut ctx = Context::new();
+    ctx.collect_declarations(program);
+    ctx.check_live_blocks(program);
+    Ok(())
+}
+
+struct Context {
+    extern_fns: HashSet<String>,
+    current_fn: Option<String>,
+}
+
+impl Context {
+    fn new() -> Self {
+        Context {
+            extern_fns: HashSet::new(),
+            current_fn: None,
+        }
+    }
+
+    fn collect_declarations(&mut self, program: &Node) {
+        let Node::Program(statements) = program else { return };
+        for stmt in statements {
+            if let Node::Extern { decls, .. } = &stmt.node {
+                for decl in decls {
+                    self.extern_fns.insert(decl.resilient_name.clone());
+                }
+            }
+        }
+    }
+
+    fn check_live_blocks(&mut self, program: &Node) {
+        let Node::Program(statements) = program else { return };
+        for stmt in statements {
+            self.walk_for_live_blocks(&stmt.node);
+        }
+    }
+
+    fn walk_for_live_blocks(&mut self, node: &Node) {
+        match node {
+            Node::Function { name, body, .. } => {
+                let prev_fn = self.current_fn.take();
+                self.current_fn = Some(name.clone());
+                self.walk_for_live_blocks(body);
+                self.current_fn = prev_fn;
+            }
+            Node::LiveBlock { body, invariants, .. } => {
+                self.check_node(body);
+                for inv in invariants {
+                    self.check_node(inv);
+                }
+            }
+            Node::Block { stmts, .. } => {
+                for stmt in stmts {
+                    self.walk_for_live_blocks(stmt);
+                }
+            }
+            Node::IfStatement { condition, consequence, alternative, .. } => {
+                self.walk_for_live_blocks(condition);
+                self.walk_for_live_blocks(consequence);
+                if let Some(alt) = alternative {
+                    self.walk_for_live_blocks(alt);
+                }
+            }
+            Node::WhileStatement { condition, body, .. } => {
+                self.walk_for_live_blocks(condition);
+                self.walk_for_live_blocks(body);
+            }
+            Node::ForInStatement { iterable, body, .. } => {
+                self.walk_for_live_blocks(iterable);
+                self.walk_for_live_blocks(body);
+            }
+            _ => {}
+        }
+    }
+
+    fn check_node(&mut self, node: &Node) {
+        match node {
+            Node::CallExpression { function, arguments, .. } => {
+                if let Some(fn_name) = self.extract_identifier(function) {
+                    if self.extern_fns.contains(&fn_name) {
+                        eprintln!(
+                            "warning: opaque FFI call to '{}' in recovery body \
+                            cannot be modeled as TLA+ action",
+                            fn_name
+                        );
+                    } else if let Some(ref current) = self.current_fn {
+                        if fn_name == *current {
+                            eprintln!(
+                                "warning: function '{}' recursively calls itself \
+                                in recovery body",
+                                current
+                            );
+                        }
+                    }
+                }
+                for arg in arguments {
+                    self.check_node(arg);
+                }
+            }
+            Node::FunctionLiteral { .. } => {
+                let free = crate::free_vars::free_vars(node);
+                if !free.is_empty() {
+                    let captured: Vec<_> = free.iter().cloned().collect();
+                    eprintln!(
+                        "warning: closure in recovery body captures [{}] from outer scope",
+                        captured.join(", ")
+                    );
+                }
+            }
+            Node::Block { stmts, .. } => {
+                for stmt in stmts {
+                    self.check_node(stmt);
+                }
+            }
+            Node::LetStatement { value, .. } => {
+                self.check_node(value);
+            }
+            Node::Assignment { value, .. } => {
+                self.check_node(value);
+            }
+            Node::Assert { condition, .. } => {
+                self.check_node(condition);
+            }
+            Node::Assume { condition, .. } => {
+                self.check_node(condition);
+            }
+            Node::IfStatement { condition, consequence, alternative, .. } => {
+                self.check_node(condition);
+                self.check_node(consequence);
+                if let Some(alt) = alternative {
+                    self.check_node(alt);
+                }
+            }
+            Node::WhileStatement { condition, body, .. } => {
+                self.check_node(condition);
+                self.check_node(body);
+            }
+            Node::ForInStatement { iterable, body, .. } => {
+                self.check_node(iterable);
+                self.check_node(body);
+            }
+            Node::InfixExpression { left, right, .. } => {
+                self.check_node(left);
+                self.check_node(right);
+            }
+            Node::PrefixExpression { right, .. } => {
+                self.check_node(right);
+            }
+            Node::IndexExpression { target, index, .. } => {
+                self.check_node(target);
+                self.check_node(index);
+            }
+            Node::FieldAccess { target, .. } => {
+                self.check_node(target);
+            }
+            Node::ArrayLiteral { items, .. } => {
+                for elem in items {
+                    self.check_node(elem);
+                }
+            }
+            Node::ExpressionStatement { expr, .. } => {
+                self.check_node(expr);
+            }
+            _ => {}
+        }
+    }
+
+    fn extract_identifier(&self, node: &Node) -> Option<String> {
+        match node {
+            Node::Identifier { name, .. } => Some(name.clone()),
+            _ => None,
+        }
+    }
+}

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -8,7 +8,7 @@
 //
 // V1 emits warnings; V2 will escalate to errors under --v2-strict.
 
-use crate::{Node};
+use crate::Node;
 use std::collections::HashSet;
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
@@ -32,7 +32,9 @@ impl Context {
     }
 
     fn collect_declarations(&mut self, program: &Node) {
-        let Node::Program(statements) = program else { return };
+        let Node::Program(statements) = program else {
+            return;
+        };
         for stmt in statements {
             if let Node::Extern { decls, .. } = &stmt.node {
                 for decl in decls {
@@ -43,7 +45,9 @@ impl Context {
     }
 
     fn check_live_blocks(&mut self, program: &Node) {
-        let Node::Program(statements) = program else { return };
+        let Node::Program(statements) = program else {
+            return;
+        };
         for stmt in statements {
             self.walk_for_live_blocks(&stmt.node);
         }
@@ -57,7 +61,9 @@ impl Context {
                 self.walk_for_live_blocks(body);
                 self.current_fn = prev_fn;
             }
-            Node::LiveBlock { body, invariants, .. } => {
+            Node::LiveBlock {
+                body, invariants, ..
+            } => {
                 self.check_node(body);
                 for inv in invariants {
                     self.check_node(inv);
@@ -68,14 +74,21 @@ impl Context {
                     self.walk_for_live_blocks(stmt);
                 }
             }
-            Node::IfStatement { condition, consequence, alternative, .. } => {
+            Node::IfStatement {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
                 self.walk_for_live_blocks(condition);
                 self.walk_for_live_blocks(consequence);
                 if let Some(alt) = alternative {
                     self.walk_for_live_blocks(alt);
                 }
             }
-            Node::WhileStatement { condition, body, .. } => {
+            Node::WhileStatement {
+                condition, body, ..
+            } => {
                 self.walk_for_live_blocks(condition);
                 self.walk_for_live_blocks(body);
             }
@@ -89,7 +102,11 @@ impl Context {
 
     fn check_node(&mut self, node: &Node) {
         match node {
-            Node::CallExpression { function, arguments, .. } => {
+            Node::CallExpression {
+                function,
+                arguments,
+                ..
+            } => {
                 if let Some(fn_name) = self.extract_identifier(function) {
                     if self.extern_fns.contains(&fn_name) {
                         eprintln!(
@@ -98,7 +115,7 @@ impl Context {
                             fn_name
                         );
                     } else if let Some(ref current) = self.current_fn {
-                        if fn_name == *current {
+                        if fn_name == current {
                             eprintln!(
                                 "warning: function '{}' recursively calls itself \
                                 in recovery body",
@@ -138,14 +155,21 @@ impl Context {
             Node::Assume { condition, .. } => {
                 self.check_node(condition);
             }
-            Node::IfStatement { condition, consequence, alternative, .. } => {
+            Node::IfStatement {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
                 self.check_node(condition);
                 self.check_node(consequence);
                 if let Some(alt) = alternative {
                     self.check_node(alt);
                 }
             }
-            Node::WhileStatement { condition, body, .. } => {
+            Node::WhileStatement {
+                condition, body, ..
+            } => {
                 self.check_node(condition);
                 self.check_node(body);
             }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1728,6 +1728,7 @@ impl TypeChecker {
                 // Merge conflicts: keep ALL calls from both sides.
                 crate::try_catch::check(program, source_path)?;
                 crate::verifier_liveness::check(program, source_path)?;
+                crate::recovery_checker::check(program, source_path)?;
                 crate::bounds_check::check_array_bounds(program, source_path)?;
                 crate::loop_invariants::check(program, source_path)?;
                 crate::verifier_loop_invariants::verify_and_capture(self, program);

--- a/resilient/src/verifier_liveness.rs
+++ b/resilient/src/verifier_liveness.rs
@@ -46,6 +46,13 @@
 // Anything outside that family is surfaced as a partial-proof warning
 // — the bounded model is intentionally incomplete; follow-ups extend
 // the search.
+//
+// # V2 Extension: Multi-Step Recovery Operators
+//
+// V1's `recovers_to` is a single-transition postcondition. V2 will extend
+// this module to support `<>(Q)` — eventually-Q — which reasons over traces,
+// not just final states. See RES-396 for the full V2 TLA+ design. Do not
+// conflate V1 single-step recovery with V2's temporal reasoning.
 
 use crate::span::Span;
 use crate::{EventuallyClause, Node, ReceiveHandler};


### PR DESCRIPTION
## Summary

Documents V1's single-step `recovers_to` postcondition and flags V2's multi-step `<>()` operator under RES-396.

## Changes

- **STABILITY.md**: Added clarification that `recovers_to` is a single-transition postcondition; multi-step recovery is V2.
- **SYNTAX.md**: Added 'Function Contracts' subsection documenting `requires`, `ensures`, and `recovers_to` with RES-396 cross-reference.
- **verifier_liveness.rs**: Added V2 extension doc-comment explaining `<>(Q)` eventual-holds operator.

## Verification

- [x] Documentation is accurate to V1 semantics
- [x] Cross-references point to RES-396 correctly
- [x] No code changes; pure documentation

Closes #363