### PR TITLE
RES-542: add array_union(a, b) — order-preserving global-dedup union

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-541-array-set-ops",
-      "claimed_at": "2026-04-30T03:25:59Z"
+      "branch": "res-542-array-union",
+      "claimed_at": "2026-04-30T03:28:45Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-541-array-set-ops",
-      "claimed_at": "2026-04-30T03:25:59Z"
+      "branch": "res-542-array-union",
+      "claimed_at": "2026-04-30T03:28:45Z"
     }
   }
 }

--- a/resilient/examples/array_union.expected.txt
+++ b/resilient/examples/array_union.expected.txt
@@ -1,0 +1,5 @@
+[1, 2, 3, 4, 5]
+[1, 2, 3]
+[1, 2]
+[5, 3, 1, 2, 4]
+Program executed successfully

--- a/resilient/examples/array_union.rz
+++ b/resilient/examples/array_union.rz
@@ -1,0 +1,11 @@
+// RES-542 demo: array_union concatenates a then b with global dedup.
+// Order-preserving: a-first, then new b-elements in b-order.
+
+fn main() {
+    println(array_union([1, 2, 3], [3, 4, 5]));
+    println(array_union([1, 1, 2], [2, 3]));
+    println(array_union([], [1, 2]));
+    println(array_union([5, 3, 1], [2, 3, 4]));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8281,6 +8281,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     // RES-541: set-like operations on arrays.
     ("array_intersect", builtin_array_intersect),
     ("array_diff", builtin_array_diff),
+    // RES-542: order-preserving global-dedup union.
+    ("array_union", builtin_array_union),
     // RES-419: Unicode-scalar ↔ single-char string conversions.
     ("chr", builtin_chr),
     ("ord", builtin_ord),
@@ -13163,6 +13165,32 @@ fn builtin_array_diff(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "array_diff: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-542: `array_union(a, b)` — concatenate `a` then `b`, removing
+/// duplicates globally. Order: `a` first, then new elements of `b`
+/// in their original order. Completes the set trio with
+/// `array_intersect` / `array_diff` (RES-541).
+fn builtin_array_union(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(a), Value::Array(b)] => {
+            let mut out: Vec<Value> = Vec::new();
+            for v in a.iter().chain(b.iter()) {
+                if !array_member_of("array_union", v, &out)? {
+                    out.push(v.clone());
+                }
+            }
+            Ok(Value::Array(out))
+        }
+        [a, b] => Err(format!(
+            "array_union: expected (array, array), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_union: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -28956,6 +28984,58 @@ mod tests {
         );
         assert!(
             builtin_array_diff(&[Value::Array(vec![])])
+                .unwrap_err()
+                .contains("expected 2 arguments")
+        );
+    }
+
+    // ---------- RES-542: array_union ----------
+
+    fn union_int(a: &[i64], b: &[i64]) -> Vec<i64> {
+        match builtin_array_union(&[int_array(a), int_array(b)]).unwrap() {
+            Value::Array(out) => out
+                .into_iter()
+                .map(|v| match v {
+                    Value::Int(n) => n,
+                    other => panic!("expected Int, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_union_basic() {
+        assert_eq!(union_int(&[1, 2, 3], &[3, 4, 5]), vec![1, 2, 3, 4, 5]);
+        assert_eq!(union_int(&[1, 1, 2], &[2, 3]), vec![1, 2, 3]);
+        assert_eq!(union_int(&[], &[1, 2]), vec![1, 2]);
+        assert_eq!(union_int(&[1, 2], &[]), vec![1, 2]);
+        assert_eq!(union_int(&[], &[]), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn array_union_preserves_a_order_then_b_extras() {
+        // a's first occurrence is preserved; only `b` items not yet
+        // in the result are appended in their b-order.
+        assert_eq!(union_int(&[5, 3, 1], &[2, 3, 4]), vec![5, 3, 1, 2, 4]);
+        // Already-deduped a unchanged when b adds nothing new.
+        assert_eq!(union_int(&[1, 2, 3], &[1, 2, 3]), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn array_union_globally_dedups() {
+        assert_eq!(union_int(&[1, 1, 1, 2, 2], &[2, 2, 3, 3]), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn array_union_rejects_non_array_and_arity() {
+        assert!(
+            builtin_array_union(&[Value::Int(1), Value::Array(vec![])])
+                .unwrap_err()
+                .contains("expected (array, array)")
+        );
+        assert!(
+            builtin_array_union(&[Value::Array(vec![])])
                 .unwrap_err()
                 .contains("expected 2 arguments")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1118,6 +1118,8 @@ impl TypeChecker {
         // RES-541: set-like operations on arrays.
         env.set("array_intersect".to_string(), fn_any_any_to_any());
         env.set("array_diff".to_string(), fn_any_any_to_any());
+        // RES-542: order-preserving global-dedup union.
+        env.set("array_union".to_string(), fn_any_any_to_any());
         // RES-419: Unicode-scalar ↔ char conversions.
         env.set(
             "chr".to_string(),
@@ -4674,6 +4676,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         // RES-541: set-like operations on arrays.
         "array_intersect",
         "array_diff",
+        // RES-542: order-preserving global-dedup union.
+        "array_union",
         // RES-419: char-code conversions.
         "chr",
         "ord",


### PR DESCRIPTION
Closes #653

Completes the set-like trio (intersect / diff / union, RES-541 + this).

- `array_union([1, 2, 3], [3, 4, 5])` → `[1, 2, 3, 4, 5]`
- `array_union([1, 1, 2], [2, 3])` → `[1, 2, 3]` (global dedup)
- `array_union([5, 3, 1], [2, 3, 4])` → `[5, 3, 1, 2, 4]` (a-order, then b-order extras)

Reuses array_member_of helper from RES-541. Inline in main.rs next to array_diff. Four unit tests + golden example pair.

## Test plan
- [x] cargo test, clippy, fmt all clean
- [x] basic / order-preserving / dedup / boundary cases
- [x] examples_golden passes