### PR TITLE
RES-879: Add set_is_subset builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -223,6 +223,7 @@ the same immutable-value semantics (each mutation returns a new map).
 | `set_union(a, b)` | (set, set) → set | RES-876: every element in either set; deduped |
 | `set_intersection(a, b)` | (set, set) → set | RES-877: only elements present in both inputs |
 | `set_difference(a, b)` | (set, set) → set | RES-878: elements in `a` but not in `b` |
+| `set_is_subset(a, b)` | (set, set) → bool | RES-879: true iff every element of `a` is in `b`; empty is subset of all |
 
 ### Bytes
 

--- a/resilient/examples/set_is_subset.expected.txt
+++ b/resilient/examples/set_is_subset.expected.txt
@@ -1,0 +1,7 @@
+true
+false
+true
+true
+false
+true
+Program executed successfully

--- a/resilient/examples/set_is_subset.rz
+++ b/resilient/examples/set_is_subset.rz
@@ -1,0 +1,28 @@
+// RES-879 demo: set_is_subset(a, b) returns true when every element of `a`
+// is in `b`. First set-relation predicate after the algebra trio.
+
+fn main(int _d) {
+    let a = #{1, 2};
+    let b = #{1, 2, 3};
+    println(set_is_subset(a, b));    // true: a ⊆ b
+
+    // Mismatch on a single element flips it false.
+    let c = #{1, 99};
+    println(set_is_subset(c, b));    // false
+
+    // Self-subset and empty-subset are both true.
+    println(set_is_subset(b, b));    // true
+    println(set_is_subset(#{}, b));  // true (vacuous)
+
+    // Nonempty-set is not a subset of empty.
+    println(set_is_subset(a, #{}));  // false
+
+    // Permission-check use case: required ⊆ granted?
+    let required = #{"read", "write"};
+    let granted = #{"read", "write", "admin"};
+    println(set_is_subset(required, granted));  // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9317,6 +9317,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("set_intersection", builtin_set_intersection),
     // RES-878.
     ("set_difference", builtin_set_difference),
+    // RES-879.
+    ("set_is_subset", builtin_set_is_subset),
     // RES-152: Bytes builtins.
     ("bytes_len", builtin_bytes_len),
     ("bytes_slice", builtin_bytes_slice),
@@ -16949,6 +16951,26 @@ fn builtin_set_difference(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "set_difference: expected 2 arguments (set, set), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-879: `set_is_subset(a, b) -> Bool` — true iff every element of `a` is
+/// in `b`. Empty set is a subset of every set; a set is a subset of itself.
+fn builtin_set_is_subset(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Set(a), Value::Set(b)] => Ok(Value::Bool(a.is_subset(b))),
+        [Value::Set(_), other] => Err(format!(
+            "set_is_subset: second argument must be a Set, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "set_is_subset: first argument must be a Set, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "set_is_subset: expected 2 arguments (set, set), got {}",
             args.len()
         )),
     }
@@ -26123,6 +26145,85 @@ mod tests {
     #[test]
     fn set_difference_rejects_wrong_arity() {
         let err = builtin_set_difference(&[]).unwrap_err();
+        assert!(err.contains("expected 2 arguments"), "err was: {}", err);
+    }
+
+    #[test]
+    fn set_is_subset_empty_is_subset_of_everything() {
+        let empty = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        assert!(as_bool(builtin_set_is_subset(&[empty.clone(), s]).unwrap()));
+        assert!(as_bool(
+            builtin_set_is_subset(&[empty.clone(), empty]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn set_is_subset_self_is_true() {
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(2)]).unwrap();
+        assert!(as_bool(builtin_set_is_subset(&[s.clone(), s]).unwrap()));
+    }
+
+    #[test]
+    fn set_is_subset_proper_subset_is_true() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(2)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(1)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(2)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(3)]).unwrap();
+        assert!(as_bool(builtin_set_is_subset(&[a, b]).unwrap()));
+    }
+
+    #[test]
+    fn set_is_subset_missing_element_is_false() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(4)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(1)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(2)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(3)]).unwrap();
+        assert!(!as_bool(builtin_set_is_subset(&[a, b]).unwrap()));
+    }
+
+    #[test]
+    fn set_is_subset_nonempty_subset_of_empty_is_false() {
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        let empty = builtin_set_new(&[]).unwrap();
+        assert!(!as_bool(builtin_set_is_subset(&[s, empty]).unwrap()));
+    }
+
+    #[test]
+    fn set_is_subset_rejects_non_set_first_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_is_subset(&[Value::Int(1), s]).unwrap_err();
+        assert!(
+            err.contains("first argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_is_subset_rejects_non_set_second_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_is_subset(&[s, Value::Int(1)]).unwrap_err();
+        assert!(
+            err.contains("second argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_is_subset_rejects_wrong_arity() {
+        let err = builtin_set_is_subset(&[]).unwrap_err();
         assert!(err.contains("expected 2 arguments"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2501,6 +2501,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Any),
             },
         );
+        // RES-879.
+        env.set(
+            "set_is_subset".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Bool),
+            },
+        );
 
         // RES-152: Bytes builtins. `bytes_slice` returns new Bytes;
         // `byte_at` returns Int — the language has no `u8` yet.
@@ -5615,6 +5623,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "set_union",
         "set_intersection",
         "set_difference",
+        "set_is_subset",
         "bytes_len",
         "bytes_slice",
         "byte_at",


### PR DESCRIPTION
Closes #946.

## Summary

First set-relation predicate. Returns true iff every element of `a` is in `b`. Empty is a subset of every set; a set is a subset of itself.

## Changes

- `set_is_subset` in [resilient/src/lib.rs](resilient/src/lib.rs).
- Registered in `BUILTINS`, typechecker prelude (return_type Bool), `PURE_BUILTINS`.
- 8 unit tests; golden example with permission-check use case.
- `STDLIB.md` row.

## Test plan

- [x] `cargo test --release` 8 new pass; full suite green
- [x] `cargo clippy --locked --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Golden matches expected