### PR TITLE
RES-507: combine docs + playground into a single GitHub Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,27 @@
-name: Deploy Docs
+name: Deploy Site
+
+# RES-507: single-source GitHub Pages deploy. Builds the Jekyll docs
+# site and the WASM playground in one job, then uploads them as a
+# combined artifact. The docs land at the repo Pages root
+# (`/Resilient/`); the playground lives at `/Resilient/playground/`.
+#
+# Before RES-507 this workflow and `playground.yml` both called
+# `actions/deploy-pages@v4` against the same `concurrency: pages`
+# group, so the most recent push won and silently overwrote the
+# other site. `playground.yml` no longer deploys; it stays as a
+# PR-only build/size-budget check.
 
 on:
   push:
     branches: [main]
+    # Trigger on either docs or playground source changes — both
+    # land in the same artifact now, so either delta requires a
+    # redeploy.
     paths:
       - "docs/**"
+      - "playground/**"
+      - "resilient/examples/**"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -39,6 +56,40 @@ jobs:
         run: bundle exec jekyll build --source docs --destination _site --baseurl "/Resilient"
         env:
           JEKYLL_ENV: production
+
+      - name: Install Rust toolchain (with wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: |
+          if ! command -v wasm-pack >/dev/null 2>&1; then
+            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          fi
+
+      - name: Cache cargo (playground)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            playground/target
+          key: ${{ runner.os }}-playground-${{ hashFiles('playground/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-playground-
+
+      - name: Build playground (WASM)
+        run: bash playground/build.sh --check-size
+
+      - name: Mount playground at /playground
+        # Copy the playground bundle into _site/playground/ so it
+        # ships alongside the docs at the same Pages URL. Trailing
+        # slashes are intentional — `cp -R src/. dst/` copies the
+        # contents of `src` into `dst` rather than nesting `src`.
+        run: |
+          mkdir -p _site/playground
+          cp -R playground/dist/. _site/playground/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,39 +1,28 @@
-# RES-368: build and deploy the WASM playground to GitHub Pages.
+# RES-368 (RES-507 update): build the WASM playground as a PR-only
+# size check. Deploy is owned by `docs.yml`, which builds Jekyll
+# docs and the playground in one job and uploads both as a single
+# Pages artifact at `/Resilient/` and `/Resilient/playground/`
+# respectively.
 #
-# Runs on every push to main that touches the playground source or
-# the bundled examples; runs on pull-request as a build-and-size
-# check (no deploy). The deploy target is the repo's Pages site at
-# https://ericspencer00.github.io/Resilient/ — playground lives at
-# /playground/ underneath.
+# Before RES-507 this workflow also called `actions/deploy-pages@v4`
+# against the same `concurrency: pages` group as `docs.yml`, so the
+# most recent push silently overwrote the other site. Keeping a
+# build-only check here means PRs that touch the WASM crate still
+# get the size budget enforced before merge, without racing the
+# main deploy.
 
 name: playground
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "playground/**"
-      - "resilient/examples/**"
-      - ".github/workflows/playground.yml"
   pull_request:
     paths:
       - "playground/**"
       - "resilient/examples/**"
       - ".github/workflows/playground.yml"
+  workflow_dispatch:
 
-# `pages` writes; `id-token: write` is required for the official
-# `actions/deploy-pages@v4` flow.
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-# Serialize deploys: a queued push and an in-flight push both
-# targeting `main` should not race. Cancel the in-flight if a newer
-# one arrives.
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
 
 jobs:
   build:
@@ -66,20 +55,3 @@ jobs:
       - name: build playground (release, size-checked)
         run: |
           bash playground/build.sh --check-size
-
-      - name: upload artifact
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: playground/dist
-
-  deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
-    "resilient/src/main.rs": {
-      "branch": "res-506-string-drop",
-      "claimed_at": "2026-04-30T01:38:45Z"
+    ".github/workflows/docs.yml": {
+      "branch": "res-507-combine-docs-playground-deploy",
+      "claimed_at": "2026-04-30T01:43:59Z"
     },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-506-string-drop",
-      "claimed_at": "2026-04-30T01:38:45Z"
+    ".github/workflows/playground.yml": {
+      "branch": "res-507-combine-docs-playground-deploy",
+      "claimed_at": "2026-04-30T01:43:59Z"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ permalink: /
     <p class="rl-hero__sub">A compiled language where failure is a first-class concern. Contracts are proven at compile time, hardware faults self-heal, and the same code runs on a dev laptop or a bare-metal Cortex-M4.</p>
     <div class="rl-hero__actions">
       <a href="{{ '/getting-started' | relative_url }}" class="rl-btn rl-btn--primary">Get started →</a>
+      <a href="{{ '/playground/' | relative_url }}" class="rl-btn rl-btn--secondary">Try the playground ↗</a>
       <a href="https://github.com/EricSpencer00/Resilient" class="rl-btn rl-btn--secondary" target="_blank">GitHub ↗</a>
     </div>
     <div class="rl-hero__badges">


### PR DESCRIPTION
Closes #584

Two workflows were racing for the same Pages deploy (`docs.yml` and `playground.yml`, both in `concurrency: pages`, both calling `actions/deploy-pages@v4`). The most recent push won, so the playground silently overwrote the docs site at `ericspencer.us/Resilient/`.

## Fix

- `docs.yml` now builds Jekyll + WASM playground in one job; uploads one combined artifact. Docs at `/Resilient/`; playground at `/Resilient/playground/`.
- `playground.yml` keeps its build + size budget check on PRs but no longer deploys (no race with docs).
- Docs landing page hero gets a "Try the playground ↗" CTA pointing at the new sub-path.

## Test plan

- [x] yaml lint OK
- [x] Playground HTML uses relative paths — no changes needed to make it work at `/Resilient/playground/`.
- [ ] Once merged, manually confirm:
  - `ericspencer.us/Resilient/` shows the Jekyll docs landing page.
  - `ericspencer.us/Resilient/playground/` shows the playground UI.
  - The new "Try the playground" hero button on the landing page navigates to the playground.

## Out of scope (follow-up)

- Wiring the actual interpreter into the WASM stub. The playground still shows `[playground scaffold — interpreter integration pending]` because `resilient/Cargo.toml` is bin-only. Will be a separate ticket — needs a `[lib]` target on `resilient`, which is a non-trivial refactor of the 35K-line `main.rs`.
- Simplifying the 30-page docs sidebar via just-the-docs `parent` / `has_children` grouping. Tracked separately.
- Auditing `README.md` and `docs/` for broken links. Tracked separately.