### PR TITLE
RES-496: add string_words(s) — split on Unicode whitespace

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-495-int-to-hex",
-      "claimed_at": "2026-04-30T01:01:24Z"
+      "branch": "res-496-string-words",
+      "claimed_at": "2026-04-30T01:03:32Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-495-int-to-hex",
-      "claimed_at": "2026-04-30T01:01:24Z"
+      "branch": "res-496-string-words",
+      "claimed_at": "2026-04-30T01:03:32Z"
     }
   }
 }

--- a/resilient/examples/string_words.expected.txt
+++ b/resilient/examples/string_words.expected.txt
@@ -1,0 +1,5 @@
+2
+2
+0
+5
+Program executed successfully

--- a/resilient/examples/string_words.rz
+++ b/resilient/examples/string_words.rz
@@ -1,0 +1,10 @@
+// RES-496 demo: string_words splits on Unicode whitespace.
+
+fn main() {
+    println(len(string_words("hello world")));
+    println(len(string_words("  foo   bar  ")));
+    println(len(string_words("")));
+    println(len(string_words("a b c d e")));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8405,6 +8405,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("string_chars", builtin_string_chars),
     // RES-434: split string into lines (LF, CRLF, no trailing empty).
     ("string_lines", builtin_string_lines),
+    // RES-496: split string on Unicode whitespace.
+    ("string_words", builtin_string_words),
     // RES-435: split array into fixed-size chunks (last may be short).
     ("array_chunk", builtin_array_chunk),
     // RES-436: non-overlapping substring count.
@@ -9758,6 +9760,26 @@ fn builtin_string_lines(args: &[Value]) -> RResult<Value> {
         [other] => Err(format!("string_lines: expected string, got {}", other)),
         _ => Err(format!(
             "string_lines: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-496: `string_words(s)` — split `s` on Unicode whitespace.
+/// Empty / whitespace-only input produces an empty array; consecutive
+/// whitespace runs collapse into a single separator. Backed by
+/// `str::split_whitespace`, which is Unicode-aware (handles tabs,
+/// newlines, NBSP, ideographic space, etc.).
+fn builtin_string_words(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s)] => Ok(Value::Array(
+            s.split_whitespace()
+                .map(|w| Value::String(w.to_string()))
+                .collect(),
+        )),
+        [other] => Err(format!("string_words: expected string, got {}", other)),
+        _ => Err(format!(
+            "string_words: expected 1 argument, got {}",
             args.len()
         )),
     }
@@ -28088,6 +28110,66 @@ mod tests {
         );
         assert!(
             builtin_string_lines(&[])
+                .unwrap_err()
+                .contains("expected 1 argument")
+        );
+    }
+
+    // ---------- RES-496: string_words ----------
+
+    #[test]
+    fn string_words_basic() {
+        assert_eq!(
+            extract_strings(builtin_string_words(&[Value::String("hello world".into())]).unwrap()),
+            vec!["hello", "world"]
+        );
+    }
+
+    #[test]
+    fn string_words_empty_returns_empty() {
+        assert_eq!(
+            extract_strings(builtin_string_words(&[Value::String("".into())]).unwrap()),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn string_words_collapses_whitespace_runs() {
+        assert_eq!(
+            extract_strings(
+                builtin_string_words(&[Value::String("  foo   bar  ".into())]).unwrap()
+            ),
+            vec!["foo", "bar"]
+        );
+    }
+
+    #[test]
+    fn string_words_handles_tabs_and_newlines() {
+        assert_eq!(
+            extract_strings(
+                builtin_string_words(&[Value::String("\tfoo\n\nbar\r\nbaz".into())]).unwrap()
+            ),
+            vec!["foo", "bar", "baz"]
+        );
+    }
+
+    #[test]
+    fn string_words_whitespace_only_input_is_empty() {
+        assert_eq!(
+            extract_strings(builtin_string_words(&[Value::String("  \t\n  ".into())]).unwrap()),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn string_words_rejects_non_string_and_arity() {
+        assert!(
+            builtin_string_words(&[Value::Int(5)])
+                .unwrap_err()
+                .contains("expected string")
+        );
+        assert!(
+            builtin_string_words(&[])
                 .unwrap_err()
                 .contains("expected 1 argument")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1404,6 +1404,8 @@ impl TypeChecker {
         env.set("string_chars".to_string(), fn_any_to_any());
         // RES-434: split string into lines (LF, CRLF).
         env.set("string_lines".to_string(), fn_any_to_any());
+        // RES-496: split on Unicode whitespace.
+        env.set("string_words".to_string(), fn_any_to_any());
         // RES-435: split array into fixed-size chunks.
         env.set("array_chunk".to_string(), fn_any_any_to_any());
         // RES-436: non-overlapping substring count.
@@ -4518,6 +4520,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "string_chars",
         // RES-434: string_lines.
         "string_lines",
+        // RES-496: split on Unicode whitespace.
+        "string_words",
         // RES-435: array_chunk.
         "array_chunk",
         // RES-436: string_count.


### PR DESCRIPTION
Closes #562

Adds `string_words(s)` — Unicode-whitespace split. Backed by `str::split_whitespace`.

- `string_words("hello world")` → `["hello", "world"]`
- `string_words("  foo   bar  ")` → `["foo", "bar"]` (collapses runs)
- `string_words("")` → `[]`
- Handles tabs, newlines, CRLF, NBSP, ideographic space (Unicode-aware)

Inline in main.rs next to string_lines. Six unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] empty / whitespace-only inputs verified
- [x] tabs / CRLF / blank lines collapsed correctly
- [x] examples_golden passes