### PR TITLE
RES-561: add array_cummin_int(arr) — running min

### DIFF
--- a/resilient/examples/array_cummin_int.expected.txt
+++ b/resilient/examples/array_cummin_int.expected.txt
@@ -1,0 +1,6 @@
+[3, 1, 1, 1, 1, 1, 1, 1]
+[5, 4, 3]
+[1, 1, 1]
+[42]
+[]
+Program executed successfully

--- a/resilient/examples/array_cummin_int.rz
+++ b/resilient/examples/array_cummin_int.rz
@@ -1,0 +1,12 @@
+// RES-561 demo: array_cummin_int returns the running minimum.
+// Companion to array_cummax_int (RES-560).
+
+fn main() {
+    println(array_cummin_int([3, 1, 4, 1, 5, 9, 2, 6]));
+    println(array_cummin_int([5, 4, 3]));
+    println(array_cummin_int([1, 2, 3]));
+    println(array_cummin_int([42]));
+    println(array_cummin_int([]));
+}
+
+main();

--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8301,6 +8301,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("array_cumsum_int", builtin_array_cumsum_int),
     // RES-560: running max.
     ("array_cummax_int", builtin_array_cummax_int),
+    // RES-561: running min.
+    ("array_cummin_int", builtin_array_cummin_int),
     // RES-503: index of max / min element (first-occurrence on ties).
     ("array_argmax_int", builtin_array_argmax_int),
     ("array_argmin_int", builtin_array_argmin_int),
@@ -13551,6 +13553,41 @@ fn builtin_array_min_or(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "array_min_or: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-561: `array_cummin_int(arr)` — running minimum. Companion
+/// to `array_cummax_int` (RES-560). Empty returns empty.
+fn builtin_array_cummin_int(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let mut acc: Option<i64> = None;
+            let mut out: Vec<Value> = Vec::with_capacity(items.len());
+            for v in items {
+                match v {
+                    Value::Int(n) => {
+                        let cur = match acc {
+                            Some(prev) => prev.min(*n),
+                            None => *n,
+                        };
+                        acc = Some(cur);
+                        out.push(Value::Int(cur));
+                    }
+                    other => {
+                        return Err(format!(
+                            "array_cummin_int: expected all int elements, got {}",
+                            other
+                        ));
+                    }
+                }
+            }
+            Ok(Value::Array(out))
+        }
+        [other] => Err(format!("array_cummin_int: expected array, got {}", other)),
+        _ => Err(format!(
+            "array_cummin_int: expected 1 argument, got {}",
             args.len()
         )),
     }
@@ -30421,6 +30458,78 @@ mod tests {
         );
         assert!(
             builtin_array_cummax_int(&[])
+                .unwrap_err()
+                .contains("expected 1 argument")
+        );
+    }
+
+    // ---------- RES-561: array_cummin_int ----------
+
+    fn cummin(xs: &[i64]) -> Vec<i64> {
+        match builtin_array_cummin_int(&[int_array(xs)]).unwrap() {
+            Value::Array(parts) => parts
+                .into_iter()
+                .map(|v| match v {
+                    Value::Int(n) => n,
+                    _ => panic!(),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_cummin_int_basic() {
+        assert_eq!(
+            cummin(&[3, 1, 4, 1, 5, 9, 2, 6]),
+            vec![3, 1, 1, 1, 1, 1, 1, 1]
+        );
+        assert_eq!(cummin(&[5, 4, 3]), vec![5, 4, 3]);
+        assert_eq!(cummin(&[1, 2, 3]), vec![1, 1, 1]);
+    }
+
+    #[test]
+    fn array_cummin_int_empty_or_single() {
+        assert_eq!(cummin(&[]), Vec::<i64>::new());
+        assert_eq!(cummin(&[42]), vec![42]);
+        assert_eq!(cummin(&[i64::MAX]), vec![i64::MAX]);
+    }
+
+    #[test]
+    fn array_cummin_int_handles_extremes() {
+        assert_eq!(
+            cummin(&[i64::MAX, 0, i64::MIN, 1]),
+            vec![i64::MAX, 0, i64::MIN, i64::MIN]
+        );
+    }
+
+    #[test]
+    fn array_cummin_int_last_element_equals_array_min() {
+        for arr in [vec![3, 1, 4], vec![-1, -2, -3], vec![42], vec![5, 1, 5]] {
+            let cm = cummin(&arr);
+            let last_cm = *cm.last().unwrap();
+            let m = match builtin_array_min(&[int_array(&arr)]).unwrap() {
+                Value::Int(n) => n,
+                _ => panic!(),
+            };
+            assert_eq!(last_cm, m, "mismatch for {:?}", arr);
+        }
+    }
+
+    #[test]
+    fn array_cummin_int_rejects_non_int_and_arity() {
+        assert!(
+            builtin_array_cummin_int(&[Value::Array(vec![Value::String("a".into())])])
+                .unwrap_err()
+                .contains("all int elements")
+        );
+        assert!(
+            builtin_array_cummin_int(&[Value::Int(1)])
+                .unwrap_err()
+                .contains("expected array")
+        );
+        assert!(
+            builtin_array_cummin_int(&[])
                 .unwrap_err()
                 .contains("expected 1 argument")
         );

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1208,6 +1208,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Array),
             },
         );
+        // RES-561: running min.
+        env.set(
+            "array_cummin_int".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Array),
+            },
+        );
         // RES-503: index of max/min element.
         env.set(
             "array_argmax_int".to_string(),
@@ -4833,6 +4841,8 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_cumsum_int",
         // RES-560: running max.
         "array_cummax_int",
+        // RES-561: running min.
+        "array_cummin_int",
         // RES-503: index of max/min int element.
         "array_argmax_int",
         "array_argmin_int",


### PR DESCRIPTION
## Summary

Adds `array_cummin_int(arr)` — running minimum. Companion to `array_cummax_int` (RES-560).

```rz
array_cummin_int([3, 1, 4, 1, 5, 9, 2, 6])   // [3, 1, 1, 1, 1, 1, 1, 1]
```

Last element equals `array_min(arr)` — checked by oracle test.

## Test plan
- [x] 5 unit tests including parity oracle
- [x] Golden example
- [x] cargo fmt / clippy / test clean

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)