### PR TITLE
RES-545: add string_split_last(s, sep) — split on last separator

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/main.rs": {
-      "branch": "res-544-array-index-of-all",
-      "claimed_at": "2026-04-30T03:34:10Z"
+      "branch": "res-545-string-split-last",
+      "claimed_at": "2026-04-30T03:36:59Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-544-array-index-of-all",
-      "claimed_at": "2026-04-30T03:34:10Z"
+      "branch": "res-545-string-split-last",
+      "claimed_at": "2026-04-30T03:36:59Z"
     }
   }
 }

--- a/resilient/examples/string_split_last.expected.txt
+++ b/resilient/examples/string_split_last.expected.txt
@@ -1,0 +1,6 @@
+["foo/bar", "baz"]
+["file.tar", "gz"]
+["a,b,c", "d"]
+["noseparator"]
+["", ""]
+Program executed successfully

--- a/resilient/examples/string_split_last.rz
+++ b/resilient/examples/string_split_last.rz
@@ -1,0 +1,13 @@
+// RES-545 demo: string_split_last splits on the LAST occurrence of
+// the separator, returning [before, after]. Useful for paths
+// (split on last "/") and filenames (split on last ".").
+
+fn main() {
+    println(string_split_last("foo/bar/baz", "/"));
+    println(string_split_last("file.tar.gz", "."));
+    println(string_split_last("a,b,c,d", ","));
+    println(string_split_last("noseparator", ","));
+    println(string_split_last(",", ","));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8259,6 +8259,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("split", builtin_split),
     // RES-535: split with a maximum number-of-splits limit.
     ("string_split_n", builtin_string_split_n),
+    // RES-545: split on the last occurrence of the separator.
+    ("string_split_last", builtin_string_split_last),
     ("trim", builtin_trim),
     ("contains", builtin_contains),
     ("to_upper", builtin_to_upper),
@@ -9354,6 +9356,37 @@ fn builtin_string_split_n(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "string_split_n: expected 3 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-545: `string_split_last(s, sep)` — split `s` on the **last**
+/// occurrence of `sep`, returning a 2-element array
+/// `[before, after]`. If `sep` does not appear, returns `[s]`.
+/// Useful for splitting paths on the last "/" or filenames on the
+/// last ".". Counterpart to `string_split_n(s, sep, 1)` (RES-535)
+/// which splits on the first occurrence.
+fn builtin_string_split_last(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s), Value::String(sep)] => {
+            if sep.is_empty() {
+                return Err("string_split_last: separator must not be empty".to_string());
+            }
+            match s.rfind(sep.as_str()) {
+                Some(idx) => Ok(Value::Array(vec![
+                    Value::String(s[..idx].to_string()),
+                    Value::String(s[idx + sep.len()..].to_string()),
+                ])),
+                None => Ok(Value::Array(vec![Value::String(s.clone())])),
+            }
+        }
+        [a, b] => Err(format!(
+            "string_split_last: expected (string, string), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "string_split_last: expected 2 arguments, got {}",
             args.len()
         )),
     }
@@ -26022,6 +26055,74 @@ mod tests {
             builtin_string_split_n(&[Value::String("a".into()), Value::String(",".into())])
                 .unwrap_err()
                 .contains("expected 3 arguments")
+        );
+    }
+
+    // ---------- RES-545: string_split_last ----------
+
+    fn split_last(s: &str, sep: &str) -> Vec<String> {
+        match builtin_string_split_last(&[Value::String(s.into()), Value::String(sep.into())])
+            .unwrap()
+        {
+            Value::Array(parts) => parts
+                .into_iter()
+                .map(|v| match v {
+                    Value::String(s) => s,
+                    other => panic!("expected String, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_split_last_basic() {
+        assert_eq!(split_last("a,b,c,d", ","), vec!["a,b,c", "d"]);
+        assert_eq!(split_last("foo/bar/baz", "/"), vec!["foo/bar", "baz"]);
+        assert_eq!(split_last("file.tar.gz", "."), vec!["file.tar", "gz"]);
+    }
+
+    #[test]
+    fn string_split_last_no_separator_returns_singleton() {
+        assert_eq!(split_last("abc", "x"), vec!["abc"]);
+        assert_eq!(split_last("", "x"), vec![""]);
+    }
+
+    #[test]
+    fn string_split_last_separator_at_edges() {
+        // Trailing separator: empty after.
+        assert_eq!(split_last("a,b,", ","), vec!["a,b", ""]);
+        // Leading-only separator: empty before.
+        assert_eq!(split_last(",a", ","), vec!["", "a"]);
+        // Just the separator: both empty.
+        assert_eq!(split_last(",", ","), vec!["", ""]);
+    }
+
+    #[test]
+    fn string_split_last_multichar_separator() {
+        assert_eq!(split_last("aa--bb--cc", "--"), vec!["aa--bb", "cc"]);
+        assert_eq!(split_last("nope", "--"), vec!["nope"]);
+    }
+
+    #[test]
+    fn string_split_last_rejects_empty_separator() {
+        let err =
+            builtin_string_split_last(&[Value::String("abc".into()), Value::String("".into())])
+                .unwrap_err();
+        assert!(err.contains("must not be empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn string_split_last_rejects_wrong_types_and_arity() {
+        assert!(
+            builtin_string_split_last(&[Value::Int(1), Value::String(",".into())])
+                .unwrap_err()
+                .contains("expected (string, string)")
+        );
+        assert!(
+            builtin_string_split_last(&[Value::String("a".into())])
+                .unwrap_err()
+                .contains("expected 2 arguments")
         );
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1054,6 +1054,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Array),
             },
         );
+        // RES-545: split on the last occurrence of the separator.
+        env.set(
+            "string_split_last".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Array),
+            },
+        );
         env.set(
             "trim".to_string(),
             Type::Function {
@@ -4663,6 +4671,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "split",
         // RES-535: split with a maximum number-of-splits limit.
         "string_split_n",
+        // RES-545: split on the last occurrence of the separator.
+        "string_split_last",
         "trim",
         "contains",
         "to_upper",


### PR DESCRIPTION
## Summary

Adds `string_split_last(s, sep)` — split `s` on the **last** occurrence of `sep`, returning a 2-element array `[before, after]`. If `sep` does not appear in `s`, returns the singleton `[s]`.

Counterpart to `string_split_n(s, sep, 1)` (RES-535) which splits on the **first** occurrence. Common uses:

```rz
string_split_last("foo/bar/baz", "/")   // ["foo/bar", "baz"]      — directory + basename
string_split_last("file.tar.gz", ".")   // ["file.tar", "gz"]      — stem + extension
string_split_last("noseparator", ",")   // ["noseparator"]          — sep absent
```

## Implementation

- `builtin_string_split_last` in `resilient/src/main.rs` uses `str::rfind` and `str::len()` for the byte index — handles multi-byte UTF-8 correctly.
- Empty separator rejected with a clear error (matches `string_split_n` policy).
- Wrong-arity / wrong-type guards mirror `string_split_n`.
- Type signature `(string, string) -> array` seeded in `typechecker.rs` env + `PURE_BUILTINS` list.

## Tests

- 6 unit tests in `#[cfg(test)] mod tests` covering: basic happy path, missing separator, edge separators (leading / trailing / sep-only), multi-char separator, empty-sep rejection, type/arity rejection.
- Golden example pair `examples/string_split_last.{rz,expected.txt}` exercising path / extension / no-sep / sep-only cases.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked` — 1988 tests pass, 0 fail
- [x] `cargo test --locked --test examples_golden` — golden output matches

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)