### PR TITLE
RES-393: Z3 fallback for region alias rejection (PR D1)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,12 @@
 {
   "claims": {
-    "docs/concurrency.md": {
-      "branch": "res-332-pr5-ping-pong",
-      "claimed_at": "2026-05-01T01:16:36Z"
+    "resilient/src/verifier_z3.rs": {
+      "branch": "res-393-pr1-z3-fallback",
+      "claimed_at": "2026-05-01T01:20:02Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "res-393-pr1-z3-fallback",
+      "claimed_at": "2026-05-01T01:20:02Z"
     }
   }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -20208,10 +20208,16 @@ pub(crate) fn check_region_aliasing(program: &Node, source_path: &str) -> Vec<St
         if let Node::Function {
             name: fn_name,
             parameters,
+            requires,
             span,
             ..
         } = &stmt.node
         {
+            // `requires` is only consumed by the Z3 fallback below;
+            // avoid an unused-variable warning in non-z3 builds.
+            #[cfg(not(feature = "z3"))]
+            let _ = requires;
+
             // Per-parameter pass: every labeled reference must name
             // a declared region.
             let mut refs: Vec<(usize, bool, Option<String>, String)> = Vec::new();
@@ -20256,6 +20262,15 @@ pub(crate) fn check_region_aliasing(program: &Node, source_path: &str) -> Vec<St
                         (None, None) => (false, String::new(), String::new()),
                     };
                     if ok {
+                        continue;
+                    }
+                    // RES-393 D1: Z3 fallback — if the function's `requires`
+                    // preconditions prove that these two parameters differ (i.e.
+                    // they refer to disjoint memory), skip the syntactic reject.
+                    #[cfg(feature = "z3")]
+                    if crate::verifier_z3::prove_alias_disjoint(i_name, j_name, requires)
+                        == Some(true)
+                    {
                         continue;
                     }
                     let i_kind = if *i_mut { "&mut" } else { "&" };
@@ -44418,6 +44433,46 @@ mod tests {
         assert!(
             borrow_errs.iter().any(|e| e.contains("undeclared region")),
             "expected undeclared-region message, got: {:?}",
+            borrow_errs
+        );
+    }
+
+    // --- RES-393 D1: Z3 alias-disjoint fallback ---
+
+    #[cfg(feature = "z3")]
+    #[test]
+    fn res393_z3_fallback_lifts_same_region_reject() {
+        // Without `requires`, same-region mut refs are always rejected.
+        let src = "region A; fn f(&mut[A] int a, &mut[A] int b) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert_eq!(borrow_errs.len(), 1, "should reject without requires");
+
+        // With `requires(a != b)`, Z3 proves the params are disjoint.
+        let src2 = "region A; fn f(&mut[A] int a, &mut[A] int b) requires(a != b) {}\n";
+        let (program2, errs2) = parse(src2);
+        assert!(errs2.is_empty(), "parse errors: {:?}", errs2);
+        let borrow_errs2 = check_region_aliasing(&program2, "<test>");
+        assert!(
+            borrow_errs2.is_empty(),
+            "Z3 should lift the rejection when requires(a != b), got: {:?}",
+            borrow_errs2
+        );
+    }
+
+    #[cfg(feature = "z3")]
+    #[test]
+    fn res393_z3_fallback_does_not_lift_true_aliasing() {
+        // `requires(a == b)` makes disjointness UNPROVABLE — error kept.
+        let src = "region A; fn f(&mut[A] int a, &mut[A] int b) requires(a == b) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert_eq!(
+            borrow_errs.len(),
+            1,
+            "a == b cannot prove disjointness, error should remain: {:?}",
             borrow_errs
         );
     }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -433,6 +433,33 @@ pub fn prove_auto(
     }
 }
 
+/// RES-393 D1: attempt to prove that two function parameters cannot alias
+/// given the function's `requires` preconditions.
+///
+/// Models each parameter as a free Z3 integer (standing for its region ID
+/// or pointer value). Returns `Some(true)` if the `requires` clauses imply
+/// `param_a != param_b`; `None` if Z3 cannot decide or `requires` is empty.
+#[allow(dead_code)]
+pub fn prove_alias_disjoint(param_a: &str, param_b: &str, requires: &[Node]) -> Option<bool> {
+    if requires.is_empty() {
+        return None;
+    }
+    let neq = Node::InfixExpression {
+        left: Box::new(Node::Identifier {
+            name: param_a.to_string(),
+            span: crate::span::Span::default(),
+        }),
+        operator: "!=".to_string(),
+        right: Box::new(Node::Identifier {
+            name: param_b.to_string(),
+            span: crate::span::Span::default(),
+        }),
+        span: crate::span::Span::default(),
+    };
+    let (verdict, _, _, _) = prove_with_axioms_and_timeout(&neq, &HashMap::new(), requires, 500);
+    verdict
+}
+
 /// Collect every identifier name seen in `node` (for BV counterexample
 /// extraction — mirrors `collect_int_identifiers` but used for BV vars).
 fn collect_bv_identifiers(node: &Node, out: &mut BTreeSet<String>) {


### PR DESCRIPTION
Closes #219

## Summary

- Add `prove_alias_disjoint(param_a, param_b, requires)` to `verifier_z3.rs`: models each parameter as a free Z3 integer and uses the function's `requires` preconditions as axioms to prove `param_a != param_b`.
- Wire the fallback into `check_region_aliasing` (lib.rs): before emitting a same-region alias error, try `#[cfg(feature = "z3")]` proof; if Z3 returns `Some(true)`, skip the syntactic reject.
- Two unit tests under `#[cfg(feature = "z3")]`: happy-path (requires a != b lifts the reject) and counter-case (requires a == b keeps the error).

## Next PRs

- D2 (`res-393-pr2-golden`): `region_z3_pos.rz` + `region_z3_neg.rz` golden examples
- D3-D5 (RES-394): region inference machinery, pass, integration
- D6-D9 (RES-395): region polymorphism (`fn<R>` syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)