### PR TITLE
RES-893: Add copysign builtin

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -41,6 +41,7 @@ This document is a human-facing summary grouped by category.
 | `sin(x)` `cos(x)` `tan(x)` | float → float | std-only |
 | `atan2(y, x)` | (float, float) → float | std-only; returns angle of `(x, y)` in `(-π, π]` (note `y` first, matching IEEE / C) |
 | `hypot(x, y)` | (float, float) → float | RES-892: sqrt(x² + y²) without overflow; std-only |
+| `copysign(x, y)` | (float, float) → float | RES-893: magnitude of x with sign of y; std-only |
 | `ln(x)` `log(x)` `exp(x)` | float → float | std-only; `ln`/`log` runtime error on non-positive args |
 | `log10(x)` | float → float | RES-889: base-10 logarithm; std-only; runtime error on non-positive |
 | `log2(x)` | float → float | RES-890: base-2 logarithm; std-only; runtime error on non-positive |

--- a/resilient/examples/copysign.expected.txt
+++ b/resilient/examples/copysign.expected.txt
@@ -1,0 +1,5 @@
+-3
+3
+-7.5
+7.5
+Program executed successfully

--- a/resilient/examples/copysign.rz
+++ b/resilient/examples/copysign.rz
@@ -1,0 +1,13 @@
+// RES-893 demo: copysign(x, y) returns the magnitude of x with the sign
+// of y. IEEE-754 standard primitive.
+
+fn main(int _d) {
+    println(copysign(3.0, -1.0));   // -3
+    println(copysign(-3.0, 1.0));   // 3
+    println(copysign(7.5, -2.0));   // -7.5
+    println(copysign(7.5, 2.0));    // 7.5
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8889,6 +8889,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("atan2", builtin_atan2),
     // RES-892.
     ("hypot", builtin_hypot),
+    // RES-893.
+    ("copysign", builtin_copysign),
     ("ln", builtin_ln),
     // RES-889.
     ("log10", builtin_log10),
@@ -9621,6 +9623,22 @@ fn builtin_hypot(args: &[Value]) -> RResult<Value> {
         )),
         _ => Err(format!(
             "hypot: expected 2 arguments (x, y), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-893: `copysign(x: Float, y: Float) -> Float` — value with the
+/// magnitude of `x` and the sign of `y`. IEEE-754 standard primitive.
+fn builtin_copysign(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(x), Value::Float(y)] => Ok(Value::Float(x.copysign(*y))),
+        [a, b] => Err(format!(
+            "copysign: expected (Float, Float), got ({:?}, {:?}) — widen Ints via `to_float`",
+            a, b
+        )),
+        _ => Err(format!(
+            "copysign: expected 2 arguments (magnitude, sign), got {}",
             args.len()
         )),
     }
@@ -31786,6 +31804,37 @@ mod tests {
     #[test]
     fn hypot_arity_check() {
         let err = builtin_hypot(&[Value::Float(1.0)]).unwrap_err();
+        assert!(err.contains("expected 2 arguments"), "err was: {}", err);
+    }
+
+    #[test]
+    fn copysign_takes_magnitude_from_first_sign_from_second() {
+        close(
+            as_float(builtin_copysign(&[Value::Float(3.0), Value::Float(-1.0)]).unwrap()),
+            -3.0,
+            "copysign(3, -1)",
+        );
+        close(
+            as_float(builtin_copysign(&[Value::Float(-3.0), Value::Float(1.0)]).unwrap()),
+            3.0,
+            "copysign(-3, 1)",
+        );
+        close(
+            as_float(builtin_copysign(&[Value::Float(0.0), Value::Float(-1.0)]).unwrap()),
+            -0.0,
+            "copysign(0, -1)",
+        );
+    }
+
+    #[test]
+    fn copysign_rejects_int() {
+        let err = builtin_copysign(&[Value::Int(1), Value::Float(-1.0)]).unwrap_err();
+        assert!(err.contains("expected (Float, Float)"), "err was: {}", err);
+    }
+
+    #[test]
+    fn copysign_arity_check() {
+        let err = builtin_copysign(&[Value::Float(1.0)]).unwrap_err();
         assert!(err.contains("expected 2 arguments"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1087,6 +1087,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Float),
             },
         );
+        // RES-893.
+        env.set(
+            "copysign".to_string(),
+            Type::Function {
+                params: vec![Type::Float, Type::Float],
+                return_type: Box::new(Type::Float),
+            },
+        );
 
         // RES-147: monotonic ms-clock builtin. std-only.
         env.set(
@@ -5319,6 +5327,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "clamp",
         "atan2",
         "hypot",
+        "copysign",
         "sqrt",
         "pow",
         "floor",


### PR DESCRIPTION
Closes #974. IEEE-754 copysign primitive.