### PR TITLE
RES-897: Add cosh builtin (hyperbolic cosine)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -49,6 +49,7 @@ This document is a human-facing summary grouped by category.
 | `log2(x)` | float → float | RES-890: base-2 logarithm; std-only; runtime error on non-positive |
 | `exp2(x)` | float → float | RES-891: 2^x; std-only; mirror of `exp` (e^x) |
 | `sinh(x)` | float → float | RES-896: hyperbolic sine; std-only; mirror of `sin` |
+| `cosh(x)` | float → float | RES-897: hyperbolic cosine; std-only; mirror of `cos` |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/cosh.expected.txt
+++ b/resilient/examples/cosh.expected.txt
@@ -1,0 +1,5 @@
+1
+0
+true
+true
+Program executed successfully

--- a/resilient/examples/cosh.rz
+++ b/resilient/examples/cosh.rz
@@ -1,0 +1,15 @@
+// RES-897 demo: cosh(x) is hyperbolic cosine. Mirror of cos (RES-146).
+// std-only; float-in / float-out per RES-130.
+
+fn main(int _d) {
+    println(cosh(0.0));                  // 1
+    // cosh is even, so cosh(x) - cosh(-x) cancels exactly.
+    println(cosh(2.0) - cosh(-2.0));     // 0
+    // cosh ≥ 1 for all real x.
+    println(cosh(0.0) >= 1.0);           // true
+    println(cosh(3.0) >= 1.0);           // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8906,6 +8906,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("exp2", builtin_exp2),
     // RES-896.
     ("sinh", builtin_sinh),
+    // RES-897.
+    ("cosh", builtin_cosh),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9807,6 +9809,18 @@ fn builtin_sinh(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("sinh: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-897: `cosh(x: Float) -> Float` — hyperbolic cosine. Mirror of `cos`.
+fn builtin_cosh(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.cosh())),
+        [other] => Err(format!(
+            "cosh: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("cosh: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27298,6 +27312,40 @@ mod tests {
     #[test]
     fn sinh_arity_check() {
         let err = builtin_sinh(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn cosh_basic() {
+        // cosh(0) = 1.
+        close(
+            as_float(builtin_cosh(&[Value::Float(0.0)]).unwrap()),
+            1.0,
+            "cosh(0)",
+        );
+        close(
+            as_float(builtin_cosh(&[Value::Float(1.0)]).unwrap()),
+            1.5430806348152437,
+            "cosh(1)",
+        );
+        // cosh is even: cosh(-x) = cosh(x).
+        close(
+            as_float(builtin_cosh(&[Value::Float(-2.0)]).unwrap()),
+            as_float(builtin_cosh(&[Value::Float(2.0)]).unwrap()),
+            "cosh even-symmetry",
+        );
+    }
+
+    #[test]
+    fn cosh_rejects_int() {
+        let err = builtin_cosh(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn cosh_arity_check() {
+        let err = builtin_cosh(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1070,6 +1070,8 @@ impl TypeChecker {
         env.set("exp2".to_string(), fn_float_to_float());
         // RES-896.
         env.set("sinh".to_string(), fn_float_to_float());
+        // RES-897.
+        env.set("cosh".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5352,6 +5354,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "exp",
         "exp2",
         "sinh",
+        "cosh",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #982.

Mirror of `cos` (RES-146) and sibling of `sinh` (RES-896): `cosh(x: Float) -> Float`, std-only, float-in / float-out per RES-130 (no implicit int↔float coercion). Rejects Int with the same "call `to_float(x)`" hint as the sibling transcendentals.

## Changes

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_cosh`, 3 unit tests (`cosh_basic`, `cosh_rejects_int`, `cosh_arity_check`).
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `cosh(x)`.
- `resilient/examples/cosh.rz` + `.expected.txt` — golden example exercising `cosh(0)=1`, even-symmetry cancellation, and the `cosh(x) ≥ 1` invariant.

## Test plan

- `cargo test --locked` (full lib + integration suite, including `examples_golden::golden_outputs_match`)
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>