### PR TITLE
RES-527: add string_eq_ignore_case(a, b) — ASCII case-insensitive equality

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-526-string-filter-char",
-      "claimed_at": "2026-04-30T02:36:15Z"
+      "branch": "res-527-string-eq-ignore-case",
+      "claimed_at": "2026-04-30T02:38:57Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-526-string-filter-char",
-      "claimed_at": "2026-04-30T02:36:15Z"
+      "branch": "res-527-string-eq-ignore-case",
+      "claimed_at": "2026-04-30T02:38:57Z"
     }
   }
 }

--- a/resilient/examples/string_eq_ignore_case.expected.txt
+++ b/resilient/examples/string_eq_ignore_case.expected.txt
@@ -1,0 +1,6 @@
+true
+true
+false
+false
+false
+Program executed successfully

--- a/resilient/examples/string_eq_ignore_case.rz
+++ b/resilient/examples/string_eq_ignore_case.rz
@@ -1,0 +1,11 @@
+// RES-527 demo: string_eq_ignore_case is ASCII case-insensitive.
+
+fn main() {
+    println(string_eq_ignore_case("hello", "HELLO"));
+    println(string_eq_ignore_case("Content-Type", "content-type"));
+    println(string_eq_ignore_case("hello", "world"));
+    println(string_eq_ignore_case("foo", "foobar"));
+    println(string_eq_ignore_case("héllo", "HÉLLO"));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8451,6 +8451,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("string_drop_while_char", builtin_string_drop_while_char),
     // RES-526: named-predicate global char filter.
     ("string_filter_char", builtin_string_filter_char),
+    // RES-527: ASCII case-insensitive string equality.
+    ("string_eq_ignore_case", builtin_string_eq_ignore_case),
     // RES-437: insert separator between adjacent array elements.
     ("array_intersperse", builtin_array_intersperse),
     // RES-516: alternate elements from two arrays.
@@ -10221,6 +10223,24 @@ fn builtin_string_filter_char(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "string_filter_char: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-527: `string_eq_ignore_case(a, b)` — ASCII case-insensitive
+/// string equality. Useful for protocol parsing (HTTP header names,
+/// MIME types). Only ASCII letters are case-folded; non-ASCII chars
+/// compare as-is, matching Rust's `str::eq_ignore_ascii_case`.
+fn builtin_string_eq_ignore_case(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(a), Value::String(b)] => Ok(Value::Bool(a.eq_ignore_ascii_case(b))),
+        [a, b] => Err(format!(
+            "string_eq_ignore_case: expected (string, string), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "string_eq_ignore_case: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -30290,6 +30310,70 @@ mod tests {
         );
         assert!(
             builtin_string_filter_char(&[Value::String("a".into())])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-527: string_eq_ignore_case ----------
+
+    fn eq_ic(a: &str, b: &str) -> bool {
+        match builtin_string_eq_ignore_case(&[Value::String(a.into()), Value::String(b.into())])
+            .unwrap()
+        {
+            Value::Bool(b) => b,
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_eq_ignore_case_basic() {
+        assert!(eq_ic("hello", "HELLO"));
+        assert!(eq_ic("Hello", "hELLO"));
+        assert!(eq_ic("HELLO", "hello"));
+        assert!(eq_ic("MixedCase", "MIXEDCASE"));
+    }
+
+    #[test]
+    fn string_eq_ignore_case_inequal_when_chars_differ() {
+        assert!(!eq_ic("hello", "world"));
+        assert!(!eq_ic("foo", "foobar"));
+        assert!(!eq_ic("foobar", "foo"));
+    }
+
+    #[test]
+    fn string_eq_ignore_case_empty_strings() {
+        assert!(eq_ic("", ""));
+        assert!(!eq_ic("", "a"));
+        assert!(!eq_ic("a", ""));
+    }
+
+    #[test]
+    fn string_eq_ignore_case_only_folds_ascii() {
+        // Per Rust's str::eq_ignore_ascii_case, non-ASCII letters
+        // are NOT case-folded — only A-Z ↔ a-z.
+        assert!(!eq_ic("héllo", "HÉLLO"));
+        // But the ASCII parts still fold:
+        assert!(eq_ic("héllo", "Héllo"));
+        assert!(!eq_ic("naïve", "NAÏVE"));
+    }
+
+    #[test]
+    fn string_eq_ignore_case_punctuation_and_digits_unchanged() {
+        // Digits and punctuation compare exactly.
+        assert!(eq_ic("Foo123!", "FOO123!"));
+        assert!(!eq_ic("Foo123!", "Foo123?"));
+    }
+
+    #[test]
+    fn string_eq_ignore_case_rejects_wrong_types_and_arity() {
+        assert!(
+            builtin_string_eq_ignore_case(&[Value::Int(1), Value::String("a".into())])
+                .unwrap_err()
+                .contains("expected (string, string)")
+        );
+        assert!(
+            builtin_string_eq_ignore_case(&[Value::String("a".into())])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1550,6 +1550,14 @@ impl TypeChecker {
         env.set("string_drop_while_char".to_string(), str_str_to_str.clone());
         // RES-526: named-predicate global char filter.
         env.set("string_filter_char".to_string(), str_str_to_str);
+        // RES-527: ASCII case-insensitive string equality.
+        env.set(
+            "string_eq_ignore_case".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Bool),
+            },
+        );
         // RES-437: insert separator between adjacent elements.
         env.set("array_intersperse".to_string(), fn_any_any_to_any());
         // RES-516: alternate elements from two arrays.
@@ -4745,6 +4753,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "string_drop_while_char",
         // RES-526: named-predicate global char filter.
         "string_filter_char",
+        // RES-527: ASCII case-insensitive string equality.
+        "string_eq_ignore_case",
         // RES-437: array_intersperse.
         "array_intersperse",
         // RES-516: alternate elements from two arrays.


### PR DESCRIPTION
Closes #623

ASCII-only case-insensitive string equality. Useful for protocol parsing (HTTP header names, MIME types).

- `string_eq_ignore_case("Content-Type", "content-type")` → true
- `string_eq_ignore_case("héllo", "HÉLLO")` → false (only ASCII folds, by design — matches Rust primitive)
- `string_eq_ignore_case("foo", "foobar")` → false (length differs)

Backed by str::eq_ignore_ascii_case. Inline in main.rs next to string_filter_char. Six unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] equal / inequal cases
- [x] non-ASCII non-folding documented + verified
- [x] empty strings
- [x] examples_golden passes