### PR TITLE
RES-403: first-class function values — closes #366

### DIFF
--- a/resilient/examples/first_class_fn_anon.expected.txt
+++ b/resilient/examples/first_class_fn_anon.expected.txt
@@ -1,0 +1,3 @@
+21
+81
+Program executed successfully

--- a/resilient/examples/first_class_fn_anon.rz
+++ b/resilient/examples/first_class_fn_anon.rz
@@ -1,0 +1,20 @@
+// RES-403: first-class function values — anonymous-literal test.
+//
+// Demonstrates the third acceptance criterion: anonymous function
+// literals can be passed inline to a higher-order function.
+
+fn apply(fn(int) -> int f, int x) -> int {
+    return f(x);
+}
+
+fn main() -> int {
+    let triple = fn(int x) -> int { return x * 3; };
+    println(apply(triple, 7));
+
+    let square = fn(int x) -> int { return x * x; };
+    println(apply(square, 9));
+
+    return 0;
+}
+
+main();

--- a/resilient/examples/first_class_fn_pass.expected.txt
+++ b/resilient/examples/first_class_fn_pass.expected.txt
@@ -1,0 +1,3 @@
+10
+42
+Program executed successfully

--- a/resilient/examples/first_class_fn_pass.rz
+++ b/resilient/examples/first_class_fn_pass.rz
@@ -1,0 +1,21 @@
+// RES-403: first-class function values — pass-as-arg test.
+//
+// `apply` takes a `fn(int) -> int` and an int, returns the result of
+// calling the function on the int. The named function `double` is
+// passed by reference.
+
+fn double(int x) -> int {
+    return x * 2;
+}
+
+fn apply(fn(int) -> int f, int x) -> int {
+    return f(x);
+}
+
+fn main() -> int {
+    println(apply(double, 5));
+    println(apply(double, 21));
+    return 0;
+}
+
+main();

--- a/resilient/examples/first_class_fn_return.expected.txt
+++ b/resilient/examples/first_class_fn_return.expected.txt
@@ -1,0 +1,3 @@
+14
+-7
+Program executed successfully

--- a/resilient/examples/first_class_fn_return.rz
+++ b/resilient/examples/first_class_fn_return.rz
@@ -1,0 +1,25 @@
+// RES-403: first-class function values — return-from-fn test.
+//
+// `pick` returns one of two functions based on a flag; the caller
+// stores it in a `let` and invokes it through the binding.
+
+fn double(int x) -> int { return x * 2; }
+fn negate(int x) -> int { return 0 - x; }
+
+fn pick(bool want_double) -> fn(int) -> int {
+    if want_double {
+        return double;
+    } else {
+        return negate;
+    }
+}
+
+fn main() -> int {
+    let f = pick(true);
+    let g = pick(false);
+    println(f(7));
+    println(g(7));
+    return 0;
+}
+
+main();

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -3944,6 +3944,57 @@ impl Parser {
                 // typed representation.
                 Some(format!("[{}; {}]", elem, len))
             }
+            // RES-403: function-type annotation
+            // `fn(T1, T2, ...) -> R`. Encoded into the single-string
+            // type slot as `fn(T1, T2) -> R`. The typechecker accepts
+            // any callable for now (Value::Function already exists);
+            // future work narrows this to verify parameter / return
+            // arities at the call site.
+            Token::Function => {
+                self.next_token(); // skip `fn`
+                if self.current_token != Token::LeftParen {
+                    let tok = self.current_token.clone();
+                    self.record_error(format!(
+                        "Expected '(' after `fn` in type annotation {}, found {}",
+                        ctx, tok
+                    ));
+                    return None;
+                }
+                self.next_token(); // skip `(`
+                let mut params: Vec<String> = Vec::new();
+                while self.current_token != Token::RightParen && self.current_token != Token::Eof {
+                    let p = self.parse_type_annotation(ctx)?;
+                    params.push(p);
+                    if self.current_token == Token::Comma {
+                        self.next_token();
+                    } else if self.current_token != Token::RightParen {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected ',' or ')' in `fn(...)` type annotation {}, found {}",
+                            ctx, tok
+                        ));
+                        return None;
+                    }
+                }
+                if self.current_token != Token::RightParen {
+                    let tok = self.current_token.clone();
+                    self.record_error(format!(
+                        "Expected ')' to close `fn(...)` type annotation {}, found {}",
+                        ctx, tok
+                    ));
+                    return None;
+                }
+                self.next_token(); // skip `)`
+                // Optional `-> Ret`. Bare `fn(...)` (no return) is
+                // equivalent to `fn(...) -> void`.
+                let ret = if self.current_token == Token::Arrow {
+                    self.next_token(); // skip `->`
+                    self.parse_type_annotation(ctx)?
+                } else {
+                    "void".to_string()
+                };
+                Some(format!("fn({}) -> {}", params.join(", "), ret))
+            }
             _ => {
                 let tok = self.current_token.clone();
                 self.record_error(format!("Expected type name {}, found {}", ctx, tok));


### PR DESCRIPTION
## Summary

The interpreter already had `Value::Function` and the parser already accepted anonymous `fn(int x) -> int { ... }` literals + `let f = some_fn;` references. The missing piece was just the **type-annotation surface**: writing `fn apply(fn(int) -> int f, int x)` failed at parse time because `parse_type_annotation` didn't recognize `fn` as the start of a type.

This PR adds that one missing arm. The result is full first-class function support per the issue's three acceptance criteria.

## Three golden tests (per the ticket)

- `first_class_fn_pass.rz` — pass-as-arg
- `first_class_fn_return.rz` — return-from-fn
- `first_class_fn_anon.rz` — anonymous-literal-call

All checked by the existing `examples_golden` test runner.

## Why the diff is small

Calls through a function value already went through the same dispatch as direct calls (Value::Function predated this feature for FFI callbacks). Only the type surface was missing.

Closures with capture remain out of scope per the ticket (tracked under RES-164c/d JIT closure capture).

## Test plan

- [x] cargo build / test / clippy / fmt clean
- [x] 3 new golden examples
- [x] All 2167 lib tests pass

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)