### PR TITLE
RES-764: fix stale docs CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ docker run --rm ghcr.io/ericspencer00/resilient:latest --help
 
 # Run a source file by mounting it in:
 docker run --rm -v "$PWD":/work -w /work \
-    ghcr.io/ericspencer00/resilient:latest examples/hello.rz
+    ghcr.io/ericspencer00/resilient:latest resilient/examples/hello.rz
 ```
 
 The image is multi-arch (linux/amd64 + linux/arm64), built from `Dockerfile`
@@ -240,7 +240,7 @@ If you'd rather not install — typical contributor workflow:
 
 ```bash
 cargo build --release --manifest-path resilient/Cargo.toml
-./resilient/target/release/rz examples/hello.rz
+./resilient/target/release/rz resilient/examples/hello.rz
 ```
 
 ### SMT-backed verification (optional)
@@ -627,7 +627,7 @@ you want to see what the scanner actually emitted, without
 editing source (RES-112). Mutually exclusive with `--lsp`.
 
 ```sh
-rz --dump-tokens examples/hello.rz
+rz --dump-tokens resilient/examples/hello.rz
 # 2:1  Function("fn")
 # 2:4  Identifier("main")("main")
 # 2:8  LeftParen("(")
@@ -642,7 +642,7 @@ columns, and absolute jump targets (RES-173). The output reflects
 the RES-172 peephole pass, so what you see is what runs.
 
 ```sh
-rz --dump-chunks examples/hello.rz
+rz --dump-chunks resilient/examples/hello.rz
 # === main ===
 # constants:
 #   const[0] = "Hello, Resilient world!"
@@ -664,7 +664,7 @@ indented under the function signature). By default it prints to
 stdout; pass `--in-place` to overwrite the file.
 
 ```bash
-rz fmt examples/hello.rz              # print to stdout
+rz fmt resilient/examples/hello.rz    # print to stdout
 rz fmt --in-place src/main.rz         # overwrite
 ```
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -434,22 +434,22 @@ For a full index of compiler error codes see the [Error Reference](errors/).
 
 ```bash
 # Run the interpreter
-resilient examples/hello.rz
+rz resilient/examples/hello.rz
 
 # With static type checking
-resilient --typecheck examples/hello.rz
+rz --typecheck resilient/examples/hello.rz
 
 # With the verification audit
-resilient --audit examples/hello.rz
+rz --audit resilient/examples/hello.rz
 
 # Bytecode VM
-resilient --vm examples/hello.rz
+rz --vm resilient/examples/hello.rz
 
 # Cranelift JIT (requires --features jit at build time)
-resilient --jit examples/hello.rz
+rz --jit resilient/examples/hello.rz
 
 # Interactive REPL
-resilient
+rz
 ```
 
 ---

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -55,7 +55,7 @@ Honours the `logos-lexer` feature flag — same output either way.
 Mutually exclusive with `--lsp`.
 
 ```bash
-rz --dump-tokens examples/hello.rz
+rz --dump-tokens resilient/examples/hello.rz
 ```
 
 ### `--dump-chunks <file>`
@@ -66,7 +66,7 @@ every bytecode chunk — `main` plus each user function — with
 constants, offsets, lines, opnames, and resolved jump targets.
 
 ```bash
-rz --dump-chunks examples/hello.rz
+rz --dump-chunks resilient/examples/hello.rz
 ```
 
 Mutually exclusive with `--dump-tokens` and `--lsp`. The column

--- a/docs/tutorial/02-variables-and-types.md
+++ b/docs/tutorial/02-variables-and-types.md
@@ -59,7 +59,7 @@ type errors to runtime. The `--typecheck` (or `-t`) flag
 enables the static checker:
 
 ```bash
-resilient --typecheck hello.rz
+rz --typecheck hello.rz
 ```
 
 When every binding and call is consistent, you get a green

--- a/docs/tutorial/03-functions-and-contracts.md
+++ b/docs/tutorial/03-functions-and-contracts.md
@@ -78,7 +78,7 @@ the compiler discharged statically versus the number it
 deferred to runtime:
 
 ```bash
-resilient --typecheck --audit your_file.rz
+rz --typecheck --audit your_file.rz
 ```
 
 Try it on this program:

--- a/docs/tutorial/05-verifying-with-z3.md
+++ b/docs/tutorial/05-verifying-with-z3.md
@@ -72,7 +72,7 @@ obligation:
 
 ```bash
 mkdir -p certs
-resilient --typecheck --emit-certificate certs path/to/ident_round.rz
+rz --typecheck --emit-certificate certs path/to/ident_round.rz
 ```
 
 You'll see:


### PR DESCRIPTION
## Description
This fixes stale user-facing command examples across the README and docs.

The docs had drifted in two ways:
- several repo-root examples still referenced `examples/hello.rz`, but the actual path in this repo is `resilient/examples/hello.rz`
- a few tutorial/reference pages still used the retired `resilient` binary name instead of the current `rz` CLI

## Linked issue
Closes #764

## Acceptance criteria
- [x] README repo-root commands use a valid example path
- [x] Docs pages use the current `rz` binary name in the touched examples
- [x] The corrected example commands were validated against the current tree

## Test evidence
```bash
$ cargo build --release --manifest-path resilient/Cargo.toml
Finished `release` profile [optimized] target(s) in 12.40s

$ ./resilient/target/release/rz resilient/examples/hello.rz
Hello, Resilient world!
Program executed successfully

$ ./resilient/target/release/rz --dump-tokens resilient/examples/hello.rz | head -n 8
2:1  Function("fn")
2:4  Identifier("main")("main")
...
```

Local docs-site validation was attempted with:
```bash
$ bundle exec jekyll build --source docs --destination /tmp/resilient-site-check --baseurl "/Resilient"
```
but this checkout is on Ruby 2.6 / Bundler 1.17, which could not resolve the repo's current `github-pages` bundle. GitHub Actions is the source of truth for the docs workflow on this PR.

- [ ] New tests added (unit and/or `.expected.txt` golden)
- [ ] `cargo fmt --all` clean
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo build --manifest-path resilient/Cargo.toml` succeeds with any feature flags this PR touches

## Stability impact
- [ ] STABILITY.md CHANGELOG updated (if user-visible syntax or builtin changed)
- [x] GitHub Issue closed via `Closes #N` in the PR body

## Notes for reviewers
This is docs-only. I intentionally did not touch any tests or golden files.
