### PR TITLE
RES-523: add string_count_char(s, c) — count single-char occurrences

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-522-array-indices",
-      "claimed_at": "2026-04-30T02:26:29Z"
+      "branch": "res-523-string-count-char",
+      "claimed_at": "2026-04-30T02:28:34Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-522-array-indices",
-      "claimed_at": "2026-04-30T02:26:29Z"
+      "branch": "res-523-string-count-char",
+      "claimed_at": "2026-04-30T02:28:34Z"
     }
   }
 }

--- a/resilient/examples/string_count_char.expected.txt
+++ b/resilient/examples/string_count_char.expected.txt
@@ -1,0 +1,5 @@
+2
+0
+5
+1
+Program executed successfully

--- a/resilient/examples/string_count_char.rz
+++ b/resilient/examples/string_count_char.rz
@@ -1,0 +1,10 @@
+// RES-523 demo: string_count_char counts a single Unicode scalar.
+
+fn main() {
+    println(string_count_char("hello", "l"));
+    println(string_count_char("hello", "x"));
+    println(string_count_char("aaaaa", "a"));
+    println(string_count_char("héllo naïve", "é"));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8442,6 +8442,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("array_chunk", builtin_array_chunk),
     // RES-436: non-overlapping substring count.
     ("string_count", builtin_string_count),
+    // RES-523: count occurrences of a single character.
+    ("string_count_char", builtin_string_count_char),
     // RES-437: insert separator between adjacent array elements.
     ("array_intersperse", builtin_array_intersperse),
     // RES-516: alternate elements from two arrays.
@@ -10051,6 +10053,40 @@ fn builtin_string_count(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "string_count: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-523: `string_count_char(s, c)` — count occurrences of the
+/// single Unicode scalar `c` in `s`. `c` must be exactly one
+/// character; empty or multi-char inputs error. Distinct from
+/// `string_count(s, sub)` (RES-436), which accepts multi-char
+/// substrings — this is a more direct (and Unicode-aware) primitive
+/// for the common single-character case.
+fn builtin_string_count_char(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s), Value::String(c)] => {
+            let mut iter = c.chars();
+            let needle = iter
+                .next()
+                .ok_or_else(|| "string_count_char: empty char argument".to_string())?;
+            if iter.next().is_some() {
+                return Err(format!(
+                    "string_count_char: expected single character, got {} chars",
+                    c.chars().count()
+                ));
+            }
+            Ok(Value::Int(
+                s.chars().filter(|ch| *ch == needle).count() as i64
+            ))
+        }
+        [a, b] => Err(format!(
+            "string_count_char: expected (string, string), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "string_count_char: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -29823,6 +29859,63 @@ mod tests {
         );
         assert!(
             builtin_string_count(&[Value::String("a".into())])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-523: string_count_char ----------
+
+    fn count_char(s: &str, c: &str) -> i64 {
+        match builtin_string_count_char(&[Value::String(s.into()), Value::String(c.into())])
+            .unwrap()
+        {
+            Value::Int(n) => n,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_count_char_basic() {
+        assert_eq!(count_char("hello", "l"), 2);
+        assert_eq!(count_char("hello", "x"), 0);
+        assert_eq!(count_char("aaa", "a"), 3);
+        assert_eq!(count_char("", "x"), 0);
+        assert_eq!(count_char("h", "h"), 1);
+    }
+
+    #[test]
+    fn string_count_char_unicode_aware() {
+        // 'é' is a 2-byte scalar; counting chars not bytes.
+        assert_eq!(count_char("héllo", "é"), 1);
+        assert_eq!(count_char("naïve naïveté", "ï"), 2);
+        // Ideograph: a single char.
+        assert_eq!(count_char("日本語日本", "本"), 2);
+    }
+
+    #[test]
+    fn string_count_char_rejects_empty_or_multichar_needle() {
+        assert!(
+            builtin_string_count_char(&[Value::String("hi".into()), Value::String("".into())])
+                .unwrap_err()
+                .contains("empty")
+        );
+        assert!(
+            builtin_string_count_char(&[Value::String("hi".into()), Value::String("hi".into())])
+                .unwrap_err()
+                .contains("single character")
+        );
+    }
+
+    #[test]
+    fn string_count_char_rejects_wrong_types_and_arity() {
+        assert!(
+            builtin_string_count_char(&[Value::Int(1), Value::String("a".into())])
+                .unwrap_err()
+                .contains("expected (string, string)")
+        );
+        assert!(
+            builtin_string_count_char(&[Value::String("a".into())])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1525,6 +1525,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Int),
             },
         );
+        // RES-523: count occurrences of a single character.
+        env.set(
+            "string_count_char".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Int),
+            },
+        );
         // RES-437: insert separator between adjacent elements.
         env.set("array_intersperse".to_string(), fn_any_any_to_any());
         // RES-516: alternate elements from two arrays.
@@ -4711,6 +4719,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_chunk",
         // RES-436: string_count.
         "string_count",
+        // RES-523: count occurrences of a single character.
+        "string_count_char",
         // RES-437: array_intersperse.
         "array_intersperse",
         // RES-516: alternate elements from two arrays.


### PR DESCRIPTION
Closes #615

Adds `string_count_char(s, c)` — count occurrences of a single char (Unicode-aware, counts chars not bytes).

- `string_count_char("hello", "l")` → 2
- `string_count_char("héllo naïve", "é")` → 1 (multi-byte scalar)
- Empty / multi-char needle errors
- Distinct from string_count (RES-436) which is for multi-char substrings

Inline in main.rs next to string_count. Four unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] Unicode multi-byte scalars verified
- [x] empty / multi-char needle rejected
- [x] examples_golden passes