### PR TITLE
RES-878: Add set_difference builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -222,6 +222,7 @@ the same immutable-value semantics (each mutation returns a new map).
 | `set_items(s)` | set → array | snapshot of items |
 | `set_union(a, b)` | (set, set) → set | RES-876: every element in either set; deduped |
 | `set_intersection(a, b)` | (set, set) → set | RES-877: only elements present in both inputs |
+| `set_difference(a, b)` | (set, set) → set | RES-878: elements in `a` but not in `b` |
 
 ### Bytes
 

--- a/resilient/examples/set_difference.expected.txt
+++ b/resilient/examples/set_difference.expected.txt
@@ -1,0 +1,6 @@
+[1, 3]
+2
+4
+0
+["alice", "carol"]
+Program executed successfully

--- a/resilient/examples/set_difference.rz
+++ b/resilient/examples/set_difference.rz
@@ -1,0 +1,27 @@
+// RES-878 demo: set_difference(a, b) returns a fresh set of elements
+// in `a` but not in `b`. Companion to set_union (RES-876) and
+// set_intersection (RES-877).
+
+fn main(int _d) {
+    let a = #{1, 2, 3, 4};
+    let b = #{2, 4};
+
+    println(set_items(set_difference(a, b)));
+    println(set_len(set_difference(a, b)));
+
+    // Disjoint b means everything in a survives.
+    let c = #{99, 100};
+    println(set_len(set_difference(a, c)));
+
+    // Self-difference is the empty set.
+    println(set_len(set_difference(a, a)));
+
+    // String elements: filter out a known suspended-account list.
+    let active = #{"alice", "bob", "carol"};
+    let suspended = #{"bob"};
+    println(set_items(set_difference(active, suspended)));
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9315,6 +9315,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("set_union", builtin_set_union),
     // RES-877.
     ("set_intersection", builtin_set_intersection),
+    // RES-878.
+    ("set_difference", builtin_set_difference),
     // RES-152: Bytes builtins.
     ("bytes_len", builtin_bytes_len),
     ("bytes_slice", builtin_bytes_slice),
@@ -16924,6 +16926,29 @@ fn builtin_set_intersection(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "set_intersection: expected 2 arguments (set, set), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-878: `set_difference(a, b) -> Set` — return a new set with elements in
+/// `a` and not in `b`. Inputs are unchanged.
+fn builtin_set_difference(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Set(a), Value::Set(b)] => {
+            let out: std::collections::HashSet<MapKey> = a.difference(b).cloned().collect();
+            Ok(Value::Set(out))
+        }
+        [Value::Set(_), other] => Err(format!(
+            "set_difference: second argument must be a Set, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "set_difference: first argument must be a Set, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "set_difference: expected 2 arguments (set, set), got {}",
             args.len()
         )),
     }
@@ -26019,6 +26044,85 @@ mod tests {
     #[test]
     fn set_intersection_rejects_wrong_arity() {
         let err = builtin_set_intersection(&[]).unwrap_err();
+        assert!(err.contains("expected 2 arguments"), "err was: {}", err);
+    }
+
+    #[test]
+    fn set_difference_removes_elements_in_b() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(2)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(3)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(2)]).unwrap();
+        let d = builtin_set_difference(&[a, b]).unwrap();
+        assert_eq!(as_set_len(d), 2);
+    }
+
+    #[test]
+    fn set_difference_disjoint_returns_a() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(2)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(3)]).unwrap();
+        let d = builtin_set_difference(&[a, b]).unwrap();
+        assert_eq!(as_set_len(d), 2);
+    }
+
+    #[test]
+    fn set_difference_self_is_empty() {
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(2)]).unwrap();
+        let d = builtin_set_difference(&[s.clone(), s]).unwrap();
+        assert_eq!(as_set_len(d), 0);
+    }
+
+    #[test]
+    fn set_difference_empty_minus_anything_is_empty() {
+        let empty = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        let d = builtin_set_difference(&[empty, s]).unwrap();
+        assert_eq!(as_set_len(d), 0);
+    }
+
+    #[test]
+    fn set_difference_minus_empty_is_a() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::String("x".into())]).unwrap();
+        let a = builtin_set_insert(&[a, Value::String("y".into())]).unwrap();
+        let empty = builtin_set_new(&[]).unwrap();
+        let d = builtin_set_difference(&[a, empty]).unwrap();
+        assert_eq!(as_set_len(d), 2);
+    }
+
+    #[test]
+    fn set_difference_rejects_non_set_first_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_difference(&[Value::Int(1), s]).unwrap_err();
+        assert!(
+            err.contains("first argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_difference_rejects_non_set_second_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_difference(&[s, Value::Int(1)]).unwrap_err();
+        assert!(
+            err.contains("second argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_difference_rejects_wrong_arity() {
+        let err = builtin_set_difference(&[]).unwrap_err();
         assert!(err.contains("expected 2 arguments"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2493,6 +2493,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Any),
             },
         );
+        // RES-878.
+        env.set(
+            "set_difference".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
 
         // RES-152: Bytes builtins. `bytes_slice` returns new Bytes;
         // `byte_at` returns Int — the language has no `u8` yet.
@@ -5606,6 +5614,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "set_items",
         "set_union",
         "set_intersection",
+        "set_difference",
         "bytes_len",
         "bytes_slice",
         "byte_at",


### PR DESCRIPTION
Closes #944.

## Summary

Final core set-algebra primitive. Returns a fresh set with elements in `a` but not in `b`.

## Changes

- New builtin `set_difference` in [resilient/src/lib.rs](resilient/src/lib.rs).
- Registered in `BUILTINS`, typechecker prelude, and `PURE_BUILTINS`.
- 8 unit tests: overlap removal, disjoint, self-difference, empty − anything, anything − empty, type errors, arity error.
- Golden example `set_difference.rz` + `.expected.txt`.
- `STDLIB.md` row.

## Test plan

- [x] `cargo test --release` — 8 new pass, full suite green
- [x] `cargo clippy --locked --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Golden example matches expected output