### PR TITLE
RES-395: region polymorphism — parser + AST node (PR D6)

### DIFF
--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1202,6 +1202,8 @@ fn node_line(n: &Node) -> Option<u32> {
         Node::EnumDecl { span, .. } => span.start.line as u32,
         // RES-406: unsafe block carries the keyword's span.
         Node::UnsafeBlock { span, .. } => span.start.line as u32,
+        // RES-395: region type-param node — carries its declaration span.
+        Node::RegionParam { span, .. } => span.start.line as u32,
     };
     if line == 0 { None } else { Some(line) }
 }

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -1116,6 +1116,7 @@ impl Formatter {
             | Node::TraitDecl { .. }
             | Node::EnumDecl { .. }
             | Node::UnsafeBlock { .. }
+            | Node::RegionParam { .. }
             | Node::Program(_) => {
                 self.fmt_stmt(node);
             }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -498,6 +498,8 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
         // RES-406: unsafe block — descend into the body so its free
         // variables flow up to the enclosing scope.
         Node::UnsafeBlock { body, .. } => walk(body, bound, free),
+        // RES-395: region type-param is a declaration marker; no free vars.
+        Node::RegionParam { .. } => {}
     }
 }
 

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -2284,6 +2284,14 @@ enum Node {
         variants: Vec<EnumVariant>,
         span: span::Span,
     },
+    /// RES-395 D6: a region type parameter declared in `fn foo<R>(...)`.
+    ///
+    /// Used to distinguish region parameters (used as labels in `[R]`
+    /// positions) from type parameters (used as types). Parsed in D6 as
+    /// entries in `type_params`; the substitution pass in D7 rewrites
+    /// call sites and upgrades these to explicit `RegionParam` nodes.
+    #[allow(dead_code)]
+    RegionParam { name: String, span: span::Span },
 }
 
 /// RES-400 PR 2: a single variant inside an `enum` declaration.
@@ -18291,6 +18299,9 @@ impl Interpreter {
             // regular block. The capability gate is enforced by the
             // typechecker / unsafe_check pass before evaluation.
             Node::UnsafeBlock { body, .. } => self.eval(body),
+            // RES-395: region type-param is a declaration marker; no
+            // runtime value.
+            Node::RegionParam { .. } => Ok(Value::Void),
         }
     }
 
@@ -20216,6 +20227,7 @@ pub(crate) fn check_region_aliasing(program: &Node, source_path: &str) -> Vec<St
             name: fn_name,
             parameters,
             requires,
+            type_params,
             span,
             ..
         } = &stmt.node
@@ -20224,14 +20236,22 @@ pub(crate) fn check_region_aliasing(program: &Node, source_path: &str) -> Vec<St
             // avoid an unused-variable warning in non-z3 builds.
             #[cfg(not(feature = "z3"))]
             let _ = requires;
+            // RES-395 D6: a function's own `<R, S, ...>` type params may
+            // serve as region parameters (used as labels in `[R]` positions).
+            // Extend the declared set with the function-scoped type params so
+            // `fn foo<R>(&mut[R] int a)` is accepted without a global `region R;`.
+            let mut fn_declared = declared.clone();
+            for tp in type_params {
+                fn_declared.insert(tp.clone());
+            }
 
             // Per-parameter pass: every labeled reference must name
-            // a declared region.
+            // a declared region (global or function-scoped).
             let mut refs: Vec<(usize, bool, Option<String>, String)> = Vec::new();
             for (idx, (ty, pname)) in parameters.iter().enumerate() {
                 if let Some((is_mut, label)) = parse_ref_type(ty) {
                     if let Some(l) = &label
-                        && !declared.contains(l)
+                        && !fn_declared.contains(l)
                     {
                         errors.push(prefix(
                             *span,
@@ -44499,6 +44519,53 @@ mod tests {
             borrow_errs.len(),
             1,
             "a == b cannot prove disjointness, error should remain: {:?}",
+            borrow_errs
+        );
+    }
+
+    // --- RES-395 D6: region type-params accepted as region labels ---
+
+    #[test]
+    fn res395_d6_type_param_accepted_as_region_label() {
+        // `fn foo<R>(&mut[R] int a, &mut[R] int b)` — same label via a
+        // function-scoped type param — should be rejected (same region,
+        // both mutable), just like `region R;` at the top level.
+        let src = "fn foo<R>(&mut[R] int a, &mut[R] int b) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert!(
+            !borrow_errs.is_empty(),
+            "two &mut[R] params must be rejected as aliasing"
+        );
+    }
+
+    #[test]
+    fn res395_d6_distinct_type_params_accepted() {
+        // `fn foo<R, S>(&mut[R] int a, &mut[S] int b)` — distinct
+        // function-scoped region params → different regions → accepted.
+        let src = "fn foo<R, S>(&mut[R] int a, &mut[S] int b) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert!(
+            borrow_errs.is_empty(),
+            "distinct region type-params should be accepted, got: {:?}",
+            borrow_errs
+        );
+    }
+
+    #[test]
+    fn res395_d6_type_param_not_confused_with_undeclared() {
+        // A label that matches a type-param should NOT be flagged as an
+        // undeclared region.
+        let src = "fn bar<Region>(&mut[Region] int x) {}\n";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let borrow_errs = check_region_aliasing(&program, "<test>");
+        assert!(
+            borrow_errs.is_empty(),
+            "type-param label should not be flagged as undeclared, got: {:?}",
             borrow_errs
         );
     }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4636,6 +4636,9 @@ impl TypeChecker {
             // the typechecker. Here we just descend into the body so
             // its statements get type-checked.
             Node::UnsafeBlock { body, .. } => self.check_node(body),
+            // RES-395: region type-param is a declaration-site marker;
+            // no type to check.
+            Node::RegionParam { .. } => Ok(Type::Void),
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `Node::RegionParam { name, span }` to the AST (infrastructure for D7 substitution pass; unused variant suppressed with `#[allow(dead_code)]` until D7 wires construction)
- Extends `check_region_aliasing` to accept function-scoped type params (e.g. `<R>`) as valid region labels, so `fn foo<R>(&mut[R] int a, &mut[R] int b)` compiles without a global `region R;` declaration
- Adds exhaustive match arms for `RegionParam` in `compiler.rs`, `typechecker.rs`, `formatter.rs`, `free_vars.rs`, and the interpreter (`eval`) — all are no-ops appropriate to each context
- 3 new unit tests covering: same-label rejection, distinct-label acceptance, multi-char type-param name not flagged as undeclared

## Planned follow-up PRs

- D7 (`res-395-pr2-subst`): typechecker substitution — substitute `R` at call sites
- D8 (`res-395-pr3-integration`): region inference integration with polymorphic params
- D9 (`res-395-pr4-docs`): SYNTAX.md region annotation entries + end-to-end golden tests

Closes #221
Built on #755 (D5)