### PR TITLE
RES-541: add array_intersect / array_diff — set-like array operations

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-540-string-pad-center",
-      "claimed_at": "2026-04-30T03:21:53Z"
+      "branch": "res-541-array-set-ops",
+      "claimed_at": "2026-04-30T03:25:59Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-540-string-pad-center",
-      "claimed_at": "2026-04-30T03:21:53Z"
+      "branch": "res-541-array-set-ops",
+      "claimed_at": "2026-04-30T03:25:59Z"
     }
   }
 }

--- a/resilient/examples/array_intersect_diff.expected.txt
+++ b/resilient/examples/array_intersect_diff.expected.txt
@@ -1,0 +1,6 @@
+[2, 3]
+[1]
+[1, 1, 2, 2]
+[2, 2, 3]
+[]
+Program executed successfully

--- a/resilient/examples/array_intersect_diff.rz
+++ b/resilient/examples/array_intersect_diff.rz
@@ -1,0 +1,12 @@
+// RES-541 demo: array_intersect and array_diff — set-like ops
+// preserving order and duplicates from the first array.
+
+fn main() {
+    println(array_intersect([1, 2, 3], [2, 3, 4]));
+    println(array_diff([1, 2, 3], [2, 3, 4]));
+    println(array_intersect([1, 1, 2, 2, 3], [1, 2]));
+    println(array_diff([1, 1, 2, 2, 3], [1]));
+    println(array_intersect([], [1, 2]));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8278,6 +8278,9 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     // RES-418: element search over an array.
     ("array_contains", builtin_array_contains),
     ("array_index_of", builtin_array_index_of),
+    // RES-541: set-like operations on arrays.
+    ("array_intersect", builtin_array_intersect),
+    ("array_diff", builtin_array_diff),
     // RES-419: Unicode-scalar ↔ single-char string conversions.
     ("chr", builtin_chr),
     ("ord", builtin_ord),
@@ -13092,6 +13095,74 @@ fn builtin_array_contains(args: &[Value]) -> RResult<Value> {
         [a, _] => Err(format!("array_contains: expected array, got {}", a)),
         _ => Err(format!(
             "array_contains: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-541: shared "is this value present in `set`?" check used by
+/// `array_intersect` and `array_diff`. Errors with `name`-prefixed
+/// messages on non-comparable elements.
+fn array_member_of(name: &str, v: &Value, set: &[Value]) -> RResult<bool> {
+    for s in set {
+        match array_search_eq(v, s) {
+            Some(true) => return Ok(true),
+            Some(false) => {}
+            None => {
+                return Err(format!(
+                    "{}: element types not comparable ({} vs {})",
+                    name, v, s
+                ));
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// RES-541: `array_intersect(a, b)` — elements of `a` that also
+/// appear in `b`. Preserves order and duplicates from `a`. Uses
+/// scalar value-equality (`array_search_eq`).
+fn builtin_array_intersect(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(a), Value::Array(b)] => {
+            let mut out: Vec<Value> = Vec::new();
+            for v in a {
+                if array_member_of("array_intersect", v, b)? {
+                    out.push(v.clone());
+                }
+            }
+            Ok(Value::Array(out))
+        }
+        [a, b] => Err(format!(
+            "array_intersect: expected (array, array), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_intersect: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-541: `array_diff(a, b)` — elements of `a` not in `b`.
+/// Preserves order and duplicates from `a`.
+fn builtin_array_diff(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(a), Value::Array(b)] => {
+            let mut out: Vec<Value> = Vec::new();
+            for v in a {
+                if !array_member_of("array_diff", v, b)? {
+                    out.push(v.clone());
+                }
+            }
+            Ok(Value::Array(out))
+        }
+        [a, b] => Err(format!(
+            "array_diff: expected (array, array), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_diff: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -28791,6 +28862,100 @@ mod tests {
         );
         assert!(
             builtin_array_index_of(&[Value::Array(vec![])])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-541: array_intersect / array_diff ----------
+
+    fn intersect_int(a: &[i64], b: &[i64]) -> Vec<i64> {
+        match builtin_array_intersect(&[int_array(a), int_array(b)]).unwrap() {
+            Value::Array(out) => out
+                .into_iter()
+                .map(|v| match v {
+                    Value::Int(n) => n,
+                    other => panic!("expected Int, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    fn diff_int(a: &[i64], b: &[i64]) -> Vec<i64> {
+        match builtin_array_diff(&[int_array(a), int_array(b)]).unwrap() {
+            Value::Array(out) => out
+                .into_iter()
+                .map(|v| match v {
+                    Value::Int(n) => n,
+                    other => panic!("expected Int, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_intersect_basic() {
+        assert_eq!(intersect_int(&[1, 2, 3], &[2, 3, 4]), vec![2, 3]);
+        assert_eq!(intersect_int(&[1, 2], &[3, 4]), Vec::<i64>::new());
+        assert_eq!(intersect_int(&[], &[1, 2]), Vec::<i64>::new());
+        assert_eq!(intersect_int(&[1, 2, 3], &[]), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn array_intersect_preserves_dupes_from_a() {
+        // Duplicates from `a` are kept; duplicates in `b` are
+        // ignored (membership-based set semantics on b).
+        assert_eq!(
+            intersect_int(&[1, 1, 2, 2, 3, 3], &[1, 2]),
+            vec![1, 1, 2, 2]
+        );
+    }
+
+    #[test]
+    fn array_intersect_preserves_a_order() {
+        assert_eq!(intersect_int(&[5, 3, 1, 4, 2], &[1, 2, 3]), vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn array_diff_basic() {
+        assert_eq!(diff_int(&[1, 2, 3], &[2, 3, 4]), vec![1]);
+        assert_eq!(diff_int(&[1, 2, 3], &[]), vec![1, 2, 3]);
+        assert_eq!(diff_int(&[], &[1, 2]), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn array_diff_preserves_dupes_from_a() {
+        assert_eq!(diff_int(&[1, 1, 2, 2, 3], &[1]), vec![2, 2, 3]);
+        assert_eq!(diff_int(&[1, 1, 2, 2], &[2]), vec![1, 1]);
+    }
+
+    #[test]
+    fn array_intersect_diff_partition_a() {
+        // For any (a, b): array_intersect(a, b) and array_diff(a, b)
+        // partition `a` — intersect ∪ diff == a (after sort/dedup
+        // both back to multiset of a).
+        let a = vec![1, 2, 2, 3, 3, 3, 4];
+        let b = vec![2, 4];
+        let inter = intersect_int(&a, &b);
+        let diffr = diff_int(&a, &b);
+        let mut combined: Vec<i64> = inter.into_iter().chain(diffr).collect();
+        combined.sort();
+        let mut a_sorted = a.clone();
+        a_sorted.sort();
+        assert_eq!(combined, a_sorted);
+    }
+
+    #[test]
+    fn array_intersect_diff_reject_non_array_and_arity() {
+        assert!(
+            builtin_array_intersect(&[Value::Int(1), Value::Array(vec![])])
+                .unwrap_err()
+                .contains("expected (array, array)")
+        );
+        assert!(
+            builtin_array_diff(&[Value::Array(vec![])])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1115,6 +1115,9 @@ impl TypeChecker {
         // RES-418: element search.
         env.set("array_contains".to_string(), fn_any_any_to_any());
         env.set("array_index_of".to_string(), fn_any_any_to_any());
+        // RES-541: set-like operations on arrays.
+        env.set("array_intersect".to_string(), fn_any_any_to_any());
+        env.set("array_diff".to_string(), fn_any_any_to_any());
         // RES-419: Unicode-scalar ↔ char conversions.
         env.set(
             "chr".to_string(),
@@ -4668,6 +4671,9 @@ fn is_known_pure_builtin(name: &str) -> bool {
         // RES-418: array search.
         "array_contains",
         "array_index_of",
+        // RES-541: set-like operations on arrays.
+        "array_intersect",
+        "array_diff",
         // RES-419: char-code conversions.
         "chr",
         "ord",


### PR DESCRIPTION
Closes #651

Set-like operations on arrays using scalar value-equality (same as array_contains / array_dedup).

- `array_intersect([1, 2, 3], [2, 3, 4])` → `[2, 3]` (preserves a-order and a-dupes)
- `array_diff([1, 1, 2, 2, 3], [1])` → `[2, 2, 3]`
- Partition property: `sort(intersect(a, b) ++ diff(a, b)) == sort(a)` (verified)

Shared array_member_of helper. Inline in main.rs next to array_contains. Six unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] empty / no-overlap / dupe-preservation / order-preservation
- [x] partition property
- [x] examples_golden passes