### PR TITLE
RES-491: add int_sqrt(n) — integer floor square root

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-490-bit-trailing-zeros",
-      "claimed_at": "2026-04-30T00:51:02Z"
+      "branch": "res-491-int-sqrt",
+      "claimed_at": "2026-04-30T00:52:58Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-490-bit-trailing-zeros",
-      "claimed_at": "2026-04-30T00:51:02Z"
+      "branch": "res-491-int-sqrt",
+      "claimed_at": "2026-04-30T00:52:58Z"
     }
   }
 }

--- a/resilient/examples/int_sqrt.expected.txt
+++ b/resilient/examples/int_sqrt.expected.txt
@@ -1,0 +1,6 @@
+0
+1
+2
+10
+9
+Program executed successfully

--- a/resilient/examples/int_sqrt.rz
+++ b/resilient/examples/int_sqrt.rz
@@ -1,0 +1,11 @@
+// RES-491 demo: int_sqrt returns floor(sqrt(n)) for non-negative n.
+
+fn main() {
+    println(int_sqrt(0));
+    println(int_sqrt(1));
+    println(int_sqrt(8));
+    println(int_sqrt(100));
+    println(int_sqrt(99));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8429,6 +8429,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("bit_leading_zeros", builtin_bit_leading_zeros),
     // RES-490: count trailing zero bits.
     ("bit_trailing_zeros", builtin_bit_trailing_zeros),
+    // RES-491: integer floor sqrt.
+    ("int_sqrt", builtin_int_sqrt),
     // RES-442: byte index of last substring occurrence, or -1.
     ("last_index_of", builtin_last_index_of),
     // RES-413: repeat a string n times.
@@ -9496,6 +9498,26 @@ fn builtin_bit_trailing_zeros(args: &[Value]) -> RResult<Value> {
             "bit_trailing_zeros: expected 1 argument, got {}",
             args.len()
         )),
+    }
+}
+
+/// RES-491: `int_sqrt(n)` — integer floor square root. Rejects
+/// negative inputs (mathematically undefined over integers; the
+/// `f64`-based `sqrt(x)` builtin already covers the float domain).
+/// Backed by `i64::isqrt`.
+fn builtin_int_sqrt(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "int_sqrt: argument must be non-negative, got {}",
+                    n
+                ));
+            }
+            Ok(Value::Int(n.isqrt()))
+        }
+        [other] => Err(format!("int_sqrt: expected int, got {}", other)),
+        _ => Err(format!("int_sqrt: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -28656,6 +28678,55 @@ mod tests {
         );
         assert!(
             builtin_bit_trailing_zeros(&[Value::Int(1), Value::Int(2)])
+                .unwrap_err()
+                .contains("expected 1 argument")
+        );
+    }
+
+    // ---------- RES-491: int_sqrt ----------
+
+    #[test]
+    fn int_sqrt_basic() {
+        assert_int(builtin_int_sqrt(&[Value::Int(0)]).unwrap(), 0, "0");
+        assert_int(builtin_int_sqrt(&[Value::Int(1)]).unwrap(), 1, "1");
+        assert_int(builtin_int_sqrt(&[Value::Int(4)]).unwrap(), 2, "4");
+        assert_int(builtin_int_sqrt(&[Value::Int(9)]).unwrap(), 3, "9");
+        assert_int(builtin_int_sqrt(&[Value::Int(100)]).unwrap(), 10, "100");
+    }
+
+    #[test]
+    fn int_sqrt_floors_non_squares() {
+        assert_int(builtin_int_sqrt(&[Value::Int(2)]).unwrap(), 1, "2");
+        assert_int(builtin_int_sqrt(&[Value::Int(8)]).unwrap(), 2, "8");
+        assert_int(builtin_int_sqrt(&[Value::Int(15)]).unwrap(), 3, "15");
+        assert_int(builtin_int_sqrt(&[Value::Int(99)]).unwrap(), 9, "99");
+    }
+
+    #[test]
+    fn int_sqrt_handles_max() {
+        // floor(sqrt(i64::MAX)) == 3_037_000_499
+        assert_int(
+            builtin_int_sqrt(&[Value::Int(i64::MAX)]).unwrap(),
+            3_037_000_499,
+            "MAX",
+        );
+    }
+
+    #[test]
+    fn int_sqrt_rejects_negative() {
+        let err = builtin_int_sqrt(&[Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"), "got: {}", err);
+    }
+
+    #[test]
+    fn int_sqrt_rejects_non_int_and_arity() {
+        assert!(
+            builtin_int_sqrt(&[Value::Float(4.0)])
+                .unwrap_err()
+                .contains("expected int")
+        );
+        assert!(
+            builtin_int_sqrt(&[])
                 .unwrap_err()
                 .contains("expected 1 argument")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1474,6 +1474,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Int),
             },
         );
+        // RES-491: integer floor sqrt.
+        env.set(
+            "int_sqrt".to_string(),
+            Type::Function {
+                params: vec![Type::Int],
+                return_type: Box::new(Type::Int),
+            },
+        );
         // RES-442: last byte index of substring.
         env.set(
             "last_index_of".to_string(),
@@ -4502,6 +4510,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "bit_leading_zeros",
         // RES-490: count trailing zero bits.
         "bit_trailing_zeros",
+        // RES-491: integer floor sqrt.
+        "int_sqrt",
         // RES-442: last_index_of.
         "last_index_of",
         // RES-413: repeat a string.


### PR DESCRIPTION
Closes #552

Adds `int_sqrt(n)` — floor(√n) for non-negative n. Backed by `i64::isqrt` (Rust 1.84+).

- `int_sqrt(0) == 0`, `int_sqrt(8) == 2`, `int_sqrt(100) == 10`
- `int_sqrt(i64::MAX) == 3_037_000_499`
- `int_sqrt(-1)` errors with "argument must be non-negative"

Inline in main.rs, registered in BUILTINS, seeded as int -> int in typechecker, added to PURE_BUILTINS. Five unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] floors non-squares (2→1, 8→2, 15→3, 99→9)
- [x] handles i64::MAX correctly
- [x] examples_golden passes