### PR TITLE
RES-877: Add set_intersection builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -221,6 +221,7 @@ the same immutable-value semantics (each mutation returns a new map).
 | `set_len(s)` | set → int | element count |
 | `set_items(s)` | set → array | snapshot of items |
 | `set_union(a, b)` | (set, set) → set | RES-876: every element in either set; deduped |
+| `set_intersection(a, b)` | (set, set) → set | RES-877: only elements present in both inputs |
 
 ### Bytes
 

--- a/resilient/examples/set_intersection.expected.txt
+++ b/resilient/examples/set_intersection.expected.txt
@@ -1,0 +1,6 @@
+[3, 4]
+2
+0
+4
+["bob"]
+Program executed successfully

--- a/resilient/examples/set_intersection.rz
+++ b/resilient/examples/set_intersection.rz
@@ -1,0 +1,27 @@
+// RES-877 demo: set_intersection(a, b) returns a fresh set containing only
+// the elements present in both inputs. Companion to set_union (RES-876).
+
+fn main(int _d) {
+    let a = #{1, 2, 3, 4};
+    let b = #{3, 4, 5, 6};
+
+    println(set_items(set_intersection(a, b)));
+    println(set_len(set_intersection(a, b)));
+
+    // Disjoint sets intersect to empty.
+    let x = #{1, 2};
+    let y = #{3, 4};
+    println(set_len(set_intersection(x, y)));
+
+    // Self-intersection is the identity.
+    println(set_len(set_intersection(a, a)));
+
+    // String elements work too.
+    let names = #{"alice", "bob", "carol"};
+    let admins = #{"bob", "dave"};
+    println(set_items(set_intersection(names, admins)));
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9313,6 +9313,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("set_items", builtin_set_items),
     // RES-876: set algebra primitives.
     ("set_union", builtin_set_union),
+    // RES-877.
+    ("set_intersection", builtin_set_intersection),
     // RES-152: Bytes builtins.
     ("bytes_len", builtin_bytes_len),
     ("bytes_slice", builtin_bytes_slice),
@@ -16899,6 +16901,29 @@ fn builtin_set_union(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "set_union: expected 2 arguments (set, set), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-877: `set_intersection(a, b) -> Set` — return a new set containing only
+/// elements present in both inputs. Inputs are unchanged.
+fn builtin_set_intersection(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Set(a), Value::Set(b)] => {
+            let out: std::collections::HashSet<MapKey> = a.intersection(b).cloned().collect();
+            Ok(Value::Set(out))
+        }
+        [Value::Set(_), other] => Err(format!(
+            "set_intersection: second argument must be a Set, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "set_intersection: first argument must be a Set, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "set_intersection: expected 2 arguments (set, set), got {}",
             args.len()
         )),
     }
@@ -25922,6 +25947,78 @@ mod tests {
     #[test]
     fn set_union_rejects_wrong_arity() {
         let err = builtin_set_union(&[]).unwrap_err();
+        assert!(err.contains("expected 2 arguments"), "err was: {}", err);
+    }
+
+    #[test]
+    fn set_intersection_keeps_common_elements() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(2)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(3)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(2)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(3)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(4)]).unwrap();
+        let i = builtin_set_intersection(&[a, b]).unwrap();
+        assert_eq!(as_set_len(i), 2);
+    }
+
+    #[test]
+    fn set_intersection_disjoint_is_empty() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(2)]).unwrap();
+        let i = builtin_set_intersection(&[a, b]).unwrap();
+        assert_eq!(as_set_len(i), 0);
+    }
+
+    #[test]
+    fn set_intersection_with_empty_is_empty() {
+        let empty = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::String("x".into())]).unwrap();
+        let i = builtin_set_intersection(&[empty.clone(), s.clone()]).unwrap();
+        assert_eq!(as_set_len(i), 0);
+        let i = builtin_set_intersection(&[s, empty]).unwrap();
+        assert_eq!(as_set_len(i), 0);
+    }
+
+    #[test]
+    fn set_intersection_self_is_self() {
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(2)]).unwrap();
+        let i = builtin_set_intersection(&[s.clone(), s]).unwrap();
+        assert_eq!(as_set_len(i), 2);
+    }
+
+    #[test]
+    fn set_intersection_rejects_non_set_first_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_intersection(&[Value::Int(1), s]).unwrap_err();
+        assert!(
+            err.contains("first argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_intersection_rejects_non_set_second_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_intersection(&[s, Value::Int(1)]).unwrap_err();
+        assert!(
+            err.contains("second argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_intersection_rejects_wrong_arity() {
+        let err = builtin_set_intersection(&[]).unwrap_err();
         assert!(err.contains("expected 2 arguments"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2485,6 +2485,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Any),
             },
         );
+        // RES-877.
+        env.set(
+            "set_intersection".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
 
         // RES-152: Bytes builtins. `bytes_slice` returns new Bytes;
         // `byte_at` returns Int — the language has no `u8` yet.
@@ -5597,6 +5605,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "set_len",
         "set_items",
         "set_union",
+        "set_intersection",
         "bytes_len",
         "bytes_slice",
         "byte_at",


### PR DESCRIPTION
Closes #942.

## Summary

Second of three core set-algebra primitives following RES-876. Returns a fresh set containing only elements present in both inputs.

## Changes

- New builtin `set_intersection` in [resilient/src/lib.rs](resilient/src/lib.rs).
- Registered in `BUILTINS`, typechecker prelude, and `PURE_BUILTINS`.
- 7 unit tests: common-element retention, disjoint sets, empty intersections (both sides), self-intersection, type errors on each arg, arity error.
- Golden example `set_intersection.rz` + `.expected.txt`.
- Documentation row in `STDLIB.md`.

## Test plan

- [x] `cargo test --release` — 7 new tests pass, full suite green
- [x] `cargo clippy --locked --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Golden example runs and matches `.expected.txt`