### PR TITLE
RES-434: string_lines(s) line splitter

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-433-string-chars",
-      "claimed_at": "2026-04-29T21:35:56Z"
+      "branch": "res-434-string-lines",
+      "claimed_at": "2026-04-29T21:37:45Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-433-string-chars",
-      "claimed_at": "2026-04-29T21:35:56Z"
+      "branch": "res-434-string-lines",
+      "claimed_at": "2026-04-29T21:37:45Z"
     }
   }
 }

--- a/resilient/examples/string_lines.expected.txt
+++ b/resilient/examples/string_lines.expected.txt
@@ -1,0 +1,5 @@
+["alpha", "beta", "gamma"]
+["a", "b"]
+["first", "", "third"]
+[]
+Program executed successfully

--- a/resilient/examples/string_lines.rz
+++ b/resilient/examples/string_lines.rz
@@ -1,0 +1,17 @@
+// RES-434 demo: string_lines splits text into lines (LF or CRLF).
+
+fn main() {
+    let text = "alpha\nbeta\ngamma";
+    println(string_lines(text));
+
+    // Trailing newline does NOT produce an empty trailing element.
+    println(string_lines("a\nb\n"));
+
+    // Blank lines are preserved.
+    println(string_lines("first\n\nthird"));
+
+    // Empty input → empty array.
+    println(string_lines(""));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8273,6 +8273,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("array_repeat", builtin_array_repeat),
     // RES-433: split string into single-character strings.
     ("string_chars", builtin_string_chars),
+    // RES-434: split string into lines (LF, CRLF, no trailing empty).
+    ("string_lines", builtin_string_lines),
     // RES-413: repeat a string n times.
     ("string_repeat", builtin_string_repeat),
     // RES-414: first byte index of substring, or -1 if not found.
@@ -9207,6 +9209,24 @@ fn builtin_array_product(args: &[Value]) -> RResult<Value> {
         [other] => Err(format!("array_product: expected array, got {}", other)),
         _ => Err(format!(
             "array_product: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-434: `string_lines(s)` — split into lines on \n, recognizing
+/// \r\n. Trailing newline does NOT produce an empty trailing element
+/// (mirrors `str::lines`).
+fn builtin_string_lines(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s)] => Ok(Value::Array(
+            s.lines()
+                .map(|line| Value::String(line.to_string()))
+                .collect(),
+        )),
+        [other] => Err(format!("string_lines: expected string, got {}", other)),
+        _ => Err(format!(
+            "string_lines: expected 1 argument, got {}",
             args.len()
         )),
     }
@@ -26041,6 +26061,72 @@ mod tests {
         );
         assert!(
             builtin_string_chars(&[])
+                .unwrap_err()
+                .contains("expected 1 argument")
+        );
+    }
+
+    // ---------- RES-434: string_lines ----------
+
+    #[test]
+    fn string_lines_lf_basic() {
+        assert_eq!(
+            extract_strings(builtin_string_lines(&[Value::String("a\nb\nc".into())]).unwrap()),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn string_lines_crlf_strips_carriage_return() {
+        assert_eq!(
+            extract_strings(
+                builtin_string_lines(&[Value::String("first\r\nsecond\r\nthird".into())]).unwrap()
+            ),
+            vec!["first", "second", "third"]
+        );
+    }
+
+    #[test]
+    fn string_lines_trailing_newline_not_empty_element() {
+        assert_eq!(
+            extract_strings(builtin_string_lines(&[Value::String("a\nb\n".into())]).unwrap()),
+            vec!["a", "b"]
+        );
+    }
+
+    #[test]
+    fn string_lines_empty_returns_empty() {
+        assert_eq!(
+            extract_strings(builtin_string_lines(&[Value::String("".into())]).unwrap()),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn string_lines_single_line_no_newline() {
+        assert_eq!(
+            extract_strings(builtin_string_lines(&[Value::String("just one".into())]).unwrap()),
+            vec!["just one"]
+        );
+    }
+
+    #[test]
+    fn string_lines_blank_lines_preserved() {
+        assert_eq!(
+            extract_strings(builtin_string_lines(&[Value::String("a\n\nb".into())]).unwrap()),
+            vec!["a", "", "b"]
+        );
+    }
+
+    #[test]
+    fn string_lines_rejects_non_string_and_arity() {
+        assert!(
+            builtin_string_lines(&[Value::Int(5)])
+                .unwrap_err()
+                .contains("expected string")
+        );
+        assert!(
+            builtin_string_lines(&[])
                 .unwrap_err()
                 .contains("expected 1 argument")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1155,6 +1155,8 @@ impl TypeChecker {
         env.set("array_repeat".to_string(), fn_any_any_to_any());
         // RES-433: split string into single-char strings.
         env.set("string_chars".to_string(), fn_any_to_any());
+        // RES-434: split string into lines (LF, CRLF).
+        env.set("string_lines".to_string(), fn_any_to_any());
         // RES-413: repeat a string n times.
         env.set(
             "string_repeat".to_string(),
@@ -4050,6 +4052,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_repeat",
         // RES-433: string_chars.
         "string_chars",
+        // RES-434: string_lines.
+        "string_lines",
         // RES-413: repeat a string.
         "string_repeat",
         // RES-414: substring search.


### PR DESCRIPTION
Closes #437

7 unit tests + golden example. fmt/clippy clean.