### PR TITLE
RES-886: Add hashmap_values builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -212,6 +212,7 @@ the same immutable-value semantics (each mutation returns a new map).
 | `hashmap_contains(m, k)` | (hashmap, K) → bool | membership test |
 | `hashmap_keys(m)` | hashmap → array | keys, sorted for determinism |
 | `hashmap_len(m)` | hashmap → int | RES-885: entry count; mirrors `map_len` |
+| `hashmap_values(m)` | hashmap → array | RES-886: values in same key-sorted order as `hashmap_keys` |
 
 ### Sets
 

--- a/resilient/examples/hashmap_values.expected.txt
+++ b/resilient/examples/hashmap_values.expected.txt
@@ -1,0 +1,5 @@
+["alice", "bob", "carol"]
+[17, 23, 42]
+3
+[]
+Program executed successfully

--- a/resilient/examples/hashmap_values.rz
+++ b/resilient/examples/hashmap_values.rz
@@ -1,0 +1,20 @@
+// RES-886 demo: hashmap_values(m) returns the HashMap's values as an
+// array, in same key-sorted order as hashmap_keys.
+
+fn main(int _d) {
+    let m = hashmap_new();
+    let m = hashmap_insert(m, "carol", 42);
+    let m = hashmap_insert(m, "alice", 17);
+    let m = hashmap_insert(m, "bob", 23);
+
+    println(hashmap_keys(m));      // ["alice", "bob", "carol"]
+    println(hashmap_values(m));    // [17, 23, 42]
+    println(hashmap_len(m));       // 3
+
+    // Empty.
+    println(hashmap_values(hashmap_new()));  // []
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9310,6 +9310,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("hashmap_keys", builtin_hashmap_keys),
     // RES-885.
     ("hashmap_len", builtin_hashmap_len),
+    // RES-886.
+    ("hashmap_values", builtin_hashmap_values),
     // RES-149: Set builtins.
     ("set_new", builtin_set_new),
     ("set_insert", builtin_set_insert),
@@ -16728,6 +16730,32 @@ fn builtin_hashmap_len(args: &[Value]) -> RResult<Value> {
         [a] => Err(format!("hashmap_len: expected a HashMap, got {}", a)),
         _ => Err(format!(
             "hashmap_len: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-886: `hashmap_values(m) -> Array<V>` — values in same key-sorted
+/// order as `hashmap_keys`. Mirrors `map_values` for the HashMap namespace.
+fn builtin_hashmap_values(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Map(m)] => {
+            let mut entries: Vec<(&MapKey, &Value)> = m.iter().collect();
+            entries.sort_by(|(a, _), (b, _)| match (a, b) {
+                (MapKey::Int(x), MapKey::Int(y)) => x.cmp(y),
+                (MapKey::Str(x), MapKey::Str(y)) => x.cmp(y),
+                (MapKey::Bool(x), MapKey::Bool(y)) => x.cmp(y),
+                (MapKey::Int(_), _) => std::cmp::Ordering::Less,
+                (_, MapKey::Int(_)) => std::cmp::Ordering::Greater,
+                (MapKey::Str(_), _) => std::cmp::Ordering::Less,
+                (_, MapKey::Str(_)) => std::cmp::Ordering::Greater,
+            });
+            let out: Vec<Value> = entries.iter().map(|(_, v)| (*v).clone()).collect();
+            Ok(Value::Array(out))
+        }
+        [a] => Err(format!("hashmap_values: expected a HashMap, got {}", a)),
+        _ => Err(format!(
+            "hashmap_values: expected 1 argument, got {}",
             args.len()
         )),
     }
@@ -27729,6 +27757,64 @@ mod tests {
     #[test]
     fn hashmap_len_rejects_wrong_arity() {
         let err = builtin_hashmap_len(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn hashmap_values_returns_array_in_key_sort_order() {
+        let m = builtin_hashmap_new(&[]).unwrap();
+        let m = builtin_hashmap_insert(&[m, Value::String("b".into()), Value::Int(2)]).unwrap();
+        let m = builtin_hashmap_insert(&[m, Value::String("a".into()), Value::Int(1)]).unwrap();
+        let m = builtin_hashmap_insert(&[m, Value::String("c".into()), Value::Int(3)]).unwrap();
+        match builtin_hashmap_values(&[m]).unwrap() {
+            Value::Array(items) => {
+                let ints: Vec<i64> = items
+                    .into_iter()
+                    .map(|v| match v {
+                        Value::Int(n) => n,
+                        other => panic!("expected Int value, got {:?}", other),
+                    })
+                    .collect();
+                assert_eq!(ints, vec![1, 2, 3]);
+            }
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn hashmap_values_empty_returns_empty_array() {
+        let m = builtin_hashmap_new(&[]).unwrap();
+        match builtin_hashmap_values(&[m]).unwrap() {
+            Value::Array(items) => assert!(items.is_empty()),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn hashmap_values_single_entry() {
+        let m = builtin_hashmap_new(&[]).unwrap();
+        let m = builtin_hashmap_insert(&[m, Value::Int(7), Value::String("seven".into())]).unwrap();
+        match builtin_hashmap_values(&[m]).unwrap() {
+            Value::Array(items) => {
+                assert_eq!(items.len(), 1);
+                match &items[0] {
+                    Value::String(s) => assert_eq!(s, "seven"),
+                    other => panic!("expected String, got {:?}", other),
+                }
+            }
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn hashmap_values_rejects_non_hashmap() {
+        let err = builtin_hashmap_values(&[Value::Int(1)]).unwrap_err();
+        assert!(err.contains("expected a HashMap"), "err was: {}", err);
+    }
+
+    #[test]
+    fn hashmap_values_rejects_wrong_arity() {
+        let err = builtin_hashmap_values(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2456,6 +2456,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Int),
             },
         );
+        // RES-886.
+        env.set(
+            "hashmap_values".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Array),
+            },
+        );
 
         // RES-149: Set builtins. Same permissive-Any convention as
         // Map — no dedicated `Type::Set<T>` until inference lands.
@@ -5665,6 +5673,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "hashmap_contains",
         "hashmap_keys",
         "hashmap_len",
+        "hashmap_values",
         "set_new",
         "set_insert",
         "set_remove",


### PR DESCRIPTION
Closes #960. Mirrors map_values for HashMap namespace.