### PR TITLE
RES-793: Mobile-friendly playground with horizontal split and output-first layout

### DIFF
--- a/playground/web/style.css
+++ b/playground/web/style.css
@@ -153,6 +153,20 @@ main {
 @media (max-width: 800px) {
   main {
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr 1fr;
+    grid-template-rows: auto 1fr;
+  }
+
+  main > :nth-child(2) {
+    order: -1;
+  }
+
+  .output-pane {
+    min-height: 200px;
+    max-height: 50vh;
+    border-bottom: 1px solid #d0d0d0;
+  }
+
+  .editor-pane {
+    flex: 1 1 auto;
   }
 }


### PR DESCRIPTION
## Summary

Implements a mobile-friendly version of the Resilient playground with:
- **Output section first** on mobile — users see execution results immediately
- **Horizontal split** with output section (50vh max) above editor
- **Preserved desktop layout** — vertical two-column layout unchanged
- Clean visual divider between sections on mobile

## Changes

### `playground/web/style.css`
- Update mobile media query to use `grid-template-rows: auto 1fr` for stacked layout
- Use CSS flexbox `order: -1` to move output pane first in visual order
- Set output pane `min-height: 200px` and `max-height: 50vh` for mobile
- Add visual divider between output and editor on mobile

## Mobile layout
On devices ≤800px width:
```
┌──────────────────────┐
│   Output Section     │ ← Appears first, max 50vh
│  (scrollable)        │
├──────────────────────┤ ← Visual divider
│   Editor Section     │ ← Takes remaining space
│  (CodeMirror)        │
└──────────────────────┘
```

## Desktop layout (unchanged)
```
┌─────────────┬────────────────┐
│   Editor    │   Output       │
│  (left)     │   (right)      │
│             │                │
└─────────────┴────────────────┘
```

## Testing
- [x] CSS changes syntax-checked
- [ ] Manual test on mobile/tablet viewport (≤800px)
- [ ] Verify desktop layout unchanged (>800px)
- [ ] Test scrolling behavior in both panes
- [ ] Verify example loading and Run button still work

Closes #793

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAp4RsGoMGnKVGwBE49WTt)_