### PR TITLE
RES-802 / RES-800 / RES-798: Add keyword docs and L0013 lint

### DIFF
--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -225,8 +225,14 @@ enum Tok {
     // Add new keyword tokens here — one #[token("keyword")] + Variant per feature.
     // Append-only. Merge conflicts: keep ALL variants from both sides.
     // RES-386/RES-388: actor keywords.
+    /// RES-332: `actor` — declares lightweight concurrent units with isolated state.
+    /// Currently the parser and type system support actor syntax, with primitives
+    /// (`spawn`, `send`, `receive`) partially shipped; full actor declarations
+    /// (with supervised restart policies) ship with RES-332.
     #[token("actor")]
     Actor,
+    /// RES-332: `receive` — declares a handler within an actor that processes
+    /// incoming messages. Syntax: `receive handler_name(params) { ... }`.
     #[token("receive")]
     Receive,
     #[token("concurrent_ensures")]

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -72,6 +72,7 @@ pub const KNOWN_CODES: &[&str] = &[
     "L0010", // function has no requires/ensures contract
     "L0011", // RES-308: unused variable warning (let binding never read)
     "L0012", // RES-397: spec annotation lacks `// source:` provenance comment
+    "L0013", // RES-798: unchecked array indexing (not proven in-bounds)
 ];
 
 /// RES-778: process-wide policy switch for safety-critical CLI mode.
@@ -109,6 +110,7 @@ pub fn check(program: &Node, source: &str) -> Vec<Lint> {
     run_l0010_no_contract(program, &mut out);
     run_l0011_unused_variable(program, &mut out);
     run_l0012_spec_provenance(program, source, &mut out);
+    run_l0013_unchecked_indexing(program, &mut out);
 
     let safety_critical = safety_critical_mode();
     if safety_critical {
@@ -1876,6 +1878,147 @@ fn l0012_walk(node: &Node, sources: &std::collections::HashSet<u32>, out: &mut V
         Node::ImplBlock { methods, .. } => {
             for method in methods {
                 l0012_walk(method, sources, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn run_l0013_unchecked_indexing(program: &Node, out: &mut Vec<Lint>) {
+    let Node::Program(stmts) = program else {
+        return;
+    };
+    for spanned in stmts {
+        l0013_walk(&spanned.node, out);
+    }
+}
+
+fn l0013_walk(node: &Node, out: &mut Vec<Lint>) {
+    match node {
+        Node::IndexExpression {
+            target,
+            index,
+            span,
+            ..
+        } => {
+            // RES-798: check if this index access was proven in-bounds by
+            // the bounds_check pass. If not, emit L0013 warning.
+            if !crate::bounds_check::is_proven_site(*span) {
+                out.push(Lint {
+                    code: "L0013".into(),
+                    severity: Severity::Warning,
+                    message:
+                        "unchecked array indexing — bounds not proven at compile time; \
+                         use --deny-unproven-bounds to require proof, or suppress with \
+                         `// resilient: allow L0013`"
+                            .to_string(),
+                    line: span.start.line as u32,
+                    column: span.start.column as u32,
+                });
+            }
+            // Recurse into both target and index
+            l0013_walk(target, out);
+            l0013_walk(index, out);
+        }
+        Node::Block { stmts, .. } => {
+            for stmt in stmts {
+                l0013_walk(stmt, out);
+            }
+        }
+        Node::Function {
+            body, requires, ensures, ..
+        } => {
+            for req in requires {
+                l0013_walk(req, out);
+            }
+            for ens in ensures {
+                l0013_walk(ens, out);
+            }
+            l0013_walk(body, out);
+        }
+        Node::IfStatement {
+            consequence,
+            alternative,
+            condition,
+            ..
+        } => {
+            l0013_walk(condition, out);
+            l0013_walk(consequence, out);
+            if let Some(alt) = alternative {
+                l0013_walk(alt, out);
+            }
+        }
+        Node::WhileStatement { body, condition, .. } => {
+            l0013_walk(condition, out);
+            l0013_walk(body, out);
+        }
+        Node::ForInStatement {
+            iterable, body, ..
+        } => {
+            l0013_walk(iterable, out);
+            l0013_walk(body, out);
+        }
+        Node::LiveBlock { body, .. } => {
+            l0013_walk(body, out);
+        }
+        Node::Match { scrutinee, arms, .. } => {
+            l0013_walk(scrutinee, out);
+            for (_, guard, body) in arms {
+                if let Some(g) = guard {
+                    l0013_walk(g, out);
+                }
+                l0013_walk(body, out);
+            }
+        }
+        Node::InfixExpression { left, right, .. } => {
+            l0013_walk(left, out);
+            l0013_walk(right, out);
+        }
+        Node::PrefixExpression { right, .. } => {
+            l0013_walk(right, out);
+        }
+        Node::CallExpression {
+            function, arguments, ..
+        } => {
+            l0013_walk(function, out);
+            for arg in arguments {
+                l0013_walk(arg, out);
+            }
+        }
+        Node::StructLiteral { fields, .. } => {
+            for (_, value) in fields {
+                l0013_walk(value, out);
+            }
+        }
+        Node::ReturnStatement { value, .. } => {
+            if let Some(val) = value {
+                l0013_walk(val, out);
+            }
+        }
+        Node::ImplBlock { methods, .. } => {
+            for method in methods {
+                l0013_walk(method, out);
+            }
+        }
+        Node::FieldAccess { target, .. } => {
+            l0013_walk(target, out);
+        }
+        Node::ExpressionStatement { expr, .. } => {
+            l0013_walk(expr, out);
+        }
+        Node::TryCatch { body, handlers, .. } => {
+            for stmt in body {
+                l0013_walk(stmt, out);
+            }
+            for (_, handler_body) in handlers {
+                for stmt in handler_body {
+                    l0013_walk(stmt, out);
+                }
+            }
+        }
+        Node::ArrayLiteral { items, .. } => {
+            for item in items {
+                l0013_walk(item, out);
             }
         }
         _ => {}

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -1907,11 +1907,10 @@ fn l0013_walk(node: &Node, out: &mut Vec<Lint>) {
                 out.push(Lint {
                     code: "L0013".into(),
                     severity: Severity::Warning,
-                    message:
-                        "unchecked array indexing — bounds not proven at compile time; \
+                    message: "unchecked array indexing — bounds not proven at compile time; \
                          use --deny-unproven-bounds to require proof, or suppress with \
                          `// resilient: allow L0013`"
-                            .to_string(),
+                        .to_string(),
                     line: span.start.line as u32,
                     column: span.start.column as u32,
                 });
@@ -1926,7 +1925,10 @@ fn l0013_walk(node: &Node, out: &mut Vec<Lint>) {
             }
         }
         Node::Function {
-            body, requires, ensures, ..
+            body,
+            requires,
+            ensures,
+            ..
         } => {
             for req in requires {
                 l0013_walk(req, out);
@@ -1948,20 +1950,22 @@ fn l0013_walk(node: &Node, out: &mut Vec<Lint>) {
                 l0013_walk(alt, out);
             }
         }
-        Node::WhileStatement { body, condition, .. } => {
+        Node::WhileStatement {
+            body, condition, ..
+        } => {
             l0013_walk(condition, out);
             l0013_walk(body, out);
         }
-        Node::ForInStatement {
-            iterable, body, ..
-        } => {
+        Node::ForInStatement { iterable, body, .. } => {
             l0013_walk(iterable, out);
             l0013_walk(body, out);
         }
         Node::LiveBlock { body, .. } => {
             l0013_walk(body, out);
         }
-        Node::Match { scrutinee, arms, .. } => {
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
             l0013_walk(scrutinee, out);
             for (_, guard, body) in arms {
                 if let Some(g) = guard {
@@ -1978,7 +1982,9 @@ fn l0013_walk(node: &Node, out: &mut Vec<Lint>) {
             l0013_walk(right, out);
         }
         Node::CallExpression {
-            function, arguments, ..
+            function,
+            arguments,
+            ..
         } => {
             l0013_walk(function, out);
             for arg in arguments {

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -1990,11 +1990,12 @@ fn l0013_walk(node: &Node, out: &mut Vec<Lint>) {
                 l0013_walk(value, out);
             }
         }
-        Node::ReturnStatement { value, .. } => {
-            if let Some(val) = value {
-                l0013_walk(val, out);
-            }
+        Node::ReturnStatement {
+            value: Some(val), ..
+        } => {
+            l0013_walk(val, out);
         }
+        Node::ReturnStatement { value: None, .. } => {}
         Node::ImplBlock { methods, .. } => {
             for method in methods {
                 l0013_walk(method, out);


### PR DESCRIPTION
## Summary

Addresses three documentation and linting issues:

- **RES-802**: Add `Token::Actor` doc comment explaining lightweight concurrent units with isolated state, referencing RES-332
- **RES-800**: Add `Token::Receive` doc comment explaining handler syntax
- **RES-798**: Add L0013 lint warning for unchecked array indexing (not proven in-bounds by static analysis)

## Details

### RES-802 / RES-800 (Keyword documentation)
Adds doc comments to lexer token enum for `actor` and `receive` keywords.

### RES-798 (L0013 lint)
Extends lint infrastructure with new warning for array indexing without static proof:
- New L0013 code added to KNOWN_CODES registry
- run_l0013_unchecked_indexing walks AST detecting unproven index accesses
- Warns in default mode; can be suppressed with `// resilient: allow L0013`
- Complements --deny-unproven-bounds flag

## Test plan

- `cargo test --manifest-path resilient/Cargo.toml` passes
- Clippy clean
- Keyword documentation is accessible to library users
- L0013 fires on unproven indexing (but existing code stays green as bounds are proven or runtime-checked)

Closes #802
Closes #800
Closes #798