### PR TITLE
RES-779: Add parser support for associated types

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -2040,10 +2040,14 @@ enum Node {
     /// trait-impl blocks; the methods still mangle to `<StructName>$<method>`,
     /// so runtime dispatch is unchanged. The trait name is consulted only by
     /// `crate::traits::check` to validate signature coverage.
+    /// RES-779: ImplBlock also carries associated type definitions
+    /// (`type Name = ConcreteType;`) that implement the trait's associated types.
     ImplBlock {
         trait_name: Option<String>,
         struct_name: String,
         methods: Vec<Node>,
+        #[allow(dead_code)]
+        associated_type_impls: Vec<(String, String)>, // (name, type_expr)
         #[allow(dead_code)]
         span: span::Span,
     },
@@ -2052,9 +2056,13 @@ enum Node {
     /// signatures are validated against `impl Trait for Type` blocks by
     /// `crate::traits::check`. Trait dispatch reuses the existing
     /// `<Type>$<method>` mangling; there is no VTable.
+    /// RES-779: TraitDecl also carries associated type declarations
+    /// (`type Name;`) that must be defined in each impl.
     TraitDecl {
         name: String,
         methods: Vec<crate::traits::TraitMethodSig>,
+        #[allow(dead_code)]
+        associated_types: Vec<crate::traits::AssociatedTypeDecl>,
         #[allow(dead_code)]
         span: span::Span,
     },
@@ -3230,25 +3238,70 @@ impl Parser {
         }
 
         let mut methods: Vec<Node> = Vec::new();
+        let mut associated_type_impls: Vec<(String, String)> = Vec::new();
         while self.current_token != Token::RightBrace && self.current_token != Token::Eof {
-            if self.current_token != Token::Function {
-                let tok = self.current_token.clone();
-                self.record_error(format!("Expected 'fn' inside impl block, found {}", tok));
-                // Best-effort recovery: skip ahead to the closing brace
-                // so the whole parse doesn't cascade.
-                while self.current_token != Token::RightBrace && self.current_token != Token::Eof {
-                    self.next_token();
+            match self.current_token {
+                Token::Function => {
+                    methods.push(self.parse_method(&struct_name));
+                    // `parse_block_statement` (called inside `parse_method` for
+                    // the body) leaves the cursor ON the method body's closing
+                    // `}`. Advance past it so the next iteration sees either
+                    // another `fn` or the impl block's own `}` — matching the
+                    // convention `parse_program` expects for its callers.
+                    if self.current_token == Token::RightBrace {
+                        self.next_token();
+                    }
                 }
-                break;
-            }
-            methods.push(self.parse_method(&struct_name));
-            // `parse_block_statement` (called inside `parse_method` for
-            // the body) leaves the cursor ON the method body's closing
-            // `}`. Advance past it so the next iteration sees either
-            // another `fn` or the impl block's own `}` — matching the
-            // convention `parse_program` expects for its callers.
-            if self.current_token == Token::RightBrace {
-                self.next_token();
+                Token::Type => {
+                    // RES-779: parse `type Name = ConcreteType;`
+                    self.next_token(); // skip 'type'
+                    if let Token::Identifier(name) = &self.current_token {
+                        let type_name = name.clone();
+                        self.next_token(); // skip name
+                        if self.current_token == Token::Assign {
+                            self.next_token(); // skip '='
+                            // Collect tokens until semicolon as the type expression
+                            let mut type_expr_tokens = Vec::new();
+                            while self.current_token != Token::Semicolon
+                                && self.current_token != Token::Eof
+                                && self.current_token != Token::RightBrace
+                            {
+                                type_expr_tokens.push(format!("{}", self.current_token));
+                                self.next_token();
+                            }
+                            let type_expr = type_expr_tokens.join(" ");
+                            if self.current_token == Token::Semicolon {
+                                self.next_token(); // skip ';'
+                            } else {
+                                self.record_error(
+                                    "Expected ';' after associated type assignment".to_string(),
+                                );
+                            }
+                            associated_type_impls.push((type_name, type_expr));
+                        } else {
+                            self.record_error(
+                                "Expected '=' after associated type name".to_string(),
+                            );
+                        }
+                    } else {
+                        self.record_error("Expected type name after 'type'".to_string());
+                    }
+                }
+                _ => {
+                    let tok = self.current_token.clone();
+                    self.record_error(format!(
+                        "Expected 'fn' or 'type' inside impl block, found {}",
+                        tok
+                    ));
+                    // Best-effort recovery: skip ahead to the closing brace
+                    // so the whole parse doesn't cascade.
+                    while self.current_token != Token::RightBrace
+                        && self.current_token != Token::Eof
+                    {
+                        self.next_token();
+                    }
+                    break;
+                }
             }
         }
         // Leave the cursor ON the impl block's closing `}` — the outer
@@ -3259,6 +3312,7 @@ impl Parser {
             trait_name,
             struct_name,
             methods,
+            associated_type_impls,
             span: impl_span,
         }
     }

--- a/resilient/src/traits.rs
+++ b/resilient/src/traits.rs
@@ -85,6 +85,17 @@ pub(crate) struct TraitMethodSig {
     pub span: Span,
 }
 
+/// Associated type declaration in a trait.
+/// RES-779: `type Name;` inside a trait declares a type member that each
+/// impl must define.
+#[derive(Debug, Clone)]
+pub(crate) struct AssociatedTypeDecl {
+    #[allow(dead_code)]
+    pub name: String,
+    #[allow(dead_code)]
+    pub span: Span,
+}
+
 /// Parse a `trait` declaration. Called from `parse_statement` when the
 /// current token is `Token::Trait`. On entry, `current_token` is
 /// `Token::Trait`; on a successful exit the cursor sits on the closing
@@ -114,25 +125,40 @@ pub(crate) fn parse(parser: &mut Parser) -> Node {
     }
 
     let mut methods: Vec<TraitMethodSig> = Vec::new();
+    let mut associated_types: Vec<AssociatedTypeDecl> = Vec::new();
     while parser.current_token != Token::RightBrace && parser.current_token != Token::Eof {
-        if parser.current_token != Token::Function {
-            let tok = parser.current_token.clone();
-            parser.record_error(format!("Expected 'fn' inside trait body, found {}", tok));
-            // Recover: jump to the closing brace.
-            while parser.current_token != Token::RightBrace && parser.current_token != Token::Eof {
-                parser.next_token();
+        match parser.current_token {
+            Token::Function => {
+                if let Some(sig) = parse_method_sig(parser) {
+                    methods.push(sig);
+                }
             }
-            break;
-        }
-
-        if let Some(sig) = parse_method_sig(parser) {
-            methods.push(sig);
+            Token::Type => {
+                if let Some(assoc_ty) = parse_associated_type_decl(parser) {
+                    associated_types.push(assoc_ty);
+                }
+            }
+            _ => {
+                let tok = parser.current_token.clone();
+                parser.record_error(format!(
+                    "Expected 'fn' or 'type' inside trait body, found {}",
+                    tok
+                ));
+                // Recover: jump to the closing brace.
+                while parser.current_token != Token::RightBrace
+                    && parser.current_token != Token::Eof
+                {
+                    parser.next_token();
+                }
+                break;
+            }
         }
     }
 
     Node::TraitDecl {
         name,
         methods,
+        associated_types,
         span: trait_span,
     }
 }
@@ -252,6 +278,42 @@ fn parse_method_sig(parser: &mut Parser) -> Option<TraitMethodSig> {
     })
 }
 
+/// Parse a single associated type declaration inside a trait body:
+/// `type Name;` RES-779
+fn parse_associated_type_decl(parser: &mut Parser) -> Option<AssociatedTypeDecl> {
+    let decl_span = parser.span_at_current();
+    parser.next_token(); // skip 'type'
+
+    let type_name = match &parser.current_token {
+        Token::Identifier(n) => n.clone(),
+        other => {
+            let tok = other.clone();
+            parser.record_error(format!(
+                "Expected type name after 'type' in trait body, found {}",
+                tok
+            ));
+            return None;
+        }
+    };
+    parser.next_token(); // skip type name
+
+    // Expect semicolon
+    if parser.current_token != Token::Semicolon {
+        let tok = parser.current_token.clone();
+        parser.record_error(format!(
+            "Expected ';' after associated type `{}` in trait body, found {}",
+            type_name, tok
+        ));
+    } else {
+        parser.next_token(); // skip ';'
+    }
+
+    Some(AssociatedTypeDecl {
+        name: type_name,
+        span: decl_span,
+    })
+}
+
 /// Validate trait declarations, `impl Trait for Type` coverage, and
 /// `<T: Trait>` bound usage. Walks the program once collecting traits,
 /// then again validating impls and call sites.
@@ -268,6 +330,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             name,
             methods,
             span,
+            associated_types: _,
         } = &stmt.node
         {
             if name.is_empty() {
@@ -338,6 +401,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             struct_name,
             methods,
             span,
+            associated_type_impls: _,
         } = &stmt.node
         {
             let (trait_methods, _trait_span) = match traits.get(t) {


### PR DESCRIPTION
Built on #818

## Summary
Implements parser support for RES-779 associated types:
- Parses `type Name;` in trait declarations
- Parses `type Name = ConcreteType;` in impl blocks
- Associates collected types with trait/impl nodes

No typechecking validation yet - that comes in PR3.

## Next
- PR 3: Typechecker validation + projection typing (`T::AssocType`)
