### PR TITLE
RES-800: Fix clippy warning - function pointer comparison in vm.rs

### DIFF
--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -3032,7 +3032,7 @@ mod tests {
             // — comparing fn pointers via address.
             let h = HANDLERS[idx];
             assert!(
-                h as usize != h_unreachable as usize,
+                !std::ptr::eq(h as *const (), h_unreachable as *const ()),
                 "op {:?} mapped to unreachable slot {}",
                 op,
                 idx


### PR DESCRIPTION
## Summary

Fixes clippy warning about unsafe function pointer casts by using idiomatic `std::ptr::eq` for pointer comparison.

**Changes:**
- Line 3035 in vm.rs: Replace `h as usize != h_unreachable as usize` with `!std::ptr::eq(h as *const (), h_unreachable as *const ())`

**Test Results:**
- `cargo test` passes
- `cargo clippy --all-targets -- -D warnings` passes with no errors

## Rationale

Modern clippy versions recommend using `std::ptr::eq` for pointer comparison instead of casting to usize. This is more idiomatic and clearer about intent.

Closes #805"

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmfyqpjQuKUY3Zb9YHkEcf)_