### PR TITLE
RES-489: add bit_leading_zeros(n) — count leading zero bits

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-488-bit-count",
-      "claimed_at": "2026-04-30T00:43:52Z"
+      "branch": "res-489-bit-leading-zeros",
+      "claimed_at": "2026-04-30T00:48:42Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-488-bit-count",
-      "claimed_at": "2026-04-30T00:43:52Z"
+      "branch": "res-489-bit-leading-zeros",
+      "claimed_at": "2026-04-30T00:48:42Z"
     }
   }
 }

--- a/resilient/examples/bit_leading_zeros.expected.txt
+++ b/resilient/examples/bit_leading_zeros.expected.txt
@@ -1,0 +1,5 @@
+64
+63
+56
+0
+Program executed successfully

--- a/resilient/examples/bit_leading_zeros.rz
+++ b/resilient/examples/bit_leading_zeros.rz
@@ -1,0 +1,10 @@
+// RES-489 demo: bit_leading_zeros counts zero bits at the high end of n.
+
+fn main() {
+    println(bit_leading_zeros(0));
+    println(bit_leading_zeros(1));
+    println(bit_leading_zeros(255));
+    println(bit_leading_zeros(-1));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8425,6 +8425,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("bit_shr", builtin_bit_shr),
     // RES-488: population count (Hamming weight).
     ("bit_count", builtin_bit_count),
+    // RES-489: count leading zero bits.
+    ("bit_leading_zeros", builtin_bit_leading_zeros),
     // RES-442: byte index of last substring occurrence, or -1.
     ("last_index_of", builtin_last_index_of),
     // RES-413: repeat a string n times.
@@ -9459,6 +9461,21 @@ fn builtin_bit_count(args: &[Value]) -> RResult<Value> {
         [other] => Err(format!("bit_count: expected int, got {}", other)),
         _ => Err(format!(
             "bit_count: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-489: `bit_leading_zeros(n)` — count of zero bits at the high end
+/// of `n`'s i64 twos-complement representation. `bit_leading_zeros(0)`
+/// is 64; `bit_leading_zeros(-1)` is 0. Lowers to LZCNT / CLZ on
+/// supporting hardware via `i64::leading_zeros`.
+fn builtin_bit_leading_zeros(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n)] => Ok(Value::Int(n.leading_zeros() as i64)),
+        [other] => Err(format!("bit_leading_zeros: expected int, got {}", other)),
+        _ => Err(format!(
+            "bit_leading_zeros: expected 1 argument, got {}",
             args.len()
         )),
     }
@@ -28491,6 +28508,68 @@ mod tests {
         );
         assert!(
             builtin_bit_count(&[Value::Int(1), Value::Int(2)])
+                .unwrap_err()
+                .contains("expected 1 argument")
+        );
+    }
+
+    // ---------- RES-489: bit_leading_zeros ----------
+
+    #[test]
+    fn bit_leading_zeros_basic() {
+        assert_int(
+            builtin_bit_leading_zeros(&[Value::Int(0)]).unwrap(),
+            64,
+            "0",
+        );
+        assert_int(
+            builtin_bit_leading_zeros(&[Value::Int(1)]).unwrap(),
+            63,
+            "1",
+        );
+        assert_int(
+            builtin_bit_leading_zeros(&[Value::Int(0xFF)]).unwrap(),
+            56,
+            "0xFF",
+        );
+    }
+
+    #[test]
+    fn bit_leading_zeros_powers_of_two() {
+        for shift in 0..63 {
+            let n: i64 = 1 << shift;
+            assert_int(
+                builtin_bit_leading_zeros(&[Value::Int(n)]).unwrap(),
+                63 - shift,
+                "pow2",
+            );
+        }
+    }
+
+    #[test]
+    fn bit_leading_zeros_negatives_have_zero() {
+        // High bit set in twos-complement → 0 leading zeros.
+        assert_int(
+            builtin_bit_leading_zeros(&[Value::Int(-1)]).unwrap(),
+            0,
+            "-1",
+        );
+        assert_int(
+            builtin_bit_leading_zeros(&[Value::Int(i64::MIN)]).unwrap(),
+            0,
+            "MIN",
+        );
+    }
+
+    #[test]
+    fn bit_leading_zeros_rejects_non_int_and_arity() {
+        assert!(
+            builtin_bit_leading_zeros(&[Value::Float(1.0)])
+                .unwrap_err()
+                .contains("expected int")
+        );
+        assert!(
+            builtin_bit_leading_zeros(&[])
                 .unwrap_err()
                 .contains("expected 1 argument")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1458,6 +1458,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Int),
             },
         );
+        // RES-489: count leading zero bits.
+        env.set(
+            "bit_leading_zeros".to_string(),
+            Type::Function {
+                params: vec![Type::Int],
+                return_type: Box::new(Type::Int),
+            },
+        );
         // RES-442: last byte index of substring.
         env.set(
             "last_index_of".to_string(),
@@ -4482,6 +4490,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "bit_shr",
         // RES-488: popcount.
         "bit_count",
+        // RES-489: count leading zero bits.
+        "bit_leading_zeros",
         // RES-442: last_index_of.
         "last_index_of",
         // RES-413: repeat a string.


### PR DESCRIPTION
Closes #548

## Summary

Adds `bit_leading_zeros(n)` — number of zero bits at the high end of `n`'s i64 twos-complement representation. Backed by `i64::leading_zeros`, lowering to LZCNT / CLZ on supporting hardware.

- \`bit_leading_zeros(0) == 64\`
- \`bit_leading_zeros(1) == 63\`
- \`bit_leading_zeros(0xFF) == 56\`
- \`bit_leading_zeros(-1) == 0\` (high bit set in twos-complement)
- \`bit_leading_zeros(i64::MIN) == 0\` (sign bit only)

Joins the RES-440 bit_* family + RES-488 \`bit_count\`. Inline in main.rs, registered in \`BUILTINS\`, seeded in typechecker as \`int -> int\`, added to \`PURE_BUILTINS\`. Four unit tests + golden example pair.

## Test plan

- [x] All cargo test suites pass.
- [x] cargo clippy --all-targets -D warnings clean.
- [x] cargo fmt -- --check clean.
- [x] Powers-of-two test verifies \`bit_leading_zeros(1<<k) == 63 - k\` for k in 0..63.
- [x] examples_golden::golden_outputs_match passes.