### PR TITLE
RES-412: array_reverse / string_reverse built-ins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-411-isnan-isinf",
-      "claimed_at": "2026-04-29T20:46:32Z"
+      "branch": "res-412-reverse",
+      "claimed_at": "2026-04-29T20:52:46Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-411-isnan-isinf",
-      "claimed_at": "2026-04-29T20:46:32Z"
+      "branch": "res-412-reverse",
+      "claimed_at": "2026-04-29T20:52:46Z"
     }
   }
 }

--- a/resilient/examples/reverse_builtins.expected.txt
+++ b/resilient/examples/reverse_builtins.expected.txt
@@ -1,0 +1,6 @@
+olleh
+
+a
+[5, 4, 3, 2, 1]
+[]
+Program executed successfully

--- a/resilient/examples/reverse_builtins.rz
+++ b/resilient/examples/reverse_builtins.rz
@@ -1,0 +1,14 @@
+// RES-412 demo: string_reverse and array_reverse.
+
+fn main() {
+    println(string_reverse("hello"));
+    println(string_reverse(""));
+    println(string_reverse("a"));
+
+    let xs = [1, 2, 3, 4, 5];
+    let ys = array_reverse(xs);
+    println(ys);
+    println(array_reverse([]));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8224,6 +8224,9 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("contains", builtin_contains),
     ("to_upper", builtin_to_upper),
     ("to_lower", builtin_to_lower),
+    // RES-412: reverse a string (Unicode-aware) or an array (clones elements).
+    ("string_reverse", builtin_string_reverse),
+    ("array_reverse", builtin_array_reverse),
     // RES-145: string manipulation expansion.
     ("replace", builtin_replace),
     ("format", builtin_format),
@@ -9045,6 +9048,36 @@ fn builtin_to_lower(args: &[Value]) -> RResult<Value> {
         [Value::String(s)] => Ok(Value::String(s.to_ascii_lowercase())),
         [other] => Err(format!("to_lower: expected string, got {}", other)),
         _ => Err(format!("to_lower: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-412: `string_reverse(s)` — returns a new string with characters
+/// reversed at the Unicode-scalar (`char`) level. Empty input returns "".
+fn builtin_string_reverse(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s)] => Ok(Value::String(s.chars().rev().collect())),
+        [other] => Err(format!("string_reverse: expected string, got {}", other)),
+        _ => Err(format!(
+            "string_reverse: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-412: `array_reverse(arr)` — returns a new array with elements
+/// in reversed order. Elements are cloned; the input is not mutated.
+fn builtin_array_reverse(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let mut reversed = items.clone();
+            reversed.reverse();
+            Ok(Value::Array(reversed))
+        }
+        [other] => Err(format!("array_reverse: expected array, got {}", other)),
+        _ => Err(format!(
+            "array_reverse: expected 1 argument, got {}",
+            args.len()
+        )),
     }
 }
 
@@ -23433,6 +23466,92 @@ mod tests {
                 .unwrap_err()
                 .contains("expected 1 argument")
         );
+    }
+
+    // ---------- RES-412: string_reverse / array_reverse ----------
+
+    #[test]
+    fn string_reverse_reverses_chars() {
+        match builtin_string_reverse(&[Value::String("abc".into())]).unwrap() {
+            Value::String(s) => assert_eq!(s, "cba"),
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_reverse_handles_empty() {
+        match builtin_string_reverse(&[Value::String("".into())]).unwrap() {
+            Value::String(s) => assert_eq!(s, ""),
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_reverse_is_unicode_aware() {
+        // Multi-byte chars (é = 2 bytes in UTF-8) reverse as single units.
+        match builtin_string_reverse(&[Value::String("café".into())]).unwrap() {
+            Value::String(s) => assert_eq!(s, "éfac"),
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_reverse_rejects_non_string() {
+        let err = builtin_string_reverse(&[Value::Int(1)]).unwrap_err();
+        assert!(err.contains("string_reverse:"), "got: {}", err);
+    }
+
+    #[test]
+    fn string_reverse_rejects_wrong_arity() {
+        let err = builtin_string_reverse(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "got: {}", err);
+    }
+
+    #[test]
+    fn array_reverse_reverses_elements() {
+        match builtin_array_reverse(&[Value::Array(vec![
+            Value::Int(1),
+            Value::Int(2),
+            Value::Int(3),
+        ])])
+        .unwrap()
+        {
+            Value::Array(items) => {
+                assert_eq!(items.len(), 3);
+                match (&items[0], &items[1], &items[2]) {
+                    (Value::Int(3), Value::Int(2), Value::Int(1)) => {}
+                    _ => panic!("expected [3,2,1], got {:?}", items),
+                }
+            }
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_reverse_handles_empty_and_single() {
+        match builtin_array_reverse(&[Value::Array(vec![])]).unwrap() {
+            Value::Array(items) => assert!(items.is_empty(), "expected []"),
+            other => panic!("expected Array, got {:?}", other),
+        }
+        match builtin_array_reverse(&[Value::Array(vec![Value::Int(7)])]).unwrap() {
+            Value::Array(items) => match items.as_slice() {
+                [Value::Int(7)] => {}
+                _ => panic!("expected [7], got {:?}", items),
+            },
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_reverse_rejects_non_array() {
+        let err = builtin_array_reverse(&[Value::String("oops".into())]).unwrap_err();
+        assert!(err.contains("array_reverse:"), "got: {}", err);
+    }
+
+    #[test]
+    fn array_reverse_rejects_wrong_arity() {
+        let err = builtin_array_reverse(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "got: {}", err);
     }
 
     // ---------- RES-034: nested index assignment ----------

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1052,6 +1052,15 @@ impl TypeChecker {
                 return_type: Box::new(Type::String),
             },
         );
+        // RES-412: reverse a string (chars) or an array (clones).
+        env.set(
+            "string_reverse".to_string(),
+            Type::Function {
+                params: vec![Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
+        env.set("array_reverse".to_string(), fn_any_to_any());
         // RES-145: replace + format.
         env.set(
             "replace".to_string(),
@@ -3882,6 +3891,9 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "contains",
         "to_upper",
         "to_lower",
+        // RES-412: reverse string/array.
+        "string_reverse",
+        "array_reverse",
         "replace",
         "format",
         "starts_with",


### PR DESCRIPTION
Closes #393

Two pure reverse built-ins: `string_reverse` (Unicode-aware via .chars().rev()) and `array_reverse` (clones elements). 9 unit tests + golden example. fmt/clippy clean, all 1260 bin tests pass locally.