### PR TITLE
RES-433: string_chars(s) split into chars

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-432-array-repeat",
-      "claimed_at": "2026-04-29T21:34:08Z"
+      "branch": "res-433-string-chars",
+      "claimed_at": "2026-04-29T21:35:56Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-432-array-repeat",
-      "claimed_at": "2026-04-29T21:34:08Z"
+      "branch": "res-433-string-chars",
+      "claimed_at": "2026-04-29T21:35:56Z"
     }
   }
 }

--- a/resilient/examples/string_chars.expected.txt
+++ b/resilient/examples/string_chars.expected.txt
@@ -1,0 +1,5 @@
+["h", "e", "l", "l", "o"]
+[]
+["a"]
+foobar
+Program executed successfully

--- a/resilient/examples/string_chars.rz
+++ b/resilient/examples/string_chars.rz
@@ -1,0 +1,11 @@
+// RES-433 demo: string_chars splits a string into single-char strings.
+
+fn main() {
+    println(string_chars("hello"));
+    println(string_chars(""));
+    println(string_chars("a"));
+    // Round-trip via array_join "" reconstructs the original.
+    println(array_join(string_chars("foobar"), ""));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8271,6 +8271,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("array_range", builtin_array_range),
     // RES-432: array of n copies of elem.
     ("array_repeat", builtin_array_repeat),
+    // RES-433: split string into single-character strings.
+    ("string_chars", builtin_string_chars),
     // RES-413: repeat a string n times.
     ("string_repeat", builtin_string_repeat),
     // RES-414: first byte index of substring, or -1 if not found.
@@ -9205,6 +9207,21 @@ fn builtin_array_product(args: &[Value]) -> RResult<Value> {
         [other] => Err(format!("array_product: expected array, got {}", other)),
         _ => Err(format!(
             "array_product: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-433: `string_chars(s)` — array of single-character strings,
+/// one per Unicode scalar. Empty input → empty array.
+fn builtin_string_chars(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s)] => Ok(Value::Array(
+            s.chars().map(|c| Value::String(c.to_string())).collect(),
+        )),
+        [other] => Err(format!("string_chars: expected string, got {}", other)),
+        _ => Err(format!(
+            "string_chars: expected 1 argument, got {}",
             args.len()
         )),
     }
@@ -25963,6 +25980,69 @@ mod tests {
             builtin_array_repeat(&[Value::Int(1)])
                 .unwrap_err()
                 .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-433: string_chars ----------
+
+    fn extract_strings(v: Value) -> Vec<String> {
+        match v {
+            Value::Array(items) => items
+                .into_iter()
+                .map(|v| match v {
+                    Value::String(s) => s,
+                    _ => panic!("non-string in array"),
+                })
+                .collect(),
+            _ => panic!("expected Array"),
+        }
+    }
+
+    #[test]
+    fn string_chars_basic() {
+        assert_eq!(
+            extract_strings(builtin_string_chars(&[Value::String("abc".into())]).unwrap()),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn string_chars_empty_returns_empty_array() {
+        assert_eq!(
+            extract_strings(builtin_string_chars(&[Value::String("".into())]).unwrap()),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn string_chars_unicode_scalar_per_element() {
+        // "café" has 4 scalars (5 bytes); each element should be a single-char string.
+        let chars = extract_strings(builtin_string_chars(&[Value::String("café".into())]).unwrap());
+        assert_eq!(chars, vec!["c", "a", "f", "é"]);
+    }
+
+    #[test]
+    fn string_chars_round_trips_with_array_join() {
+        // string_chars + array_join with "" should reconstruct original.
+        let parts = builtin_string_chars(&[Value::String("hello".into())]).unwrap();
+        let joined = builtin_array_join(&[parts, Value::String("".into())]).unwrap();
+        match joined {
+            Value::String(s) => assert_eq!(s, "hello"),
+            _ => panic!("expected String"),
+        }
+    }
+
+    #[test]
+    fn string_chars_rejects_non_string_and_arity() {
+        assert!(
+            builtin_string_chars(&[Value::Int(5)])
+                .unwrap_err()
+                .contains("expected string")
+        );
+        assert!(
+            builtin_string_chars(&[])
+                .unwrap_err()
+                .contains("expected 1 argument")
         );
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1153,6 +1153,8 @@ impl TypeChecker {
         env.set("array_range".to_string(), fn_any_any_to_any());
         // RES-432: array of n copies.
         env.set("array_repeat".to_string(), fn_any_any_to_any());
+        // RES-433: split string into single-char strings.
+        env.set("string_chars".to_string(), fn_any_to_any());
         // RES-413: repeat a string n times.
         env.set(
             "string_repeat".to_string(),
@@ -4046,6 +4048,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_range",
         // RES-432: array_repeat.
         "array_repeat",
+        // RES-433: string_chars.
+        "string_chars",
         // RES-413: repeat a string.
         "string_repeat",
         // RES-414: substring search.


### PR DESCRIPTION
Closes #435

5 unit tests including round-trip + golden example. fmt/clippy clean.