### PR TITLE
RES-495: add int_to_hex(n) — lowercase hex string

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-494-next-pow2",
-      "claimed_at": "2026-04-30T00:59:12Z"
+      "branch": "res-495-int-to-hex",
+      "claimed_at": "2026-04-30T01:01:24Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-494-next-pow2",
-      "claimed_at": "2026-04-30T00:59:12Z"
+      "branch": "res-495-int-to-hex",
+      "claimed_at": "2026-04-30T01:01:24Z"
     }
   }
 }

--- a/resilient/examples/int_to_hex.expected.txt
+++ b/resilient/examples/int_to_hex.expected.txt
@@ -1,0 +1,6 @@
+0
+ff
+100
+-1
+-1000
+Program executed successfully

--- a/resilient/examples/int_to_hex.rz
+++ b/resilient/examples/int_to_hex.rz
@@ -1,0 +1,11 @@
+// RES-495 demo: int_to_hex returns lowercase hex with sign prefix for negatives.
+
+fn main() {
+    println(int_to_hex(0));
+    println(int_to_hex(255));
+    println(int_to_hex(256));
+    println(int_to_hex(-1));
+    println(int_to_hex(-4096));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8437,6 +8437,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("is_pow2", builtin_is_pow2),
     // RES-494: round up to next power of two.
     ("next_pow2", builtin_next_pow2),
+    // RES-495: lowercase hex string (sign-prefixed for negatives).
+    ("int_to_hex", builtin_int_to_hex),
     // RES-442: byte index of last substring occurrence, or -1.
     ("last_index_of", builtin_last_index_of),
     // RES-413: repeat a string n times.
@@ -9552,6 +9554,26 @@ fn builtin_is_pow2(args: &[Value]) -> RResult<Value> {
         [Value::Int(n)] => Ok(Value::Bool(*n > 0 && (n & (n - 1)) == 0)),
         [other] => Err(format!("is_pow2: expected int, got {}", other)),
         _ => Err(format!("is_pow2: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-495: `int_to_hex(n)` — format `n` as a lowercase hex string,
+/// sign-prefixing negatives. No `0x` prefix (consistent with the
+/// existing `int_to_base` builtin). Shorthand for
+/// `int_to_base(n, 16)`.
+fn builtin_int_to_hex(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n)] => {
+            let abs = n.unsigned_abs();
+            let body = format!("{:x}", abs);
+            let s = if *n < 0 { format!("-{}", body) } else { body };
+            Ok(Value::String(s))
+        }
+        [other] => Err(format!("int_to_hex: expected int, got {}", other)),
+        _ => Err(format!(
+            "int_to_hex: expected 1 argument, got {}",
+            args.len()
+        )),
     }
 }
 
@@ -28969,6 +28991,54 @@ mod tests {
         );
         assert!(
             builtin_next_pow2(&[])
+                .unwrap_err()
+                .contains("expected 1 argument")
+        );
+    }
+
+    // ---------- RES-495: int_to_hex ----------
+
+    fn int_to_hex_str(n: i64) -> String {
+        match builtin_int_to_hex(&[Value::Int(n)]).unwrap() {
+            Value::String(s) => s,
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn int_to_hex_basic() {
+        assert_eq!(int_to_hex_str(0), "0");
+        assert_eq!(int_to_hex_str(1), "1");
+        assert_eq!(int_to_hex_str(15), "f");
+        assert_eq!(int_to_hex_str(16), "10");
+        assert_eq!(int_to_hex_str(255), "ff");
+        assert_eq!(int_to_hex_str(256), "100");
+        assert_eq!(int_to_hex_str(0xDEAD_BEEF), "deadbeef");
+    }
+
+    #[test]
+    fn int_to_hex_negatives_sign_prefix() {
+        assert_eq!(int_to_hex_str(-1), "-1");
+        assert_eq!(int_to_hex_str(-255), "-ff");
+        assert_eq!(int_to_hex_str(-4096), "-1000");
+    }
+
+    #[test]
+    fn int_to_hex_handles_min_and_max() {
+        assert_eq!(int_to_hex_str(i64::MAX), "7fffffffffffffff");
+        // i64::MIN: unsigned_abs() == 2^63 → 8000000000000000.
+        assert_eq!(int_to_hex_str(i64::MIN), "-8000000000000000");
+    }
+
+    #[test]
+    fn int_to_hex_rejects_non_int_and_arity() {
+        assert!(
+            builtin_int_to_hex(&[Value::Float(2.0)])
+                .unwrap_err()
+                .contains("expected int")
+        );
+        assert!(
+            builtin_int_to_hex(&[])
                 .unwrap_err()
                 .contains("expected 1 argument")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1506,6 +1506,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Int),
             },
         );
+        // RES-495: int → lowercase hex string.
+        env.set(
+            "int_to_hex".to_string(),
+            Type::Function {
+                params: vec![Type::Int],
+                return_type: Box::new(Type::String),
+            },
+        );
         // RES-442: last byte index of substring.
         env.set(
             "last_index_of".to_string(),
@@ -4542,6 +4550,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "is_pow2",
         // RES-494: round up to next power of two.
         "next_pow2",
+        // RES-495: int → lowercase hex string.
+        "int_to_hex",
         // RES-442: last_index_of.
         "last_index_of",
         // RES-413: repeat a string.


### PR DESCRIPTION
Closes #560

Adds `int_to_hex(n)` — shorthand for `int_to_base(n, 16)`. Lowercase, sign-prefix for negatives, no `0x` prefix.

- `int_to_hex(255) == "ff"`, `int_to_hex(0xDEAD_BEEF) == "deadbeef"`
- `int_to_hex(-1) == "-1"`
- `int_to_hex(i64::MIN) == "-8000000000000000"` (twos-complement abs)

Inline in main.rs. Four unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] i64::MIN / MAX boundaries verified
- [x] examples_golden passes