### PR TITLE
RES-406: volatile MMIO + unsafe block (impl PRs 1-2/5) — refs #369

### DIFF
--- a/resilient/examples/unsafe_block_smoke.expected.txt
+++ b/resilient/examples/unsafe_block_smoke.expected.txt
@@ -1,0 +1,2 @@
+unsafe block parses; volatile intrinsics are reachable
+Program executed successfully

--- a/resilient/examples/unsafe_block_smoke.rz
+++ b/resilient/examples/unsafe_block_smoke.rz
@@ -1,0 +1,25 @@
+// RES-406: `unsafe { ... }` block + volatile MMIO intrinsics.
+//
+// Demonstrates the parser-level surface and the capability gate:
+// volatile_* calls inside `unsafe` parse and run; outside, they
+// would be a compile-time error (covered by unsafe_check tests).
+//
+// This example doesn't touch a real device — that requires a
+// known peripheral address. The unit tests in src/volatile.rs
+// exercise the round-trip semantics against a host-allocated
+// buffer.
+
+fn main() -> int {
+    unsafe {
+        // The eight intrinsics are visible inside `unsafe`:
+        //   volatile_read_u8 / _u16 / _u32 / _u64
+        //   volatile_write_u8 / _u16 / _u32 / _u64
+        // A real driver would target an MMIO address like
+        // 0x4002_1000 (STM32 RCC) and operate on its register
+        // shape per the chip datasheet.
+        println("unsafe block parses; volatile intrinsics are reachable");
+    }
+    return 0;
+}
+
+main();

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1200,6 +1200,8 @@ fn node_line(n: &Node) -> Option<u32> {
         Node::TraitDecl { span, .. } => span.start.line as u32,
         // RES-400 PR 1: enum declarations carry a span.
         Node::EnumDecl { span, .. } => span.start.line as u32,
+        // RES-406: unsafe block carries the keyword's span.
+        Node::UnsafeBlock { span, .. } => span.start.line as u32,
     };
     if line == 0 { None } else { Some(line) }
 }

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -232,6 +232,12 @@ impl Formatter {
                 self.write(&format!("type {} = {};", name, target));
                 self.newline();
             }
+            // RES-406: re-emit `unsafe { ... }`. The body is a regular
+            // block; we just prepend the keyword.
+            Node::UnsafeBlock { body, .. } => {
+                self.write("unsafe ");
+                self.fmt_stmt(body);
+            }
             // RES-400 PR 1: re-emit a payload-less enum declaration.
             // PR 2 will extend this with payload kinds (named-field
             // and tuple-style); the format follows Rust convention so
@@ -1109,6 +1115,7 @@ impl Formatter {
             | Node::SupervisorDecl { .. }
             | Node::TraitDecl { .. }
             | Node::EnumDecl { .. }
+            | Node::UnsafeBlock { .. }
             | Node::Program(_) => {
                 self.fmt_stmt(node);
             }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -495,6 +495,9 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
         // RES-400 PR 1: enum declarations are pure data (variant names
         // only at this stage); no free variables either.
         Node::EnumDecl { .. } => {}
+        // RES-406: unsafe block — descend into the body so its free
+        // variables flow up to the enclosing scope.
+        Node::UnsafeBlock { body, .. } => walk(body, bound, free),
     }
 }
 

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -40,7 +40,16 @@ mod span;
 // constructor expressions, exhaustive `match`, and the typechecker
 // integration.
 mod sum_types;
+// RES-406: volatile MMIO intrinsics. The eight `volatile_read_*` /
+// `volatile_write_*` builtins live here; the `unsafe { … }` gate
+// (capability check at typecheck time) is in the typechecker
+// extension block.
+mod volatile;
+// RES-406: capability gate for the volatile intrinsics. Walks the
+// program AST after parse and rejects any `volatile_*` call
+// outside an `unsafe { ... }` block.
 mod typechecker;
+mod unsafe_check;
 #[cfg(feature = "z3")]
 mod verifier_z3;
 // RES-390: distributed-invariant verifier — a joint Z3 state
@@ -403,6 +412,10 @@ enum Token {
     /// variants only; payload variants and exhaustive `match` follow in
     /// later PRs.
     Enum,
+    /// RES-406: `unsafe { ... }` — capability gate for privileged
+    /// operations like `volatile_read_u32` / `volatile_write_u32` that
+    /// can't be reached from a regular block.
+    Unsafe,
     // </EXTENSION_TOKENS>
 
     // Literals
@@ -541,6 +554,7 @@ impl Token {
             Token::Supervisor => "`supervisor`".to_string(),
             Token::Trait => "`trait`".to_string(),
             Token::Enum => "`enum`".to_string(),
+            Token::Unsafe => "`unsafe`".to_string(),
             Token::Underscore => "`_`".to_string(),
             Token::Default => "`default`".to_string(),
             Token::Dot => "`.`".to_string(),
@@ -999,6 +1013,7 @@ impl Lexer {
                         "supervisor" => Token::Supervisor,
                         "trait" => Token::Trait,
                         "enum" => Token::Enum,
+                        "unsafe" => Token::Unsafe,
                         // </EXTENSION_KEYWORDS>
                         "_" => Token::Underscore,
                         // RES-163: `default` is a reserved alias
@@ -2198,6 +2213,17 @@ enum Node {
         value: Box<Node>,
         span: span::Span,
     },
+    /// RES-406: capability-gated block.
+    ///
+    /// `unsafe { ... }` lifts the typechecker's gate on calls to
+    /// the volatile MMIO intrinsics (and, future, raw-pointer ops).
+    /// At runtime it's identical to a regular block — the body is
+    /// evaluated as a sequence of statements. The capability check
+    /// happens during typechecking: a call to `volatile_read_u32`
+    /// (or any of the eight intrinsics) outside an enclosing
+    /// `UnsafeBlock` is rejected with a compile-time error pointing
+    /// at the suggested fix (`unsafe { ... }`).
+    UnsafeBlock { body: Box<Node>, span: span::Span },
     /// RES-400: sum-type declaration. PR 1 covers the parser scaffold
     /// for payload-less variants only:
     ///
@@ -2553,6 +2579,7 @@ impl Parser {
             Token::Supervisor => Some(crate::supervisor::parse(self)),
             Token::Trait => Some(crate::traits::parse(self)),
             Token::Enum => Some(crate::sum_types::parse_enum_decl(self)),
+            Token::Unsafe => Some(self.parse_unsafe_block()),
             Token::Extern => self.parse_extern_block(),
             Token::Use => self.parse_use_statement(),
             Token::Let => Some(self.parse_let_statement()),
@@ -4366,6 +4393,30 @@ impl Parser {
 
         self.next_token(); // Skip ')'
         (parameters, defaults)
+    }
+
+    /// RES-406: parse `unsafe { ... }`. Lifts the typechecker's
+    /// capability gate on the volatile MMIO intrinsics inside the
+    /// body. At runtime it's identical to a regular block.
+    fn parse_unsafe_block(&mut self) -> Node {
+        let kw_span = self.span_at_current();
+        self.next_token(); // consume `unsafe`
+        if self.current_token != Token::LeftBrace {
+            let tok = self.current_token.clone();
+            self.record_error(format!("Expected '{{' after 'unsafe', found {}", tok));
+            return Node::UnsafeBlock {
+                body: Box::new(Node::Block {
+                    stmts: Vec::new(),
+                    span: kw_span,
+                }),
+                span: kw_span,
+            };
+        }
+        let body = self.parse_block_statement();
+        Node::UnsafeBlock {
+            body: Box::new(body),
+            span: kw_span,
+        }
     }
 
     fn parse_block_statement(&mut self) -> Node {
@@ -8685,6 +8736,16 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("array_indices_where", builtin_array_indices_where),
     // RES-485: |a - b|.
     ("abs_diff", builtin_abs_diff),
+    // RES-406: volatile MMIO intrinsics. Calls outside an `unsafe`
+    // block are rejected by the typechecker.
+    ("volatile_read_u8", crate::volatile::volatile_read_u8),
+    ("volatile_read_u16", crate::volatile::volatile_read_u16),
+    ("volatile_read_u32", crate::volatile::volatile_read_u32),
+    ("volatile_read_u64", crate::volatile::volatile_read_u64),
+    ("volatile_write_u8", crate::volatile::volatile_write_u8),
+    ("volatile_write_u16", crate::volatile::volatile_write_u16),
+    ("volatile_write_u32", crate::volatile::volatile_write_u32),
+    ("volatile_write_u64", crate::volatile::volatile_write_u64),
     // RES-486: (quotient, remainder) tuple.
     ("divmod", builtin_divmod),
     // RES-423: flatten one level of nesting.
@@ -17802,6 +17863,10 @@ impl Interpreter {
             // up constructor expressions and match-arm evaluation;
             // until then, an enum decl is a no-op at runtime.
             Node::EnumDecl { .. } => Ok(Value::Void),
+            // RES-406: unsafe block — at runtime it's identical to a
+            // regular block. The capability gate is enforced by the
+            // typechecker / unsafe_check pass before evaluation.
+            Node::UnsafeBlock { body, .. } => self.eval(body),
         }
     }
 
@@ -20207,6 +20272,21 @@ fn execute_file(
         return Err(format!(
             "Borrow check failed: {} error(s)",
             region_errors.len()
+        ));
+    }
+
+    // RES-406: capability gate for the volatile MMIO intrinsics.
+    // Rejects calls to `volatile_*` outside an `unsafe { ... }`
+    // block. Runs after region checking so the user's diagnostic
+    // ordering matches the lexical order of failures.
+    let unsafe_errors = unsafe_check::check_program(&program);
+    if !unsafe_errors.is_empty() {
+        for e in &unsafe_errors {
+            eprintln!("\x1B[31m{}\x1B[0m", e);
+        }
+        return Err(format!(
+            "Capability check failed: {} error(s)",
+            unsafe_errors.len()
         ));
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4403,6 +4403,13 @@ impl TypeChecker {
             // it under `name`, and validate that every variant payload
             // resolves; for now we just acknowledge the node.
             Node::EnumDecl { .. } => Ok(Type::Void),
+            // RES-406: unsafe block. The volatile-call gate (compile-
+            // time error when calling `volatile_*` outside an
+            // unsafe block) is enforced in a sibling pass —
+            // `crate::unsafe_check::check_program` — that runs after
+            // the typechecker. Here we just descend into the body so
+            // its statements get type-checked.
+            Node::UnsafeBlock { body, .. } => self.check_node(body),
         }
     }
 

--- a/resilient/src/unsafe_check.rs
+++ b/resilient/src/unsafe_check.rs
@@ -1,0 +1,198 @@
+//! RES-406: capability gate for the volatile MMIO intrinsics.
+//!
+//! Walks the program AST after typechecking and rejects any call to
+//! one of the eight volatile intrinsics
+//! (`volatile_read_u8/16/32/64`, `volatile_write_u8/16/32/64`) that
+//! is not lexically inside an `unsafe { … }` block.
+//!
+//! The pass runs once per compilation unit; it doesn't change the
+//! AST, only collects diagnostics. Errors are surfaced through the
+//! same channel as parser errors — the driver routes them into
+//! `eprintln!` with the `Borrow check`-style caret renderer.
+//!
+//! Why this is a separate pass (not folded into the typechecker):
+//!
+//! * It needs only the AST shape, not the type environment. Keeping
+//!   it standalone makes it cheap to run and trivial to test.
+//! * The set of "privileged builtins" is closed; growing it later
+//!   (raw-pointer ops, etc.) means adding to one constant rather
+//!   than threading a state flag through every typechecker arm.
+//! * The error messages are highly specific ("call to
+//!   `volatile_read_u32` outside an `unsafe` block — wrap in
+//!   `unsafe { … }`") and benefit from being authored in one place
+//!   rather than as a guard inside the call typecheck arm.
+
+use crate::Node;
+use crate::volatile::VOLATILE_INTRINSIC_NAMES;
+
+/// Walk `program`, returning a list of human-readable diagnostics
+/// for every privileged-builtin call that's not inside an `unsafe`
+/// block. Empty list means clean.
+pub fn check_program(program: &Node) -> Vec<String> {
+    let mut errs: Vec<String> = Vec::new();
+    walk(program, false, &mut errs);
+    errs
+}
+
+fn walk(node: &Node, inside_unsafe: bool, errs: &mut Vec<String>) {
+    match node {
+        Node::UnsafeBlock { body, .. } => walk(body, true, errs),
+        Node::CallExpression {
+            function,
+            arguments,
+            ..
+        } => {
+            if let Node::Identifier { name, span, .. } = function.as_ref()
+                && VOLATILE_INTRINSIC_NAMES.contains(&name.as_str())
+                && !inside_unsafe
+            {
+                errs.push(format!(
+                    "{}:{}: call to `{}` outside an `unsafe` block — wrap in `unsafe {{ ... }}`",
+                    span.start.line, span.start.column, name
+                ));
+            }
+            // Always descend into args / function to catch nested calls.
+            walk(function, inside_unsafe, errs);
+            for a in arguments {
+                walk(a, inside_unsafe, errs);
+            }
+        }
+        // Generic structural recursion: descend into every Node-
+        // shaped child without enumerating the (large) variant set.
+        // We rely on the smaller set of "container" Node variants
+        // and treat everything else as a leaf.
+        Node::Program(stmts) => {
+            for s in stmts {
+                walk(&s.node, inside_unsafe, errs);
+            }
+        }
+        Node::Block { stmts, .. } => {
+            for s in stmts {
+                walk(s, inside_unsafe, errs);
+            }
+        }
+        Node::ExpressionStatement { expr, .. } => walk(expr, inside_unsafe, errs),
+        Node::LetStatement { value, .. } => walk(value, inside_unsafe, errs),
+        Node::Assignment { value, .. } => walk(value, inside_unsafe, errs),
+        Node::ReturnStatement { value: Some(v), .. } => walk(v, inside_unsafe, errs),
+        Node::ReturnStatement { value: None, .. } => {}
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            walk(condition, inside_unsafe, errs);
+            walk(consequence, inside_unsafe, errs);
+            if let Some(e) = alternative {
+                walk(e, inside_unsafe, errs);
+            }
+        }
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
+            walk(condition, inside_unsafe, errs);
+            walk(body, inside_unsafe, errs);
+        }
+        Node::ForInStatement { iterable, body, .. } => {
+            walk(iterable, inside_unsafe, errs);
+            walk(body, inside_unsafe, errs);
+        }
+        Node::Function { body, .. } => walk(body, inside_unsafe, errs),
+        Node::PrefixExpression { right, .. } => walk(right, inside_unsafe, errs),
+        Node::InfixExpression { left, right, .. } => {
+            walk(left, inside_unsafe, errs);
+            walk(right, inside_unsafe, errs);
+        }
+        Node::IndexExpression { target, index, .. } => {
+            walk(target, inside_unsafe, errs);
+            walk(index, inside_unsafe, errs);
+        }
+        Node::FieldAccess { target, .. } => walk(target, inside_unsafe, errs),
+        // Other node variants are leaves for our purposes (literals,
+        // identifiers, type aliases, ...). Walking past them is a
+        // no-op.
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parse;
+
+    fn errs(src: &str) -> Vec<String> {
+        let (program, parse_errs) = parse(src);
+        assert!(parse_errs.is_empty(), "parse errors: {:?}", parse_errs);
+        super::check_program(&program)
+    }
+
+    #[test]
+    fn volatile_outside_unsafe_is_an_error() {
+        let e = errs("let x = volatile_read_u32(1024);");
+        assert_eq!(e.len(), 1);
+        assert!(e[0].contains("volatile_read_u32"));
+        assert!(e[0].contains("unsafe"));
+    }
+
+    #[test]
+    fn volatile_inside_unsafe_is_clean() {
+        let e = errs(
+            "fn main() {\n\
+             unsafe {\n\
+                 let x = volatile_read_u32(0);\n\
+             }\n\
+         }",
+        );
+        assert!(e.is_empty(), "expected clean, got: {:?}", e);
+    }
+
+    #[test]
+    fn nested_unsafe_inherits_capability() {
+        let e = errs(
+            "fn main() {\n\
+             unsafe {\n\
+                 if true {\n\
+                     volatile_write_u8(0, 1);\n\
+                 }\n\
+             }\n\
+         }",
+        );
+        assert!(e.is_empty(), "expected clean, got: {:?}", e);
+    }
+
+    #[test]
+    fn unsafe_does_not_leak_to_sibling_blocks() {
+        // Two top-level lets: the first is inside unsafe, the second isn't.
+        let e = errs(
+            "fn main() {\n\
+             unsafe { volatile_write_u8(0, 1); }\n\
+             let bad = volatile_read_u8(0);\n\
+         }",
+        );
+        assert_eq!(e.len(), 1, "expected exactly one error, got: {:?}", e);
+        assert!(e[0].contains("volatile_read_u8"));
+    }
+
+    #[test]
+    fn all_eight_intrinsics_are_gated() {
+        for name in [
+            "volatile_read_u8",
+            "volatile_read_u16",
+            "volatile_read_u32",
+            "volatile_read_u64",
+            "volatile_write_u8",
+            "volatile_write_u16",
+            "volatile_write_u32",
+            "volatile_write_u64",
+        ] {
+            // Use 0 / (0,0) — argument validity isn't this pass's job.
+            let src = if name.starts_with("volatile_read") {
+                format!("let dummy = {}(0);", name)
+            } else {
+                format!("let dummy = {}(0, 0);", name)
+            };
+            let e = super::check_program(&crate::parse(&src).0);
+            assert_eq!(e.len(), 1, "expected error for `{}`, got: {:?}", name, e);
+        }
+    }
+}

--- a/resilient/src/volatile.rs
+++ b/resilient/src/volatile.rs
@@ -1,0 +1,294 @@
+//! RES-406: volatile MMIO intrinsics.
+//!
+//! Per the design lock-in spec
+//! ([docs/superpowers/specs/2026-04-30-mmio-isr-design.md](../../docs/superpowers/specs/2026-04-30-mmio-isr-design.md)),
+//! V1 ships eight fixed-width intrinsics — one read + one write
+//! for each of u8, u16, u32, u64. The generic `volatile_read<T>`
+//! facade lands once RES-405 (generics) is in.
+//!
+//! Each intrinsic:
+//!
+//! * Takes the address as `int` (i64) and reads/writes the bit
+//!   pattern at that address.
+//! * Is a regular builtin in `BUILTINS` — the `unsafe { … }` gate
+//!   is enforced by the typechecker, not the runtime, so the
+//!   interpreter / VM / JIT all share the same dispatch path.
+//! * Lowers to `core::ptr::read_volatile` / `write_volatile` in
+//!   the runtime path. The pointer cast is justified by the
+//!   `unsafe { … }` gate at the call site.
+//!
+//! The intrinsics are tagged "non-modelable" by the verifier —
+//! same path FFI takes (per the [TLA+ V2.0 design lock-in's Q4](../../docs/superpowers/specs/2026-04-30-tla-v2-design-lock-in.md#q4-ffi-side-effects--choose-or-contract)).
+//! Returns from a volatile read are nondeterministic to Z3
+//! (`CHOOSE x \in T : true`); writes are no-ops at the Z3 level.
+//!
+//! Tests use a small allocated buffer and the address-of trick —
+//! we cast a `Vec<u8>` pointer back to `usize`, hand it to the
+//! intrinsic, and verify round-trip semantics. No real MMIO
+//! addresses are touched.
+
+use crate::{RResult, Value};
+
+/// Type-tag for the eight intrinsic variants. Used by the unified
+/// `read` / `write` paths to centralize bounds + alignment checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Width {
+    U8,
+    U16,
+    U32,
+    U64,
+}
+
+impl Width {
+    fn bytes(self) -> usize {
+        match self {
+            Self::U8 => 1,
+            Self::U16 => 2,
+            Self::U32 => 4,
+            Self::U64 => 8,
+        }
+    }
+
+    /// Width name for diagnostics. Read by future tooling; not used
+    /// directly today but kept for symmetry with `bytes()`.
+    #[allow(dead_code)]
+    fn name(self) -> &'static str {
+        match self {
+            Self::U8 => "u8",
+            Self::U16 => "u16",
+            Self::U32 => "u32",
+            Self::U64 => "u64",
+        }
+    }
+}
+
+/// Common implementation: read `width` bytes from `addr` and return
+/// the resulting unsigned value, zero-extended into i64 for the
+/// runtime's int slot.
+///
+/// # Safety
+///
+/// The caller must ensure `addr` is a valid, aligned pointer to
+/// `width` bytes of memory the program is permitted to read. The
+/// `unsafe { … }` block at the call site is the language-level
+/// authorization for this; the runtime can't verify it without
+/// modeling the address space, so we trust the caller.
+fn read_at(addr: usize, width: Width) -> u64 {
+    unsafe {
+        match width {
+            Width::U8 => core::ptr::read_volatile(addr as *const u8) as u64,
+            Width::U16 => core::ptr::read_volatile(addr as *const u16) as u64,
+            Width::U32 => core::ptr::read_volatile(addr as *const u32) as u64,
+            Width::U64 => core::ptr::read_volatile(addr as *const u64),
+        }
+    }
+}
+
+/// Common implementation: write the low `width` bytes of `value` to
+/// `addr` as a volatile store.
+fn write_at(addr: usize, value: u64, width: Width) {
+    unsafe {
+        match width {
+            Width::U8 => core::ptr::write_volatile(addr as *mut u8, value as u8),
+            Width::U16 => core::ptr::write_volatile(addr as *mut u16, value as u16),
+            Width::U32 => core::ptr::write_volatile(addr as *mut u32, value as u32),
+            Width::U64 => core::ptr::write_volatile(addr as *mut u64, value),
+        }
+    }
+}
+
+/// Validate the address argument. Bounds-checks that `addr` fits
+/// in `usize` (the address-space pointer width on the host) and is
+/// non-negative; a negative `addr` is almost certainly a bug,
+/// definitely not a valid MMIO address.
+fn coerce_addr(name: &'static str, args: &[Value]) -> Result<usize, String> {
+    match args.first() {
+        Some(Value::Int(addr)) => {
+            if *addr < 0 {
+                return Err(format!("{name}: address must be non-negative, got {addr}"));
+            }
+            usize::try_from(*addr)
+                .map_err(|_| format!("{name}: address {addr} does not fit in usize"))
+        }
+        Some(other) => Err(format!("{name}: expected (int, ...), got ({other}, ...)")),
+        None => Err(format!("{name}: expected at least 1 argument, got 0")),
+    }
+}
+
+/// Generic read-builtin body parameterised by `Width`. The width
+/// is captured by the calling builtin function (see the eight
+/// monomorphic shims below).
+fn builtin_volatile_read(name: &'static str, args: &[Value], width: Width) -> RResult<Value> {
+    if args.len() != 1 {
+        return Err(format!(
+            "{name}: expected 1 argument (address), got {}",
+            args.len()
+        ));
+    }
+    let addr = coerce_addr(name, args)?;
+    if addr % width.bytes() != 0 {
+        return Err(format!(
+            "{name}: address {addr:#x} is not aligned to {} bytes",
+            width.bytes()
+        ));
+    }
+    Ok(Value::Int(read_at(addr, width) as i64))
+}
+
+/// Generic write-builtin body parameterised by `Width`.
+fn builtin_volatile_write(name: &'static str, args: &[Value], width: Width) -> RResult<Value> {
+    if args.len() != 2 {
+        return Err(format!(
+            "{name}: expected 2 arguments (address, value), got {}",
+            args.len()
+        ));
+    }
+    let addr = coerce_addr(name, args)?;
+    if addr % width.bytes() != 0 {
+        return Err(format!(
+            "{name}: address {addr:#x} is not aligned to {} bytes",
+            width.bytes()
+        ));
+    }
+    let value = match &args[1] {
+        Value::Int(n) => *n as u64,
+        other => {
+            return Err(format!("{name}: expected (int, int), got (..., {other})"));
+        }
+    };
+    write_at(addr, value, width);
+    Ok(Value::Void)
+}
+
+// The eight shipped intrinsics. Each is a thin shim over the
+// generic body that pins the width.
+
+pub fn volatile_read_u8(args: &[Value]) -> RResult<Value> {
+    builtin_volatile_read("volatile_read_u8", args, Width::U8)
+}
+pub fn volatile_read_u16(args: &[Value]) -> RResult<Value> {
+    builtin_volatile_read("volatile_read_u16", args, Width::U16)
+}
+pub fn volatile_read_u32(args: &[Value]) -> RResult<Value> {
+    builtin_volatile_read("volatile_read_u32", args, Width::U32)
+}
+pub fn volatile_read_u64(args: &[Value]) -> RResult<Value> {
+    builtin_volatile_read("volatile_read_u64", args, Width::U64)
+}
+pub fn volatile_write_u8(args: &[Value]) -> RResult<Value> {
+    builtin_volatile_write("volatile_write_u8", args, Width::U8)
+}
+pub fn volatile_write_u16(args: &[Value]) -> RResult<Value> {
+    builtin_volatile_write("volatile_write_u16", args, Width::U16)
+}
+pub fn volatile_write_u32(args: &[Value]) -> RResult<Value> {
+    builtin_volatile_write("volatile_write_u32", args, Width::U32)
+}
+pub fn volatile_write_u64(args: &[Value]) -> RResult<Value> {
+    builtin_volatile_write("volatile_write_u64", args, Width::U64)
+}
+
+/// Names of the eight intrinsics, in (read, write, width) tuples.
+/// Used by the typechecker (RES-406's `unsafe { … }` gate) to
+/// refuse calls outside an unsafe block.
+pub const VOLATILE_INTRINSIC_NAMES: &[&str] = &[
+    "volatile_read_u8",
+    "volatile_read_u16",
+    "volatile_read_u32",
+    "volatile_read_u64",
+    "volatile_write_u8",
+    "volatile_write_u16",
+    "volatile_write_u32",
+    "volatile_write_u64",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buf_addr(buf: &[u8]) -> i64 {
+        buf.as_ptr() as i64
+    }
+    fn buf_addr_mut(buf: &mut [u8]) -> i64 {
+        buf.as_mut_ptr() as i64
+    }
+
+    #[test]
+    fn round_trip_u8() {
+        let mut buf = vec![0u8; 1];
+        let addr = buf_addr_mut(&mut buf);
+        let _ = volatile_write_u8(&[Value::Int(addr), Value::Int(0xAB)]).unwrap();
+        let v = volatile_read_u8(&[Value::Int(addr)]).unwrap();
+        match v {
+            Value::Int(n) => assert_eq!(n, 0xAB),
+            other => panic!("expected Int(0xAB), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn round_trip_u16_aligned() {
+        let mut buf = vec![0u8; 2];
+        let addr = buf_addr_mut(&mut buf);
+        let _ = volatile_write_u16(&[Value::Int(addr), Value::Int(0xCAFE)]).unwrap();
+        let v = volatile_read_u16(&[Value::Int(addr)]).unwrap();
+        match v {
+            Value::Int(n) => assert_eq!(n, 0xCAFE),
+            other => panic!("expected Int(0xCAFE), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn round_trip_u32_aligned() {
+        // Force alignment by using a fixed-size array.
+        let buf: [u32; 1] = [0];
+        let addr = buf_addr(unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, 4) });
+        let _ = volatile_write_u32(&[Value::Int(addr), Value::Int(0xDEAD_BEEF_i64)]).unwrap();
+        let v = volatile_read_u32(&[Value::Int(addr)]).unwrap();
+        match v {
+            Value::Int(n) => assert_eq!(n as u32, 0xDEADBEEFu32),
+            other => panic!("got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn round_trip_u64_aligned() {
+        let buf: [u64; 1] = [0];
+        let addr = buf_addr(unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, 8) });
+        let _ = volatile_write_u64(&[Value::Int(addr), Value::Int(0x0102030405060708)]).unwrap();
+        let v = volatile_read_u64(&[Value::Int(addr)]).unwrap();
+        match v {
+            Value::Int(n) => assert_eq!(n, 0x0102030405060708),
+            other => panic!("got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unaligned_read_errors_for_u32() {
+        // Address 1 inside a 4-byte buffer is not 4-aligned.
+        let buf = vec![0u8; 8];
+        let addr = buf_addr(&buf) + 1;
+        let err = volatile_read_u32(&[Value::Int(addr)]).unwrap_err();
+        assert!(err.contains("not aligned"), "got: {}", err);
+    }
+
+    #[test]
+    fn negative_address_errors() {
+        let err = volatile_read_u8(&[Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"), "got: {}", err);
+    }
+
+    #[test]
+    fn wrong_arity_errors() {
+        let err = volatile_read_u8(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "got: {}", err);
+        let err = volatile_write_u8(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected 2 arguments"), "got: {}", err);
+    }
+
+    #[test]
+    fn intrinsic_name_list_matches_eight_known() {
+        assert_eq!(VOLATILE_INTRINSIC_NAMES.len(), 8);
+        assert!(VOLATILE_INTRINSIC_NAMES.contains(&"volatile_read_u8"));
+        assert!(VOLATILE_INTRINSIC_NAMES.contains(&"volatile_write_u64"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements PRs 1+2 from the [design lock-in spec](https://github.com/EricSpencer00/Resilient/blob/main/docs/superpowers/specs/2026-04-30-mmio-isr-design.md):

- **PR 1**: `unsafe` keyword + parser + AST + typechecker gate
- **PR 2**: 8 fixed-width `volatile_*` intrinsics

A Resilient program can now read/write memory-mapped registers inside `unsafe { ... }`. Outside, calling a volatile intrinsic is a compile-time error.

## Changes

- New `Token::Unsafe` + `Node::UnsafeBlock { body, span }`
- New `resilient/src/volatile.rs` — 8 intrinsics with width-alignment + negative-address checks
- New `resilient/src/unsafe_check.rs` — capability-gate pass that runs after the borrow checker
- AST arms in compiler/typechecker/formatter/free_vars for `UnsafeBlock`

## Test plan

- [x] 8 unit tests in volatile (round-trip per width, alignment, negative addr, arity, name list)
- [x] 5 unit tests in unsafe_check (gate enforcement, nested unsafe, sibling isolation, all 8 intrinsics)
- [x] 1 golden example
- [x] cargo build / test / clippy / fmt clean (2180 tests)

## Deferred (PRs 3-5)

- `#[interrupt(name = ...)]` attribute parser + lowering
- Weak-alias vector table in cortex-m demo
- Docs updates (SYNTAX.md / STABILITY.md / no-std.md)

Refs #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)