### PR TITLE
RES-796: Typechecker integration for mutual recursion detection

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -279,6 +279,11 @@ mod supervisor;
 // reuses the existing `<Type>$<method>` mangling — no VTable.
 mod traits;
 
+// RES-796: Mutual recursion termination check via SCC (Strongly Connected Component)
+// analysis of the function call graph. Detects cycles that direct-recursion checking
+// (RES-398) misses.
+mod mutual_recursion_scc;
+
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
 

--- a/resilient/src/mutual_recursion_scc.rs
+++ b/resilient/src/mutual_recursion_scc.rs
@@ -33,6 +33,14 @@ impl CallGraph {
         CallGraph { graph }
     }
 
+    /// Check if a function calls itself (direct recursion).
+    pub fn has_self_call(&self, fn_name: &str) -> bool {
+        self.graph
+            .get(fn_name)
+            .map(|calls| calls.contains(fn_name))
+            .unwrap_or(false)
+    }
+
     /// Find all strongly-connected components using Kosaraju's algorithm.
     pub fn find_sccs(&self) -> Vec<Vec<String>> {
         if self.graph.is_empty() {
@@ -61,6 +69,15 @@ impl CallGraph {
         }
 
         sccs
+    }
+
+    /// Find mutual recursion cycles (non-trivial SCCs of size > 1).
+    /// Returns a list of cycles, where each cycle is a list of function names forming the cycle.
+    pub fn find_mutual_recursion_cycles(&self) -> Vec<Vec<String>> {
+        let sccs = self.find_sccs();
+        sccs.into_iter()
+            .filter(|scc| scc.len() > 1)
+            .collect()
     }
 
     /// Return the transposed graph (edges reversed).

--- a/resilient/src/mutual_recursion_scc.rs
+++ b/resilient/src/mutual_recursion_scc.rs
@@ -85,11 +85,11 @@ impl CallGraph {
         let mut transposed: HashMap<String, HashSet<String>> = HashMap::new();
 
         for (src, dests) in &self.graph {
-            transposed.entry(src.clone()).or_insert_with(HashSet::new);
+            transposed.entry(src.clone()).or_default();
             for dest in dests {
                 transposed
                     .entry(dest.clone())
-                    .or_insert_with(HashSet::new)
+                    .or_default()
                     .insert(src.clone());
             }
         }
@@ -140,7 +140,7 @@ fn collect_called_functions(
             if let Node::Identifier { name, .. } = function.as_ref() {
                 graph
                     .entry(current_fn.to_string())
-                    .or_insert_with(HashSet::new)
+                    .or_default()
                     .insert(name.clone());
             }
 

--- a/resilient/src/mutual_recursion_scc.rs
+++ b/resilient/src/mutual_recursion_scc.rs
@@ -1,0 +1,299 @@
+//! RES-796: Mutual recursion termination check via SCC (Strongly Connected Component) analysis.
+//!
+//! This module implements Kosaraju's algorithm to detect cycles in the function call graph,
+//! identifying mutual recursion patterns that the direct-recursion checker (RES-398) misses.
+//!
+//! A strongly-connected component (SCC) is a maximal set of vertices such that there is a
+//! path from each vertex to every other vertex. An SCC of size > 1 in the call graph
+//! indicates mutual recursion (cycles). An SCC of size 1 with a self-loop is direct recursion
+//! (already handled by RES-398).
+
+use crate::Node;
+use std::collections::{HashMap, HashSet};
+
+/// Represents a function call graph where edges are function calls.
+#[derive(Debug, Clone)]
+pub struct CallGraph {
+    /// Map from function name to set of functions it calls.
+    graph: HashMap<String, HashSet<String>>,
+}
+
+impl CallGraph {
+    /// Build a call graph by walking all function definitions in the program.
+    pub fn build(program: &Node) -> Self {
+        let mut graph = HashMap::new();
+        let Node::Program(stmts) = program else {
+            return CallGraph { graph };
+        };
+
+        for stmt in stmts {
+            build_graph_for_node(&stmt.node, &mut graph);
+        }
+
+        CallGraph { graph }
+    }
+
+    /// Find all strongly-connected components using Kosaraju's algorithm.
+    pub fn find_sccs(&self) -> Vec<Vec<String>> {
+        if self.graph.is_empty() {
+            return vec![];
+        }
+
+        // Step 1: DFS on original graph to get finish times (stack order).
+        let mut visited = HashSet::new();
+        let mut finish_stack = Vec::new();
+        for node in self.graph.keys() {
+            if !visited.contains(node) {
+                dfs_finish_order(node, &self.graph, &mut visited, &mut finish_stack);
+            }
+        }
+
+        // Step 2: DFS on transposed graph in reverse finish order.
+        let transposed = self.transpose();
+        let mut visited = HashSet::new();
+        let mut sccs = Vec::new();
+        for node in finish_stack.into_iter().rev() {
+            if !visited.contains(&node) {
+                let mut scc = Vec::new();
+                dfs_collect(&node, &transposed, &mut visited, &mut scc);
+                sccs.push(scc);
+            }
+        }
+
+        sccs
+    }
+
+    /// Return the transposed graph (edges reversed).
+    fn transpose(&self) -> HashMap<String, HashSet<String>> {
+        let mut transposed: HashMap<String, HashSet<String>> = HashMap::new();
+
+        for (src, dests) in &self.graph {
+            transposed.entry(src.clone()).or_insert_with(HashSet::new);
+            for dest in dests {
+                transposed
+                    .entry(dest.clone())
+                    .or_insert_with(HashSet::new)
+                    .insert(src.clone());
+            }
+        }
+
+        transposed
+    }
+}
+
+/// Walk a node and record all function calls made within it.
+/// `current_fn` tracks which function we're currently analyzing.
+fn build_graph_for_node(
+    node: &Node,
+    graph: &mut HashMap<String, HashSet<String>>,
+) {
+    match node {
+        Node::Function {
+            name, body, ..
+        } => {
+            let fn_name = name.clone();
+            if !graph.contains_key(&fn_name) {
+                graph.insert(fn_name.clone(), HashSet::new());
+            }
+
+            // Recursively walk the function body to find calls
+            collect_called_functions(body, &fn_name, graph);
+        }
+        Node::Program(stmts) => {
+            for stmt in stmts {
+                build_graph_for_node(&stmt.node, graph);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Collect all functions called within a node, recording them in the graph
+/// under the `current_fn` entry.
+fn collect_called_functions(
+    node: &Node,
+    current_fn: &str,
+    graph: &mut HashMap<String, HashSet<String>>,
+) {
+    match node {
+        Node::CallExpression {
+            function, arguments, ..
+        } => {
+            // Extract function name from identifier or field access
+            if let Node::Identifier { name, .. } = function.as_ref() {
+                graph
+                    .entry(current_fn.to_string())
+                    .or_insert_with(HashSet::new)
+                    .insert(name.clone());
+            }
+
+            // Recurse into arguments
+            for arg in arguments {
+                collect_called_functions(arg, current_fn, graph);
+            }
+        }
+        Node::Block { stmts, .. } => {
+            for stmt in stmts {
+                collect_called_functions(stmt, current_fn, graph);
+            }
+        }
+        Node::IfStatement {
+            consequence,
+            alternative,
+            condition,
+            ..
+        } => {
+            collect_called_functions(condition, current_fn, graph);
+            collect_called_functions(consequence, current_fn, graph);
+            if let Some(alt) = alternative {
+                collect_called_functions(alt, current_fn, graph);
+            }
+        }
+        Node::WhileStatement { condition, body, .. } => {
+            collect_called_functions(condition, current_fn, graph);
+            collect_called_functions(body, current_fn, graph);
+        }
+        Node::ForInStatement {
+            iterable, body, ..
+        } => {
+            collect_called_functions(iterable, current_fn, graph);
+            collect_called_functions(body, current_fn, graph);
+        }
+        Node::Match { scrutinee, arms, .. } => {
+            collect_called_functions(scrutinee, current_fn, graph);
+            for (_, guard, body) in arms {
+                if let Some(g) = guard {
+                    collect_called_functions(g, current_fn, graph);
+                }
+                collect_called_functions(body, current_fn, graph);
+            }
+        }
+        Node::ExpressionStatement { expr, .. } => {
+            collect_called_functions(expr, current_fn, graph);
+        }
+        Node::ReturnStatement {
+            value: Some(val), ..
+        } => {
+            collect_called_functions(val, current_fn, graph);
+        }
+        Node::InfixExpression { left, right, .. } => {
+            collect_called_functions(left, current_fn, graph);
+            collect_called_functions(right, current_fn, graph);
+        }
+        Node::PrefixExpression { right, .. } => {
+            collect_called_functions(right, current_fn, graph);
+        }
+        Node::StructLiteral { fields, .. } => {
+            for (_, value) in fields {
+                collect_called_functions(value, current_fn, graph);
+            }
+        }
+        Node::ArrayLiteral { items, .. } => {
+            for item in items {
+                collect_called_functions(item, current_fn, graph);
+            }
+        }
+        Node::FieldAccess { target, .. } => {
+            collect_called_functions(target, current_fn, graph);
+        }
+        _ => {}
+    }
+}
+
+/// DFS to establish finish order (first DFS pass of Kosaraju).
+fn dfs_finish_order(
+    node: &str,
+    graph: &HashMap<String, HashSet<String>>,
+    visited: &mut HashSet<String>,
+    finish_stack: &mut Vec<String>,
+) {
+    visited.insert(node.to_string());
+
+    if let Some(neighbors) = graph.get(node) {
+        for neighbor in neighbors {
+            if !visited.contains(neighbor) {
+                dfs_finish_order(neighbor, graph, visited, finish_stack);
+            }
+        }
+    }
+
+    finish_stack.push(node.to_string());
+}
+
+/// DFS to collect SCC nodes (second DFS pass of Kosaraju on transposed graph).
+fn dfs_collect(
+    node: &str,
+    transposed: &HashMap<String, HashSet<String>>,
+    visited: &mut HashSet<String>,
+    scc: &mut Vec<String>,
+) {
+    visited.insert(node.to_string());
+    scc.push(node.to_string());
+
+    if let Some(neighbors) = transposed.get(node) {
+        for neighbor in neighbors {
+            if !visited.contains(neighbor) {
+                dfs_collect(neighbor, transposed, visited, scc);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+
+    #[test]
+    fn scc_detects_simple_mutual_recursion() {
+        let src = "fn f(int n) { if (n > 0) { g(n - 1); } }
+                   fn g(int n) { if (n > 0) { f(n + 1); } }";
+        let (program, _) = parse(src);
+        let graph = CallGraph::build(&program);
+        let sccs = graph.find_sccs();
+
+        // Should find exactly one SCC containing {f, g}
+        assert_eq!(sccs.len(), 1);
+        let scc = &sccs[0];
+        assert_eq!(scc.len(), 2);
+        assert!(scc.contains(&"f".to_string()));
+        assert!(scc.contains(&"g".to_string()));
+    }
+
+    #[test]
+    fn scc_detects_complex_cycle() {
+        let src = "fn a(int n) { b(n); }
+                   fn b(int n) { c(n); }
+                   fn c(int n) { a(n); }";
+        let (program, _) = parse(src);
+        let graph = CallGraph::build(&program);
+        let sccs = graph.find_sccs();
+
+        // Should find one SCC with all three functions
+        assert!(sccs.iter().any(|scc| scc.len() == 3));
+    }
+
+    #[test]
+    fn scc_allows_direct_recursion() {
+        let src = "fn f(int n) { if (n > 0) { f(n - 1); } }";
+        let (program, _) = parse(src);
+        let graph = CallGraph::build(&program);
+        let sccs = graph.find_sccs();
+
+        // Self-loop is size-1 SCC; RES-398 already handles it
+        assert!(sccs.iter().any(|scc| scc.len() == 1));
+    }
+
+    #[test]
+    fn scc_ignores_non_recursive_code() {
+        let src = "fn f(int n) { return n + 1; }
+                   fn g(int n) { return n * 2; }";
+        let (program, _) = parse(src);
+        let graph = CallGraph::build(&program);
+        let sccs = graph.find_sccs();
+
+        // Each function is its own SCC (no edges)
+        let single_sccs: Vec<_> = sccs.iter().filter(|scc| scc.len() == 1).collect();
+        assert_eq!(single_sccs.len(), 2);
+    }
+}

--- a/resilient/src/termination.rs
+++ b/resilient/src/termination.rs
@@ -151,7 +151,7 @@ pub fn check(program: &Node, source_path: &str) -> Result<(), String> {
                 if *fn_line < 2 {
                     let cycle_str = cycle.join(" → ");
                     return Err(format!(
-                        "{}:{}:{}: error: function `{}` is in mutual recursion cycle ({}) \
+                        "{}:{}:{}: error: function `{}` is mutually recursive ({}) \
                          but has no termination annotation; expected `// @decreases <metric>` \
                          or `// @may_diverge` on the line above",
                         source_path, fn_line, col, name, cycle_str
@@ -161,7 +161,7 @@ pub fn check(program: &Node, source_path: &str) -> Result<(), String> {
                 if !has_termination_annotation(prev) {
                     let cycle_str = cycle.join(" → ");
                     return Err(format!(
-                        "{}:{}:{}: error: function `{}` is in mutual recursion cycle ({}) \
+                        "{}:{}:{}: error: function `{}` is mutually recursive ({}) \
                          but has no termination annotation; expected `// @decreases <metric>` \
                          or `// @may_diverge` on the line above",
                         source_path, fn_line, col, name, cycle_str

--- a/resilient/src/termination.rs
+++ b/resilient/src/termination.rs
@@ -65,9 +65,10 @@
 //! termination annotations under `--strict-termination`.
 //!
 //! **Algorithm**: Build a call graph from function definitions, then
-//! compute strongly-connected components (SCCs) using Tarjan's algorithm.
-//! Any SCC with size > 1 (or a self-loop for size == 1) requires all
-//! functions in it to declare `// @decreases` or `// @may_diverge`.
+//! compute strongly-connected components (SCCs) using Kosaraju's algorithm
+//! (see `mutual_recursion_scc` module). Any SCC with size > 1 (or a self-loop
+//! for size == 1) requires all functions in it to declare `// @decreases` or
+//! `// @may_diverge`.
 //!
 //! **Diagnostics**: When a mutually-recursive function lacks an annotation,
 //! the error message identifies the full cycle (e.g., "f → g → f") and
@@ -95,7 +96,8 @@
 //! ```
 
 use crate::Node;
-use std::collections::{HashMap, HashSet};
+use crate::mutual_recursion_scc::CallGraph;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// RES-398: process-wide flag controlling whether the termination
@@ -128,85 +130,72 @@ pub fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let source = std::fs::read_to_string(source_path).unwrap_or_default();
     let lines: Vec<&str> = source.lines().collect();
 
-    // Build call graph: fn_name -> set of functions it calls
-    let mut call_graph: HashMap<String, HashSet<String>> = HashMap::new();
-    let mut fn_info: HashMap<String, (usize, usize)> = HashMap::new(); // name -> (line, col)
-
+    // Build function location map for error reporting
+    let mut fn_info: HashMap<String, (usize, usize)> = HashMap::new();
     for spanned in stmts {
-        if let Node::Function {
-            name, body, span, ..
-        } = &spanned.node
-        {
-            if name.is_empty() {
-                continue;
+        if let Node::Function { name, span, .. } = &spanned.node {
+            if !name.is_empty() {
+                fn_info.insert(name.clone(), (span.start.line, span.start.column));
             }
-            fn_info.insert(name.clone(), (span.start.line, span.start.column));
-            let mut callees = HashSet::new();
-            collect_calls(body, &mut callees);
-            call_graph.insert(name.clone(), callees);
         }
     }
 
-    // Find SCCs using Tarjan's algorithm
-    let sccs = find_sccs(&call_graph);
+    // Use mutual_recursion_scc module to build call graph and find cycles
+    let call_graph = CallGraph::build(program);
+    let cycles = call_graph.find_mutual_recursion_cycles();
 
-    // Check each SCC: if it has cycles, all functions in it need annotations
-    for scc in sccs {
-        if scc.len() == 1 {
-            // Single function: check if it has cycles (self-calls)
-            let name = &scc[0];
-            if !call_graph
-                .get(name)
-                .map(|calls| calls.contains(name))
-                .unwrap_or(false)
-            {
-                continue; // No recursion
-            }
-        } else {
-            // Multiple functions: check if any edge within SCC exists
-            let scc_set: HashSet<&str> = scc.iter().map(|s| s.as_str()).collect();
-            let has_cycle = scc.iter().any(|name| {
-                call_graph
-                    .get(name)
-                    .map(|calls| calls.iter().any(|c| scc_set.contains(c.as_str())))
-                    .unwrap_or(false)
-            });
-            if !has_cycle {
-                continue;
-            }
-        }
-
-        // This SCC is recursive; check annotations for all functions in it
-        for name in &scc {
+    // Check mutual recursion cycles
+    for cycle in cycles {
+        for name in &cycle {
             if let Some((fn_line, col)) = fn_info.get(name) {
                 if *fn_line < 2 {
-                    let recursion_type = if scc.len() == 1 {
-                        "directly recursive"
-                    } else {
-                        "mutually recursive"
-                    };
+                    let cycle_str = cycle.join(" → ");
                     return Err(format!(
-                        "{}:{}:{}: error: function `{}` is {} but has no termination annotation; \
-                         expected `// @decreases <metric>` or `// @may_diverge` on the line above",
-                        source_path, fn_line, col, name, recursion_type
+                        "{}:{}:{}: error: function `{}` is in mutual recursion cycle ({}) \
+                         but has no termination annotation; expected `// @decreases <metric>` \
+                         or `// @may_diverge` on the line above",
+                        source_path, fn_line, col, name, cycle_str
                     ));
                 }
                 let prev = lines.get(fn_line - 2).copied().unwrap_or("");
                 if !has_termination_annotation(prev) {
-                    let recursion_type = if scc.len() == 1 {
-                        "directly recursive"
-                    } else {
-                        "mutually recursive"
-                    };
+                    let cycle_str = cycle.join(" → ");
                     return Err(format!(
-                        "{}:{}:{}: error: function `{}` is {} but has no termination annotation; \
-                         expected `// @decreases <metric>` or `// @may_diverge` on the line above",
-                        source_path, fn_line, col, name, recursion_type
+                        "{}:{}:{}: error: function `{}` is in mutual recursion cycle ({}) \
+                         but has no termination annotation; expected `// @decreases <metric>` \
+                         or `// @may_diverge` on the line above",
+                        source_path, fn_line, col, name, cycle_str
                     ));
                 }
             }
         }
     }
+
+    // Check direct recursion (self-calls)
+    for (name, _) in &fn_info {
+        if call_graph.has_self_call(name) {
+            if let Some((fn_line, col)) = fn_info.get(name) {
+                if *fn_line < 2 {
+                    return Err(format!(
+                        "{}:{}:{}: error: function `{}` is directly recursive but has no \
+                         termination annotation; expected `// @decreases <metric>` or \
+                         `// @may_diverge` on the line above",
+                        source_path, fn_line, col, name
+                    ));
+                }
+                let prev = lines.get(fn_line - 2).copied().unwrap_or("");
+                if !has_termination_annotation(prev) {
+                    return Err(format!(
+                        "{}:{}:{}: error: function `{}` is directly recursive but has no \
+                         termination annotation; expected `// @decreases <metric>` or \
+                         `// @may_diverge` on the line above",
+                        source_path, fn_line, col, name
+                    ));
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -228,149 +217,6 @@ fn has_termination_annotation(line: &str) -> bool {
     false
 }
 
-/// RES-774: collect all function names called by a node, adding them to
-/// the `callees` set. Used to build the call graph for SCC analysis.
-fn collect_calls(node: &Node, callees: &mut HashSet<String>) {
-    match node {
-        Node::CallExpression {
-            function,
-            arguments,
-            ..
-        } => {
-            if let Node::Identifier { name, .. } = function.as_ref() {
-                callees.insert(name.clone());
-            }
-            collect_calls(function, callees);
-            for arg in arguments {
-                collect_calls(arg, callees);
-            }
-        }
-        Node::Block { stmts, .. } => {
-            for stmt in stmts {
-                collect_calls(stmt, callees);
-            }
-        }
-        Node::IfStatement {
-            condition,
-            consequence,
-            alternative,
-            ..
-        } => {
-            collect_calls(condition, callees);
-            collect_calls(consequence, callees);
-            if let Some(alt) = alternative {
-                collect_calls(alt, callees);
-            }
-        }
-        Node::WhileStatement {
-            condition, body, ..
-        } => {
-            collect_calls(condition, callees);
-            collect_calls(body, callees);
-        }
-        Node::ForInStatement { iterable, body, .. } => {
-            collect_calls(iterable, callees);
-            collect_calls(body, callees);
-        }
-        Node::LiveBlock { body, .. } => collect_calls(body, callees),
-        Node::ReturnStatement { value: Some(v), .. } => collect_calls(v, callees),
-        Node::ExpressionStatement { expr, .. } => collect_calls(expr, callees),
-        Node::LetStatement { value, .. } => collect_calls(value, callees),
-        Node::InfixExpression { left, right, .. } => {
-            collect_calls(left, callees);
-            collect_calls(right, callees);
-        }
-        Node::PrefixExpression { right, .. } => collect_calls(right, callees),
-        Node::FieldAccess { target, .. } => collect_calls(target, callees),
-        _ => {}
-    }
-}
-
-/// RES-774: Tarjan's algorithm for finding strongly connected components.
-/// Returns a Vec of SCCs (each SCC is a Vec of function names).
-fn find_sccs(graph: &HashMap<String, HashSet<String>>) -> Vec<Vec<String>> {
-    let mut index_counter = 0;
-    let mut stack: Vec<String> = Vec::new();
-    let mut indices: HashMap<String, usize> = HashMap::new();
-    let mut lowlinks: HashMap<String, usize> = HashMap::new();
-    let mut on_stack: HashSet<String> = HashSet::new();
-    let mut sccs: Vec<Vec<String>> = Vec::new();
-
-    for node in graph.keys() {
-        if !indices.contains_key(node) {
-            strongconnect(
-                node,
-                &mut index_counter,
-                &mut indices,
-                &mut lowlinks,
-                &mut stack,
-                &mut on_stack,
-                &mut sccs,
-                graph,
-            );
-        }
-    }
-    sccs
-}
-
-#[allow(clippy::too_many_arguments)]
-fn strongconnect(
-    node: &str,
-    index_counter: &mut usize,
-    indices: &mut HashMap<String, usize>,
-    lowlinks: &mut HashMap<String, usize>,
-    stack: &mut Vec<String>,
-    on_stack: &mut HashSet<String>,
-    sccs: &mut Vec<Vec<String>>,
-    graph: &HashMap<String, HashSet<String>>,
-) {
-    indices.insert(node.to_string(), *index_counter);
-    lowlinks.insert(node.to_string(), *index_counter);
-    *index_counter += 1;
-    stack.push(node.to_string());
-    on_stack.insert(node.to_string());
-
-    if let Some(successors) = graph.get(node) {
-        for successor in successors {
-            if !indices.contains_key(successor) {
-                strongconnect(
-                    successor,
-                    index_counter,
-                    indices,
-                    lowlinks,
-                    stack,
-                    on_stack,
-                    sccs,
-                    graph,
-                );
-                let succ_lowlink = *lowlinks.get(successor).unwrap_or(&0);
-                lowlinks.insert(
-                    node.to_string(),
-                    (*lowlinks.get(node).unwrap_or(&0)).min(succ_lowlink),
-                );
-            } else if on_stack.contains(successor) {
-                let succ_index = *indices.get(successor).unwrap_or(&0);
-                lowlinks.insert(
-                    node.to_string(),
-                    (*lowlinks.get(node).unwrap_or(&0)).min(succ_index),
-                );
-            }
-        }
-    }
-
-    if lowlinks.get(node) == indices.get(node) {
-        let mut scc = Vec::new();
-        loop {
-            let w = stack.pop().unwrap();
-            on_stack.remove(&w);
-            scc.push(w.clone());
-            if w == node {
-                break;
-            }
-        }
-        sccs.push(scc);
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/resilient/src/termination.rs
+++ b/resilient/src/termination.rs
@@ -133,10 +133,13 @@ pub fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // Build function location map for error reporting
     let mut fn_info: HashMap<String, (usize, usize)> = HashMap::new();
     for spanned in stmts {
-        if let Node::Function { name, span, .. } = &spanned.node {
-            if !name.is_empty() {
-                fn_info.insert(name.clone(), (span.start.line, span.start.column));
-            }
+        if let Node::Function { name, span, .. } = &spanned.node
+            && !name.is_empty()
+        {
+            fn_info.insert(
+                name.clone(),
+                (span.start.line, span.start.column),
+            );
         }
     }
 
@@ -172,26 +175,26 @@ pub fn check(program: &Node, source_path: &str) -> Result<(), String> {
     }
 
     // Check direct recursion (self-calls)
-    for (name, _) in &fn_info {
-        if call_graph.has_self_call(name) {
-            if let Some((fn_line, col)) = fn_info.get(name) {
-                if *fn_line < 2 {
-                    return Err(format!(
-                        "{}:{}:{}: error: function `{}` is directly recursive but has no \
-                         termination annotation; expected `// @decreases <metric>` or \
-                         `// @may_diverge` on the line above",
-                        source_path, fn_line, col, name
-                    ));
-                }
-                let prev = lines.get(fn_line - 2).copied().unwrap_or("");
-                if !has_termination_annotation(prev) {
-                    return Err(format!(
-                        "{}:{}:{}: error: function `{}` is directly recursive but has no \
-                         termination annotation; expected `// @decreases <metric>` or \
-                         `// @may_diverge` on the line above",
-                        source_path, fn_line, col, name
-                    ));
-                }
+    for name in fn_info.keys() {
+        if call_graph.has_self_call(name)
+            && let Some((fn_line, col)) = fn_info.get(name)
+        {
+            if *fn_line < 2 {
+                return Err(format!(
+                    "{}:{}:{}: error: function `{}` is directly recursive but has no \
+                     termination annotation; expected `// @decreases <metric>` or \
+                     `// @may_diverge` on the line above",
+                    source_path, fn_line, col, name
+                ));
+            }
+            let prev = lines.get(fn_line - 2).copied().unwrap_or("");
+            if !has_termination_annotation(prev) {
+                return Err(format!(
+                    "{}:{}:{}: error: function `{}` is directly recursive but has no \
+                     termination annotation; expected `// @decreases <metric>` or \
+                     `// @may_diverge` on the line above",
+                    source_path, fn_line, col, name
+                ));
             }
         }
     }


### PR DESCRIPTION
## Summary

PR2 of RES-796 implementation: Typechecker integration and diagnostic messages for mutual recursion detection.

- Integrate CallGraph from mutual_recursion_scc module into termination checker
- Replace Tarjan's algorithm with cleaner Kosaraju API
- Add has_self_call() method for direct recursion detection
- Emit cycle path in diagnostic messages (e.g., f → g → f)
- Consolidate duplicate SCC logic into single well-designed module
- Remove 170+ lines of Tarjan implementation

## Test results

All termination annotation tests pass:
- test unannotated_recursion_runs_without_flag
- test unannotated_recursion_rejected_under_strict_flag
- test decreases_annotation_satisfies_strict_flag
- test may_diverge_annotation_satisfies_strict_flag
- test non_recursive_fn_unaffected_by_strict_flag
- test unannotated_mutual_recursion_rejected_under_strict_flag (NEW)
- test annotated_mutual_recursion_accepted_under_strict_flag (NEW)

## Next PR

PR3: Add examples and documentation for mutual recursion patterns

Closes #796

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmfyqpjQuKUY3Zb9YHkEcf)_