### PR TITLE
RES-332: cooperative actor scheduler (PR 3/5)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/actor_runtime.rs": {
-      "branch": "res-332-pr2-builtins-new",
-      "claimed_at": "2026-05-01T00:54:04Z"
+      "branch": "res-332-pr3-scheduler",
+      "claimed_at": "2026-05-01T01:05:19Z"
     },
     "resilient/src/lib.rs": {
-      "branch": "res-332-pr2-builtins-new",
-      "claimed_at": "2026-05-01T00:54:04Z"
+      "branch": "res-332-pr3-scheduler",
+      "claimed_at": "2026-05-01T01:05:19Z"
     }
   }
 }

--- a/resilient/examples/actor_spawn_send.expected.txt
+++ b/resilient/examples/actor_spawn_send.expected.txt
@@ -1,2 +1,3 @@
 spawned and sent
+42
 Program executed successfully

--- a/resilient/examples/actor_spawn_send.rz
+++ b/resilient/examples/actor_spawn_send.rz
@@ -1,10 +1,10 @@
-// RES-332 PR 2: hand-rolled test — spawn a worker actor, send it a
-// message, and verify send/spawn return without error.
-// Full end-to-end execution (scheduler driving the actor to print)
-// requires PR 3's cooperative scheduler.  This example demonstrates
-// that spawn() returns an ActorPid and send() accepts it.
+// RES-332 PR 3: cooperative-scheduler integration test.
+// Main script spawns a worker, sends 42, then finishes.
+// The scheduler runs the worker actor after main exits;
+// the worker receives the message and prints it.
 fn worker() {
-    println("worker running");
+    let msg = receive();
+    println(msg);
 }
 let pid = spawn(worker);
 send(pid, 42);

--- a/resilient/src/actor_runtime.rs
+++ b/resilient/src/actor_runtime.rs
@@ -330,6 +330,23 @@ pub fn get_actor_fn(pid: ActorPid) -> Option<Value> {
     ACTOR_FN_REGISTRY.with(|r| r.borrow().get(&pid).cloned())
 }
 
+/// Pop the next runnable actor PID. Called by `lib.rs`'s cooperative-
+/// scheduler loop; returns `None` when the runnable queue is empty.
+pub fn next_runnable_actor() -> Option<ActorPid> {
+    SCHEDULER.with(|s| s.borrow_mut().pop_runnable())
+}
+
+/// True when there are no runnable actors and at least one blocked actor
+/// (deadlock condition). PR 4 surfaces this as a user-visible error.
+pub fn is_deadlocked() -> bool {
+    SCHEDULER.with(|s| s.borrow().is_deadlocked())
+}
+
+/// Snapshot of currently-blocked PIDs. Used by PR 4's deadlock diagnostic.
+pub fn blocked_pids() -> Vec<ActorPid> {
+    SCHEDULER.with(|s| s.borrow().blocked_pids())
+}
+
 /// Reset every thread-local for a fresh test run. Test-only — calling
 /// this from production code would corrupt any in-flight scheduling.
 #[cfg(test)]

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -6294,6 +6294,15 @@ impl Parser {
             // to the quantifiers module so the prefix dispatch stays
             // append-only and conflict-resistant.
             Token::Forall | Token::Exists => crate::quantifiers::parse_quantifier(self),
+            // RES-332 PR 3: `receive()` — the zero-arg actor mailbox dequeue.
+            // `receive` is also a keyword in actor-body handler declarations
+            // (`receive msg_name(...) { ... }`), which always have an
+            // identifier immediately after the keyword. When followed by `(`
+            // directly it can only be the builtin call form.
+            Token::Receive if self.peek_token == Token::LeftParen => Some(Node::Identifier {
+                name: "receive".to_string(),
+                span: tok_span,
+            }),
             _ => None,
         };
 
@@ -20781,6 +20790,62 @@ fn run_actor_verification(program: &Node) {
 #[cfg(not(feature = "z3"))]
 fn run_actor_verification(_program: &Node) {}
 
+// ---------------------------------------------------------------------------
+// RES-332 PR 3: Cooperative actor scheduler
+// ---------------------------------------------------------------------------
+
+/// Run all pending actors to completion (or until they block on `receive`).
+///
+/// Called by `execute_file` and `run_program` after the main script
+/// finishes. The loop pops each runnable PID, calls its registered
+/// function via the interpreter, then deregisters it (completed) or
+/// leaves it blocked (awaiting a message). Cycles end naturally because
+/// each step either completes an actor or moves it to the blocked set —
+/// neither of which puts it back in the runnable queue until a new
+/// `send()` arrives.
+///
+/// The safety cap (`MAX_ACTOR_STEPS`) catches runaway programs where
+/// actors keep re-spawning or sending in a tight loop without making
+/// progress toward termination.
+fn run_pending_actors(interpreter: &mut Interpreter) -> RResult<()> {
+    const MAX_ACTOR_STEPS: usize = 100_000;
+    let mut steps = 0;
+    while let Some(pid) = actor_runtime::next_runnable_actor() {
+        if steps >= MAX_ACTOR_STEPS {
+            return Err(format!(
+                "actor scheduler exceeded step limit ({MAX_ACTOR_STEPS}); \
+                 possible infinite loop in actor body"
+            ));
+        }
+        steps += 1;
+        let fn_val = match actor_runtime::get_actor_fn(pid) {
+            Some(v) => v,
+            None => {
+                let _ = actor_runtime::deregister_actor(pid);
+                continue;
+            }
+        };
+        actor_runtime::set_current_actor(Some(pid));
+        let result = interpreter.apply_function(fn_val, vec![]);
+        actor_runtime::set_current_actor(None);
+        match result {
+            Ok(_) => {
+                let _ = actor_runtime::deregister_actor(pid);
+            }
+            Err(e) if e.starts_with("WouldBlock:") => {
+                // Actor blocked on receive() — already marked blocked;
+                // do not deregister; a future send() will re-queue it.
+            }
+            Err(e) => {
+                // Drop-on-crash: deregister the actor and log the failure.
+                let _ = actor_runtime::deregister_actor(pid);
+                eprintln!("actor {} crashed: {}", pid.0, e);
+            }
+        }
+    }
+    Ok(())
+}
+
 // Execute a Resilient source file
 #[allow(clippy::too_many_arguments)] // CLI glue fn — all args come from flags
 fn execute_file(
@@ -21135,6 +21200,9 @@ fn execute_file(
             header
         }
     })?;
+
+    // RES-332 PR 3: drain spawned actors after the main script finishes.
+    run_pending_actors(&mut interpreter).map_err(|e| format_interpreter_error(filename, &e))?;
 
     // RES-355: persist a cache entry so the next run can detect
     // that this source compiled successfully. Errors here are
@@ -22397,7 +22465,10 @@ pub fn run_program(src: &str) -> RunResult {
     }
     let (eval_result, captured) = output_sink::with_captured_output(|| {
         let mut interp = Interpreter::new();
-        interp.eval(&program)
+        interp.eval(&program)?;
+        // RES-332 PR 3: drain spawned actors after the main script.
+        run_pending_actors(&mut interp)?;
+        Ok(Value::Void)
     });
     match eval_result {
         Ok(_) => RunResult {


### PR DESCRIPTION
Closes #124

## Summary

- Adds `run_pending_actors()` in `lib.rs` — the cooperative scheduler loop that drains all runnable actors after the main script exits
- Adds `next_runnable_actor()`, `is_deadlocked()`, `blocked_pids()` public helpers to `actor_runtime.rs`
- Parses `receive()` (keyword + `(` with no identifier between) as a builtin function call rather than an actor-handler declaration — disambiguates the two uses of the `receive` keyword
- Wires the scheduler into both `execute_file` (CLI path) and `run_program` (test API)
- Updates `actor_spawn_send.rz` golden: worker now calls `receive()`, dequeues the 42 the main script sent, and prints it

## Verification

```
cargo run -- examples/actor_spawn_send.rz
# spawned and sent
# 42
# Program executed successfully
```

## Built on

[PR 2: #748](https://github.com/EricSpencer00/Resilient/pull/748) — spawn/send/receive builtins

## Next PRs

- PR 4: `res-332-pr4-deadlock` — deadlock detection
- PR 5: `res-332-pr5-ping-pong` — ping-pong example + docs