### PR TITLE
RES-888: Add bytes_eq builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -240,6 +240,7 @@ the same immutable-value semantics (each mutation returns a new map).
 | `bytes_slice(b, start, end)` | (bytes, int, int) → bytes | half-open range |
 | `byte_at(b, i)` | (bytes, int) → int | byte at index |
 | `bytes_concat(a, b)` | (bytes, bytes) → bytes | RES-887: a followed by b; inputs unchanged |
+| `bytes_eq(a, b)` | (bytes, bytes) → bool | RES-888: byte-equality of two Bytes values |
 
 ## Bitwise (RES-440)
 

--- a/resilient/examples/bytes_eq.expected.txt
+++ b/resilient/examples/bytes_eq.expected.txt
@@ -1,0 +1,6 @@
+true
+false
+false
+true
+false
+Program executed successfully

--- a/resilient/examples/bytes_eq.rz
+++ b/resilient/examples/bytes_eq.rz
@@ -1,0 +1,14 @@
+// RES-888 demo: bytes_eq(a, b) returns true iff both Bytes values have the
+// same length and identical bytes at every position.
+
+fn main(int _d) {
+    println(bytes_eq(b"hello", b"hello"));   // true
+    println(bytes_eq(b"hello", b"world"));   // false
+    println(bytes_eq(b"hello", b"hell"));    // false (length mismatch)
+    println(bytes_eq(b"", b""));             // true (empty == empty)
+    println(bytes_eq(b"\x00", b"\x01"));     // false (raw-byte difference)
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9339,6 +9339,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("byte_at", builtin_byte_at),
     // RES-887.
     ("bytes_concat", builtin_bytes_concat),
+    // RES-888.
+    ("bytes_eq", builtin_bytes_eq),
     // RES-385: explicit consumption of a linear value. At runtime
     // `drop(v)` simply evaluates and discards its argument; the
     // semantic weight lives in the type checker's linear-use pass,
@@ -16895,6 +16897,26 @@ fn builtin_bytes_concat(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "bytes_concat: expected 2 arguments (bytes, bytes), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-888: `bytes_eq(a, b) -> Bool` — true iff both Bytes values have the
+/// same length and identical bytes at every position.
+fn builtin_bytes_eq(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(a), Value::Bytes(b)] => Ok(Value::Bool(a == b)),
+        [Value::Bytes(_), other] => Err(format!(
+            "bytes_eq: second argument must be Bytes, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "bytes_eq: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_eq: expected 2 arguments (bytes, bytes), got {}",
             args.len()
         )),
     }
@@ -25822,6 +25844,58 @@ mod tests {
     #[test]
     fn bytes_concat_rejects_wrong_arity() {
         let err = builtin_bytes_concat(&[]).unwrap_err();
+        assert!(err.contains("expected 2 arguments"), "err was: {}", err);
+    }
+
+    #[test]
+    fn bytes_eq_empty_empty_is_true() {
+        let v = builtin_bytes_eq(&[Value::Bytes(vec![]), Value::Bytes(vec![])]).unwrap();
+        assert!(as_bool(v));
+    }
+
+    #[test]
+    fn bytes_eq_equal_nonempty_is_true() {
+        let v =
+            builtin_bytes_eq(&[Value::Bytes(vec![1, 2, 3]), Value::Bytes(vec![1, 2, 3])]).unwrap();
+        assert!(as_bool(v));
+    }
+
+    #[test]
+    fn bytes_eq_differing_length_is_false() {
+        let v = builtin_bytes_eq(&[Value::Bytes(vec![1, 2, 3]), Value::Bytes(vec![1, 2])]).unwrap();
+        assert!(!as_bool(v));
+    }
+
+    #[test]
+    fn bytes_eq_same_length_differing_content_is_false() {
+        let v =
+            builtin_bytes_eq(&[Value::Bytes(vec![1, 2, 3]), Value::Bytes(vec![1, 2, 4])]).unwrap();
+        assert!(!as_bool(v));
+    }
+
+    #[test]
+    fn bytes_eq_rejects_non_bytes_first_arg() {
+        let err = builtin_bytes_eq(&[Value::Int(1), Value::Bytes(vec![])]).unwrap_err();
+        assert!(
+            err.contains("first argument must be Bytes"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn bytes_eq_rejects_non_bytes_second_arg() {
+        let err = builtin_bytes_eq(&[Value::Bytes(vec![]), Value::Int(1)]).unwrap_err();
+        assert!(
+            err.contains("second argument must be Bytes"),
+            "err was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn bytes_eq_rejects_wrong_arity() {
+        let err = builtin_bytes_eq(&[]).unwrap_err();
         assert!(err.contains("expected 2 arguments"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2597,6 +2597,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Bytes),
             },
         );
+        // RES-888.
+        env.set(
+            "bytes_eq".to_string(),
+            Type::Function {
+                params: vec![Type::Bytes, Type::Bytes],
+                return_type: Box::new(Type::Bool),
+            },
+        );
 
         // Result builtins
         env.set("Ok".to_string(), fn_any_to_result());
@@ -5699,6 +5707,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "bytes_slice",
         "byte_at",
         "bytes_concat",
+        "bytes_eq",
     ];
     PURE_BUILTINS.contains(&name)
 }


### PR DESCRIPTION
Closes #964. Byte-equality of two Bytes values.