### PR TITLE
RES-530: add array_count_int(arr, pred) — named-predicate count

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-529-parse-int-or",
-      "claimed_at": "2026-04-30T02:43:46Z"
+      "branch": "res-530-array-count-int",
+      "claimed_at": "2026-04-30T02:46:48Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-529-parse-int-or",
-      "claimed_at": "2026-04-30T02:43:46Z"
+      "branch": "res-530-array-count-int",
+      "claimed_at": "2026-04-30T02:46:48Z"
     }
   }
 }

--- a/resilient/examples/array_count_int.expected.txt
+++ b/resilient/examples/array_count_int.expected.txt
@@ -1,0 +1,6 @@
+2
+3
+3
+3
+0
+Program executed successfully

--- a/resilient/examples/array_count_int.rz
+++ b/resilient/examples/array_count_int.rz
@@ -1,0 +1,12 @@
+// RES-530 demo: array_count_int counts integer elements satisfying
+// a named predicate (positive/negative/zero/nonzero/even/odd).
+
+fn main() {
+    println(array_count_int([1, -2, 3, -4, 5], "negative"));
+    println(array_count_int([1, -2, 3, -4, 5], "positive"));
+    println(array_count_int([1, 2, 3, 4, 5, 6], "even"));
+    println(array_count_int([0, 1, 0, 2, 0], "zero"));
+    println(array_count_int([], "positive"));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8396,6 +8396,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("array_any_int", builtin_array_any_int),
     // RES-501: named-predicate all/every on int arrays.
     ("array_all_int", builtin_array_all_int),
+    // RES-530: named-predicate count on int arrays.
+    ("array_count_int", builtin_array_count_int),
     // RES-485: |a - b|.
     ("abs_diff", builtin_abs_diff),
     // RES-486: (quotient, remainder) tuple.
@@ -10967,6 +10969,42 @@ fn builtin_array_all_int(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "array_all_int: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-530: `array_count_int(arr, pred)` — count integer elements
+/// satisfying the named predicate. Equivalent to
+/// `len(array_filter_int(arr, pred))` but without materialising the
+/// filtered array. Joins the RES-483 named-predicate family.
+fn builtin_array_count_int(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::String(kind)] => {
+            let pred = int_predicate_kind("array_count_int", kind)?;
+            let mut count: i64 = 0;
+            for v in items {
+                let n = match v {
+                    Value::Int(n) => *n,
+                    other => {
+                        return Err(format!(
+                            "array_count_int: expected all int elements, got {}",
+                            other
+                        ));
+                    }
+                };
+                if pred(n) {
+                    count += 1;
+                }
+            }
+            Ok(Value::Int(count))
+        }
+        [a, b] => Err(format!(
+            "array_count_int: expected (array, string), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_count_int: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -35577,6 +35615,78 @@ mod tests {
         );
         assert!(
             builtin_array_all_int(&[int_array(&[1])])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-530: array_count_int ----------
+
+    fn count_int(items: &[i64], pred: &str) -> i64 {
+        match builtin_array_count_int(&[int_array(items), Value::String(pred.into())]).unwrap() {
+            Value::Int(n) => n,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_count_int_basic() {
+        assert_eq!(count_int(&[1, -2, 3, -4, 5], "negative"), 2);
+        assert_eq!(count_int(&[1, -2, 3, -4, 5], "positive"), 3);
+        assert_eq!(count_int(&[1, 2, 3, 4], "even"), 2);
+        assert_eq!(count_int(&[1, 2, 3, 4], "odd"), 2);
+        assert_eq!(count_int(&[0, 1, 0, 2, 0], "zero"), 3);
+        assert_eq!(count_int(&[0, 1, 0, 2, 0], "nonzero"), 2);
+    }
+
+    #[test]
+    fn array_count_int_empty_is_zero() {
+        for kind in ["positive", "negative", "zero", "nonzero", "even", "odd"] {
+            assert_eq!(count_int(&[], kind), 0, "kind={}", kind);
+        }
+    }
+
+    #[test]
+    fn array_count_int_matches_filter_length() {
+        // Identity: array_count_int(arr, k) == len(array_filter_int(arr, k)).
+        for items in [
+            vec![1, 2, 3],
+            vec![-5, 0, 5],
+            vec![],
+            vec![100, 200, -300, 0, 0, 7],
+        ] {
+            for kind in ["positive", "negative", "zero", "even"] {
+                let cnt = count_int(&items, kind);
+                let filtered = match builtin_array_filter_int(&[
+                    int_array(&items),
+                    Value::String(kind.into()),
+                ])
+                .unwrap()
+                {
+                    Value::Array(out) => out.len() as i64,
+                    _ => panic!(),
+                };
+                assert_eq!(cnt, filtered, "items={:?} kind={}", items, kind);
+            }
+        }
+    }
+
+    #[test]
+    fn array_count_int_unknown_predicate_errors() {
+        let err =
+            builtin_array_count_int(&[int_array(&[1]), Value::String("xyz".into())]).unwrap_err();
+        assert!(err.contains("unknown predicate"), "got: {}", err);
+    }
+
+    #[test]
+    fn array_count_int_rejects_wrong_types_and_arity() {
+        assert!(
+            builtin_array_count_int(&[Value::Int(1), Value::String("positive".into())])
+                .unwrap_err()
+                .contains("expected (array, string)")
+        );
+        assert!(
+            builtin_array_count_int(&[int_array(&[1])])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1413,6 +1413,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Bool),
             },
         );
+        // RES-530: named-predicate count on int arrays.
+        env.set(
+            "array_count_int".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::String],
+                return_type: Box::new(Type::Int),
+            },
+        );
         // RES-485: |a - b|.
         env.set(
             "abs_diff".to_string(),
@@ -4713,6 +4721,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_any_int",
         // RES-501: named-predicate every.
         "array_all_int",
+        // RES-530: named-predicate count.
+        "array_count_int",
         "array_partition_int",
         // RES-485: abs_diff.
         "abs_diff",


### PR DESCRIPTION
Closes #629

Counts int elements satisfying named predicate. Joins the RES-483 named-predicate family.

- `array_count_int([1, -2, 3, -4, 5], "negative")` → 2
- `array_count_int([0, 1, 0, 2, 0], "zero")` → 3
- Identity: `array_count_int(arr, k) == len(array_filter_int(arr, k))` (verified)

Inline in main.rs next to array_filter_int / array_partition_int. Five unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] all six predicates verified
- [x] empty array returns 0
- [x] identity with array_filter_int verified across grid
- [x] examples_golden passes