### PR TITLE
RES-885: Add hashmap_len builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -211,6 +211,7 @@ the same immutable-value semantics (each mutation returns a new map).
 | `hashmap_remove(m, k)` | (hashmap, K) → hashmap | no-op when key missing |
 | `hashmap_contains(m, k)` | (hashmap, K) → bool | membership test |
 | `hashmap_keys(m)` | hashmap → array | keys, sorted for determinism |
+| `hashmap_len(m)` | hashmap → int | RES-885: entry count; mirrors `map_len` |
 
 ### Sets
 

--- a/resilient/examples/hashmap_len.expected.txt
+++ b/resilient/examples/hashmap_len.expected.txt
@@ -1,0 +1,5 @@
+0
+3
+3
+2
+Program executed successfully

--- a/resilient/examples/hashmap_len.rz
+++ b/resilient/examples/hashmap_len.rz
@@ -1,0 +1,24 @@
+// RES-885 demo: hashmap_len(m) returns entry count. Mirrors map_len for
+// the HashMap stdlib namespace.
+
+fn main(int _d) {
+    let m = hashmap_new();
+    println(hashmap_len(m));    // 0
+
+    let m = hashmap_insert(m, "alice", 1);
+    let m = hashmap_insert(m, "bob", 2);
+    let m = hashmap_insert(m, "carol", 3);
+    println(hashmap_len(m));    // 3
+
+    // Reinserting an existing key updates the value but doesn't grow len.
+    let m = hashmap_insert(m, "alice", 99);
+    println(hashmap_len(m));    // 3
+
+    // Removing shrinks len.
+    let m = hashmap_remove(m, "alice");
+    println(hashmap_len(m));    // 2
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9308,6 +9308,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("hashmap_remove", builtin_hashmap_remove),
     ("hashmap_contains", builtin_hashmap_contains),
     ("hashmap_keys", builtin_hashmap_keys),
+    // RES-885.
+    ("hashmap_len", builtin_hashmap_len),
     // RES-149: Set builtins.
     ("set_new", builtin_set_new),
     ("set_insert", builtin_set_insert),
@@ -16713,6 +16715,19 @@ fn builtin_hashmap_contains(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "hashmap_contains: expected 2 arguments (hashmap, key), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-885: `hashmap_len(m) -> Int` — number of entries. Mirrors
+/// `map_len` for the HashMap stdlib namespace.
+fn builtin_hashmap_len(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Map(m)] => Ok(Value::Int(m.len() as i64)),
+        [a] => Err(format!("hashmap_len: expected a HashMap, got {}", a)),
+        _ => Err(format!(
+            "hashmap_len: expected 1 argument, got {}",
             args.len()
         )),
     }
@@ -27670,6 +27685,51 @@ mod tests {
             Value::Array(items) => assert!(items.is_empty()),
             other => panic!("expected Array, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn hashmap_len_counts_entries() {
+        let m = builtin_hashmap_new(&[]).unwrap();
+        let m = builtin_hashmap_insert(&[m, Value::Int(1), Value::String("one".into())]).unwrap();
+        let m = builtin_hashmap_insert(&[m, Value::Int(2), Value::String("two".into())]).unwrap();
+        let m = builtin_hashmap_insert(&[m, Value::Int(3), Value::String("three".into())]).unwrap();
+        match builtin_hashmap_len(&[m]).unwrap() {
+            Value::Int(3) => {}
+            other => panic!("expected Int(3), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn hashmap_len_on_empty_is_zero() {
+        let m = builtin_hashmap_new(&[]).unwrap();
+        match builtin_hashmap_len(&[m]).unwrap() {
+            Value::Int(0) => {}
+            other => panic!("expected Int(0), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn hashmap_len_dedupes_overwrites() {
+        // Reinserting the same key updates the existing entry; len stays at 1.
+        let m = builtin_hashmap_new(&[]).unwrap();
+        let m = builtin_hashmap_insert(&[m, Value::Int(1), Value::String("a".into())]).unwrap();
+        let m = builtin_hashmap_insert(&[m, Value::Int(1), Value::String("b".into())]).unwrap();
+        match builtin_hashmap_len(&[m]).unwrap() {
+            Value::Int(1) => {}
+            other => panic!("expected Int(1), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn hashmap_len_rejects_non_hashmap() {
+        let err = builtin_hashmap_len(&[Value::Int(1)]).unwrap_err();
+        assert!(err.contains("expected a HashMap"), "err was: {}", err);
+    }
+
+    #[test]
+    fn hashmap_len_rejects_wrong_arity() {
+        let err = builtin_hashmap_len(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 
     #[test]

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2448,6 +2448,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Array),
             },
         );
+        // RES-885.
+        env.set(
+            "hashmap_len".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Int),
+            },
+        );
 
         // RES-149: Set builtins. Same permissive-Any convention as
         // Map — no dedicated `Type::Set<T>` until inference lands.
@@ -5656,6 +5664,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "hashmap_remove",
         "hashmap_contains",
         "hashmap_keys",
+        "hashmap_len",
         "set_new",
         "set_insert",
         "set_remove",


### PR DESCRIPTION
Closes #958. Mirrors map_len for HashMap namespace.