### PR TITLE
RES-332: actor deadlock detection (PR 4/5)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/actor_runtime.rs": {
-      "branch": "res-332-pr3-scheduler",
-      "claimed_at": "2026-05-01T01:05:19Z"
+      "branch": "res-332-pr4-deadlock",
+      "claimed_at": "2026-05-01T01:12:19Z"
     },
     "resilient/src/lib.rs": {
-      "branch": "res-332-pr3-scheduler",
-      "claimed_at": "2026-05-01T01:05:19Z"
+      "branch": "res-332-pr4-deadlock",
+      "claimed_at": "2026-05-01T01:12:19Z"
     }
   }
 }

--- a/resilient/examples/actor_deadlock.expected.txt
+++ b/resilient/examples/actor_deadlock.expected.txt
@@ -1,0 +1,2 @@
+worker spawned, no message sent
+error: deadlock detected; 1 actor(s) blocked on receive() with empty mailboxes; PIDs: [1]

--- a/resilient/examples/actor_deadlock.rz
+++ b/resilient/examples/actor_deadlock.rz
@@ -1,0 +1,10 @@
+// RES-332 PR 4: deadlock detection golden test.
+// The worker calls receive() but no message is ever sent to it.
+// After the main script finishes, the scheduler detects that the
+// only actor is blocked with an empty mailbox and reports a deadlock.
+fn waiting_worker() {
+    let msg = receive();
+    println(msg);
+}
+let pid = spawn(waiting_worker);
+println("worker spawned, no message sent");

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -20843,6 +20843,27 @@ fn run_pending_actors(interpreter: &mut Interpreter) -> RResult<()> {
             }
         }
     }
+
+    // RES-332 PR 4: deadlock detection. After the runnable queue is
+    // empty, if any actors remain blocked on receive() with no sender
+    // able to wake them, the program cannot make progress.
+    if actor_runtime::is_deadlocked() {
+        let pids = actor_runtime::blocked_pids();
+        let pid_list: Vec<String> = pids.iter().map(|p| p.0.to_string()).collect();
+        let msg = format!(
+            "error: deadlock detected; {} actor(s) blocked on receive() \
+             with empty mailboxes; PIDs: [{}]",
+            pids.len(),
+            pid_list.join(", ")
+        );
+        // Write through the output sink so golden tests and run_program
+        // capture the message on stdout; the caller also propagates it
+        // as an Err so the process exits with a non-zero status code.
+        crate::output_sink::write_str(&msg);
+        crate::output_sink::write_str("\n");
+        return Err(msg);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Closes #124

## Summary

- Extends `run_pending_actors` with a post-loop deadlock check: if the runnable queue is empty but actors remain blocked on `receive()`, emits a structured diagnostic and returns `Err`
- Deadlock message written through `output_sink` so it appears in stdout (captured by golden tests and `run_program`)
- Golden sidecar `actor_deadlock.rz`: spawns a worker that calls `receive()` with no sender; expected output includes the deadlock error line

## Verification

```
cargo run -- examples/actor_deadlock.rz
# worker spawned, no message sent
# error: deadlock detected; 1 actor(s) blocked on receive() with empty mailboxes; PIDs: [1]
# (exits 1)
```

## Built on

[PR 3: #749](https://github.com/EricSpencer00/Resilient/pull/749) — cooperative scheduler

## Next PRs

- PR 5: `res-332-pr5-ping-pong` — ping-pong example + docs/concurrency.md