### PR TITLE
RES-896: Add sinh builtin (hyperbolic sine)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -48,6 +48,7 @@ This document is a human-facing summary grouped by category.
 | `log10(x)` | float → float | RES-889: base-10 logarithm; std-only; runtime error on non-positive |
 | `log2(x)` | float → float | RES-890: base-2 logarithm; std-only; runtime error on non-positive |
 | `exp2(x)` | float → float | RES-891: 2^x; std-only; mirror of `exp` (e^x) |
+| `sinh(x)` | float → float | RES-896: hyperbolic sine; std-only; mirror of `sin` |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/sinh.expected.txt
+++ b/resilient/examples/sinh.expected.txt
@@ -1,0 +1,5 @@
+0
+0
+true
+true
+Program executed successfully

--- a/resilient/examples/sinh.rz
+++ b/resilient/examples/sinh.rz
@@ -1,0 +1,14 @@
+// RES-896 demo: sinh(x) is hyperbolic sine. Mirror of sin (RES-146).
+// std-only; float-in / float-out per RES-130.
+
+fn main(int _d) {
+    println(sinh(0.0));                  // 0
+    // sinh is odd, so sinh(x) + sinh(-x) cancels exactly.
+    println(sinh(2.0) + sinh(-2.0));     // 0
+    println(sinh(1.0) > 0.0);            // true
+    println(sinh(-1.0) < 0.0);           // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8904,6 +8904,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("exp", builtin_exp),
     // RES-891.
     ("exp2", builtin_exp2),
+    // RES-896.
+    ("sinh", builtin_sinh),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9793,6 +9795,18 @@ fn builtin_exp2(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("exp2: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-896: `sinh(x: Float) -> Float` — hyperbolic sine. Mirror of `sin`.
+fn builtin_sinh(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.sinh())),
+        [other] => Err(format!(
+            "sinh: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("sinh: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27251,6 +27265,39 @@ mod tests {
     #[test]
     fn exp2_rejects_wrong_arity() {
         let err = builtin_exp2(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn sinh_basic() {
+        close(
+            as_float(builtin_sinh(&[Value::Float(0.0)]).unwrap()),
+            0.0,
+            "sinh(0)",
+        );
+        close(
+            as_float(builtin_sinh(&[Value::Float(1.0)]).unwrap()),
+            1.1752011936438014,
+            "sinh(1)",
+        );
+        // sinh is odd: sinh(-x) = -sinh(x).
+        close(
+            as_float(builtin_sinh(&[Value::Float(-2.0)]).unwrap()),
+            -as_float(builtin_sinh(&[Value::Float(2.0)]).unwrap()),
+            "sinh odd-symmetry",
+        );
+    }
+
+    #[test]
+    fn sinh_rejects_int() {
+        let err = builtin_sinh(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn sinh_arity_check() {
+        let err = builtin_sinh(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1068,6 +1068,8 @@ impl TypeChecker {
         env.set("exp".to_string(), fn_float_to_float());
         // RES-891.
         env.set("exp2".to_string(), fn_float_to_float());
+        // RES-896.
+        env.set("sinh".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5349,6 +5351,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "log",
         "exp",
         "exp2",
+        "sinh",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #980.

Mirror of `sin` (RES-146): `sinh(x: Float) -> Float`, std-only, float-in / float-out per RES-130 (no implicit int↔float coercion). Rejects Int with the same "call `to_float(x)`" hint as the sibling transcendentals.

## Changes

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_sinh`, 3 unit tests (`sinh_basic`, `sinh_rejects_int`, `sinh_arity_check`).
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `sinh(x)`.
- `resilient/examples/sinh.rz` + `.expected.txt` — golden example exercising `sinh(0)`, odd-symmetry cancellation, and signedness.

## Test plan

- `cargo test --locked` (full lib + integration suite, including `examples_golden::golden_outputs_match`)
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_