### PR TITLE
RES-876: Add set_union builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -220,6 +220,7 @@ the same immutable-value semantics (each mutation returns a new map).
 | `set_has(s, x)` | (set, T) → bool | membership test |
 | `set_len(s)` | set → int | element count |
 | `set_items(s)` | set → array | snapshot of items |
+| `set_union(a, b)` | (set, set) → set | RES-876: every element in either set; deduped |
 
 ### Bytes
 

--- a/resilient/examples/set_union.expected.txt
+++ b/resilient/examples/set_union.expected.txt
@@ -1,0 +1,6 @@
+[1, 2, 3, 4, 5]
+5
+[1, 2, 3]
+3
+["alice", "bob", "carol"]
+Program executed successfully

--- a/resilient/examples/set_union.rz
+++ b/resilient/examples/set_union.rz
@@ -1,0 +1,27 @@
+// RES-876 demo: set_union(a, b) returns a fresh set containing every
+// element from either input. Inputs are unchanged; duplicates are
+// collapsed by set semantics.
+
+fn main(int _d) {
+    let a = #{1, 2, 3};
+    let b = #{3, 4, 5};
+
+    println(set_items(set_union(a, b)));
+    println(set_len(set_union(a, b)));
+
+    // Empty-set identity: union with empty leaves the other side intact.
+    let empty = #{};
+    println(set_items(set_union(a, empty)));
+
+    // Self-union is idempotent.
+    println(set_len(set_union(a, a)));
+
+    // String elements work too.
+    let names = #{"alice", "bob"};
+    let more = #{"bob", "carol"};
+    println(set_items(set_union(names, more)));
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9311,6 +9311,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("set_has", builtin_set_has),
     ("set_len", builtin_set_len),
     ("set_items", builtin_set_items),
+    // RES-876: set algebra primitives.
+    ("set_union", builtin_set_union),
     // RES-152: Bytes builtins.
     ("bytes_len", builtin_bytes_len),
     ("bytes_slice", builtin_bytes_slice),
@@ -16871,6 +16873,32 @@ fn builtin_set_items(args: &[Value]) -> RResult<Value> {
         [a] => Err(format!("set_items: expected a Set, got {}", a)),
         _ => Err(format!(
             "set_items: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-876: `set_union(a, b) -> Set` — return a new set containing every
+/// element from either input. Inputs are unchanged (immutable convention).
+fn builtin_set_union(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Set(a), Value::Set(b)] => {
+            let mut out = a.clone();
+            for k in b.iter() {
+                out.insert(k.clone());
+            }
+            Ok(Value::Set(out))
+        }
+        [Value::Set(_), other] => Err(format!(
+            "set_union: second argument must be a Set, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "set_union: first argument must be a Set, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "set_union: expected 2 arguments (set, set), got {}",
             args.len()
         )),
     }
@@ -25821,6 +25849,80 @@ mod tests {
             Value::Int(n) => assert_eq!(n, 3),
             other => panic!("expected Int, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn set_union_combines_disjoint_sets() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(2)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(3)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(4)]).unwrap();
+        let u = builtin_set_union(&[a, b]).unwrap();
+        assert_eq!(as_set_len(u), 4);
+    }
+
+    #[test]
+    fn set_union_dedupes_overlap() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(2)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(2)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(3)]).unwrap();
+        let u = builtin_set_union(&[a, b]).unwrap();
+        assert_eq!(as_set_len(u), 3);
+    }
+
+    #[test]
+    fn set_union_empty_identity() {
+        let empty = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::String("x".into())]).unwrap();
+        let u = builtin_set_union(&[empty.clone(), s.clone()]).unwrap();
+        assert_eq!(as_set_len(u), 1);
+        let u = builtin_set_union(&[s, empty.clone()]).unwrap();
+        assert_eq!(as_set_len(u), 1);
+        let u = builtin_set_union(&[empty.clone(), empty]).unwrap();
+        assert_eq!(as_set_len(u), 0);
+    }
+
+    #[test]
+    fn set_union_idempotent_on_self() {
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(2)]).unwrap();
+        let u = builtin_set_union(&[s.clone(), s]).unwrap();
+        assert_eq!(as_set_len(u), 2);
+    }
+
+    #[test]
+    fn set_union_rejects_non_set_first_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_union(&[Value::Int(1), s]).unwrap_err();
+        assert!(
+            err.contains("first argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_union_rejects_non_set_second_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_union(&[s, Value::Int(1)]).unwrap_err();
+        assert!(
+            err.contains("second argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_union_rejects_wrong_arity() {
+        let err = builtin_set_union(&[]).unwrap_err();
+        assert!(err.contains("expected 2 arguments"), "err was: {}", err);
     }
 
     #[test]

--- a/resilient/src/mutual_recursion_scc.rs
+++ b/resilient/src/mutual_recursion_scc.rs
@@ -75,9 +75,7 @@ impl CallGraph {
     /// Returns a list of cycles, where each cycle is a list of function names forming the cycle.
     pub fn find_mutual_recursion_cycles(&self) -> Vec<Vec<String>> {
         let sccs = self.find_sccs();
-        sccs.into_iter()
-            .filter(|scc| scc.len() > 1)
-            .collect()
+        sccs.into_iter().filter(|scc| scc.len() > 1).collect()
     }
 
     /// Return the transposed graph (edges reversed).
@@ -85,11 +83,11 @@ impl CallGraph {
         let mut transposed: HashMap<String, HashSet<String>> = HashMap::new();
 
         for (src, dests) in &self.graph {
-            transposed.entry(src.clone()).or_insert_with(HashSet::new);
+            transposed.entry(src.clone()).or_default();
             for dest in dests {
                 transposed
                     .entry(dest.clone())
-                    .or_insert_with(HashSet::new)
+                    .or_default()
                     .insert(src.clone());
             }
         }
@@ -100,14 +98,9 @@ impl CallGraph {
 
 /// Walk a node and record all function calls made within it.
 /// `current_fn` tracks which function we're currently analyzing.
-fn build_graph_for_node(
-    node: &Node,
-    graph: &mut HashMap<String, HashSet<String>>,
-) {
+fn build_graph_for_node(node: &Node, graph: &mut HashMap<String, HashSet<String>>) {
     match node {
-        Node::Function {
-            name, body, ..
-        } => {
+        Node::Function { name, body, .. } => {
             let fn_name = name.clone();
             if !graph.contains_key(&fn_name) {
                 graph.insert(fn_name.clone(), HashSet::new());
@@ -134,13 +127,15 @@ fn collect_called_functions(
 ) {
     match node {
         Node::CallExpression {
-            function, arguments, ..
+            function,
+            arguments,
+            ..
         } => {
             // Extract function name from identifier or field access
             if let Node::Identifier { name, .. } = function.as_ref() {
                 graph
                     .entry(current_fn.to_string())
-                    .or_insert_with(HashSet::new)
+                    .or_default()
                     .insert(name.clone());
             }
 
@@ -166,17 +161,19 @@ fn collect_called_functions(
                 collect_called_functions(alt, current_fn, graph);
             }
         }
-        Node::WhileStatement { condition, body, .. } => {
+        Node::WhileStatement {
+            condition, body, ..
+        } => {
             collect_called_functions(condition, current_fn, graph);
             collect_called_functions(body, current_fn, graph);
         }
-        Node::ForInStatement {
-            iterable, body, ..
-        } => {
+        Node::ForInStatement { iterable, body, .. } => {
             collect_called_functions(iterable, current_fn, graph);
             collect_called_functions(body, current_fn, graph);
         }
-        Node::Match { scrutinee, arms, .. } => {
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
             collect_called_functions(scrutinee, current_fn, graph);
             for (_, guard, body) in arms {
                 if let Some(g) = guard {

--- a/resilient/src/termination.rs
+++ b/resilient/src/termination.rs
@@ -133,10 +133,10 @@ pub fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // Build function location map for error reporting
     let mut fn_info: HashMap<String, (usize, usize)> = HashMap::new();
     for spanned in stmts {
-        if let Node::Function { name, span, .. } = &spanned.node {
-            if !name.is_empty() {
-                fn_info.insert(name.clone(), (span.start.line, span.start.column));
-            }
+        if let Node::Function { name, span, .. } = &spanned.node
+            && !name.is_empty()
+        {
+            fn_info.insert(name.clone(), (span.start.line, span.start.column));
         }
     }
 
@@ -172,26 +172,24 @@ pub fn check(program: &Node, source_path: &str) -> Result<(), String> {
     }
 
     // Check direct recursion (self-calls)
-    for (name, _) in &fn_info {
+    for (name, (fn_line, col)) in &fn_info {
         if call_graph.has_self_call(name) {
-            if let Some((fn_line, col)) = fn_info.get(name) {
-                if *fn_line < 2 {
-                    return Err(format!(
-                        "{}:{}:{}: error: function `{}` is directly recursive but has no \
-                         termination annotation; expected `// @decreases <metric>` or \
-                         `// @may_diverge` on the line above",
-                        source_path, fn_line, col, name
-                    ));
-                }
-                let prev = lines.get(fn_line - 2).copied().unwrap_or("");
-                if !has_termination_annotation(prev) {
-                    return Err(format!(
-                        "{}:{}:{}: error: function `{}` is directly recursive but has no \
-                         termination annotation; expected `// @decreases <metric>` or \
-                         `// @may_diverge` on the line above",
-                        source_path, fn_line, col, name
-                    ));
-                }
+            if *fn_line < 2 {
+                return Err(format!(
+                    "{}:{}:{}: error: function `{}` is directly recursive but has no \
+                     termination annotation; expected `// @decreases <metric>` or \
+                     `// @may_diverge` on the line above",
+                    source_path, fn_line, col, name
+                ));
+            }
+            let prev = lines.get(fn_line - 2).copied().unwrap_or("");
+            if !has_termination_annotation(prev) {
+                return Err(format!(
+                    "{}:{}:{}: error: function `{}` is directly recursive but has no \
+                     termination annotation; expected `// @decreases <metric>` or \
+                     `// @may_diverge` on the line above",
+                    source_path, fn_line, col, name
+                ));
             }
         }
     }
@@ -216,7 +214,6 @@ fn has_termination_annotation(line: &str) -> bool {
     }
     false
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2477,6 +2477,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Array),
             },
         );
+        // RES-876: set algebra primitives.
+        env.set(
+            "set_union".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
 
         // RES-152: Bytes builtins. `bytes_slice` returns new Bytes;
         // `byte_at` returns Int — the language has no `u8` yet.
@@ -5588,6 +5596,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "set_has",
         "set_len",
         "set_items",
+        "set_union",
         "bytes_len",
         "bytes_slice",
         "byte_at",


### PR DESCRIPTION
Closes #940.

## Summary

Implements `set_union(a, b) -> Set` — the basic set-algebra union that the language was missing. Uses the same immutable convention as the rest of the Set API (returns a fresh set; inputs unchanged).

## Changes

- New builtin `set_union` in [resilient/src/lib.rs](resilient/src/lib.rs).
- Registered in `BUILTINS`, typechecker prelude, and `PURE_BUILTINS`.
- 7 unit tests: disjoint, overlap dedupe, empty identity (both sides), self-idempotence, type errors on either arg, arity error.
- Golden example `set_union.rz` + `.expected.txt`.
- Documentation row in `STDLIB.md`.

## Incidental clippy fixes

To unblock CI on Rust 1.91 (latest stable clippy was failing on `main`), this PR also fixes:
- `mutual_recursion_scc.rs`: `or_insert_with(HashSet::new)` → `or_default()` (×3)
- `termination.rs`: collapse two if-let chains and iterate `fn_info.keys()` directly

These were pre-existing failures unrelated to set_union but unavoidable to land green CI.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --locked` — 2289+ pass
- [x] `cargo clippy --locked --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Golden example runs and matches `.expected.txt`