### PR TITLE
RES-535: add string_split_n(s, sep, n) — split with maximum splits limit

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-534-bit-byte",
-      "claimed_at": "2026-04-30T03:00:58Z"
+      "branch": "res-535-string-split-n",
+      "claimed_at": "2026-04-30T03:04:28Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-534-bit-byte",
-      "claimed_at": "2026-04-30T03:00:58Z"
+      "branch": "res-535-string-split-n",
+      "claimed_at": "2026-04-30T03:04:28Z"
     }
   }
 }

--- a/resilient/examples/string_split_n.expected.txt
+++ b/resilient/examples/string_split_n.expected.txt
@@ -1,0 +1,6 @@
+["a", "b", "c,d"]
+["k", "v=more"]
+["a,b,c"]
+["a", "b", "c"]
+["noseparator"]
+Program executed successfully

--- a/resilient/examples/string_split_n.rz
+++ b/resilient/examples/string_split_n.rz
@@ -1,0 +1,12 @@
+// RES-535 demo: string_split_n splits at most n times. Useful for
+// parsing key/value pairs and bounded delimited fields.
+
+fn main() {
+    println(string_split_n("a,b,c,d", ",", 2));
+    println(string_split_n("k=v=more", "=", 1));
+    println(string_split_n("a,b,c", ",", 0));
+    println(string_split_n("a,b,c", ",", 100));
+    println(string_split_n("noseparator", ",", 5));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8254,6 +8254,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("pop", builtin_pop),
     ("slice", builtin_slice),
     ("split", builtin_split),
+    // RES-535: split with a maximum number-of-splits limit.
+    ("string_split_n", builtin_string_split_n),
     ("trim", builtin_trim),
     ("contains", builtin_contains),
     ("to_upper", builtin_to_upper),
@@ -9295,6 +9297,43 @@ fn builtin_split(args: &[Value]) -> RResult<Value> {
             a, b
         )),
         _ => Err(format!("split: expected 2 arguments, got {}", args.len())),
+    }
+}
+
+/// RES-535: `string_split_n(s, sep, n)` — split `s` at most `n`
+/// times on `sep`, returning at most `n + 1` parts. The last
+/// element is the unsplit remainder. Useful for parsing key/value
+/// pairs (`split_n("k=v=more", "=", 1) -> ["k", "v=more"]`).
+/// Errors on empty separator and negative `n`.
+fn builtin_string_split_n(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s), Value::String(sep), Value::Int(n)] => {
+            if sep.is_empty() {
+                return Err("string_split_n: separator must not be empty".to_string());
+            }
+            if *n < 0 {
+                return Err(format!(
+                    "string_split_n: max splits must be non-negative, got {}",
+                    n
+                ));
+            }
+            // `splitn(k, sep)` produces at most `k` parts (so at most
+            // `k - 1` splits). Saturate to `usize::MAX` for huge n.
+            let parts_cap = (*n as usize).saturating_add(1);
+            Ok(Value::Array(
+                s.splitn(parts_cap, sep.as_str())
+                    .map(|p| Value::String(p.to_string()))
+                    .collect(),
+            ))
+        }
+        [a, b, c] => Err(format!(
+            "string_split_n: expected (string, string, int), got ({}, {}, {})",
+            a, b, c
+        )),
+        _ => Err(format!(
+            "string_split_n: expected 3 arguments, got {}",
+            args.len()
+        )),
     }
 }
 
@@ -25450,6 +25489,92 @@ mod tests {
             builtin_parse_float_or(&[Value::String("3.14".into())])
                 .unwrap_err()
                 .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-535: string_split_n ----------
+
+    fn split_n(s: &str, sep: &str, n: i64) -> Vec<String> {
+        match builtin_string_split_n(&[
+            Value::String(s.into()),
+            Value::String(sep.into()),
+            Value::Int(n),
+        ])
+        .unwrap()
+        {
+            Value::Array(parts) => parts
+                .into_iter()
+                .map(|v| match v {
+                    Value::String(s) => s,
+                    other => panic!("expected String, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_split_n_basic() {
+        assert_eq!(split_n("a,b,c,d", ",", 2), vec!["a", "b", "c,d"]);
+        assert_eq!(split_n("a,b,c,d", ",", 1), vec!["a", "b,c,d"]);
+        assert_eq!(split_n("a,b,c,d", ",", 3), vec!["a", "b", "c", "d"]);
+        assert_eq!(split_n("a,b,c,d", ",", 100), vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn string_split_n_zero_splits_returns_whole_string() {
+        assert_eq!(split_n("a,b,c", ",", 0), vec!["a,b,c"]);
+        assert_eq!(split_n("", ",", 0), vec![""]);
+    }
+
+    #[test]
+    fn string_split_n_no_separator_returns_singleton() {
+        assert_eq!(split_n("abc", "x", 5), vec!["abc"]);
+        assert_eq!(split_n("", "x", 5), vec![""]);
+    }
+
+    #[test]
+    fn string_split_n_canonical_pair_split() {
+        // Canonical use: parse "key=value=something" as ("key", "value=something").
+        assert_eq!(split_n("k=v", "=", 1), vec!["k", "v"]);
+        assert_eq!(split_n("k=v=more", "=", 1), vec!["k", "v=more"]);
+        assert_eq!(split_n("noequals", "=", 1), vec!["noequals"]);
+    }
+
+    #[test]
+    fn string_split_n_multichar_separator() {
+        assert_eq!(split_n("aa--bb--cc--dd", "--", 1), vec!["aa", "bb--cc--dd"]);
+    }
+
+    #[test]
+    fn string_split_n_rejects_empty_separator_and_negative_n() {
+        let err = builtin_string_split_n(&[
+            Value::String("abc".into()),
+            Value::String("".into()),
+            Value::Int(2),
+        ])
+        .unwrap_err();
+        assert!(err.contains("must not be empty"), "got: {}", err);
+        let err = builtin_string_split_n(&[
+            Value::String("abc".into()),
+            Value::String(",".into()),
+            Value::Int(-1),
+        ])
+        .unwrap_err();
+        assert!(err.contains("non-negative"), "got: {}", err);
+    }
+
+    #[test]
+    fn string_split_n_rejects_wrong_types_and_arity() {
+        assert!(
+            builtin_string_split_n(&[Value::Int(1), Value::String(",".into()), Value::Int(2)])
+                .unwrap_err()
+                .contains("expected (string, string, int)")
+        );
+        assert!(
+            builtin_string_split_n(&[Value::String("a".into()), Value::String(",".into())])
+                .unwrap_err()
+                .contains("expected 3 arguments")
         );
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1039,6 +1039,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Array),
             },
         );
+        // RES-535: split with a maximum number-of-splits limit.
+        env.set(
+            "string_split_n".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String, Type::Int],
+                return_type: Box::new(Type::Array),
+            },
+        );
         env.set(
             "trim".to_string(),
             Type::Function {
@@ -4602,6 +4610,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "pop",
         "slice",
         "split",
+        // RES-535: split with a maximum number-of-splits limit.
+        "string_split_n",
         "trim",
         "contains",
         "to_upper",


### PR DESCRIPTION
Closes #639

Splits at most n times, returning at most n+1 parts (last is the unsplit remainder).

- `string_split_n("a,b,c,d", ",", 2)` → `["a", "b", "c,d"]`
- `string_split_n("k=v=more", "=", 1)` → `["k", "v=more"]` (canonical pair)
- `string_split_n("a,b,c", ",", 0)` → `["a,b,c"]`
- Empty separator and negative n error

Backed by str::splitn(n+1, sep). Inline in main.rs next to split. Seven unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] zero / one / many / over-limit splits
- [x] empty separator / negative n rejected
- [x] multi-char separator
- [x] examples_golden passes