### PR TITLE
RES-494: add next_pow2(n) — round up to next power of two

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-493-is-pow2",
-      "claimed_at": "2026-04-30T00:56:58Z"
+      "branch": "res-494-next-pow2",
+      "claimed_at": "2026-04-30T00:59:12Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-493-is-pow2",
-      "claimed_at": "2026-04-30T00:56:58Z"
+      "branch": "res-494-next-pow2",
+      "claimed_at": "2026-04-30T00:59:12Z"
     }
   }
 }

--- a/resilient/examples/next_pow2.expected.txt
+++ b/resilient/examples/next_pow2.expected.txt
@@ -1,0 +1,6 @@
+1
+1
+8
+8
+2048
+Program executed successfully

--- a/resilient/examples/next_pow2.rz
+++ b/resilient/examples/next_pow2.rz
@@ -1,0 +1,11 @@
+// RES-494 demo: next_pow2 returns the smallest power of two >= n.
+
+fn main() {
+    println(next_pow2(0));
+    println(next_pow2(1));
+    println(next_pow2(5));
+    println(next_pow2(8));
+    println(next_pow2(1025));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8435,6 +8435,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("int_log2", builtin_int_log2),
     // RES-493: power-of-two predicate.
     ("is_pow2", builtin_is_pow2),
+    // RES-494: round up to next power of two.
+    ("next_pow2", builtin_next_pow2),
     // RES-442: byte index of last substring occurrence, or -1.
     ("last_index_of", builtin_last_index_of),
     // RES-413: repeat a string n times.
@@ -9550,6 +9552,47 @@ fn builtin_is_pow2(args: &[Value]) -> RResult<Value> {
         [Value::Int(n)] => Ok(Value::Bool(*n > 0 && (n & (n - 1)) == 0)),
         [other] => Err(format!("is_pow2: expected int, got {}", other)),
         _ => Err(format!("is_pow2: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-494: `next_pow2(n)` — smallest power of two `>= n`. Inputs
+/// `<= 1` round up to 1 (the smallest positive power of two).
+/// Negatives error (no defined power of two below 1). Inputs that
+/// would round up beyond `i64::MAX` (i.e. `n > 2^62`) error rather
+/// than overflowing.
+fn builtin_next_pow2(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "next_pow2: argument must be non-negative, got {}",
+                    n
+                ));
+            }
+            // 0 and 1 both round to 1.
+            if *n <= 1 {
+                return Ok(Value::Int(1));
+            }
+            // For n > 2^62 the next power of two would be 2^63, which
+            // does not fit in i64. Error rather than wrap.
+            const MAX_OK: i64 = 1i64 << 62;
+            if *n > MAX_OK {
+                return Err(format!(
+                    "next_pow2: argument {} exceeds i64::MAX_POW2 (2^62)",
+                    n
+                ));
+            }
+            // Standard bit trick: 64 - lz(n-1) is the number of bits
+            // needed to represent n-1, hence the exponent of the next
+            // power of two.
+            let exp = 64 - (n - 1).leading_zeros();
+            Ok(Value::Int(1i64 << exp))
+        }
+        [other] => Err(format!("next_pow2: expected int, got {}", other)),
+        _ => Err(format!(
+            "next_pow2: expected 1 argument, got {}",
+            args.len()
+        )),
     }
 }
 
@@ -28866,6 +28909,66 @@ mod tests {
         );
         assert!(
             builtin_is_pow2(&[])
+                .unwrap_err()
+                .contains("expected 1 argument")
+        );
+    }
+
+    // ---------- RES-494: next_pow2 ----------
+
+    #[test]
+    fn next_pow2_basic() {
+        assert_int(builtin_next_pow2(&[Value::Int(0)]).unwrap(), 1, "0");
+        assert_int(builtin_next_pow2(&[Value::Int(1)]).unwrap(), 1, "1");
+        assert_int(builtin_next_pow2(&[Value::Int(2)]).unwrap(), 2, "2");
+        assert_int(builtin_next_pow2(&[Value::Int(3)]).unwrap(), 4, "3");
+        assert_int(builtin_next_pow2(&[Value::Int(5)]).unwrap(), 8, "5");
+        assert_int(builtin_next_pow2(&[Value::Int(9)]).unwrap(), 16, "9");
+        assert_int(
+            builtin_next_pow2(&[Value::Int(1024)]).unwrap(),
+            1024,
+            "1024",
+        );
+        assert_int(
+            builtin_next_pow2(&[Value::Int(1025)]).unwrap(),
+            2048,
+            "1025",
+        );
+    }
+
+    #[test]
+    fn next_pow2_already_power_of_two_is_identity() {
+        for shift in 0..62 {
+            let n: i64 = 1 << shift;
+            assert_int(builtin_next_pow2(&[Value::Int(n)]).unwrap(), n, "pow2");
+        }
+    }
+
+    #[test]
+    fn next_pow2_rejects_negative() {
+        let err = builtin_next_pow2(&[Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"), "got: {}", err);
+    }
+
+    #[test]
+    fn next_pow2_handles_2_to_62_boundary() {
+        // 2^62 itself is OK (already a power of two).
+        let max = 1i64 << 62;
+        assert_int(builtin_next_pow2(&[Value::Int(max)]).unwrap(), max, "2^62");
+        // 2^62 + 1 would round to 2^63 which overflows i64 — error.
+        let err = builtin_next_pow2(&[Value::Int(max + 1)]).unwrap_err();
+        assert!(err.contains("exceeds"), "got: {}", err);
+    }
+
+    #[test]
+    fn next_pow2_rejects_non_int_and_arity() {
+        assert!(
+            builtin_next_pow2(&[Value::Float(8.0)])
+                .unwrap_err()
+                .contains("expected int")
+        );
+        assert!(
+            builtin_next_pow2(&[])
                 .unwrap_err()
                 .contains("expected 1 argument")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1498,6 +1498,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Bool),
             },
         );
+        // RES-494: round up to next power of two.
+        env.set(
+            "next_pow2".to_string(),
+            Type::Function {
+                params: vec![Type::Int],
+                return_type: Box::new(Type::Int),
+            },
+        );
         // RES-442: last byte index of substring.
         env.set(
             "last_index_of".to_string(),
@@ -4532,6 +4540,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "int_log2",
         // RES-493: power-of-two predicate.
         "is_pow2",
+        // RES-494: round up to next power of two.
+        "next_pow2",
         // RES-442: last_index_of.
         "last_index_of",
         // RES-413: repeat a string.


### PR DESCRIPTION
Closes #558

Adds `next_pow2(n)` — smallest power of two >= n. Useful for capacity rounding.

- `next_pow2(5) == 8`, `next_pow2(1025) == 2048`
- `next_pow2(0) == next_pow2(1) == 1`
- `next_pow2(2^62) == 2^62`; `next_pow2(2^62 + 1)` errors (would overflow i64)
- `next_pow2(-1)` errors

Implementation: `64 - leading_zeros(n - 1)` to compute the exponent. Inline in main.rs next to is_pow2. Five unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] every power of two in 0..62 is identity
- [x] 2^62 boundary verified
- [x] examples_golden passes