### PR TITLE
fix(ci): add .interactive sidecar for ffi_libm_demo.rz

### DIFF
--- a/resilient/examples/ffi_libm_demo.interactive
+++ b/resilient/examples/ffi_libm_demo.interactive
@@ -1,0 +1,13 @@
+# FFI demo: requires `--features ffi` to parse `extern "libm.dylib" { ... }`.
+#
+# The golden-file audit (`cargo test --test examples_golden`) builds the
+# `rz` binary without `--features ffi`, so the parser rejects the
+# `extern "libm.dylib" { ... }` block at compile time and the program
+# produces no output — mismatching the saved `.expected.txt`.
+#
+# Until the golden runner gains a per-example feature-flag mechanism,
+# this example is exempt from the audit. Run it manually with:
+#   cargo run --features ffi -- examples/ffi_libm_demo.rz
+#
+# Pre-existing platform note: the example hardcodes `libm.dylib` (macOS).
+# On Linux change it to `libm.so.6`.


### PR DESCRIPTION
## Summary

* The `.res` → `.rz` migration in #733 brought `ffi_libm_demo.rz` under the golden-file audit (the test runner filters by `.rz` extension).
* The example uses `extern \"libm.dylib\" { ... }` which is rejected by the parser without `--features ffi`. The audit's no-features build produces empty stdout that doesn't match the saved `.expected.txt`.
* `golden_outputs_match` is therefore failing on **every** open PR's CI plus on main itself — blocking auto-merge for the whole fleet.
* Add the `.interactive` sidecar (already used for `ffi_libm.rz`) so the runner skips this example until the golden runner grows a per-example feature-flag mechanism.

## Test plan

- [x] `cargo test --test examples_golden` passes locally with this change. Without it, the test fails identically on macOS and Linux CI.
- [x] Manual invocation still works: `cargo run --features ffi -- examples/ffi_libm_demo.rz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)