### PR TITLE
RES-516: add array_interleave(a, b) — alternate elements

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-515-array-concat3",
-      "claimed_at": "2026-04-30T02:04:56Z"
+      "branch": "res-516-array-interleave",
+      "claimed_at": "2026-04-30T02:07:35Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-515-array-concat3",
-      "claimed_at": "2026-04-30T02:04:56Z"
+      "branch": "res-516-array-interleave",
+      "claimed_at": "2026-04-30T02:07:35Z"
     }
   }
 }

--- a/resilient/examples/array_interleave.expected.txt
+++ b/resilient/examples/array_interleave.expected.txt
@@ -1,0 +1,6 @@
+[1, 2, 3, 4, 5, 6]
+[1, 2, 3, 4, 5]
+[1, 2, 4, 6]
+[42, 43]
+0
+Program executed successfully

--- a/resilient/examples/array_interleave.rz
+++ b/resilient/examples/array_interleave.rz
@@ -1,0 +1,11 @@
+// RES-516 demo: array_interleave alternates elements from two arrays.
+
+fn main() {
+    println(array_interleave([1, 3, 5], [2, 4, 6]));
+    println(array_interleave([1, 3, 5], [2, 4]));
+    println(array_interleave([1], [2, 4, 6]));
+    println(array_interleave([], [42, 43]));
+    println(len(array_interleave([], [])));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8440,6 +8440,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("string_count", builtin_string_count),
     // RES-437: insert separator between adjacent array elements.
     ("array_intersperse", builtin_array_intersperse),
+    // RES-516: alternate elements from two arrays.
+    ("array_interleave", builtin_array_interleave),
     // RES-438: one-sided whitespace trimmers.
     ("trim_start", builtin_trim_start),
     ("trim_end", builtin_trim_end),
@@ -9801,6 +9803,48 @@ fn builtin_trim_end(args: &[Value]) -> RResult<Value> {
         [Value::String(s)] => Ok(Value::String(s.trim_end().to_string())),
         [other] => Err(format!("trim_end: expected string, got {}", other)),
         _ => Err(format!("trim_end: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-516: `array_interleave(a, b)` — alternate elements from two
+/// arrays. Trailing elements of the longer array are appended after
+/// interleaving runs out. Distinct from `array_zip` (RES-430), which
+/// produces tuple pairs and truncates to the shorter input.
+fn builtin_array_interleave(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(a), Value::Array(b)] => {
+            let mut out = Vec::with_capacity(a.len() + b.len());
+            let mut ai = a.iter();
+            let mut bi = b.iter();
+            loop {
+                match (ai.next(), bi.next()) {
+                    (Some(x), Some(y)) => {
+                        out.push(x.clone());
+                        out.push(y.clone());
+                    }
+                    (Some(x), None) => {
+                        out.push(x.clone());
+                        out.extend(ai.cloned());
+                        break;
+                    }
+                    (None, Some(y)) => {
+                        out.push(y.clone());
+                        out.extend(bi.cloned());
+                        break;
+                    }
+                    (None, None) => break,
+                }
+            }
+            Ok(Value::Array(out))
+        }
+        [a, b] => Err(format!(
+            "array_interleave: expected (array, array), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_interleave: expected 2 arguments, got {}",
+            args.len()
+        )),
     }
 }
 
@@ -29557,6 +29601,62 @@ mod tests {
         );
         assert!(
             builtin_array_intersperse(&[Value::Array(vec![])])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-516: array_interleave ----------
+
+    fn interleave_int(a: &[i64], b: &[i64]) -> Vec<i64> {
+        match builtin_array_interleave(&[int_array(a), int_array(b)]).unwrap() {
+            Value::Array(items) => items
+                .into_iter()
+                .map(|v| match v {
+                    Value::Int(n) => n,
+                    other => panic!("expected Int, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_interleave_equal_length() {
+        assert_eq!(
+            interleave_int(&[1, 3, 5], &[2, 4, 6]),
+            vec![1, 2, 3, 4, 5, 6]
+        );
+    }
+
+    #[test]
+    fn array_interleave_a_longer_appends_a_tail() {
+        assert_eq!(interleave_int(&[1, 3, 5], &[2, 4]), vec![1, 2, 3, 4, 5]);
+        assert_eq!(interleave_int(&[1, 2, 3, 4], &[10]), vec![1, 10, 2, 3, 4]);
+    }
+
+    #[test]
+    fn array_interleave_b_longer_appends_b_tail() {
+        assert_eq!(interleave_int(&[1], &[2, 4, 6]), vec![1, 2, 4, 6]);
+        assert_eq!(interleave_int(&[10], &[1, 2, 3, 4]), vec![10, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn array_interleave_with_empty_inputs() {
+        assert_eq!(interleave_int(&[], &[1, 2, 3]), vec![1, 2, 3]);
+        assert_eq!(interleave_int(&[1, 2], &[]), vec![1, 2]);
+        assert_eq!(interleave_int(&[], &[]), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn array_interleave_rejects_non_array_and_arity() {
+        assert!(
+            builtin_array_interleave(&[Value::Int(1), Value::Array(vec![])])
+                .unwrap_err()
+                .contains("expected (array, array)")
+        );
+        assert!(
+            builtin_array_interleave(&[Value::Array(vec![])])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1517,6 +1517,8 @@ impl TypeChecker {
         );
         // RES-437: insert separator between adjacent elements.
         env.set("array_intersperse".to_string(), fn_any_any_to_any());
+        // RES-516: alternate elements from two arrays.
+        env.set("array_interleave".to_string(), fn_any_any_to_any());
         // RES-438: one-sided trimmers.
         env.set(
             "trim_start".to_string(),
@@ -4677,6 +4679,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "string_count",
         // RES-437: array_intersperse.
         "array_intersperse",
+        // RES-516: alternate elements from two arrays.
+        "array_interleave",
         // RES-438: one-sided trimmers.
         "trim_start",
         "trim_end",


### PR DESCRIPTION
Closes #601

Adds `array_interleave(a, b)` — alternates elements from two arrays; appends the longer one's tail.

- `array_interleave([1, 3, 5], [2, 4, 6])` → `[1, 2, 3, 4, 5, 6]`
- `array_interleave([1, 3, 5], [2, 4])` → `[1, 2, 3, 4, 5]` (a longer)
- `array_interleave([1], [2, 4, 6])` → `[1, 2, 4, 6]` (b longer)

Distinct from array_zip (truncates) and array_intersperse (separator).

Inline in main.rs next to array_intersperse. Five unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] equal / a-longer / b-longer / empty cases verified
- [x] examples_golden passes