### PR TITLE
RES-402: negative golden test for mixed-element-type array rejection

### DIFF
--- a/resilient/examples/array_polymorphic_neg.expected.txt
+++ b/resilient/examples/array_polymorphic_neg.expected.txt
@@ -1,0 +1,2 @@
+1
+Program executed successfully

--- a/resilient/examples/array_polymorphic_neg.rz
+++ b/resilient/examples/array_polymorphic_neg.rz
@@ -1,0 +1,11 @@
+// RES-402: mixed-element-type array literal is a compile-time error.
+//
+// `[1, "two"]` mixes Int and String elements. The typechecker rejects
+// it with a diagnostic naming both types.
+
+fn main() {
+    let xs = [1, "two"];
+    println(xs[0]);
+}
+
+main();

--- a/resilient/tests/examples_smoke.rs
+++ b/resilient/tests/examples_smoke.rs
@@ -1151,3 +1151,29 @@ fn res395_d8_call_site_aliasing_detected() {
         "region_poly_call.rz must fail — call-site region aliasing should be detected"
     );
 }
+
+/// RES-402: mixed-element-type array literal is rejected by `--typecheck`.
+/// `[1, "two"]` mixes Int and String; the typechecker must exit non-zero
+/// and emit a diagnostic naming both types.
+#[test]
+fn res402_mixed_array_literal_rejected_by_typecheck() {
+    let path = format!(
+        "{}/examples/array_polymorphic_neg.rz",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let output = Command::new(bin())
+        .arg("--typecheck")
+        .arg(&path)
+        .output()
+        .expect("spawn resilient --typecheck");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "mixed-type array literal must fail typecheck; got zero exit\nstderr={stderr}"
+    );
+    assert!(
+        stderr.contains("mixed element types"),
+        "diagnostic must mention 'mixed element types'; got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `array_polymorphic_neg.rz`: a `[1, "two"]` mixed-type array literal. In default interpreter mode it runs successfully (prints `1`); under `--typecheck` the typechecker rejects it with "mixed element types" at the construction site.
- Adds `array_polymorphic_neg.expected.txt` sidecar (interpreter mode output) so the golden harness covers it.
- Adds smoke test `res402_mixed_array_literal_rejected_by_typecheck` that runs `--typecheck` and asserts non-zero exit + "mixed element types" in stderr.

This satisfies the last open acceptance criterion in #365 (negative golden test).

Closes #365

## Test plan

- [x] `cargo test` — all tests pass (19 in examples_smoke, 2246 in lib tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `array_polymorphic_neg.rz` exits 0 in interpreter mode (golden matches)
- [x] `array_polymorphic_neg.rz --typecheck` exits non-zero with "mixed element types"

🤖 Generated with [Claude Code](https://claude.com/claude-code)