### PR TITLE
RES-393: golden tests for Z3 alias-disjoint fallback (PR D2)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,24 @@
 {
   "claims": {
-    "resilient/src/verifier_z3.rs": {
-      "branch": "res-393-pr1-z3-fallback",
-      "claimed_at": "2026-05-01T01:20:02Z"
+    "docs/concurrency.md": {
+      "branch": "res-332-pr5-ping-pong",
+      "claimed_at": "2026-05-01T01:16:36Z"
     },
-    "resilient/src/lib.rs": {
-      "branch": "res-393-pr1-z3-fallback",
-      "claimed_at": "2026-05-01T01:20:02Z"
+    "resilient/examples/region_z3_pos.rz": {
+      "branch": "res-393-pr2-golden",
+      "claimed_at": "2026-05-01T01:31:08Z"
+    },
+    "resilient/examples/region_z3_pos.expected.txt": {
+      "branch": "res-393-pr2-golden",
+      "claimed_at": "2026-05-01T01:31:08Z"
+    },
+    "resilient/examples/region_z3_neg.rz": {
+      "branch": "res-393-pr2-golden",
+      "claimed_at": "2026-05-01T01:31:08Z"
+    },
+    "resilient/examples/region_z3_neg.expected.txt": {
+      "branch": "res-393-pr2-golden",
+      "claimed_at": "2026-05-01T01:31:08Z"
     }
   }
 }

--- a/resilient/examples/region_z3_neg.rz
+++ b/resilient/examples/region_z3_neg.rz
@@ -1,0 +1,16 @@
+// RES-393 D2: Z3 confirms a genuine aliasing violation.
+//
+// Two `&mut[A]` parameters share the same region label AND the
+// `requires` clause asserts they ARE equal — Z3 cannot prove disjointness,
+// so the borrow check error is kept in both z3 and non-z3 builds.
+region A;
+
+fn update_same(&mut[A] int a, &mut[A] int b) requires(a == b) {
+    println("should never reach this — borrow check rejects same-region mut refs");
+}
+
+fn main() {
+    update_same(1, 2);
+}
+
+main();

--- a/resilient/examples/region_z3_pos.rz
+++ b/resilient/examples/region_z3_pos.rz
@@ -1,0 +1,16 @@
+// RES-393 D2: Z3 proves two same-region `&mut` parameters are disjoint.
+//
+// The syntactic rule rejects same-region mut refs, but `requires(a != b)`
+// lets Z3 prove they can never alias. Build with `--features z3` to see
+// this example pass; without z3 the borrow check rejects it.
+region A;
+
+fn update_disjoint(&mut[A] int a, &mut[A] int b) requires(a != b) {
+    println("ok: Z3 proved a and b are disjoint");
+}
+
+fn main() {
+    update_disjoint(1, 2);
+}
+
+main();

--- a/resilient/tests/examples_smoke.rs
+++ b/resilient/tests/examples_smoke.rs
@@ -1107,3 +1107,34 @@ fn bytecode_vm_for_in_inside_fn_body_returns_correct_value() {
     );
     let _ = std::fs::remove_file(&tmp);
 }
+
+/// RES-393 D2: verify that the Z3 alias-disjoint fallback lets a
+/// `requires(a != b)` fn with same-region mut refs compile and run.
+#[test]
+#[cfg(feature = "z3")]
+fn res393_z3_pos_same_region_with_requires_neq_passes() {
+    let (stdout, stderr, code) = run_example("region_z3_pos.rz");
+    assert_eq!(
+        code,
+        Some(0),
+        "region_z3_pos.rz must exit 0 under --features z3; \
+         stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("ok: Z3 proved a and b are disjoint"),
+        "expected success message in stdout; got:\nstdout={stdout}\nstderr={stderr}"
+    );
+}
+
+/// RES-393 D2: verify that Z3 keeps the error when `requires(a == b)` —
+/// the constraint proves aliasing, not disjointness.
+#[test]
+#[cfg(feature = "z3")]
+fn res393_z3_neg_requires_eq_does_not_lift_error() {
+    let (_stdout, _stderr, code) = run_example("region_z3_neg.rz");
+    assert_ne!(
+        code,
+        Some(0),
+        "region_z3_neg.rz must fail; requires(a == b) cannot prove disjointness"
+    );
+}


### PR DESCRIPTION
Closes #219

Built on #752 (D1).

## Summary

- `region_z3_pos.rz`: same-region `&mut` params with `requires(a != b)`. Z3 proves disjointness → program runs under `--features z3`. No `.expected.txt` because output differs between z3 and non-z3 builds; covered by a `#[cfg(feature = "z3")]` smoke test in `examples_smoke.rs`.
- `region_z3_neg.rz` + empty `.expected.txt`: same-region refs with `requires(a == b)`. Z3 sees the constraint asserts aliasing, not disjointness → borrow check error retained in both builds. Same behaviour as `region_aliasing_err.rz`.

## Next PRs

- D3 (`res-394-pr1-inference-machinery`): create `region_inference.rs`, add `RegionVar(u32)` + unification table
- D4 (`res-394-pr2-inference-pass`): wire inference into typechecker EXTENSION_PASSES
- D5 (`res-394-pr3-integration`): integrate inferred regions into aliasing check

🤖 Generated with [Claude Code](https://claude.com/claude-code)