### PR TITLE
RES-499: add string_take(s, n) — first n Unicode scalars

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-498-string-unwords",
-      "claimed_at": "2026-04-30T01:10:12Z"
+      "branch": "res-499-string-take",
+      "claimed_at": "2026-04-30T01:14:07Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-498-string-unwords",
-      "claimed_at": "2026-04-30T01:10:12Z"
+      "branch": "res-499-string-take",
+      "claimed_at": "2026-04-30T01:14:07Z"
     }
   }
 }

--- a/resilient/examples/string_take.expected.txt
+++ b/resilient/examples/string_take.expected.txt
@@ -1,0 +1,5 @@
+hello
+hello
+hé
+0
+Program executed successfully

--- a/resilient/examples/string_take.rz
+++ b/resilient/examples/string_take.rz
@@ -1,0 +1,10 @@
+// RES-499 demo: string_take returns the first n Unicode scalars.
+
+fn main() {
+    println(string_take("hello, world!", 5));
+    println(string_take("hello", 100));
+    println(string_take("héllo", 2));
+    println(len(string_take("hello", 0)));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8411,6 +8411,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("string_join_lines", builtin_string_join_lines),
     // RES-498: join string array with single-space separator.
     ("string_unwords", builtin_string_unwords),
+    // RES-499: take first n Unicode scalars.
+    ("string_take", builtin_string_take),
     // RES-435: split array into fixed-size chunks (last may be short).
     ("array_chunk", builtin_array_chunk),
     // RES-436: non-overlapping substring count.
@@ -9842,6 +9844,42 @@ fn builtin_string_unwords(args: &[Value]) -> RResult<Value> {
         [other] => Err(format!("string_unwords: expected array, got {}", other)),
         _ => Err(format!(
             "string_unwords: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-499: `string_take(s, n)` — return the prefix of `s` consisting
+/// of its first `n` Unicode scalars. `n` past the string's char count
+/// clamps to the full string. Negative `n` errors. Counts chars, not
+/// bytes — consistent with `string_at`, `string_substring`,
+/// `string_chars`.
+fn builtin_string_take(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "string_take: count must be non-negative, got {}",
+                    n
+                ));
+            }
+            let take = *n as usize;
+            // Find the byte index where we have consumed `take` scalars
+            // (or end of string), then slice. This avoids re-allocating
+            // when the count exceeds the full string.
+            let end_byte = s
+                .char_indices()
+                .nth(take)
+                .map(|(b, _)| b)
+                .unwrap_or(s.len());
+            Ok(Value::String(s[..end_byte].to_string()))
+        }
+        [a, b] => Err(format!(
+            "string_take: expected (string, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "string_take: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -28340,6 +28378,58 @@ mod tests {
             builtin_string_unwords(&[])
                 .unwrap_err()
                 .contains("expected 1 argument")
+        );
+    }
+
+    // ---------- RES-499: string_take ----------
+
+    fn take_str(s: &str, n: i64) -> String {
+        match builtin_string_take(&[Value::String(s.into()), Value::Int(n)]).unwrap() {
+            Value::String(s) => s,
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_take_basic() {
+        assert_eq!(take_str("hello", 0), "");
+        assert_eq!(take_str("hello", 1), "h");
+        assert_eq!(take_str("hello", 3), "hel");
+        assert_eq!(take_str("hello", 5), "hello");
+    }
+
+    #[test]
+    fn string_take_clamps_past_end() {
+        assert_eq!(take_str("hello", 100), "hello");
+        assert_eq!(take_str("", 5), "");
+    }
+
+    #[test]
+    fn string_take_unicode_aware() {
+        // 'é' is a 2-byte scalar; counting chars not bytes.
+        assert_eq!(take_str("héllo", 2), "hé");
+        // Multi-byte scalars: ideographs.
+        assert_eq!(take_str("日本語", 1), "日");
+        assert_eq!(take_str("日本語", 2), "日本");
+    }
+
+    #[test]
+    fn string_take_rejects_negative_count() {
+        let err = builtin_string_take(&[Value::String("foo".into()), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"), "got: {}", err);
+    }
+
+    #[test]
+    fn string_take_rejects_wrong_types_and_arity() {
+        assert!(
+            builtin_string_take(&[Value::Int(5), Value::Int(2)])
+                .unwrap_err()
+                .contains("expected (string, int)")
+        );
+        assert!(
+            builtin_string_take(&[Value::String("x".into())])
+                .unwrap_err()
+                .contains("expected 2 arguments")
         );
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1422,6 +1422,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::String),
             },
         );
+        // RES-499: take first n Unicode scalars.
+        env.set(
+            "string_take".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::Int],
+                return_type: Box::new(Type::String),
+            },
+        );
         // RES-435: split array into fixed-size chunks.
         env.set("array_chunk".to_string(), fn_any_any_to_any());
         // RES-436: non-overlapping substring count.
@@ -4542,6 +4550,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "string_join_lines",
         // RES-498: join string array with single space.
         "string_unwords",
+        // RES-499: take first n Unicode scalars.
+        "string_take",
         // RES-435: array_chunk.
         "array_chunk",
         // RES-436: string_count.


### PR DESCRIPTION
Closes #568

Adds `string_take(s, n)` — first n Unicode scalars. Counts chars not bytes (consistent with string_at, string_substring).

- `string_take("hello", 3)` → `"hel"`
- `string_take("héllo", 2)` → `"hé"` (Unicode-aware)
- `string_take("日本語", 2)` → `"日本"`
- Past-end clamps to full string; negative errors

Inline in main.rs next to string_unwords. Five unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] Unicode multi-byte scalars (é, ideographs) verified
- [x] negative count rejected
- [x] examples_golden passes