### PR TITLE
RES-767: fix remaining stale docs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ re-verify it under their own solver — without trusting the Resilient
 binary:
 
 ```bash
-rz --emit-certificate ./certs examples/cert_demo.rz   # requires --features z3 build
+rz --emit-certificate ./certs resilient/examples/cert_demo.rz   # requires --features z3 build
 ```
 
 One file is written per discharged obligation:

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -31,7 +31,7 @@ fn main() {
 main();
 ```
 
-Run with: `rz examples/ffi_libm.rz` (binary built with `--features ffi`).
+Run with: `rz resilient/examples/ffi_libm.rz` (binary built with `--features ffi`).
 
 ## Extern block syntax
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -213,7 +213,7 @@ per discharged obligation, each independently re-verifiable
 under any compatible solver.
 
 ```bash
-rz --emit-certificate ./certs examples/cert_demo.rz   # binary built with --features z3
+rz --emit-certificate ./certs resilient/examples/cert_demo.rz   # binary built with --features z3
 z3 -smt2 ./certs/ident_round__decl__0.smt2
 # unsat   ← the proof: negation is unsatisfiable, so the original holds
 ```

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -98,7 +98,7 @@ proven statically vs left to runtime. Useful for understanding
 what the verifier is (and isn't) doing on a given program.
 
 ```bash
-rz --audit examples/sensor_monitor.rz
+rz --audit resilient/examples/sensor_monitor.rz
 ```
 
 ### `--emit-certificate <dir>`
@@ -110,7 +110,7 @@ binary. One file per obligation, named `<fn>__<kind>__<idx>.smt2`.
 Implies `--typecheck`. Requires `--features z3`.
 
 ```bash
-rz --emit-certificate ./certs examples/cert_demo.rz   # binary built with --features z3
+rz --emit-certificate ./certs resilient/examples/cert_demo.rz   # binary built with --features z3
 ```
 
 Every run also writes a `manifest.json` index with per-obligation

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -38,7 +38,7 @@ a snippet stops working, CI notices.
 Code blocks marked ```resilient are runnable as-is:
 
 ```bash
-resilient path/to/snippet.rz
+rz path/to/snippet.rz
 ```
 
 Copy-paste any one of them into a `.rz` file and run it. Or skip


### PR DESCRIPTION
## Description
This fixes the remaining user-facing runnable command examples that had drifted from the current CLI / repo layout.

The touched docs were still split between:
- repo-root `examples/...` paths, even though examples live under `resilient/examples/...`
- one tutorial page still telling users to invoke the retired `resilient` binary name instead of `rz`

## Linked issue
Closes #767

## Acceptance criteria
- [x] Touched docs use valid repo-root example paths
- [x] Touched docs use the current `rz` CLI name
- [x] Referenced example files were validated against the current tree

## Test evidence
```bash
$ test -f resilient/examples/cert_demo.rz \
    && test -f resilient/examples/sensor_monitor.rz \
    && test -f resilient/examples/ffi_libm.rz
ok

$ rg -n 'examples/cert_demo\\.rz|examples/sensor_monitor\\.rz|examples/ffi_libm\\.rz|resilient path/to/snippet\\.rz' README.md docs/tooling.md docs/getting-started.md docs/tutorial.md docs/ffi.md
# only the corrected resilient/examples/... and rz forms remain
```

- [ ] New tests added (unit and/or `.expected.txt` golden)
- [ ] `cargo fmt --all` clean
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo build --manifest-path resilient/Cargo.toml` succeeds with any feature flags this PR touches

## Stability impact
- [ ] STABILITY.md CHANGELOG updated (if user-visible syntax or builtin changed)
- [x] GitHub Issue closed via `Closes #N` in the PR body

## Notes for reviewers
Docs-only. No tests or golden files were modified.
