### PR TITLE
RES-529: add parse_int_or(s, default) — non-erroring parse with fallback

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-528-array-get-or",
-      "claimed_at": "2026-04-30T02:41:13Z"
+      "branch": "res-529-parse-int-or",
+      "claimed_at": "2026-04-30T02:43:46Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-528-array-get-or",
-      "claimed_at": "2026-04-30T02:41:13Z"
+      "branch": "res-529-parse-int-or",
+      "claimed_at": "2026-04-30T02:43:46Z"
     }
   }
 }

--- a/resilient/examples/parse_int_or.expected.txt
+++ b/resilient/examples/parse_int_or.expected.txt
@@ -1,0 +1,6 @@
+42
+-1
+-7
+0
+-999
+Program executed successfully

--- a/resilient/examples/parse_int_or.rz
+++ b/resilient/examples/parse_int_or.rz
@@ -1,0 +1,12 @@
+// RES-529 demo: parse_int_or returns the parsed int or a fallback
+// default if parsing fails. Useful for CSV cells, env vars, etc.
+
+fn main() {
+    println(parse_int_or("42", -1));
+    println(parse_int_or("not a number", -1));
+    println(parse_int_or(" -7 ", 0));
+    println(parse_int_or("3.14", 0));
+    println(parse_int_or("", -999));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8519,6 +8519,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("repeat", builtin_repeat),
     // RES-339: string parsing and formatting.
     ("parse_int", builtin_parse_int),
+    // RES-529: non-erroring parse with fallback default.
+    ("parse_int_or", builtin_parse_int_or),
     ("parse_float", builtin_parse_float),
     ("char_at", builtin_char_at),
     ("pad_left", builtin_pad_left),
@@ -13048,6 +13050,28 @@ fn builtin_parse_int(args: &[Value]) -> RResult<Value> {
         [other] => Err(format!("parse_int: expected string, got {}", other)),
         _ => Err(format!(
             "parse_int: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-529: `parse_int_or(s, default)` — non-erroring base-10 parse.
+/// Returns the parsed integer or `default` if `s` is not a valid
+/// base-10 integer (empty, non-numeric, overflow, etc.). Trims
+/// surrounding whitespace, matching `parse_int` (RES-339). Pairs
+/// with `parse_int` (which returns a `Result`) for code that
+/// already has a fallback in mind.
+fn builtin_parse_int_or(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s), Value::Int(default)] => {
+            Ok(Value::Int(s.trim().parse::<i64>().unwrap_or(*default)))
+        }
+        [a, b] => Err(format!(
+            "parse_int_or: expected (string, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "parse_int_or: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -25157,6 +25181,64 @@ mod tests {
             err.contains("parse_int: expected string"),
             "err was: {}",
             err
+        );
+    }
+
+    // ---------- RES-529: parse_int_or ----------
+
+    fn pioi(s: &str, default: i64) -> i64 {
+        match builtin_parse_int_or(&[Value::String(s.into()), Value::Int(default)]).unwrap() {
+            Value::Int(n) => n,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_int_or_valid_inputs_return_parsed() {
+        assert_eq!(pioi("42", -1), 42);
+        assert_eq!(pioi("0", -1), 0);
+        assert_eq!(pioi("-5", -1), -5);
+        // Leading / trailing whitespace stripped, matching parse_int.
+        assert_eq!(pioi(" 42 ", -1), 42);
+        assert_eq!(pioi("\t-7\n", 0), -7);
+    }
+
+    #[test]
+    fn parse_int_or_invalid_returns_default() {
+        for s in &[
+            "",
+            "abc",
+            "1.5",
+            "0xFF",
+            "9999999999999999999999",
+            "  ",
+            "12abc",
+        ] {
+            assert_eq!(pioi(s, -1), -1, "s={:?}", s);
+        }
+    }
+
+    #[test]
+    fn parse_int_or_default_is_returned_unchanged() {
+        // Different defaults are returned independently of input.
+        assert_eq!(pioi("bad", 0), 0);
+        assert_eq!(pioi("bad", 999), 999);
+        assert_eq!(pioi("bad", -1), -1);
+        assert_eq!(pioi("bad", i64::MIN), i64::MIN);
+        assert_eq!(pioi("bad", i64::MAX), i64::MAX);
+    }
+
+    #[test]
+    fn parse_int_or_rejects_wrong_types_and_arity() {
+        assert!(
+            builtin_parse_int_or(&[Value::Int(1), Value::Int(0)])
+                .unwrap_err()
+                .contains("expected (string, int)")
+        );
+        assert!(
+            builtin_parse_int_or(&[Value::String("42".into())])
+                .unwrap_err()
+                .contains("expected 2 arguments")
         );
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1783,6 +1783,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Result),
             },
         );
+        // RES-529: non-erroring parse with fallback default.
+        env.set(
+            "parse_int_or".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::Int],
+                return_type: Box::new(Type::Int),
+            },
+        );
         env.set(
             "parse_float".to_string(),
             Type::Function {
@@ -4827,6 +4835,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "repeat",
         // RES-339: string parsing and formatting.
         "parse_int",
+        // RES-529: non-erroring parse with fallback default.
+        "parse_int_or",
         "parse_float",
         "char_at",
         "pad_left",


### PR DESCRIPTION
Closes #627

Adds `parse_int_or` — non-erroring base-10 parse with caller-supplied default.

- `parse_int_or("42", -1)` → 42
- `parse_int_or("not a number", -1)` → -1
- `parse_int_or(" -7 ", 0)` → -7 (trims whitespace, like parse_int)
- `parse_int_or("3.14", -1)` → -1 (strict integer parse)
- `parse_int_or("", -1)` → -1
- Pairs with parse_int (which returns a Result type)

Inline in main.rs next to parse_int. Four unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] valid / invalid inputs verified
- [x] whitespace trimming consistent with parse_int
- [x] default returned unchanged across i64 range incl. MIN/MAX
- [x] examples_golden passes