### PR TITLE
RES-898: Add tanh builtin (hyperbolic tangent)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -50,6 +50,7 @@ This document is a human-facing summary grouped by category.
 | `exp2(x)` | float → float | RES-891: 2^x; std-only; mirror of `exp` (e^x) |
 | `sinh(x)` | float → float | RES-896: hyperbolic sine; std-only; mirror of `sin` |
 | `cosh(x)` | float → float | RES-897: hyperbolic cosine; std-only; mirror of `cos` |
+| `tanh(x)` | float → float | RES-898: hyperbolic tangent; std-only; mirror of `tan`; saturates to ±1 |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/tanh.expected.txt
+++ b/resilient/examples/tanh.expected.txt
@@ -1,0 +1,5 @@
+0
+0
+true
+true
+Program executed successfully

--- a/resilient/examples/tanh.rz
+++ b/resilient/examples/tanh.rz
@@ -1,0 +1,15 @@
+// RES-898 demo: tanh(x) is hyperbolic tangent. Mirror of tan (RES-146).
+// std-only; float-in / float-out per RES-130.
+
+fn main(int _d) {
+    println(tanh(0.0));                  // 0
+    // tanh is odd, so tanh(x) + tanh(-x) cancels exactly.
+    println(tanh(2.0) + tanh(-2.0));     // 0
+    // |tanh(x)| < 1 for moderate x — saturates toward ±1.
+    println(tanh(3.0) < 1.0);            // true
+    println(tanh(-3.0) > -1.0);          // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8908,6 +8908,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("sinh", builtin_sinh),
     // RES-897.
     ("cosh", builtin_cosh),
+    // RES-898.
+    ("tanh", builtin_tanh),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9821,6 +9823,18 @@ fn builtin_cosh(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("cosh: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-898: `tanh(x: Float) -> Float` — hyperbolic tangent. Mirror of `tan`.
+fn builtin_tanh(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.tanh())),
+        [other] => Err(format!(
+            "tanh: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("tanh: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27346,6 +27360,48 @@ mod tests {
     #[test]
     fn cosh_arity_check() {
         let err = builtin_cosh(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn tanh_basic() {
+        // tanh(0) = 0.
+        close(
+            as_float(builtin_tanh(&[Value::Float(0.0)]).unwrap()),
+            0.0,
+            "tanh(0)",
+        );
+        close(
+            as_float(builtin_tanh(&[Value::Float(1.0)]).unwrap()),
+            0.7615941559557649,
+            "tanh(1)",
+        );
+        // tanh is odd: tanh(-x) = -tanh(x).
+        close(
+            as_float(builtin_tanh(&[Value::Float(-2.0)]).unwrap()),
+            -as_float(builtin_tanh(&[Value::Float(2.0)]).unwrap()),
+            "tanh odd-symmetry",
+        );
+        // |tanh(x)| < 1 for finite x; tanh(10) is close to but strictly
+        // below 1.0. (Larger x like 20 saturates to exactly 1.0 in f64.)
+        let large = as_float(builtin_tanh(&[Value::Float(10.0)]).unwrap());
+        assert!(
+            large < 1.0 && large > 0.999_999_99,
+            "tanh(10) was {}",
+            large
+        );
+    }
+
+    #[test]
+    fn tanh_rejects_int() {
+        let err = builtin_tanh(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn tanh_arity_check() {
+        let err = builtin_tanh(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1072,6 +1072,8 @@ impl TypeChecker {
         env.set("sinh".to_string(), fn_float_to_float());
         // RES-897.
         env.set("cosh".to_string(), fn_float_to_float());
+        // RES-898.
+        env.set("tanh".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5355,6 +5357,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "exp2",
         "sinh",
         "cosh",
+        "tanh",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #984.

Completes the hyperbolic-trig trio (`sinh` RES-896, `cosh` RES-897, `tanh` RES-898). Mirror of `tan` (RES-146): `tanh(x: Float) -> Float`, std-only, float-in / float-out per RES-130. Rejects Int with the same "call `to_float(x)`" hint as the sibling transcendentals.

## Changes

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_tanh`, 3 unit tests covering `tanh(0)=0`, odd-symmetry, and saturation (using `tanh(10)` since `f64::tanh(20)` saturates to exactly 1.0).
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `tanh(x)` with saturation note.
- `resilient/examples/tanh.rz` + `.expected.txt` — golden example exercising `tanh(0)`, odd-symmetry cancellation, and the `|tanh(x)| < 1` invariant.

## Test plan

- `cargo test --locked` (full lib + integration suite, including `examples_golden::golden_outputs_match`)
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_