### PR TITLE
RES-497: add string_join_lines(arr) — join string array with newlines

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-496-string-words",
-      "claimed_at": "2026-04-30T01:03:32Z"
+      "branch": "res-497-string-join-lines",
+      "claimed_at": "2026-04-30T01:06:52Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-496-string-words",
-      "claimed_at": "2026-04-30T01:03:32Z"
+      "branch": "res-497-string-join-lines",
+      "claimed_at": "2026-04-30T01:06:52Z"
     }
   }
 }

--- a/resilient/examples/string_join_lines.expected.txt
+++ b/resilient/examples/string_join_lines.expected.txt
@@ -1,0 +1,8 @@
+one
+two
+three
+---
+just one
+---
+0
+Program executed successfully

--- a/resilient/examples/string_join_lines.rz
+++ b/resilient/examples/string_join_lines.rz
@@ -1,0 +1,13 @@
+// RES-497 demo: string_join_lines glues an array of strings with newlines.
+
+fn main() {
+    let lines = ["one", "two", "three"];
+    println(string_join_lines(lines));
+    println("---");
+    println(string_join_lines(["just one"]));
+    println("---");
+    let empty = [];
+    println(len(string_join_lines(empty)));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8407,6 +8407,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("string_lines", builtin_string_lines),
     // RES-496: split string on Unicode whitespace.
     ("string_words", builtin_string_words),
+    // RES-497: join string array with newline separator.
+    ("string_join_lines", builtin_string_join_lines),
     // RES-435: split array into fixed-size chunks (last may be short).
     ("array_chunk", builtin_array_chunk),
     // RES-436: non-overlapping substring count.
@@ -9780,6 +9782,34 @@ fn builtin_string_words(args: &[Value]) -> RResult<Value> {
         [other] => Err(format!("string_words: expected string, got {}", other)),
         _ => Err(format!(
             "string_words: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-497: `string_join_lines(arr)` — join an array of strings with
+/// `\n` between elements. Empty array → empty string. Pairs with
+/// `string_split_lines` (RES-498) and `string_lines` (RES-434).
+fn builtin_string_join_lines(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let mut parts: Vec<&str> = Vec::with_capacity(items.len());
+            for v in items {
+                match v {
+                    Value::String(s) => parts.push(s.as_str()),
+                    other => {
+                        return Err(format!(
+                            "string_join_lines: array element must be string, got {}",
+                            other
+                        ));
+                    }
+                }
+            }
+            Ok(Value::String(parts.join("\n")))
+        }
+        [other] => Err(format!("string_join_lines: expected array, got {}", other)),
+        _ => Err(format!(
+            "string_join_lines: expected 1 argument, got {}",
             args.len()
         )),
     }
@@ -28170,6 +28200,59 @@ mod tests {
         );
         assert!(
             builtin_string_words(&[])
+                .unwrap_err()
+                .contains("expected 1 argument")
+        );
+    }
+
+    // ---------- RES-497: string_join_lines ----------
+
+    fn s(t: &str) -> Value {
+        Value::String(t.to_string())
+    }
+
+    fn join_lines_str(items: Vec<Value>) -> String {
+        match builtin_string_join_lines(&[Value::Array(items)]).unwrap() {
+            Value::String(s) => s,
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_join_lines_basic() {
+        assert_eq!(join_lines_str(vec![s("a"), s("b"), s("c")]), "a\nb\nc");
+        assert_eq!(join_lines_str(vec![s("hello")]), "hello");
+        assert_eq!(join_lines_str(vec![]), "");
+    }
+
+    #[test]
+    fn string_join_lines_preserves_empty_lines() {
+        assert_eq!(join_lines_str(vec![s("a"), s(""), s("b")]), "a\n\nb");
+    }
+
+    #[test]
+    fn string_join_lines_round_trip_with_string_lines() {
+        let original = "first\nsecond\nthird";
+        let parts = builtin_string_lines(&[Value::String(original.into())]).unwrap();
+        let Value::Array(items) = parts else { panic!() };
+        let rejoined = join_lines_str(items);
+        assert_eq!(rejoined, original);
+    }
+
+    #[test]
+    fn string_join_lines_rejects_non_array_and_non_string_elements() {
+        assert!(
+            builtin_string_join_lines(&[Value::Int(5)])
+                .unwrap_err()
+                .contains("expected array")
+        );
+        assert!(
+            builtin_string_join_lines(&[Value::Array(vec![Value::Int(5)])])
+                .unwrap_err()
+                .contains("element must be string")
+        );
+        assert!(
+            builtin_string_join_lines(&[])
                 .unwrap_err()
                 .contains("expected 1 argument")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1406,6 +1406,14 @@ impl TypeChecker {
         env.set("string_lines".to_string(), fn_any_to_any());
         // RES-496: split on Unicode whitespace.
         env.set("string_words".to_string(), fn_any_to_any());
+        // RES-497: join string array with newline.
+        env.set(
+            "string_join_lines".to_string(),
+            Type::Function {
+                params: vec![Type::Array],
+                return_type: Box::new(Type::String),
+            },
+        );
         // RES-435: split array into fixed-size chunks.
         env.set("array_chunk".to_string(), fn_any_any_to_any());
         // RES-436: non-overlapping substring count.
@@ -4522,6 +4530,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "string_lines",
         // RES-496: split on Unicode whitespace.
         "string_words",
+        // RES-497: join string array with newline.
+        "string_join_lines",
         // RES-435: array_chunk.
         "array_chunk",
         // RES-436: string_count.


### PR DESCRIPTION
Closes #564

Adds `string_join_lines(arr)` — joins an array of strings with `\n`. Pairs with `string_lines` (RES-434).

- `string_join_lines(["a", "b", "c"])` → `"a\nb\nc"`
- `string_join_lines([])` → `""`
- Round-trip with string_lines verified

Errors on non-array input or non-string elements. Inline in main.rs. Four unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] round-trip with string_lines verified
- [x] empty/single/multi cases verified
- [x] examples_golden passes