### PR TITLE
RES-514: add array_step(arr, n) — pick every nth element

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-513-digit-to-char",
-      "claimed_at": "2026-04-30T02:00:17Z"
+      "branch": "res-514-array-step",
+      "claimed_at": "2026-04-30T02:02:31Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-513-digit-to-char",
-      "claimed_at": "2026-04-30T02:00:17Z"
+      "branch": "res-514-array-step",
+      "claimed_at": "2026-04-30T02:02:31Z"
     }
   }
 }

--- a/resilient/examples/array_step.expected.txt
+++ b/resilient/examples/array_step.expected.txt
@@ -1,0 +1,6 @@
+[1, 2, 3, 4, 5, 6, 7, 8]
+[1, 3, 5, 7]
+[1, 4, 7]
+[1]
+0
+Program executed successfully

--- a/resilient/examples/array_step.rz
+++ b/resilient/examples/array_step.rz
@@ -1,0 +1,12 @@
+// RES-514 demo: array_step picks every nth element.
+
+fn main() {
+    let xs = [1, 2, 3, 4, 5, 6, 7, 8];
+    println(array_step(xs, 1));
+    println(array_step(xs, 2));
+    println(array_step(xs, 3));
+    println(array_step(xs, 99));
+    println(len(array_step([], 2)));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8285,6 +8285,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     // RES-421: take/drop first n elements.
     ("array_take", builtin_array_take),
     ("array_drop", builtin_array_drop),
+    // RES-514: pick every nth element.
+    ("array_step", builtin_array_step),
     // RES-422: ascending sort over an integer array.
     ("array_sort", builtin_array_sort),
     // RES-443: descending sort.
@@ -12021,6 +12023,29 @@ fn builtin_array_take(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "array_take: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-514: `array_step(arr, n)` — pick every `n`th element starting
+/// at index 0. Useful for downsampling and decimation. `n` must be
+/// positive.
+fn builtin_array_step(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::Int(n)] => {
+            if *n <= 0 {
+                return Err(format!("array_step: step must be positive, got {}", n));
+            }
+            let step = *n as usize;
+            Ok(Value::Array(items.iter().step_by(step).cloned().collect()))
+        }
+        [a, b] => Err(format!(
+            "array_step: expected (array, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_step: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -27876,6 +27901,65 @@ mod tests {
         );
         assert!(
             builtin_array_drop(&[int_array(&[1])])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-514: array_step ----------
+
+    fn step_int(items: &[i64], n: i64) -> Vec<i64> {
+        match builtin_array_step(&[int_array(items), Value::Int(n)]).unwrap() {
+            Value::Array(out) => out
+                .into_iter()
+                .map(|v| match v {
+                    Value::Int(n) => n,
+                    other => panic!("expected Int, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_step_basic() {
+        assert_eq!(step_int(&[1, 2, 3, 4, 5, 6], 2), vec![1, 3, 5]);
+        assert_eq!(step_int(&[1, 2, 3, 4, 5, 6], 3), vec![1, 4]);
+        assert_eq!(step_int(&[1, 2, 3, 4, 5, 6], 1), vec![1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn array_step_step_larger_than_len_keeps_first() {
+        assert_eq!(step_int(&[1, 2, 3], 7), vec![1]);
+    }
+
+    #[test]
+    fn array_step_empty_input_is_empty() {
+        assert_eq!(step_int(&[], 2), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn array_step_singleton_is_singleton() {
+        assert_eq!(step_int(&[42], 5), vec![42]);
+    }
+
+    #[test]
+    fn array_step_rejects_zero_or_negative() {
+        let err = builtin_array_step(&[int_array(&[1]), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("positive"), "got: {}", err);
+        let err = builtin_array_step(&[int_array(&[1]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("positive"), "got: {}", err);
+    }
+
+    #[test]
+    fn array_step_rejects_wrong_types_and_arity() {
+        assert!(
+            builtin_array_step(&[Value::Int(5), Value::Int(2)])
+                .unwrap_err()
+                .contains("expected (array, int)")
+        );
+        assert!(
+            builtin_array_step(&[int_array(&[1])])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1136,6 +1136,8 @@ impl TypeChecker {
         // RES-421: take/drop first n.
         env.set("array_take".to_string(), fn_any_any_to_any());
         env.set("array_drop".to_string(), fn_any_any_to_any());
+        // RES-514: pick every nth element.
+        env.set("array_step".to_string(), fn_any_any_to_any());
         // RES-422: integer sort ascending.
         env.set("array_sort".to_string(), fn_any_to_any());
         // RES-443: integer sort descending.
@@ -4514,6 +4516,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         // RES-421: take/drop.
         "array_take",
         "array_drop",
+        // RES-514: pick every nth element.
+        "array_step",
         // RES-422: integer sort.
         "array_sort",
         // RES-443: descending sort.


### PR DESCRIPTION
Closes #597

Adds `array_step(arr, n)` — every nth element starting at index 0. Useful for downsampling, decimation.

- `array_step([1, 2, 3, 4, 5, 6], 2)` → `[1, 3, 5]`
- `array_step([1, 2, 3], 7)` → `[1]` (only index 0)
- `array_step([], 2)` → `[]`
- `n <= 0` errors

Inline in main.rs next to array_take. Six unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] step larger than len keeps only first
- [x] empty / singleton edge cases verified
- [x] examples_golden passes