### PR TITLE
RES-520: add bit_rotate_left / bit_rotate_right — circular bit rotation

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-519-modulo",
-      "claimed_at": "2026-04-30T02:16:15Z"
+      "branch": "res-520-bit-rotate",
+      "claimed_at": "2026-04-30T02:19:08Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-519-modulo",
-      "claimed_at": "2026-04-30T02:16:15Z"
+      "branch": "res-520-bit-rotate",
+      "claimed_at": "2026-04-30T02:19:08Z"
     }
   }
 }

--- a/resilient/examples/bit_rotate.expected.txt
+++ b/resilient/examples/bit_rotate.expected.txt
@@ -1,0 +1,5 @@
+240
+65280
+15
+255
+Program executed successfully

--- a/resilient/examples/bit_rotate.rz
+++ b/resilient/examples/bit_rotate.rz
@@ -1,0 +1,11 @@
+// RES-520 demo: bit_rotate_left / bit_rotate_right do circular
+// rotation. Bits shifted off one end wrap to the other.
+
+fn main() {
+    println(bit_rotate_left(15, 4));
+    println(bit_rotate_left(255, 8));
+    println(bit_rotate_right(240, 4));
+    println(bit_rotate_right(65280, 8));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8465,6 +8465,9 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("bit_set", builtin_bit_set),
     ("bit_clear", builtin_bit_clear),
     ("bit_toggle", builtin_bit_toggle),
+    // RES-520: circular bit rotation.
+    ("bit_rotate_left", builtin_bit_rotate_left),
+    ("bit_rotate_right", builtin_bit_rotate_right),
     // RES-491: integer floor sqrt.
     ("int_sqrt", builtin_int_sqrt),
     // RES-517: integer exponentiation.
@@ -9629,6 +9632,47 @@ fn builtin_bit_toggle(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "bit_toggle: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-520: `bit_rotate_left(n, k)` — rotate `n`'s bits left by `k`
+/// positions (circular; bits shifted off the high end wrap to the
+/// low end). Distinct from `bit_shl` (RES-440), which discards
+/// shifted bits. `k` must be in `0..=63`.
+fn builtin_bit_rotate_left(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n), Value::Int(k)] => {
+            let bits = check_bit_pos("bit_rotate_left", *k)?;
+            Ok(Value::Int(n.rotate_left(bits)))
+        }
+        [a, b] => Err(format!(
+            "bit_rotate_left: expected (int, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "bit_rotate_left: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-520: `bit_rotate_right(n, k)` — rotate `n`'s bits right by `k`
+/// positions (circular; bits shifted off the low end wrap to the
+/// high end). `k` must be in `0..=63`.
+fn builtin_bit_rotate_right(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n), Value::Int(k)] => {
+            let bits = check_bit_pos("bit_rotate_right", *k)?;
+            Ok(Value::Int(n.rotate_right(bits)))
+        }
+        [a, b] => Err(format!(
+            "bit_rotate_right: expected (int, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "bit_rotate_right: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -30384,6 +30428,90 @@ mod tests {
         );
         assert!(
             builtin_bit_set(&[Value::Int(1)])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-520: bit_rotate_left / bit_rotate_right ----------
+
+    fn rol(n: i64, k: i64) -> i64 {
+        match builtin_bit_rotate_left(&[Value::Int(n), Value::Int(k)]).unwrap() {
+            Value::Int(m) => m,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    fn ror(n: i64, k: i64) -> i64 {
+        match builtin_bit_rotate_right(&[Value::Int(n), Value::Int(k)]).unwrap() {
+            Value::Int(m) => m,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bit_rotate_zero_is_identity() {
+        for n in [0i64, 1, -1, 0xDEAD_BEEF, i64::MIN, i64::MAX] {
+            assert_eq!(rol(n, 0), n, "rol(_, 0)");
+            assert_eq!(ror(n, 0), n, "ror(_, 0)");
+        }
+    }
+
+    #[test]
+    fn bit_rotate_left_basic() {
+        assert_eq!(rol(0x0F, 4), 0xF0);
+        assert_eq!(rol(0xFF, 8), 0xFF00);
+        // High bit wraps to low.
+        assert_eq!(rol(i64::MIN, 1), 1);
+    }
+
+    #[test]
+    fn bit_rotate_right_basic() {
+        assert_eq!(ror(0xF0, 4), 0x0F);
+        assert_eq!(ror(0xFF00, 8), 0xFF);
+        // Low bit wraps to high (sign bit).
+        assert_eq!(ror(1, 1), i64::MIN);
+    }
+
+    #[test]
+    fn bit_rotate_left_right_inverse() {
+        // ror(rol(n, k), k) == n for any n and k in 0..=63.
+        for n in [1i64, 0xDEAD_BEEF, -1, i64::MIN, 12345] {
+            for k in [0, 1, 7, 32, 63] {
+                assert_eq!(ror(rol(n, k), k), n, "round-trip n={} k={}", n, k);
+            }
+        }
+    }
+
+    #[test]
+    fn bit_rotate_64_is_identity() {
+        // The Rust impl wraps modulo 64; bit position 64 is out of
+        // range and we reject it. But k=0 (above) and k=63 (max
+        // valid) cover the boundary.
+        for n in [0xDEAD_BEEFi64, -1] {
+            assert_eq!(rol(n, 63), ror(n, 1), "rol 63 == ror 1");
+        }
+    }
+
+    #[test]
+    fn bit_rotate_reject_out_of_range_and_wrong_types() {
+        assert!(
+            builtin_bit_rotate_left(&[Value::Int(0), Value::Int(64)])
+                .unwrap_err()
+                .contains("0..=63")
+        );
+        assert!(
+            builtin_bit_rotate_right(&[Value::Int(0), Value::Int(-1)])
+                .unwrap_err()
+                .contains("0..=63")
+        );
+        assert!(
+            builtin_bit_rotate_left(&[Value::Float(0.0), Value::Int(0)])
+                .unwrap_err()
+                .contains("expected (int, int)")
+        );
+        assert!(
+            builtin_bit_rotate_right(&[Value::Int(0)])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1591,7 +1591,10 @@ impl TypeChecker {
         );
         env.set("bit_set".to_string(), int_int_to_int.clone());
         env.set("bit_clear".to_string(), int_int_to_int.clone());
-        env.set("bit_toggle".to_string(), int_int_to_int);
+        env.set("bit_toggle".to_string(), int_int_to_int.clone());
+        // RES-520: circular bit rotation.
+        env.set("bit_rotate_left".to_string(), int_int_to_int.clone());
+        env.set("bit_rotate_right".to_string(), int_int_to_int);
         // RES-491: integer floor sqrt.
         env.set(
             "int_sqrt".to_string(),
@@ -4721,6 +4724,9 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "bit_set",
         "bit_clear",
         "bit_toggle",
+        // RES-520: circular bit rotation.
+        "bit_rotate_left",
+        "bit_rotate_right",
         // RES-491: integer floor sqrt.
         "int_sqrt",
         // RES-517: integer exponentiation.


### PR DESCRIPTION
Closes #609

Two builtins for circular bit rotation — distinct from bit_shl/bit_shr (which discard bits).

- `bit_rotate_left(0x0F, 4)` → `0xF0`
- `bit_rotate_left(i64::MIN, 1)` → `1` (high bit wraps to low)
- `bit_rotate_right(1, 1)` → `i64::MIN` (low bit wraps to sign)
- Inverse round-trip verified
- k validated 0..=63 via check_bit_pos

Backed by i64::rotate_left / rotate_right. Inline in main.rs after the RES-511 single-bit builtins. Six unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] zero-rotation identity for various n (incl. i64::MIN/MAX)
- [x] inverse round-trip rol(ror(n, k), k) == n
- [x] rol(n, 63) == ror(n, 1) boundary
- [x] examples_golden passes