### PR TITLE
docs: surface playground link prominently across the site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -34,8 +34,10 @@ search:
   rel_url: true
   button: false
 
-# Repo header link in the top right.
+# Header links in the top right.
 aux_links:
+  "🛝 Playground":
+    - "https://ericspencer.us/Resilient/playground/"
   "GitHub":
     - "https://github.com/EricSpencer00/Resilient"
 aux_links_new_tab: true

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,6 +20,15 @@ program, and picking the right backend for your workload.
 
 ---
 
+## Try without installing
+
+The fastest way to see Resilient run is the in-browser
+[**🛝 playground**](https://ericspencer.us/Resilient/playground/) —
+a WASM build of the compiler, no install required. Edit, run, and
+share examples directly from your browser.
+
+---
+
 ## Install
 
 The shipped CLI is **`rz`**. Three install paths, pick whichever

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,7 @@ Resilient is MIT-licensed. Contributions from humans and AI agents are equally w
 
 ## Where next?
 
+- **Try in your browser, no install** → [🛝 Playground ↗](https://ericspencer.us/Resilient/playground/)
 - **New here?** → [Getting Started](getting-started)
 - **Mission-critical example projects** → [Resilient-examples ↗](https://github.com/EricSpencer00/Resilient-examples) (pacemaker, infusion pump, ABS, traffic-light interlock, reactor monitor, CAN parser)
 - **Learn the syntax** → [Syntax Reference](syntax)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -41,7 +41,12 @@ Code blocks marked ```resilient are runnable as-is:
 resilient path/to/snippet.rz
 ```
 
-Copy-paste any one of them into a `.rz` file and run it.
+Copy-paste any one of them into a `.rz` file and run it. Or skip
+the install entirely and try them in the
+[**🛝 in-browser playground**](https://ericspencer.us/Resilient/playground/) —
+a WASM build of the compiler that runs Resilient code without
+leaving your browser.
+
 Install the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=fromamerica.resilient-vscode)
 for syntax highlighting and one-click run. See the
 [syntax reference]({{ site.baseurl }}/syntax) for the grammar.


### PR DESCRIPTION
## Summary

The docs site has been deploying the WASM playground at `/Resilient/playground/` since RES-507, but only the homepage hero CTA mentioned it. This PR lifts it to first-class status so visitors who land on any doc page can find it.

## Changes

- **docs/_config.yml** — add "🛝 Playground" to `aux_links` so it shows in the header on every page (alongside GitHub).
- **docs/getting-started.md** — add a "Try without installing" section at the top, before the install instructions.
- **docs/tutorial.md** — mention the playground in the "Conventions" section so readers copying snippets see the no-install option.
- **docs/index.md** — add the playground as the first entry of the "Where next?" list.

No URL change — the path is still `/Resilient/playground/`, which is what the docs.yml workflow has been deploying.

## Test plan

- [x] All docs paths use `/Resilient/playground/` (correct GitHub Pages base URL via `baseurl: "/Resilient"`)
- [x] aux_links syntax matches just-the-docs theme conventions
- [ ] After deploy, verify header link works on a deep page (e.g. `/Resilient/no-std`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)