### PR TITLE
RES-782: Cluster verifier phase 1 design documentation

### DIFF
--- a/resilient/examples/cluster_leader_election_partitioned.rz
+++ b/resilient/examples/cluster_leader_election_partitioned.rz
@@ -1,0 +1,79 @@
+// RES-782: Cluster verifier follow-up — network partitions and dropped delivery
+// This example shows the desired syntax for modeling partitioned clusters.
+// NOT YET IMPLEMENTED — this is a design reference for RES-782 phase 1.
+
+// Phase 1 goal: Extend the cluster verifier to model network partitions
+// and dropped delivery, allowing users to verify invariants under
+// failure assumptions instead of assuming fully connected, reliable networks.
+
+cluster LeaderElection {
+    members: [A, B, C],
+
+    // The fully-connected ideal case: all members can communicate
+    // (This is the current MVP behavior)
+    cluster_invariant: count_leaders(state) <= 1,
+
+    // Phase 1: Users can now specify partition assumptions
+    // and verify invariants under those assumptions
+    partition_tests: [
+        {
+            name: "no_partition_fully_connected",
+            partition: none,  // No partition — all members connected
+            invariant: count_leaders(state) <= 1,
+        },
+        {
+            name: "split_brain_A_isolated",
+            partition: {
+                disconnected_edges: [(A, B), (A, C)]
+            },
+            // In a split-brain, we expect the invariant might be violated
+            // if both sides elect leaders independently
+            should_hold: false,
+            expected_violation: "split-brain scenario can elect multiple leaders",
+        },
+        {
+            name: "partition_tolerant_quorum",
+            partition: {
+                disconnected_edges: [(A, B), (A, C)]
+            },
+            // A quorum-based variant of the invariant that IS partition-tolerant:
+            // "at most one leader exists in any connected quorum of 2+ members"
+            invariant: count_leaders_in_quorum(state) <= 1,
+            should_hold: true,
+        },
+    ]
+}
+
+// Actor implementation (sample structure)
+actor LeaderA {
+    is_leader: bool = false,
+    term: int = 0,
+}
+
+actor LeaderB {
+    is_leader: bool = false,
+    term: int = 0,
+}
+
+actor LeaderC {
+    is_leader: bool = false,
+    term: int = 0,
+}
+
+// Handlers would implement election logic here
+// (Simplified for design reference)
+
+// Design notes:
+// - Partition model: explicit declaration of disconnected edges
+// - Dropped delivery: handlers cannot assume messages cross partition edges
+// - The verifier checks invariants against the specified partition topology
+// - Users can verify both:
+//   * That invariants are violated under specific failures (split-brain)
+//   * That partition-resilient variants hold despite partitions (quorum-based)
+//
+// Phase 1 work (RES-782):
+// 1. Parser: `partition { disconnected_edges: [...] }` syntax in cluster blocks
+// 2. Verifier model: filter inter-actor send/receive based on partition edges
+// 3. Constraint generation: generate Z3 constraints accounting for dropped messages
+// 4. Examples: split-brain, quorum-based, and partition-tolerant invariants
+// 5. Diagnostics: explain which partition scenario violates the invariant

--- a/resilient/src/cluster_verifier.rs
+++ b/resilient/src/cluster_verifier.rs
@@ -44,6 +44,34 @@
 //!   existential quantification over payloads.
 //! - No dynamic cluster membership, no inter-cluster communication,
 //!   no liveness — out of scope per the ticket, filed as follow-ups.
+//!
+//! # RES-782: Network Partition and Dropped Delivery Modeling
+//!
+//! The MVP assumes a fully connected, reliable network: every message
+//! sent is delivered. This is sound for verifying in the ideal case,
+//! but many real distributed systems must tolerate network partitions
+//! and dropped messages.
+//!
+//! Phase 1 (RES-782) extends the verifier surface to let users state
+//! and check invariants under explicit partition / failure assumptions:
+//!
+//! - **Partition model**: A partition is a declaration of which members
+//!   cannot communicate. For example, `partition { (A, B), (B, C) }`
+//!   means A ↔ B cannot send/receive, B ↔ C cannot send/receive, but
+//!   A ↔ C can. Messages sent across a partition edge are dropped.
+//!
+//! - **Dropped delivery**: A handler may not assume all sent messages
+//!   arrive. For example, `send(other, msg)` in a partitioned context
+//!   does not guarantee the receiver's mailbox is populated.
+//!
+//! - **Partition-resilient invariants**: An invariant can be checked
+//!   under a specific partition assumption. A split-brain scenario that
+//!   should violate the invariant will be rejected with a diagnostic.
+//!   A partition-tolerant invariant remains provable under the same model.
+//!
+//! Example: a leader-election protocol should maintain "exactly one
+//! leader in the connected set" within a partition. The verifier
+//! should reject a scenario where two disjoint sets both elect leaders.
 
 #[cfg(feature = "z3")]
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary
Documents the goal and desired behavior for RES-782 phase 1: extending the cluster invariant verifier to model network partitions and dropped delivery.

The MVP assumes a fully connected, reliable network where every message sent is delivered. Many real distributed systems must tolerate network partitions and dropped messages. Phase 1 extends the verifier surface to let users state and check invariants under explicit failure assumptions.

## Changes
- Extended `resilient/src/cluster_verifier.rs` documentation with RES-782 phase 1 overview
- Created `cluster_leader_election_partitioned.rz` as a design reference showing desired syntax

## Design Overview

### Partition Model
Users declare which members cannot communicate. For example:
```
partition { disconnected_edges: [(A, B), (B, C)] }
```
Messages sent across partition edges are dropped.

### Partition-Resilient Invariants
Invariants can be checked under specific partition assumptions:
- **Split-brain scenarios**: Verify that certain partitions violate the invariant (e.g., two disjoint sets elect leaders)
- **Partition-tolerant variants**: Verify that modified invariants remain provable despite partitions (e.g., quorum-based leadership)

### Example: Leader Election Under Partition
A classic split-brain scenario where partition creates two isolated groups that independently elect leaders:
- Under "no_partition": "at most one leader" holds
- Under partition A—(B,C): the split-brain invariant is violated
- A quorum-based variant "one leader per quorum of 2+ members" remains provable

## Next Steps
1. Parser: support `partition { disconnected_edges: [...] }` syntax in cluster blocks
2. Verifier model: filter inter-actor send/receive based on partition edges
3. Constraint generation: generate Z3 constraints accounting for dropped messages
4. Examples: split-brain, quorum-based, and partition-tolerant invariants
5. Diagnostics: explain which partition scenario violates the invariant

Closes #786