### PR TITLE
RES-884: Add map_contains_key builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -194,6 +194,7 @@ match r {
 | `map_keys(m)` | map → array | all keys, sorted for determinism |
 | `map_len(m)` | map → int | entry count |
 | `map_values(m)` | map → array | RES-883: all values in same key-sorted order as `map_keys` |
+| `map_contains_key(m, k)` | (map, K) → bool | RES-884: membership test; mirrors `hashmap_contains` |
 
 ### HashMap (RES-293)
 

--- a/resilient/examples/map_contains_key.expected.txt
+++ b/resilient/examples/map_contains_key.expected.txt
@@ -1,0 +1,8 @@
+true
+false
+false
+true
+false
+true
+false
+Program executed successfully

--- a/resilient/examples/map_contains_key.rz
+++ b/resilient/examples/map_contains_key.rz
@@ -1,0 +1,27 @@
+// RES-884 demo: map_contains_key(m, k) returns true if k is a key in m.
+// Mirrors hashmap_contains for the map_* namespace.
+
+fn main(int _d) {
+    let m = map_new();
+    let m = map_insert(m, "alice", 1);
+    let m = map_insert(m, "bob", 2);
+
+    println(map_contains_key(m, "alice"));     // true
+    println(map_contains_key(m, "carol"));     // false
+    println(map_contains_key(map_new(), 0));   // false (empty map)
+
+    // Int and Bool keys also work.
+    let nums = map_new();
+    let nums = map_insert(nums, 42, "answer");
+    println(map_contains_key(nums, 42));       // true
+    println(map_contains_key(nums, 41));       // false
+
+    let flags = map_new();
+    let flags = map_insert(flags, true, "yes");
+    println(map_contains_key(flags, true));    // true
+    println(map_contains_key(flags, false));   // false
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9296,6 +9296,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("map_len", builtin_map_len),
     // RES-883.
     ("map_values", builtin_map_values),
+    // RES-884.
+    ("map_contains_key", builtin_map_contains_key),
     // RES-293: HashMap stdlib builtins. Surface the same `Value::Map`
     // backend under the user-facing `hashmap_*` names called out in
     // the language guide. `hashmap_contains` is genuinely new — it
@@ -16554,6 +16556,25 @@ fn builtin_map_len(args: &[Value]) -> RResult<Value> {
         [Value::Map(m)] => Ok(Value::Int(m.len() as i64)),
         [a] => Err(format!("map_len: expected a Map, got {}", a)),
         _ => Err(format!("map_len: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-884: `map_contains_key(m, k) -> Bool` — true iff `m` contains `k`.
+/// Mirrors `hashmap_contains` for the `map_*` namespace.
+fn builtin_map_contains_key(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Map(m), k] => {
+            let key = MapKey::from_value(k)?;
+            Ok(Value::Bool(m.contains_key(&key)))
+        }
+        [a, _] => Err(format!(
+            "map_contains_key: first argument must be a Map, got {}",
+            a
+        )),
+        _ => Err(format!(
+            "map_contains_key: expected 2 arguments (map, key), got {}",
+            args.len()
+        )),
     }
 }
 
@@ -27431,6 +27452,59 @@ mod tests {
     fn map_values_rejects_wrong_arity() {
         let err = builtin_map_values(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn map_contains_key_present_is_true() {
+        let m = builtin_map_new(&[]).unwrap();
+        let m = builtin_map_insert(&[m, Value::String("hello".into()), Value::Int(1)]).unwrap();
+        assert!(as_bool(
+            builtin_map_contains_key(&[m, Value::String("hello".into())]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn map_contains_key_absent_is_false() {
+        let m = builtin_map_new(&[]).unwrap();
+        let m = builtin_map_insert(&[m, Value::String("hello".into()), Value::Int(1)]).unwrap();
+        assert!(!as_bool(
+            builtin_map_contains_key(&[m, Value::String("missing".into())]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn map_contains_key_empty_is_false() {
+        let m = builtin_map_new(&[]).unwrap();
+        assert!(!as_bool(
+            builtin_map_contains_key(&[m, Value::Int(0)]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn map_contains_key_rejects_non_map_first_arg() {
+        let err = builtin_map_contains_key(&[Value::Int(1), Value::Int(0)]).unwrap_err();
+        assert!(
+            err.contains("first argument must be a Map"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn map_contains_key_rejects_non_hashable_key() {
+        let m = builtin_map_new(&[]).unwrap();
+        let err = builtin_map_contains_key(&[m, Value::Float(1.5)]).unwrap_err();
+        assert!(
+            err.contains("Map key must be Int, String, or Bool"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn map_contains_key_rejects_wrong_arity() {
+        let err = builtin_map_contains_key(&[]).unwrap_err();
+        assert!(err.contains("expected 2 arguments"), "err was: {}", err);
     }
 
     #[test]

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2394,6 +2394,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Array),
             },
         );
+        // RES-884.
+        env.set(
+            "map_contains_key".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Bool),
+            },
+        );
 
         // RES-293: HashMap stdlib builtins. Same permissive-Any
         // shape as the Map builtins above — once G7 inference lands
@@ -5639,6 +5647,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "map_keys",
         "map_len",
         "map_values",
+        "map_contains_key",
         // RES-293: HashMap stdlib builtins (purely functional —
         // each returns a new map / scalar; no IO).
         "hashmap_new",


### PR DESCRIPTION
Closes #956. Mirrors hashmap_contains for the map_* namespace.