### PR TITLE
RES-779: Add AST nodes for trait associated types

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -2040,10 +2040,14 @@ enum Node {
     /// trait-impl blocks; the methods still mangle to `<StructName>$<method>`,
     /// so runtime dispatch is unchanged. The trait name is consulted only by
     /// `crate::traits::check` to validate signature coverage.
+    /// RES-779: ImplBlock also carries associated type definitions
+    /// (`type Name = ConcreteType;`) that implement the trait's associated types.
     ImplBlock {
         trait_name: Option<String>,
         struct_name: String,
         methods: Vec<Node>,
+        #[allow(dead_code)]
+        associated_type_impls: Vec<(String, String)>, // (name, type_expr)
         #[allow(dead_code)]
         span: span::Span,
     },
@@ -2052,9 +2056,13 @@ enum Node {
     /// signatures are validated against `impl Trait for Type` blocks by
     /// `crate::traits::check`. Trait dispatch reuses the existing
     /// `<Type>$<method>` mangling; there is no VTable.
+    /// RES-779: TraitDecl also carries associated type declarations
+    /// (`type Name;`) that must be defined in each impl.
     TraitDecl {
         name: String,
         methods: Vec<crate::traits::TraitMethodSig>,
+        #[allow(dead_code)]
+        associated_types: Vec<crate::traits::AssociatedTypeDecl>,
         #[allow(dead_code)]
         span: span::Span,
     },
@@ -3259,6 +3267,7 @@ impl Parser {
             trait_name,
             struct_name,
             methods,
+            associated_type_impls: Vec::new(), // RES-779: to be populated when parsing support is added
             span: impl_span,
         }
     }

--- a/resilient/src/traits.rs
+++ b/resilient/src/traits.rs
@@ -85,6 +85,17 @@ pub(crate) struct TraitMethodSig {
     pub span: Span,
 }
 
+/// Associated type declaration in a trait.
+/// RES-779: `type Name;` inside a trait declares a type member that each
+/// impl must define.
+#[derive(Debug, Clone)]
+pub(crate) struct AssociatedTypeDecl {
+    #[allow(dead_code)]
+    pub name: String,
+    #[allow(dead_code)]
+    pub span: Span,
+}
+
 /// Parse a `trait` declaration. Called from `parse_statement` when the
 /// current token is `Token::Trait`. On entry, `current_token` is
 /// `Token::Trait`; on a successful exit the cursor sits on the closing
@@ -133,6 +144,7 @@ pub(crate) fn parse(parser: &mut Parser) -> Node {
     Node::TraitDecl {
         name,
         methods,
+        associated_types: Vec::new(), // RES-779: to be populated when parsing support is added
         span: trait_span,
     }
 }
@@ -268,6 +280,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             name,
             methods,
             span,
+            associated_types: _,
         } = &stmt.node
         {
             if name.is_empty() {
@@ -338,6 +351,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             struct_name,
             methods,
             span,
+            associated_type_impls: _,
         } = &stmt.node
         {
             let (trait_methods, _trait_span) = match traits.get(t) {


### PR DESCRIPTION
Closes #783

## Summary
Establishes the data structures for RES-779 (trait associated types). This PR adds:
- AssociatedTypeDecl struct for trait-level associated type declarations
- TraitDecl.associated_types field to store associated types in trait declarations
- ImplBlock.associated_type_impls field to store concrete type implementations

No parsing or typechecking is implemented yet - this is structure setup for subsequent PRs.

## Acceptance Criteria (Phase 1)
- [x] AST nodes defined and compile cleanly
- [x] All existing tests pass
- [x] Clippy and formatting clean

## Next Steps
- PR 2: Parser support for `type Name = ConcreteType;` syntax
- PR 3: Typechecker integration and projection typing
- PR 4: Monomorphization support
- PR 5: Examples and documentation
