### PR TITLE
RES-880: Add set_is_superset builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -224,6 +224,7 @@ the same immutable-value semantics (each mutation returns a new map).
 | `set_intersection(a, b)` | (set, set) → set | RES-877: only elements present in both inputs |
 | `set_difference(a, b)` | (set, set) → set | RES-878: elements in `a` but not in `b` |
 | `set_is_subset(a, b)` | (set, set) → bool | RES-879: true iff every element of `a` is in `b`; empty is subset of all |
+| `set_is_superset(a, b)` | (set, set) → bool | RES-880: true iff every element of `b` is in `a` |
 
 ### Bytes
 

--- a/resilient/examples/set_is_superset.expected.txt
+++ b/resilient/examples/set_is_superset.expected.txt
@@ -1,0 +1,7 @@
+true
+false
+true
+true
+false
+true
+Program executed successfully

--- a/resilient/examples/set_is_superset.rz
+++ b/resilient/examples/set_is_superset.rz
@@ -1,0 +1,26 @@
+// RES-880 demo: set_is_superset(a, b) returns true when every element of `b`
+// is in `a`. Mirror of set_is_subset (RES-879).
+
+fn main(int _d) {
+    let big = #{1, 2, 3, 4};
+    let small = #{1, 2};
+    println(set_is_superset(big, small));    // true
+
+    // Mismatch flips it false.
+    let small2 = #{1, 99};
+    println(set_is_superset(big, small2));   // false
+
+    // Self and empty cases.
+    println(set_is_superset(big, big));      // true
+    println(set_is_superset(big, #{}));      // true (every set is superset of empty)
+    println(set_is_superset(#{}, big));      // false
+
+    // Capability check: granted ⊇ required?
+    let granted = #{"read", "write", "admin"};
+    let required = #{"read", "write"};
+    println(set_is_superset(granted, required));  // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9319,6 +9319,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("set_difference", builtin_set_difference),
     // RES-879.
     ("set_is_subset", builtin_set_is_subset),
+    // RES-880.
+    ("set_is_superset", builtin_set_is_superset),
     // RES-152: Bytes builtins.
     ("bytes_len", builtin_bytes_len),
     ("bytes_slice", builtin_bytes_slice),
@@ -16971,6 +16973,26 @@ fn builtin_set_is_subset(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "set_is_subset: expected 2 arguments (set, set), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-880: `set_is_superset(a, b) -> Bool` — true iff every element of `b`
+/// is in `a`. Mirror of `set_is_subset`.
+fn builtin_set_is_superset(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Set(a), Value::Set(b)] => Ok(Value::Bool(a.is_superset(b))),
+        [Value::Set(_), other] => Err(format!(
+            "set_is_superset: second argument must be a Set, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "set_is_superset: first argument must be a Set, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "set_is_superset: expected 2 arguments (set, set), got {}",
             args.len()
         )),
     }
@@ -26224,6 +26246,86 @@ mod tests {
     #[test]
     fn set_is_subset_rejects_wrong_arity() {
         let err = builtin_set_is_subset(&[]).unwrap_err();
+        assert!(err.contains("expected 2 arguments"), "err was: {}", err);
+    }
+
+    #[test]
+    fn set_is_superset_self_is_true() {
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(2)]).unwrap();
+        assert!(as_bool(builtin_set_is_superset(&[s.clone(), s]).unwrap()));
+    }
+
+    #[test]
+    fn set_is_superset_of_empty_is_always_true() {
+        let empty = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        assert!(as_bool(
+            builtin_set_is_superset(&[s, empty.clone()]).unwrap()
+        ));
+        assert!(as_bool(
+            builtin_set_is_superset(&[empty.clone(), empty]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn set_is_superset_proper_superset_is_true() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(2)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(3)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(1)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(2)]).unwrap();
+        assert!(as_bool(builtin_set_is_superset(&[a, b]).unwrap()));
+    }
+
+    #[test]
+    fn set_is_superset_missing_element_is_false() {
+        let a = builtin_set_new(&[]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(1)]).unwrap();
+        let a = builtin_set_insert(&[a, Value::Int(2)]).unwrap();
+        let b = builtin_set_new(&[]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(1)]).unwrap();
+        let b = builtin_set_insert(&[b, Value::Int(3)]).unwrap();
+        assert!(!as_bool(builtin_set_is_superset(&[a, b]).unwrap()));
+    }
+
+    #[test]
+    fn set_is_superset_empty_of_nonempty_is_false() {
+        let empty = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_new(&[]).unwrap();
+        let s = builtin_set_insert(&[s, Value::Int(1)]).unwrap();
+        assert!(!as_bool(builtin_set_is_superset(&[empty, s]).unwrap()));
+    }
+
+    #[test]
+    fn set_is_superset_rejects_non_set_first_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_is_superset(&[Value::Int(1), s]).unwrap_err();
+        assert!(
+            err.contains("first argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_is_superset_rejects_non_set_second_arg() {
+        let s = builtin_set_new(&[]).unwrap();
+        let err = builtin_set_is_superset(&[s, Value::Int(1)]).unwrap_err();
+        assert!(
+            err.contains("second argument must be a Set"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_is_superset_rejects_wrong_arity() {
+        let err = builtin_set_is_superset(&[]).unwrap_err();
         assert!(err.contains("expected 2 arguments"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2509,6 +2509,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Bool),
             },
         );
+        // RES-880.
+        env.set(
+            "set_is_superset".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Bool),
+            },
+        );
 
         // RES-152: Bytes builtins. `bytes_slice` returns new Bytes;
         // `byte_at` returns Int — the language has no `u8` yet.
@@ -5624,6 +5632,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "set_intersection",
         "set_difference",
         "set_is_subset",
+        "set_is_superset",
         "bytes_len",
         "bytes_slice",
         "byte_at",


### PR DESCRIPTION
Closes #948.

Mirror of RES-879. Returns true iff every element of `b` is in `a`. 8 unit tests, golden example, STDLIB.md row.

## Test plan
- [x] cargo test --release: 8 new pass, full suite green
- [x] cargo clippy --locked --all-targets -- -D warnings: clean
- [x] cargo fmt --check: clean
- [x] golden output matches