### PR TITLE
RES-425: to_string(x) explicit scalar conversion

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-424-array-join",
-      "claimed_at": "2026-04-29T21:17:46Z"
+      "branch": "res-425-to-string",
+      "claimed_at": "2026-04-29T21:19:40Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-424-array-join",
-      "claimed_at": "2026-04-29T21:17:46Z"
+      "branch": "res-425-to-string",
+      "claimed_at": "2026-04-29T21:19:40Z"
     }
   }
 }

--- a/resilient/examples/to_string.expected.txt
+++ b/resilient/examples/to_string.expected.txt
@@ -1,0 +1,8 @@
+42
+-7
+1.5
+true
+false
+already a string
+count: 7
+Program executed successfully

--- a/resilient/examples/to_string.rz
+++ b/resilient/examples/to_string.rz
@@ -1,0 +1,16 @@
+// RES-425 demo: to_string converts scalar values to strings.
+
+fn main() {
+    println(to_string(42));
+    println(to_string(-7));
+    println(to_string(1.5));
+    println(to_string(true));
+    println(to_string(false));
+    println(to_string("already a string"));
+
+    // Useful for building strings without format().
+    let n = 7;
+    println(array_join(["count:", to_string(n)], " "));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8253,6 +8253,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("array_flatten", builtin_array_flatten),
     // RES-424: join a string array with a separator.
     ("array_join", builtin_array_join),
+    // RES-425: explicit scalar-to-string conversion.
+    ("to_string", builtin_to_string),
     // RES-413: repeat a string n times.
     ("string_repeat", builtin_string_repeat),
     // RES-414: first byte index of substring, or -1 if not found.
@@ -9187,6 +9189,23 @@ fn builtin_array_product(args: &[Value]) -> RResult<Value> {
         [other] => Err(format!("array_product: expected array, got {}", other)),
         _ => Err(format!(
             "array_product: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-425: `to_string(x)` — explicit conversion of a scalar value
+/// (Int/Float/Bool/String) to its String representation. Strings are
+/// returned unchanged. Non-scalar values raise a typed error.
+fn builtin_to_string(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s)] => Ok(Value::String(s.clone())),
+        [Value::Int(n)] => Ok(Value::String(n.to_string())),
+        [Value::Float(f)] => Ok(Value::String(f.to_string())),
+        [Value::Bool(b)] => Ok(Value::String(b.to_string())),
+        [other] => Err(format!("to_string: expected scalar value, got {}", other)),
+        _ => Err(format!(
+            "to_string: expected 1 argument, got {}",
             args.len()
         )),
     }
@@ -25020,6 +25039,77 @@ mod tests {
             builtin_array_join(&[str_array(&["a"])])
                 .unwrap_err()
                 .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-425: to_string ----------
+
+    #[test]
+    fn to_string_int_renders_decimal() {
+        assert_eq!(
+            extract_string(builtin_to_string(&[Value::Int(42)]).unwrap()),
+            "42"
+        );
+        assert_eq!(
+            extract_string(builtin_to_string(&[Value::Int(-7)]).unwrap()),
+            "-7"
+        );
+    }
+
+    #[test]
+    fn to_string_float_basic() {
+        assert_eq!(
+            extract_string(builtin_to_string(&[Value::Float(1.5)]).unwrap()),
+            "1.5"
+        );
+        // Whole-number floats render without trailing zero in default Display.
+        assert_eq!(
+            extract_string(builtin_to_string(&[Value::Float(2.0)]).unwrap()),
+            "2"
+        );
+    }
+
+    #[test]
+    fn to_string_bool() {
+        assert_eq!(
+            extract_string(builtin_to_string(&[Value::Bool(true)]).unwrap()),
+            "true"
+        );
+        assert_eq!(
+            extract_string(builtin_to_string(&[Value::Bool(false)]).unwrap()),
+            "false"
+        );
+    }
+
+    #[test]
+    fn to_string_string_round_trips() {
+        assert_eq!(
+            extract_string(builtin_to_string(&[Value::String("hello".into())]).unwrap()),
+            "hello"
+        );
+        assert_eq!(
+            extract_string(builtin_to_string(&[Value::String("".into())]).unwrap()),
+            ""
+        );
+    }
+
+    #[test]
+    fn to_string_rejects_non_scalar() {
+        let err = builtin_to_string(&[Value::Array(vec![Value::Int(1)])]).unwrap_err();
+        assert!(err.contains("scalar value"), "got: {}", err);
+    }
+
+    #[test]
+    fn to_string_rejects_wrong_arity() {
+        assert!(
+            builtin_to_string(&[])
+                .unwrap_err()
+                .contains("expected 1 argument")
+        );
+        assert!(
+            builtin_to_string(&[Value::Int(1), Value::Int(2)])
+                .unwrap_err()
+                .contains("expected 1 argument")
         );
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1117,6 +1117,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::String),
             },
         );
+        // RES-425: scalar-to-string conversion.
+        env.set(
+            "to_string".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::String),
+            },
+        );
         // RES-413: repeat a string n times.
         env.set(
             "string_repeat".to_string(),
@@ -3992,6 +4000,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_flatten",
         // RES-424: array_join.
         "array_join",
+        // RES-425: to_string.
+        "to_string",
         // RES-413: repeat a string.
         "string_repeat",
         // RES-414: substring search.


### PR DESCRIPTION
Closes #419

6 unit tests + golden example. fmt/clippy clean.