### PR TITLE
RES-400: sum types — payload-less constructors (PR 3/N) — refs #362

### DIFF
--- a/resilient/examples/sum_types_constructor.expected.txt
+++ b/resilient/examples/sum_types_constructor.expected.txt
@@ -1,0 +1,4 @@
+Color::Red
+Direction::North
+Color::Blue
+Program executed successfully

--- a/resilient/examples/sum_types_constructor.rz
+++ b/resilient/examples/sum_types_constructor.rz
@@ -1,0 +1,28 @@
+// RES-400 PR 3: payload-less variant constructors.
+//
+// `Color::Red` is a constructor expression that resolves to a
+// tagged value at runtime. The interpreter binds each variant
+// under the qualified key `EnumName::VariantName` when an `enum`
+// declaration is evaluated; the constructor expression looks up
+// that key. Payload-carrying constructors (`Shape::Circle { r:
+// 1.0 }`) need call-style evaluation that lands in PR 4.
+
+enum Color { Red, Green, Blue }
+enum Direction { North, South, East, West }
+
+fn main() -> int {
+    let c = Color::Red;
+    println(c);
+
+    let d = Direction::North;
+    println(d);
+
+    // Variants from different enums coexist without collision —
+    // they're keyed by full path.
+    let c2 = Color::Blue;
+    println(c2);
+
+    return 0;
+}
+
+main();

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -17894,11 +17894,19 @@ impl Interpreter {
             // RES-290: trait declarations carry no runtime payload — the
             // typechecker validates them; here we just produce Void.
             Node::TraitDecl { .. } => Ok(Value::Void),
-            // RES-400 PR 1: enum declarations are parsed and validated
-            // but the interpreter doesn't act on them yet. PR 5 wires
-            // up constructor expressions and match-arm evaluation;
-            // until then, an enum decl is a no-op at runtime.
-            Node::EnumDecl { .. } => Ok(Value::Void),
+            // RES-400 PR 3: enum declarations register each variant
+            // under the qualified key `EnumName::VariantName` in the
+            // current scope. Payload-less variants resolve to a
+            // string-tag value (`"Color::Red"`); payload-carrying
+            // variants need constructor-call evaluation that lands
+            // in PR 4.
+            Node::EnumDecl { name, variants, .. } => {
+                for v in variants {
+                    let key = format!("{}::{}", name, v.name);
+                    self.env.set(key.clone(), Value::String(key));
+                }
+                Ok(Value::Void)
+            }
             // RES-406: unsafe block — at runtime it's identical to a
             // regular block. The capability gate is enforced by the
             // typechecker / unsafe_check pass before evaluation.

--- a/resilient/src/sum_types.rs
+++ b/resilient/src/sum_types.rs
@@ -110,7 +110,11 @@ pub(crate) fn parse_enum_decl(parser: &mut Parser) -> Node {
     loop {
         match &parser.current_token {
             Token::RightBrace => {
-                parser.next_token(); // consume '}'
+                // Leave the closing `}` on `current_token` so the
+                // outer statement-loop's bookkeeping (which expects
+                // a declaration to terminate on its closing brace,
+                // not one token past) remains correct. Matches
+                // `parse_struct_decl_with_attrs`'s convention.
                 break;
             }
             Token::Eof => {


### PR DESCRIPTION
## Summary

PR 3 of the sum-types chain. Wires up the runtime side of payload-less variant constructors and fixes a pre-existing parser bug where `enum E { A } fn main()` failed to parse.

```rz
enum Color { Red, Green, Blue }
let c = Color::Red;
println(c);  // → "Color::Red"
```

## Changes

- **Parser fix**: `parse_enum_decl` no longer consumes the closing `}`. PR 1's test only validated `enum + let` (which masked the bug because `let` doesn't dispatch off the next-token state); `enum + fn` failed pre-existing. Matches `parse_struct_decl_with_attrs`'s convention.
- **Interpreter**: `EnumDecl` arm registers each variant under `EnumName::VariantName` as a `Value::String` tag. Constructor expressions use the existing RES-360 scoped-lookup path.
- **Golden test** exercising `Color::Red`, `Direction::North`, `Color::Blue`.

## Deferred to PR 4

- Payload-carrying constructors (`Shape::Circle { r: 1.0 }`)
- Pattern matching against variants
- Richer `Value::EnumVariant` distinct from string-tag

## Test plan

- [x] cargo build / test / clippy / fmt clean
- [x] 2180 tests pass

Refs #362
Built on #719 (PR 1) and #725 (PR 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)