### PR TITLE
RES-780: Supervisor runtime phase 1 design documentation

### DIFF
--- a/resilient/examples/supervisor_crash_restart.rz
+++ b/resilient/examples/supervisor_crash_restart.rz
@@ -1,0 +1,75 @@
+// RES-780: Supervisor runtime phase 1 — crash propagation and restart policy enforcement
+// This example shows the desired supervisor-controlled crash/restart behavior.
+// NOT YET IMPLEMENTED — this is a design reference for RES-780 phase 1.
+
+// Phase 1 goal: Wire supervisor{} declarations into actual actor crash handling,
+// enabling supervisor-directed restart policies instead of silently dropping crashed actors.
+
+supervisor {
+    strategy: one_for_one,
+    children: [
+        { id: "reader", fn: read_sensor, restart: permanent },
+        { id: "writer", fn: write_log, restart: transient }
+    ]
+}
+
+// Permanent restart: crashes are restarted immediately, unlimited times
+fn read_sensor() {
+    loop {
+        let val = receive();
+        // If this function crashes (e.g., due to assertion failure),
+        // the supervisor will restart it immediately
+        assert(val >= 0, "sensor value out of range");
+        println(val);
+    }
+}
+
+// Transient restart: crashes cause the actor to stop permanently
+fn write_log() {
+    loop {
+        let msg = receive();
+        // If this crashes, the supervisor will NOT restart it
+        // This is useful for worker processes that shouldn't auto-recover
+        println(msg);
+    }
+}
+
+fn main() {
+    let reader_pid = spawn(read_sensor);
+    let writer_pid = spawn(write_log);
+
+    // Send messages to the supervised actors
+    send(reader_pid, 42);   // OK
+    send(writer_pid, "log entry");
+
+    // Scenario 1: reader crashes (assertion fails)
+    // - Supervisor detects crash
+    // - permanent policy → restart reader immediately
+    // - writer continues running
+    send(reader_pid, -5);  // Violates assertion
+    // → read_sensor restarts, waiting for new messages
+
+    // Scenario 2: writer crashes
+    // - Supervisor detects crash
+    // - transient policy → writer stops permanently
+    // - reader continues running
+    send(writer_pid, "this will crash the writer");
+    // → write_log does NOT restart
+}
+
+// Design notes:
+// - Crash detection: unhandled error or assertion failure in actor function
+// - Restart policies:
+//   * permanent: infinite auto-restart on crash
+//   * transient: one-shot, no restart on crash
+//   * temporary: restart with bounded attempts (future extension)
+// - Supervisor strategy (one_for_one): each child is restarted independently
+// - If restart fails (e.g., repeated crashes), escalate to parent supervisor
+//
+// Phase 1 work (RES-780):
+// 1. Data model: SupervisorState, CrashEvent, RestartPolicy types
+// 2. Crash detection: trap errors/panics in actor execution
+// 3. Supervisor dispatch: route crash events to appropriate supervisor
+// 4. Restart enforcement: implement permanent/transient policies
+// 5. Examples: demonstrate one_for_one strategy with different restart types
+// 6. Tests: verify crash → supervisor → restart flow end-to-end

--- a/resilient/src/actor_runtime.rs
+++ b/resilient/src/actor_runtime.rs
@@ -34,6 +34,41 @@
 //! single `Value::ActorPid(u64)` arm to `Value` and three calls to
 //! `register_builtins` in `lib.rs`. PRs 3-4 will modify the
 //! interpreter's outer loop. PR 5 lands the ping-pong example.
+//!
+//! ## RES-780: Supervisor Runtime Phase 1
+//!
+//! The parser and typechecker now accept `supervisor { strategy, children }`
+//! declarations that specify restart policies for supervised actors. However,
+//! the runtime does not yet enforce these policies. Phase 1 of RES-780 wires
+//! supervisor declarations into actual crash propagation and restart logic:
+//!
+//! **Data model extensions needed**:
+//! - `SupervisorState`: tracks a supervisor's strategy, child PIDs, and restart counts
+//! - `CrashEvent`: signal that an actor crashed with reason (unhandled error, panic, etc.)
+//! - `RestartPolicy`: enum for permanent/transient/temporary restart behaviors
+//!
+//! **Scheduler loop changes**:
+//! - When an actor crashes, emit a `CrashEvent` to its supervisor (if any)
+//! - Supervisor decides: restart the actor, escalate to its own supervisor, or stop
+//! - Enforce restart policy: permanent → immediate restart, transient → no auto-restart,
+//!   temporary → restart with bounded attempts
+//!
+//! **Example behavior**:
+//! ```rz
+//! supervisor {
+//!     strategy: one_for_one,
+//!     children: [
+//!         { id: "worker", fn: handle_work, restart: permanent }
+//!     ]
+//! }
+//! ```
+//! When the worker crashes:
+//! - one_for_one strategy → restart only the worker
+//! - permanent policy → immediate restart, unlimited retries
+//! - If restart fails, escalate to the supervisor's own supervisor
+//!
+//! Phase 1 focuses on the supervisor-declared child case; cascading supervisor
+//! hierarchies are a follow-up.
 
 // PR 2-5 of RES-332 consume the surface laid down here; PR 1 sets it up
 // without yet calling into it from non-test sites, so dead-code lint


### PR DESCRIPTION
## Summary
Documents the goal and desired behavior for RES-780 phase 1: wiring supervisor declarations into actual actor crash handling and restart policy enforcement.

The parser and typechecker accept `supervisor { strategy, children }` declarations, but the runtime does not yet enforce the declared restart policies. Phase 1 connects these declarations to actual crash propagation and restart logic.

## Changes
- Extended `resilient/src/actor_runtime.rs` with RES-780 phase 1 documentation
- Created `supervisor_crash_restart.rz` design reference showing desired crash/restart behavior

## Design Overview

### Restart Policies
- **permanent**: Actor is restarted immediately on crash, unlimited times
- **transient**: Actor stops permanently on crash, no auto-restart
- **temporary**: Actor is restarted with bounded attempts (future extension)

### Supervisor Strategy (Phase 1)
- **one_for_one**: When a child crashes, restart only that child
  - Other children continue running
  - Supervisor decides restart based on child's policy
- **one_for_all**: When any child crashes, restart all children
  - All children stop and restart together
  - Enables correlated failure recovery

### Example Behavior
```rz
supervisor {
    strategy: one_for_one,
    children: [
        { id: "worker", fn: handle_work, restart: permanent }
    ]
}
```
When the worker crashes:
- Supervisor detects the crash event
- one_for_one strategy → restart only this child
- permanent policy → restart immediately, unlimited retries
- If restart fails, escalate to parent supervisor

## Next Steps
1. Data model: SupervisorState, CrashEvent, RestartPolicy types
2. Crash detection: trap errors/panics in actor execution
3. Supervisor dispatch: route crash events to appropriate supervisor
4. Restart enforcement: implement permanent/transient policies
5. Scheduler integration: modify actor execution loop for crash handling
6. Examples: demonstrate crash/restart under different policies
7. Tests: verify crash → supervisor → restart flow end-to-end

Closes #780