### PR TITLE
RES-532: add parse_float_or(s, default) — non-erroring float parse

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-531-array-unzip",
-      "claimed_at": "2026-04-30T02:50:08Z"
+      "branch": "res-532-parse-float-or",
+      "claimed_at": "2026-04-30T02:53:07Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-531-array-unzip",
-      "claimed_at": "2026-04-30T02:50:08Z"
+      "branch": "res-532-parse-float-or",
+      "claimed_at": "2026-04-30T02:53:07Z"
     }
   }
 }

--- a/resilient/examples/parse_float_or.expected.txt
+++ b/resilient/examples/parse_float_or.expected.txt
@@ -1,0 +1,6 @@
+3.14
+-2.5
+-1
+0
+42
+Program executed successfully

--- a/resilient/examples/parse_float_or.rz
+++ b/resilient/examples/parse_float_or.rz
@@ -1,0 +1,11 @@
+// RES-532 demo: parse_float_or returns the parsed float or a fallback.
+
+fn main() {
+    println(parse_float_or("3.14", 0.0));
+    println(parse_float_or("-2.5", 0.0));
+    println(parse_float_or("not a num", -1.0));
+    println(parse_float_or("", 0.0));
+    println(parse_float_or("42", 0.0));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8525,6 +8525,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("parse_int", builtin_parse_int),
     // RES-529: non-erroring parse with fallback default.
     ("parse_int_or", builtin_parse_int_or),
+    // RES-532: non-erroring float parse with fallback default.
+    ("parse_float_or", builtin_parse_float_or),
     ("parse_float", builtin_parse_float),
     ("char_at", builtin_char_at),
     ("pad_left", builtin_pad_left),
@@ -13147,6 +13149,26 @@ fn builtin_parse_int_or(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "parse_int_or: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-532: `parse_float_or(s, default)` — non-erroring float parse.
+/// Returns the parsed float or `default` if `s` is not a valid
+/// float. Trims surrounding whitespace, matching `parse_float`
+/// (RES-339). Pairs with `parse_float` (which returns a Result).
+fn builtin_parse_float_or(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s), Value::Float(default)] => {
+            Ok(Value::Float(s.trim().parse::<f64>().unwrap_or(*default)))
+        }
+        [a, b] => Err(format!(
+            "parse_float_or: expected (string, float), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "parse_float_or: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -25312,6 +25334,55 @@ mod tests {
         );
         assert!(
             builtin_parse_int_or(&[Value::String("42".into())])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-532: parse_float_or ----------
+
+    fn pfof(s: &str, default: f64) -> f64 {
+        match builtin_parse_float_or(&[Value::String(s.into()), Value::Float(default)]).unwrap() {
+            Value::Float(n) => n,
+            other => panic!("expected Float, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_float_or_valid_inputs() {
+        assert!((pfof("1.5", 0.0) - 1.5).abs() < 1e-12);
+        assert!((pfof("-2.5", 0.0) + 2.5).abs() < 1e-12);
+        // Integer literal accepted by f64::from_str.
+        assert!((pfof("42", 0.0) - 42.0).abs() < 1e-12);
+        // Whitespace stripped.
+        assert!((pfof(" 1.5 ", 0.0) - 1.5).abs() < 1e-12);
+        assert_eq!(pfof("0", 99.0), 0.0);
+    }
+
+    #[test]
+    fn parse_float_or_invalid_returns_default() {
+        for s in &["", "abc", "12abc", "  ", "1.2.3"] {
+            assert_eq!(pfof(s, -1.0), -1.0, "s={:?}", s);
+        }
+    }
+
+    #[test]
+    fn parse_float_or_special_values_succeed() {
+        // Rust's f64::from_str accepts these.
+        assert!(pfof("inf", 0.0).is_infinite());
+        assert!(pfof("-inf", 0.0).is_infinite());
+        assert!(pfof("nan", 0.0).is_nan());
+    }
+
+    #[test]
+    fn parse_float_or_rejects_wrong_types_and_arity() {
+        assert!(
+            builtin_parse_float_or(&[Value::Int(1), Value::Float(0.0)])
+                .unwrap_err()
+                .contains("expected (string, float)")
+        );
+        assert!(
+            builtin_parse_float_or(&[Value::String("3.14".into())])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1801,6 +1801,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Int),
             },
         );
+        // RES-532: non-erroring float parse with fallback default.
+        env.set(
+            "parse_float_or".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::Float],
+                return_type: Box::new(Type::Float),
+            },
+        );
         env.set(
             "parse_float".to_string(),
             Type::Function {
@@ -4851,6 +4859,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "parse_int",
         // RES-529: non-erroring parse with fallback default.
         "parse_int_or",
+        // RES-532: non-erroring float parse with fallback default.
+        "parse_float_or",
         "parse_float",
         "char_at",
         "pad_left",


### PR DESCRIPTION
Closes #633

Symmetric to parse_int_or (RES-529). Returns parsed float or fallback default.

- `parse_float_or("3.14", 0.0)` → 3.14
- `parse_float_or("42", 0.0)` → 42.0 (integer literal accepted)
- `parse_float_or("not a num", -1.0)` → -1.0
- inf / nan parse successfully (f64::from_str semantics)

Inline in main.rs next to parse_int_or. Four unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] valid / invalid / special-value inputs verified
- [x] examples_golden passes