### PR TITLE
RES-510: wire playground to real interpreter (PR 3/3) — closes #590

### DIFF
--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -22,6 +22,11 @@ wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-wasm-bindgen = "0.6"
+# RES-510 PR 3: real Resilient interpreter. The crate gates its
+# CLI-only deps (rustyline, notify) on `cfg(not(target_arch =
+# "wasm32"))` and pulls `getrandom`'s `js` feature on wasm32, so
+# this dep edge compiles cleanly to wasm32-unknown-unknown.
+resilient = { path = "../resilient" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # `js_sys::Date::now()` is the cheapest way to read a wall-clock in

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -1,4 +1,5 @@
-// RES-368: WASM-bindgen entry point for the Resilient web playground.
+// RES-368 / RES-510: WASM-bindgen entry point for the Resilient
+// web playground.
 //
 // Exposes `compile_and_run(source) -> JSON` so the browser can drive
 // the language without going through a server. The playground is a
@@ -7,10 +8,13 @@
 // and the playground value is the language semantics, not the
 // supporting tooling).
 //
-// Status: scaffold. The interpreter integration is deferred until
-// `resilient/Cargo.toml` exposes a library target — currently it is
-// `[[bin]]`-only (see comment at `resilient/Cargo.toml:138`). Tracked
-// in the PR description for #160.
+// RES-510 PR 3: previously a stub that echoed the source text. Now
+// calls into the real `resilient::run_program` interpreter — the lib
+// refactor (PR 1) and injectable stdout sink (PR 2) made that
+// possible. The CLI-only deps in `resilient` are cfg-gated on
+// `not(target_arch = "wasm32")`, so this crate compiles to
+// `wasm32-unknown-unknown` without dragging termios or fs-watcher
+// platform APIs in.
 
 #![allow(clippy::needless_pass_by_value)]
 
@@ -35,9 +39,9 @@ struct RunResult {
     /// Wall-clock milliseconds the run took, for the result pane's
     /// "ran in N ms" footer.
     duration_ms: f64,
-    /// Build flavor — `"stub"` until the interpreter integration
-    /// lands, then `"tree-walker"`. Surfaces to the UI so the
-    /// "scaffold" banner can hide once the real interpreter is wired.
+    /// Build flavor — `"tree-walker"` once the real interpreter is
+    /// wired (RES-510 PR 3). The page's "scaffold" banner hides
+    /// itself on any non-`"stub"` flavor.
     flavor: &'static str,
 }
 
@@ -45,11 +49,8 @@ struct RunResult {
 ///
 /// `source` is the editor buffer; `_input` is reserved for future
 /// stdin-style input (e.g. when the playground grows examples that
-/// read user keystrokes).
-///
-/// Today this is a stub that echoes the program text and surfaces a
-/// "scaffold" notice, so the page round-trip (editor → wasm → output)
-/// is verifiable end-to-end before the interpreter integration lands.
+/// read user keystrokes — `input()` calls today block on real
+/// stdin and won't return useful data inside the WASM sandbox).
 #[wasm_bindgen]
 pub fn compile_and_run(source: &str, _input: &str) -> JsValue {
     let started = now_ms();
@@ -60,13 +61,23 @@ pub fn compile_and_run(source: &str, _input: &str) -> JsValue {
         stderr: result.stderr,
         exit_code: result.exit_code,
         duration_ms: elapsed,
-        flavor: "stub",
+        flavor: "tree-walker",
     };
     serde_wasm_bindgen::to_value(&payload).unwrap_or(JsValue::NULL)
 }
 
 /// `compile_and_run` implementation, factored out so it can be
 /// exercised from native `cargo test` without touching `JsValue`.
+///
+/// Calls `resilient::run_program` (RES-510 PR 2) which captures
+/// stdout into a buffer and returns parser / runtime errors as a
+/// flat list of human-readable lines. The mapping into the
+/// `InnerResult` shape is intentionally narrow:
+///
+/// * `ok == true`  → `exit_code = 0`, stderr `None`.
+/// * `ok == false` → `exit_code = 1`, errors joined with newlines
+///   into stderr. Any partial stdout (lines printed before a
+///   runtime error) flows through unchanged.
 fn run_inner(source: &str) -> InnerResult {
     if source.trim().is_empty() {
         return InnerResult {
@@ -76,19 +87,19 @@ fn run_inner(source: &str) -> InnerResult {
         };
     }
 
-    let preview = source.lines().take(5).collect::<Vec<_>>().join("\n");
-    let stdout = format!(
-        "[playground scaffold — interpreter integration pending]\n\
-         received {} bytes; first {} line(s):\n\
-         {}\n",
-        source.len(),
-        source.lines().take(5).count(),
-        preview
-    );
-    InnerResult {
-        stdout,
-        stderr: None,
-        exit_code: 0,
+    let result = resilient::run_program(source);
+    if result.ok {
+        InnerResult {
+            stdout: result.stdout,
+            stderr: None,
+            exit_code: 0,
+        }
+    } else {
+        InnerResult {
+            stdout: result.stdout,
+            stderr: Some(result.errors.join("\n")),
+            exit_code: 1,
+        }
     }
 }
 
@@ -98,11 +109,11 @@ struct InnerResult {
     exit_code: i32,
 }
 
-/// Library version string (e.g. `"0.1.0-stub"`) so the page banner
-/// can pin a build to a known scaffold version when filing bugs.
+/// Library version string (e.g. `"0.1.0-tree-walker"`) so the page
+/// banner can pin a build to a known version when filing bugs.
 #[wasm_bindgen]
 pub fn playground_version() -> String {
-    format!("{}-stub", env!("CARGO_PKG_VERSION"))
+    format!("{}-tree-walker", env!("CARGO_PKG_VERSION"))
 }
 
 /// Best-effort wall-clock millisecond timer. Uses
@@ -135,11 +146,59 @@ mod tests {
     }
 
     #[test]
-    fn nonempty_source_is_echoed_with_scaffold_marker() {
-        let r = run_inner("fn main() { println(\"hi\"); }");
-        assert_eq!(r.exit_code, 0);
+    fn whitespace_only_is_also_empty() {
+        let r = run_inner("   \n\t\n");
+        assert_eq!(r.exit_code, 2);
+    }
+
+    #[test]
+    fn hello_world_runs_through_real_interpreter() {
+        let r = run_inner(r#"println("Hello, Resilient world!");"#);
+        assert_eq!(r.exit_code, 0, "stderr: {:?}", r.stderr);
         assert!(r.stderr.is_none());
-        assert!(r.stdout.contains("playground scaffold"));
-        assert!(r.stdout.contains("first 1 line(s)"));
+        assert_eq!(r.stdout, "Hello, Resilient world!\n");
+    }
+
+    #[test]
+    fn arithmetic_evaluates_and_prints() {
+        let r = run_inner(
+            r#"
+            let x = 40;
+            let y = x + 2;
+            println(y);
+            "#,
+        );
+        assert_eq!(r.exit_code, 0, "stderr: {:?}", r.stderr);
+        assert_eq!(r.stdout, "42\n");
+    }
+
+    #[test]
+    fn parser_error_surfaces_in_stderr() {
+        let r = run_inner("let x = ;");
+        assert_eq!(r.exit_code, 1);
+        let msg = r.stderr.expect("expected stderr");
+        assert!(!msg.is_empty(), "stderr was empty");
+        assert!(r.stdout.is_empty());
+    }
+
+    #[test]
+    fn runtime_error_keeps_partial_stdout() {
+        let r = run_inner(
+            r#"
+            println("before");
+            let x = 1 / 0;
+            println("after");
+            "#,
+        );
+        assert_eq!(r.exit_code, 1);
+        assert!(r.stdout.contains("before"), "stdout: {:?}", r.stdout);
+        assert!(!r.stdout.contains("after"));
+        assert!(r.stderr.is_some());
+    }
+
+    #[test]
+    fn version_string_is_no_longer_stub() {
+        let v = playground_version();
+        assert!(v.ends_with("-tree-walker"), "version: {}", v);
     }
 }

--- a/resilient/Cargo.lock
+++ b/resilient/Cargo.lock
@@ -835,8 +835,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1678,6 +1680,7 @@ dependencies = [
  "cranelift-native",
  "criterion",
  "ed25519-dalek",
+ "getrandom 0.2.17",
  "insta",
  "libloading",
  "logos",

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -102,7 +102,6 @@ resilient-runtime = { path = "../resilient-runtime" }
 clap = { version = "4.4", features = ["derive"] }
 libloading = { version = "0.8", optional = true }
 logos = { version = "0.14", optional = true }
-rustyline = "12.0.0"
 z3 = { version = "0.12", optional = true }
 tower-lsp = { version = "0.20", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std"], optional = true }
@@ -114,12 +113,6 @@ cranelift-module = { version = "0.108", optional = true }
 # doesn't widen the default build's dep tree; activate with
 # `--features proptest`.
 proptest = { version = "1", optional = true }
-# RES-228: `--watch` mode — cross-platform file watcher with 200ms debounce.
-# Both crates are unconditional so the CLI flag is always available; the
-# overhead is minimal (< 1 ms on the hot path) because the watcher thread
-# only starts when --watch is actually passed.
-notify = { version = "8", features = ["macos_fsevent"] }
-notify-debouncer-mini = "0.7"
 # RES-194: Ed25519 signatures on RES-071 verification certificates.
 # `rand_core` brings in the OS RNG we use for keypair generation
 # in the test helpers (see `resilient/src/cert_sign.rs`).
@@ -132,6 +125,31 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 # tree for correctness.
 sha2 = "0.10"
 serde_json = "1"
+
+# RES-510 PR 3: deps that are CLI-only and don't compile to wasm32
+# (or aren't useful there). Moved out of the unconditional
+# `[dependencies]` block so the WASM playground can pull `resilient`
+# in as a library without dragging termios / inotify / fsevent in.
+#
+# - rustyline: REPL line editor; uses termios + ncurses-shaped APIs.
+# - notify, notify-debouncer-mini: file watcher for `--watch` mode;
+#   uses platform-specific fs notification (inotify / kqueue /
+#   ReadDirectoryChangesW / FSEvents), none of which are available
+#   in the wasm32-unknown-unknown sandbox.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rustyline = "12.0.0"
+notify = { version = "8", features = ["macos_fsevent"] }
+notify-debouncer-mini = "0.7"
+
+# RES-510 PR 3: WASM-only dep edges. `getrandom` is a transitive of
+# `rand_core` (via `ed25519-dalek`); on `wasm32-unknown-unknown` it
+# needs the `js` feature to call `crypto.getRandomValues` through
+# `wasm-bindgen`. Without this feature, `cargo build --target
+# wasm32-unknown-unknown` aborts during getrandom's compile step.
+# We promote getrandom to a direct dep on wasm32 only, so the
+# native build's transitive resolution stays untouched.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 # RES-200: snapshot tests for diagnostic rendering. Test-only dep —

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -12,7 +12,16 @@ mod bytecode;
 mod compiler;
 mod const_fold;
 mod disasm;
+// RES-510 PR 3: REPL is CLI-only — uses rustyline (termios) which
+// doesn't compile to wasm32. Gated so the playground can depend on
+// the lib without dragging it in.
+#[cfg(not(target_arch = "wasm32"))]
+mod repl;
+// RES-510 PR 3: file watcher for `--watch` mode. Same reason — uses
+// platform fs-notification APIs (inotify / FSEvents / ...).
 mod imports;
+#[cfg(not(target_arch = "wasm32"))]
+mod watch_mode;
 // RES-510 PR 2: injectable stdout sink. The `print` / `println` /
 // `input`-prompt builtins route through this so non-CLI consumers
 // (the WASM playground, in-process test harnesses) can capture
@@ -25,7 +34,6 @@ mod jit_backend;
 mod lsp_server;
 pub mod output_sink;
 mod peephole;
-mod repl;
 mod span;
 mod typechecker;
 #[cfg(feature = "z3")]
@@ -212,10 +220,6 @@ mod modules;
 // A post-parse lowering pass fills in omitted trailing arguments with
 // their declared default expressions before the interpreter runs.
 mod default_params;
-// RES-228: `rz --watch <file>` — re-run on every save with a 200 ms
-// debounce. All watch logic lives in this module; main.rs only adds the
-// `mod` declaration and the dispatch call just before `execute_file`.
-mod watch_mode;
 // RES-289 (RES-81): generic type parameters — `fn identity<T>(x: T) -> T`.
 // Parse-time support (Token::Less/Greater reuse, parse_optional_type_params,
 // Node::Function::type_params field) lives in main.rs; this module owns the
@@ -247,7 +251,10 @@ mod traits;
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
 
+// RES-510 PR 3: rustyline is CLI-only (termios — no wasm32 build).
+#[cfg(not(target_arch = "wasm32"))]
 use rustyline::error::ReadlineError;
+#[cfg(not(target_arch = "wasm32"))]
 use rustyline::{DefaultEditor, Result as RustylineResult};
 
 // Token types for our lexer
@@ -18870,6 +18877,8 @@ impl Interpreter {
 
 // REPL for interactive evaluation.
 // Kept as a reference implementation; the actual REPL used is `repl::EnhancedREPL`.
+// RES-510 PR 3: gated on non-wasm because it depends on rustyline.
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(dead_code)]
 fn start_repl() -> RustylineResult<()> {
     let mut interpreter = Interpreter::new();
@@ -21407,6 +21416,11 @@ pub fn run_program(src: &str) -> RunResult {
 /// shim that calls into here; non-CLI consumers (the WASM playground,
 /// future LSP refactor, integration test harnesses) can depend on
 /// `resilient` as a library and skip the CLI entirely.
+///
+/// CLI-only because it pulls in `repl` (rustyline) and `watch_mode`
+/// (notify), neither of which builds for `wasm32-unknown-unknown`.
+/// WASM consumers use `run_program` instead.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn run_cli() {
     // Get command line arguments
     let args: Vec<String> = env::args().collect();


### PR DESCRIPTION
## Summary

Final piece of the playground integration. The `[playground scaffold — interpreter integration pending]` banner is now gone: the WASM playground actually runs Resilient programs end-to-end.

```
cargo test (playground native):
  test tests::hello_world_runs_through_real_interpreter ... ok
  test tests::arithmetic_evaluates_and_prints ... ok
  test tests::parser_error_surfaces_in_stderr ... ok
  test tests::runtime_error_keeps_partial_stdout ... ok
  test tests::version_string_is_no_longer_stub ... ok
  ...
  test result: ok. 7 passed
```

## Changes

### `resilient` (the lib crate)

- **Cargo.toml**: split CLI-only deps (rustyline, notify, notify-debouncer-mini) into a `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` block, and add a wasm32-only `getrandom = { features = ["js"] }` to satisfy ed25519-dalek's transitive RNG dep.
- **lib.rs**: cfg-gate `mod repl;`, `mod watch_mode;`, the rustyline `use` lines, the dead-code `start_repl` helper, and `pub fn run_cli` itself behind `cfg(not(target_arch = "wasm32"))`. Result: `cargo build --target wasm32-unknown-unknown --release` succeeds.

### `playground` (the WASM crate)

- **Cargo.toml**: add `resilient = { path = "../resilient" }`. The cfg gates upstream make this dep edge clean for wasm32.
- **src/lib.rs**: replace the stub `run_inner` with a call to `resilient::run_program` (PR 2's API). Mapping: `ok=true` → exit 0 / no stderr; `ok=false` → exit 1 / joined errors / partial captured stdout.
- **flavor**: `"stub"` → `"tree-walker"`. The JS banner-hide logic already keys off the version string ending; banner stays hidden.
- 7 native tests including end-to-end `Hello, Resilient world!`.

## Acceptance criteria from #590

- [x] `playground/src/lib.rs` calls `resilient::run_program(src)` (real interpreter, not a stub).
- [x] `playground_version()` returns a non-`-stub` flavor; page banner stays hidden.
- [x] `examples/hello.rz` prints "Hello, Resilient world!" — verified by `hello_world_runs_through_real_interpreter` test.
- [x] Bundled examples produce the same output as `rz` natively (shared interpreter; the existing `examples_golden` test validates parity in `cargo test`).
- [x] `playground/build.sh --check-size` passes: resilient → wasm32 produces 1.04 MiB raw / **289 KiB gzip**, well under the 2 MiB budget. wasm-pack's wasm-opt pass typically shrinks this further.

## Out of scope (deferred)

- Running the resilient test suite against the wasm32 build target. Native coverage exercises the same code paths.
- Stdin support — `input()` builtin's prompt routes through the sink correctly but there's no real stdin in the sandbox. JS-side input pane is a separate ticket.
- Dead-code-elimination tuning to shrink the WASM further. Far enough under budget that this isn't pressing.
- Visibility audit of the `pub` surface beyond `run_program` and `run_cli`.

## Test plan

- [x] `cargo build --locked` (resilient native) clean
- [x] `cargo test --locked` (resilient native): 2145 lib + every integration test pass
- [x] `cargo build --target wasm32-unknown-unknown --release` (resilient lib + playground) clean
- [x] `cargo test` (playground native): 7 pass
- [x] `cargo clippy --locked --all-targets -- -D warnings` clean for both crates
- [x] `cargo fmt --check` clean for both crates
- [x] WASM blob: 1.04 MiB raw, 289 KiB gzip — well under 2 MiB budget

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)