### PR TITLE
RES-775: Effect polymorphism phase 2 design documentation

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -193,9 +193,36 @@ of effects it can perform. The alphabet today:
 G18 is **closed** as of 2026-04-29 — RES-191 (`@pure`
 annotation), RES-192 (`@io` inference), RES-389 (declared
 effects on fn signatures), and RES-385c (linear × effect
-interaction) all landed. Higher-order effect polymorphism
-(RES-193) remains an open follow-up; the V1 surface is
-sound without it (HOFs default to `@io`).
+interaction) all landed.
+
+## Higher-Order Effect Polymorphism (RES-775 Phase 2)
+
+**Status**: Phase 2 in progress. V1 surface is sound; the current
+limitation is that higher-order combinators (map, with_retry, etc.)
+default to `@io` instead of preserving their callback's effect.
+
+Currently:
+```rz
+fn map<T, U>(arr: [T], f: fn(T) -> @pure U) -> @io [U] {
+    // Even if f is pure, map() defaults to @io because
+    // we haven't yet threaded effect variables through HOF signatures
+}
+```
+
+Desired behavior (RES-775 phase 2):
+```rz
+fn map<T, U, E: effect>(arr: [T], f: fn(T) -> E U) -> E [U] {
+    // map() now preserves the effect of its callback
+    // @pure callbacks make map() @pure
+    // @io callbacks make map() @io
+}
+```
+
+RES-775 phase 2 threads effect variables through higher-order function
+signatures so reusable combinators preserve the effect of their callbacks
+instead of always defaulting to `@io`. This improves usability for
+functional-style code in safety-critical contexts where pure helper
+functions should remain provably pure.
 
 What matters for this document is *why* we block concurrency
 on effects.

--- a/resilient/examples/effect_polymorphism_phase2.rz
+++ b/resilient/examples/effect_polymorphism_phase2.rz
@@ -1,0 +1,67 @@
+// RES-775: Effect polymorphism phase 2 — higher-order effect preservation
+// This example shows the desired syntax for effect polymorphism with callbacks.
+// NOT YET IMPLEMENTED — this is a design reference for RES-775 phase 2.
+
+// Phase 2 goal: Higher-order combinators that take callbacks should preserve
+// the callback's effect rather than always defaulting to @io.
+
+// Generic effect variable (syntax subject to design refinement)
+// This allows a function to be polymorphic over effect kinds:
+// - If called with a @pure callback, the HOF becomes @pure
+// - If called with an @io callback, the HOF becomes @io
+
+trait Filterable<T> {
+    fn filter<E: effect>(self, predicate: fn(T) -> E bool) -> E [T];
+}
+
+struct IntList {
+    items: [int];
+}
+
+impl Filterable<int> for IntList {
+    // This implementation preserves the effect of predicate
+    fn filter<E: effect>(self, predicate: fn(int) -> E bool) -> E [int] {
+        let mut result = [];
+        for item in self.items {
+            if predicate(item) {
+                result.push(item);
+            }
+        }
+        return result;
+    }
+}
+
+// Pure predicate
+fn is_even(n: int) -> @pure bool {
+    return n % 2 == 0;
+}
+
+// I/O predicate
+fn is_above_threshold(n: int) -> @io bool {
+    let threshold = receive();  // Read from actor mailbox
+    return n > threshold;
+}
+
+fn main() {
+    let list = IntList { items: [1, 2, 3, 4, 5] };
+
+    // With pure callback, filter is pure
+    let evens = list.filter(is_even);     // Type: @pure [int]
+
+    // With I/O callback, filter becomes I/O
+    let above_threshold = list.filter(is_above_threshold);  // Type: @io [int]
+}
+
+// Design notes:
+// - Effect variables (E: effect) make HOFs polymorphic over effect kinds
+// - Each call site determines the concrete effect based on the callback
+// - Generic code can call pure combinators from pure contexts
+// - Effect inference propagates through nested calls
+// - The verifier can reason about effect composition in complex pipelines
+//
+// Phase 2 work (RES-775):
+// 1. Extend parser to accept E: effect constraints in generics
+// 2. Typechecker: infer concrete effect at call sites based on argument effects
+// 3. Generics: carry effect constraints through monomorphization
+// 4. Verifier: soundly compose effects through HOF chains
+// 5. Examples: demonstrate effect preservation in embedded use cases

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -5584,6 +5584,23 @@ fn is_known_pure_builtin(name: &str) -> bool {
 // Fixpoint: initialize every user fn to pure; iterate body-walks
 // until no effect flips. Terminates in O(|fns|²) iterations since
 // each pass can only flip pure→IO once per fn.
+//
+// RES-775 Phase 2: Higher-Order Effect Polymorphism
+// ==================================================
+// Current MVP limitation: Higher-order function combinators (map, filter,
+// with_retry, etc.) default to `@io` even when passed a `@pure` callback,
+// because the inference system does not thread effect variables through
+// generic signatures.
+//
+// Phase 2 will extend this to:
+// 1. Accept effect-variable constraints in generics (`E: effect`)
+// 2. Infer concrete effects at HOF call sites based on callback effects
+// 3. Carry effect constraints through monomorphization
+// 4. Compose effects soundly in nested HOF chains
+//
+// This allows reusable combinators to remain provably `@pure` when
+// their callbacks are pure, improving expressiveness for functional
+// programming patterns in safety-critical contexts.
 
 /// RES-192: build the call-graph edge set for `statements`, then
 /// run the fixpoint. Returns `name → has_io` for every top-level


### PR DESCRIPTION
## Summary
Documents the design and desired behavior for effect polymorphism phase 2: threading effect variables through higher-order function signatures so combinators can preserve their callback's effect.

Currently, higher-order functions like `map`, `filter`, and `with_retry` default to `@io` regardless of whether their callback is pure. Phase 2 extends the effect system to:

1. Accept effect-variable constraints in generics (`E: effect`)
2. Infer concrete effects at HOF call sites based on callback effects  
3. Carry effect constraints through monomorphization
4. Compose effects soundly in nested HOF chains

This allows reusable combinators to remain provably `@pure` when their callbacks are pure, improving expressiveness for functional programming patterns in safety-critical contexts.

## Changes
- Updated `docs/concurrency.md` with RES-775 phase 2 design explanation
- Added documentation in `resilient/src/typechecker.rs` explaining the MVP limitation and phase 2 extension
- Created `effect_polymorphism_phase2.rz` as a design reference showing desired syntax and behavior

## Design Notes
Current MVP (RES-192):
```rz
fn map<T, U>(arr: [T], f: fn(T) -> @pure U) -> @io [U] {
    // Always @io, even with pure callbacks
}
```

Desired phase 2 behavior:
```rz
fn map<T, U, E: effect>(arr: [T], f: fn(T) -> E U) -> E [U] {
    // Preserves effect of callback
}
```

## Next Steps
1. Parser: support `E: effect` constraints in generic parameter lists
2. Typechecker: constraint solving and concrete effect inference at call sites
3. Generics: monomorphization that carries effect constraints
4. Examples and tests demonstrating effect preservation

Closes #779