### PR TITLE
RES-408: quantified invariants over array contents — refs #371

### DIFF
--- a/resilient/examples/array_contains.expected.txt
+++ b/resilient/examples/array_contains.expected.txt
@@ -1,0 +1,3 @@
+contains
+absent
+Program executed successfully

--- a/resilient/examples/array_contains.rz
+++ b/resilient/examples/array_contains.rz
@@ -1,0 +1,34 @@
+// RES-408: existential quantifier over array contents.
+//
+// `exists i in 0..len(a): a[i] == k` is the natural witness
+// shape for a "linear search succeeded" claim. Companion to the
+// sorted-invariant example; together they exercise both forall
+// and exists over array indices with the body referencing `a[i]`.
+//
+// Runtime semantics: short-circuits on the first true witness
+// (returns true when found, false otherwise). Z3 lowering to
+// array theory is tracked in #371.
+
+fn main(int dummy) -> int {
+    let a = [10, 20, 30, 40, 50];
+    let k = 30;
+
+    // The existence claim — "k is somewhere in a" — is just a
+    // direct call to the existential quantifier over a's indices.
+    // At runtime, the quantifier short-circuits on the first true
+    // witness; verification at compile time is tracked in #371.
+    assert(exists i in 0..len(a): a[i] == k);
+    println("contains");
+
+    let absent = 99;
+    let found = exists i in 0..len(a): a[i] == absent;
+    if found {
+        println("error: 99 should not be in a");
+    } else {
+        println("absent");
+    }
+
+    return 0;
+}
+
+main(0);

--- a/resilient/examples/array_sorted_invariant.expected.txt
+++ b/resilient/examples/array_sorted_invariant.expected.txt
@@ -1,0 +1,2 @@
+sorted invariant holds
+Program executed successfully

--- a/resilient/examples/array_sorted_invariant.rz
+++ b/resilient/examples/array_sorted_invariant.rz
@@ -1,0 +1,26 @@
+// RES-408: quantified invariants over array contents.
+//
+// `forall i in 0..len(a): P(a[i])` ranges over array indices and
+// binds `i` inside `P` so the predicate can read `a[i]`.
+//
+// At runtime the quantifier short-circuits on the first false
+// witness for `forall` (true witness for `exists`). At compile
+// time, the Z3 backend currently leaves these as `Unknown` —
+// extending the encoding to use Z3's array theory
+// `(forall ((i Int)) (=> (and (<= 0 i) (< i len_a)) P(select a i)))`
+// is tracked in #371 (this ticket); the runtime-side surface
+// shipped here is the precondition the Z3 lowering targets.
+
+fn main(int dummy) -> int {
+    let a = [1, 2, 3, 4, 5];
+
+    // Sorted-invariant — every adjacent pair is non-decreasing.
+    // This is the canonical "preserves invariant" check that
+    // insertion sort's outer loop maintains.
+    assert(forall i in 1..len(a): a[i - 1] <= a[i]);
+    println("sorted invariant holds");
+
+    return 0;
+}
+
+main(0);


### PR DESCRIPTION
## Summary

Two golden examples per the issue's acceptance:

- `array_sorted_invariant.rz`: `forall i in 1..len(a): a[i-1] <= a[i]`
- `array_contains.rz`: `exists i in 0..len(a): a[i] == k`

Both run end-to-end at runtime — the runtime quantifier already short-circuits correctly. The Z3-side lowering to array theory is the bulk of the remaining ticket scope and lands as its own PR (touches `verifier_z3::translate_int` to lower `a[i]` to `(select a i)` against `(Array Int Int)`).

## Test plan

- [x] Both examples run cleanly via `cargo test --test examples_golden`
- [x] Existing forall/exists Z3 encoding (bounded-range) is unchanged

Refs #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)