### PR TITLE
RES-784: Fix mutual recursion example syntax and add golden test coverage

### DIFF
--- a/resilient/examples/mutual_recursion_strict_termination.expected.txt
+++ b/resilient/examples/mutual_recursion_strict_termination.expected.txt
@@ -1,0 +1,1 @@
+Program executed successfully

--- a/resilient/examples/mutual_recursion_strict_termination.rz
+++ b/resilient/examples/mutual_recursion_strict_termination.rz
@@ -5,14 +5,14 @@
 // Example 1: REJECTED — mutual recursion without termination annotation
 // The compiler detects that f and g form a cycle (strongly-connected component)
 // Without @decreases or @may_diverge, this is rejected under --strict-termination
-fn f(n: int) {
-    if (n > 0) {
+fn f(int n) {
+    if n > 0 {
         g(n - 1);
     }
 }
 
-fn g(n: int) {
-    if (n > 0) {
+fn g(int n) {
+    if n > 0 {
         f(n + 1);  // This escapes direct-recursion check (f doesn't call itself)
                    // But SCC analysis detects the cycle f → g → f
     }
@@ -21,51 +21,51 @@ fn g(n: int) {
 // Example 2: ACCEPTED — mutual recursion with termination annotation
 // Adding @decreases annotation satisfies the checker
 // @decreases n
-fn safe_f(n: int) {
-    if (n > 0) {
+fn safe_f(int n) {
+    if n > 0 {
         safe_g(n - 1);
     }
 }
 
 // @decreases n
-fn safe_g(n: int) {
-    if (n > 0) {
+fn safe_g(int n) {
+    if n > 0 {
         safe_f(n - 1);  // n strictly decreases
     }
 }
 
-// Example 3: ACCEPTED — no recursion in SCC, even with mutual calls
-// If all functions in an SCC are non-recursive, the check passes
-fn caller() {
-    helper();
+// Example 3: REJECTED — even non-recursive functions in a cycle are flagged
+// caller() and helper() form a cycle: caller → helper → caller
+// Both need annotations, even though neither function body is recursive
+fn caller(int _dummy) {
+    helper(_dummy);
 }
 
-fn helper() {
-    caller();  // This is a cycle, but caller() is not recursive body
+fn helper(int _dummy) {
+    caller(_dummy);  // Forms a cycle with caller
 }
 
 // Example 4: ACCEPTED — @may_diverge for intentional loops
 // @may_diverge
-fn event_loop() {
-    process_event();
+fn event_loop(int _dummy) {
+    process_event(_dummy);
 }
 
 // @may_diverge
-fn process_event() {
-    event_loop();  // Intentional infinite loop
+fn process_event(int _dummy) {
+    event_loop(_dummy);  // Intentional infinite loop
 }
 
-fn main() {
+fn main(int _dummy) {
     // safe_f and safe_g compile successfully with @decreases annotations
     safe_f(5);
     safe_g(3);
 
-    // caller() and helper() form a cycle but are non-recursive
-    // (they don't recursively call themselves in their bodies)
-    caller();
+    // caller() and helper() form a cycle and need annotations
+    // caller(0);  // Would fail termination check without @decreases or @may_diverge
 
     // event_loop with @may_diverge compiles (escape hatch for intentional loops)
-    // event_loop();  // Would run forever, so commented out
+    // event_loop(0);  // Would run forever, so commented out
 }
 
 // Design notes:

--- a/resilient/tests/termination_smoke.rs
+++ b/resilient/tests/termination_smoke.rs
@@ -127,3 +127,49 @@ fn non_recursive_fn_unaffected_by_strict_flag() {
     );
     let _ = std::fs::remove_file(&src);
 }
+
+#[test]
+fn unannotated_mutual_recursion_rejected_under_strict_flag() {
+    // RES-774/RES-784: mutual recursion (SCC size > 1) is also rejected without annotations
+    let src = tmp_file(
+        "strict_mutual_rec",
+        "fn f(int n) { if n > 0 { g(n - 1); } }\nfn g(int n) { if n > 0 { f(n + 1); } }\nf(2);\n",
+    );
+    let out = Command::new(bin())
+        .args(["--strict-termination"])
+        .arg(&src)
+        .output()
+        .expect("spawn rz");
+    assert!(
+        !out.status.success(),
+        "expected failure for unannotated mutual recursion under --strict-termination, got {:?}",
+        out.status
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("mutually recursive") || stderr.contains("recursive"),
+        "stderr should explain the mutual recursion, got: {stderr}"
+    );
+    let _ = std::fs::remove_file(&src);
+}
+
+#[test]
+fn annotated_mutual_recursion_accepted_under_strict_flag() {
+    // With @decreases annotations, mutual recursion is accepted
+    let src = tmp_file(
+        "strict_mutual_annotated",
+        "// @decreases n\nfn f(int n) { if n > 0 { g(n - 1); } }\n// @decreases n\nfn g(int n) { if n > 0 { f(n - 1); } }\nf(2);\n",
+    );
+    let out = Command::new(bin())
+        .args(["--strict-termination"])
+        .arg(&src)
+        .output()
+        .expect("spawn rz");
+    assert!(
+        out.status.success(),
+        "expected success for annotated mutual recursion under --strict-termination, got {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let _ = std::fs::remove_file(&src);
+}


### PR DESCRIPTION
## Summary

Fixed the mutual recursion example file to use correct Resilient syntax and added comprehensive test coverage for the SCC-based mutual recursion detection feature.

## Changes

- **Example file syntax**: Fixed `fn name(param: type)` → `fn name(type param)` to match Resilient's syntax
- **Example documentation**: Updated to accurately reflect SCC analysis behavior (all functions in a recursive SCC need annotations, including non-directly-recursive functions)
- **Golden test file**: Added `.expected.txt` file for the examples_golden.rs test runner
- **Test coverage**: Added 2 new integration tests to termination_smoke.rs for mutual recursion scenarios

## Test Results

All 7 termination tests pass ✅, confirming that:
- Unannotated mutual recursion is rejected under `--strict-termination`
- Annotated mutual recursion with `@decreases` is accepted
- The SCC detection correctly identifies all functions in a recursive cycle

No existing tests were modified or loosened.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>