### PR TITLE
RES-438: trim_start / trim_end one-sided trimmers

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-437-array-intersperse",
-      "claimed_at": "2026-04-29T21:53:37Z"
+      "branch": "res-438-trim-sides",
+      "claimed_at": "2026-04-29T21:56:12Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-437-array-intersperse",
-      "claimed_at": "2026-04-29T21:53:37Z"
+      "branch": "res-438-trim-sides",
+      "claimed_at": "2026-04-29T21:56:12Z"
     }
   }
 }

--- a/resilient/examples/trim_sides.expected.txt
+++ b/resilient/examples/trim_sides.expected.txt
@@ -1,0 +1,7 @@
+hello
+   hello
+hello
+hello
+hello
+hello
+Program executed successfully

--- a/resilient/examples/trim_sides.rz
+++ b/resilient/examples/trim_sides.rz
@@ -1,0 +1,12 @@
+// RES-438 demo: trim_start and trim_end strip whitespace from one side.
+
+fn main() {
+    println(trim_start("   hello   "));
+    println(trim_end("   hello   "));
+    println(trim_start("hello"));
+    println(trim_end("hello"));
+    println(trim_start("\t\n hello"));
+    println(trim_end("hello\t\n "));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8281,6 +8281,9 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("string_count", builtin_string_count),
     // RES-437: insert separator between adjacent array elements.
     ("array_intersperse", builtin_array_intersperse),
+    // RES-438: one-sided whitespace trimmers.
+    ("trim_start", builtin_trim_start),
+    ("trim_end", builtin_trim_end),
     // RES-413: repeat a string n times.
     ("string_repeat", builtin_string_repeat),
     // RES-414: first byte index of substring, or -1 if not found.
@@ -9217,6 +9220,27 @@ fn builtin_array_product(args: &[Value]) -> RResult<Value> {
             "array_product: expected 1 argument, got {}",
             args.len()
         )),
+    }
+}
+
+/// RES-438: `trim_start(s)` — strip leading Unicode whitespace only.
+fn builtin_trim_start(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s)] => Ok(Value::String(s.trim_start().to_string())),
+        [other] => Err(format!("trim_start: expected string, got {}", other)),
+        _ => Err(format!(
+            "trim_start: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-438: `trim_end(s)` — strip trailing Unicode whitespace only.
+fn builtin_trim_end(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s)] => Ok(Value::String(s.trim_end().to_string())),
+        [other] => Err(format!("trim_end: expected string, got {}", other)),
+        _ => Err(format!("trim_end: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -26434,6 +26458,86 @@ mod tests {
             builtin_array_intersperse(&[Value::Array(vec![])])
                 .unwrap_err()
                 .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-438: trim_start / trim_end ----------
+
+    #[test]
+    fn trim_start_strips_leading_whitespace_only() {
+        assert_eq!(
+            extract_string(builtin_trim_start(&[Value::String("   hello   ".into())]).unwrap()),
+            "hello   "
+        );
+    }
+
+    #[test]
+    fn trim_end_strips_trailing_whitespace_only() {
+        assert_eq!(
+            extract_string(builtin_trim_end(&[Value::String("   hello   ".into())]).unwrap()),
+            "   hello"
+        );
+    }
+
+    #[test]
+    fn trim_sides_handle_no_whitespace() {
+        assert_eq!(
+            extract_string(builtin_trim_start(&[Value::String("hello".into())]).unwrap()),
+            "hello"
+        );
+        assert_eq!(
+            extract_string(builtin_trim_end(&[Value::String("hello".into())]).unwrap()),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn trim_sides_empty_returns_empty() {
+        assert_eq!(
+            extract_string(builtin_trim_start(&[Value::String("".into())]).unwrap()),
+            ""
+        );
+        assert_eq!(
+            extract_string(builtin_trim_end(&[Value::String("".into())]).unwrap()),
+            ""
+        );
+    }
+
+    #[test]
+    fn trim_sides_only_whitespace_collapses_to_empty() {
+        assert_eq!(
+            extract_string(builtin_trim_start(&[Value::String("   ".into())]).unwrap()),
+            ""
+        );
+        assert_eq!(
+            extract_string(builtin_trim_end(&[Value::String("   ".into())]).unwrap()),
+            ""
+        );
+    }
+
+    #[test]
+    fn trim_sides_handle_tabs_and_newlines() {
+        assert_eq!(
+            extract_string(builtin_trim_start(&[Value::String("\t\n hello".into())]).unwrap()),
+            "hello"
+        );
+        assert_eq!(
+            extract_string(builtin_trim_end(&[Value::String("hello\t\n ".into())]).unwrap()),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn trim_sides_reject_non_string_and_arity() {
+        assert!(
+            builtin_trim_start(&[Value::Int(5)])
+                .unwrap_err()
+                .contains("expected string")
+        );
+        assert!(
+            builtin_trim_end(&[])
+                .unwrap_err()
+                .contains("expected 1 argument")
         );
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1169,6 +1169,21 @@ impl TypeChecker {
         );
         // RES-437: insert separator between adjacent elements.
         env.set("array_intersperse".to_string(), fn_any_any_to_any());
+        // RES-438: one-sided trimmers.
+        env.set(
+            "trim_start".to_string(),
+            Type::Function {
+                params: vec![Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
+        env.set(
+            "trim_end".to_string(),
+            Type::Function {
+                params: vec![Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
         // RES-413: repeat a string n times.
         env.set(
             "string_repeat".to_string(),
@@ -4072,6 +4087,9 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "string_count",
         // RES-437: array_intersperse.
         "array_intersperse",
+        // RES-438: one-sided trimmers.
+        "trim_start",
+        "trim_end",
         // RES-413: repeat a string.
         "string_repeat",
         // RES-414: substring search.


### PR DESCRIPTION
Closes #445

7 unit tests + golden example. fmt/clippy clean.