### PR TITLE
RES-133c: detect assume(false) and warn about dead-code regions

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,16 +1,16 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-290-trait-system",
-      "claimed_at": "2026-04-29T05:38:49Z"
+      "branch": "res-133c-assume-false-dead-code",
+      "claimed_at": "2026-04-29T20:00:32Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-290-trait-system",
-      "claimed_at": "2026-04-29T05:38:49Z"
+      "branch": "res-133c-assume-false-dead-code",
+      "claimed_at": "2026-04-29T20:00:32Z"
     },
     "resilient/src/lexer_logos.rs": {
-      "branch": "res-290-trait-system",
-      "claimed_at": "2026-04-29T05:38:49Z"
+      "branch": "res-133c-assume-false-dead-code",
+      "claimed_at": "2026-04-29T20:00:32Z"
     }
   }
 }

--- a/resilient/examples/assume_false_dead_code.rz
+++ b/resilient/examples/assume_false_dead_code.rz
@@ -1,0 +1,20 @@
+// RES-133c test: assume(false) should warn about dead code
+
+fn test_dead_code() -> void {
+    assume(false);
+    println("this code is unreachable");
+}
+
+fn test_multiple_dead() -> void {
+    let x = 5;
+    assume(false);
+    let y = x + 1;
+    println(y);
+}
+
+fn main() {
+    test_dead_code();
+    test_multiple_dead();
+}
+
+main();

--- a/resilient/src/assume_false_checker.rs
+++ b/resilient/src/assume_false_checker.rs
@@ -1,0 +1,111 @@
+// RES-133c: Detect assume(false) and warn about dead-code regions.
+//
+// When assume(false) is used, the following statements are unreachable
+// in any valid model. This pass walks the AST to detect assume(false)
+// predicates and warns at the next statement boundary.
+
+use crate::Node;
+
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    let mut checker = AssumeChecker::new(source_path);
+    checker.walk(program);
+    Ok(())
+}
+
+struct AssumeChecker<'a> {
+    source_path: &'a str,
+}
+
+impl<'a> AssumeChecker<'a> {
+    fn new(source_path: &'a str) -> Self {
+        AssumeChecker { source_path }
+    }
+
+    fn walk(&mut self, node: &Node) {
+        match node {
+            Node::Program(statements) => {
+                self.check_statement_sequence(statements);
+            }
+            Node::Block { stmts, .. } => {
+                self.check_block(stmts);
+            }
+            _ => self.walk_children(node),
+        }
+    }
+
+    fn check_statement_sequence(&mut self, statements: &[crate::span::Spanned<Node>]) {
+        for (i, stmt) in statements.iter().enumerate() {
+            self.walk(&stmt.node);
+
+            // Check if this statement is assume(false)
+            if self.is_assume_false(&stmt.node) {
+                // Warn about statements after assume(false)
+                if i + 1 < statements.len() {
+                    let next_stmt = &statements[i + 1];
+                    eprintln!(
+                        "{}:{}  warning: dead-code region following assume(false)",
+                        self.source_path, next_stmt.span.start
+                    );
+                }
+            }
+        }
+    }
+
+    fn check_block(&mut self, stmts: &[Node]) {
+        for (i, stmt) in stmts.iter().enumerate() {
+            self.walk(stmt);
+
+            // Check if this statement is assume(false)
+            if self.is_assume_false(stmt) {
+                // Warn about statements after assume(false)
+                if i + 1 < stmts.len() {
+                    eprintln!(
+                        "{}:  warning: dead-code region following assume(false)",
+                        self.source_path
+                    );
+                }
+            }
+        }
+    }
+
+    fn is_assume_false(&self, node: &Node) -> bool {
+        match node {
+            Node::Assume { condition, .. } => {
+                // Check if condition is literally false
+                matches!(**condition, Node::BooleanLiteral { value: false, .. })
+            }
+            _ => false,
+        }
+    }
+
+    fn walk_children(&mut self, node: &Node) {
+        match node {
+            Node::IfStatement {
+                condition,
+                consequence,
+                alternative,
+                ..
+            } => {
+                self.walk(condition);
+                self.walk(consequence);
+                if let Some(alt) = alternative {
+                    self.walk(alt);
+                }
+            }
+            Node::WhileStatement {
+                condition, body, ..
+            } => {
+                self.walk(condition);
+                self.walk(body);
+            }
+            Node::ForInStatement { iterable, body, .. } => {
+                self.walk(iterable);
+                self.walk(body);
+            }
+            Node::Function { body, .. } => {
+                self.walk(body);
+            }
+            _ => {}
+        }
+    }
+}

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -117,6 +117,10 @@ mod dce;
 // This pass detects violations early: opaque FFI calls, recursion,
 // closures capturing from outer scope. V1 emits warnings; V2 escalates.
 mod recovery_checker;
+// RES-133c: Detect assume(false) and warn about dead-code regions.
+// When assume(false) is used, the following statements are unreachable
+// in any valid model. This pass walks the AST to detect and warn.
+mod assume_false_checker;
 
 // RES-224 (RES-387 follow-up): `try { ... } catch V { ... }` structured
 // failure handlers. Holds parser + typechecker logic for the feature;

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1729,6 +1729,7 @@ impl TypeChecker {
                 crate::try_catch::check(program, source_path)?;
                 crate::verifier_liveness::check(program, source_path)?;
                 crate::recovery_checker::check(program, source_path)?;
+                crate::assume_false_checker::check(program, source_path)?;
                 crate::bounds_check::check_array_bounds(program, source_path)?;
                 crate::loop_invariants::check(program, source_path)?;
                 crate::verifier_loop_invariants::verify_and_capture(self, program);


### PR DESCRIPTION
Closes #386

## Summary
Implement assume_false_checker pass that walks the AST to detect assume(false) predicates and emits warnings about unreachable code following them.

## Changes
- New module: resilient/src/assume_false_checker.rs
- Integrated into typechecker.rs EXTENSION_PASSES
- Added module declaration in main.rs
- Created test example with assume(false) patterns

## Testing
- cargo build: ✅
- cargo test: ✅
- cargo clippy: ✅
