### PR TITLE
RES-437: array_intersperse(arr, x) separator insertion

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-436-string-count",
-      "claimed_at": "2026-04-29T21:51:01Z"
+      "branch": "res-437-array-intersperse",
+      "claimed_at": "2026-04-29T21:53:37Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-436-string-count",
-      "claimed_at": "2026-04-29T21:51:01Z"
+      "branch": "res-437-array-intersperse",
+      "claimed_at": "2026-04-29T21:53:37Z"
     }
   }
 }

--- a/resilient/examples/array_intersperse.expected.txt
+++ b/resilient/examples/array_intersperse.expected.txt
@@ -1,0 +1,5 @@
+[1, 0, 2, 0, 3]
+[42]
+[]
+["a", "-", "b", "-", "c"]
+Program executed successfully

--- a/resilient/examples/array_intersperse.rz
+++ b/resilient/examples/array_intersperse.rz
@@ -1,0 +1,10 @@
+// RES-437 demo: array_intersperse inserts a separator between elements.
+
+fn main() {
+    println(array_intersperse([1, 2, 3], 0));
+    println(array_intersperse([42], 0));
+    println(array_intersperse([], 0));
+    println(array_intersperse(["a", "b", "c"], "-"));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8279,6 +8279,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("array_chunk", builtin_array_chunk),
     // RES-436: non-overlapping substring count.
     ("string_count", builtin_string_count),
+    // RES-437: insert separator between adjacent array elements.
+    ("array_intersperse", builtin_array_intersperse),
     // RES-413: repeat a string n times.
     ("string_repeat", builtin_string_repeat),
     // RES-414: first byte index of substring, or -1 if not found.
@@ -9213,6 +9215,32 @@ fn builtin_array_product(args: &[Value]) -> RResult<Value> {
         [other] => Err(format!("array_product: expected array, got {}", other)),
         _ => Err(format!(
             "array_product: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-437: `array_intersperse(arr, x)` — insert `x` between every
+/// pair of adjacent elements. `[a, b, c]` ⇒ `[a, x, b, x, c]`.
+/// Empty or single-element arrays return a clone unchanged.
+fn builtin_array_intersperse(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), sep] => {
+            if items.len() < 2 {
+                return Ok(Value::Array(items.clone()));
+            }
+            let mut out = Vec::with_capacity(items.len() * 2 - 1);
+            for (i, v) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(sep.clone());
+                }
+                out.push(v.clone());
+            }
+            Ok(Value::Array(out))
+        }
+        [a, _] => Err(format!("array_intersperse: expected array, got {}", a)),
+        _ => Err(format!(
+            "array_intersperse: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -26331,6 +26359,79 @@ mod tests {
         );
         assert!(
             builtin_string_count(&[Value::String("a".into())])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-437: array_intersperse ----------
+
+    #[test]
+    fn array_intersperse_inserts_between_pairs() {
+        assert_eq!(
+            extract_int_array(
+                builtin_array_intersperse(&[int_array(&[1, 2, 3]), Value::Int(0)]).unwrap()
+            ),
+            vec![1, 0, 2, 0, 3]
+        );
+    }
+
+    #[test]
+    fn array_intersperse_single_element_unchanged() {
+        assert_eq!(
+            extract_int_array(
+                builtin_array_intersperse(&[int_array(&[42]), Value::Int(0)]).unwrap()
+            ),
+            vec![42]
+        );
+    }
+
+    #[test]
+    fn array_intersperse_empty_unchanged() {
+        assert_eq!(
+            extract_int_array(
+                builtin_array_intersperse(&[Value::Array(vec![]), Value::Int(0)]).unwrap()
+            ),
+            Vec::<i64>::new()
+        );
+    }
+
+    #[test]
+    fn array_intersperse_two_elements_produces_three() {
+        assert_eq!(
+            extract_int_array(
+                builtin_array_intersperse(&[int_array(&[1, 2]), Value::Int(99)]).unwrap()
+            ),
+            vec![1, 99, 2]
+        );
+    }
+
+    #[test]
+    fn array_intersperse_string_separator() {
+        let result = builtin_array_intersperse(&[
+            Value::Array(vec![
+                Value::String("a".into()),
+                Value::String("b".into()),
+                Value::String("c".into()),
+            ]),
+            Value::String(",".into()),
+        ])
+        .unwrap();
+        match result {
+            Value::Array(items) => assert_eq!(items.len(), 5),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_intersperse_rejects_non_array_and_arity() {
+        assert!(
+            builtin_array_intersperse(&[Value::Int(1), Value::Int(2)])
+                .unwrap_err()
+                .contains("expected array")
+        );
+        assert!(
+            builtin_array_intersperse(&[Value::Array(vec![])])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1167,6 +1167,8 @@ impl TypeChecker {
                 return_type: Box::new(Type::Int),
             },
         );
+        // RES-437: insert separator between adjacent elements.
+        env.set("array_intersperse".to_string(), fn_any_any_to_any());
         // RES-413: repeat a string n times.
         env.set(
             "string_repeat".to_string(),
@@ -4068,6 +4070,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_chunk",
         // RES-436: string_count.
         "string_count",
+        // RES-437: array_intersperse.
+        "array_intersperse",
         // RES-413: repeat a string.
         "string_repeat",
         // RES-414: substring search.


### PR DESCRIPTION
Closes #443

6 unit tests + golden example. fmt/clippy clean.