### PR TITLE
RES-899: Add asinh builtin (inverse hyperbolic sine)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -51,6 +51,7 @@ This document is a human-facing summary grouped by category.
 | `sinh(x)` | float → float | RES-896: hyperbolic sine; std-only; mirror of `sin` |
 | `cosh(x)` | float → float | RES-897: hyperbolic cosine; std-only; mirror of `cos` |
 | `tanh(x)` | float → float | RES-898: hyperbolic tangent; std-only; mirror of `tan`; saturates to ±1 |
+| `asinh(x)` | float → float | RES-899: inverse hyperbolic sine; std-only; total domain (no NaN cases) |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/asinh.expected.txt
+++ b/resilient/examples/asinh.expected.txt
@@ -1,0 +1,4 @@
+0
+2.5
+0
+Program executed successfully

--- a/resilient/examples/asinh.rz
+++ b/resilient/examples/asinh.rz
@@ -1,0 +1,14 @@
+// RES-899 demo: asinh(x) is the inverse hyperbolic sine. Inverse of
+// sinh (RES-896). std-only; float-in / float-out per RES-130.
+
+fn main(int _d) {
+    println(asinh(0.0));                  // 0
+    // sinh(asinh(x)) = x for any real x.
+    println(sinh(asinh(2.5)));            // 2.5
+    // asinh is odd: asinh(x) + asinh(-x) cancels.
+    println(asinh(3.0) + asinh(-3.0));    // 0
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8910,6 +8910,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("cosh", builtin_cosh),
     // RES-898.
     ("tanh", builtin_tanh),
+    // RES-899.
+    ("asinh", builtin_asinh),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9835,6 +9837,19 @@ fn builtin_tanh(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("tanh: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-899: `asinh(x: Float) -> Float` — inverse hyperbolic sine. Inverse
+/// of `sinh`; total domain (defined for every real input — no NaN cases).
+fn builtin_asinh(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.asinh())),
+        [other] => Err(format!(
+            "asinh: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("asinh: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27402,6 +27417,41 @@ mod tests {
     #[test]
     fn tanh_arity_check() {
         let err = builtin_tanh(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn asinh_basic() {
+        // asinh(0) = 0.
+        close(
+            as_float(builtin_asinh(&[Value::Float(0.0)]).unwrap()),
+            0.0,
+            "asinh(0)",
+        );
+        // sinh(asinh(x)) = x — round-trip identity.
+        close(
+            as_float(builtin_sinh(&[builtin_asinh(&[Value::Float(2.5)]).unwrap()]).unwrap()),
+            2.5,
+            "sinh(asinh(2.5))",
+        );
+        // asinh is odd: asinh(-x) = -asinh(x).
+        close(
+            as_float(builtin_asinh(&[Value::Float(-3.0)]).unwrap()),
+            -as_float(builtin_asinh(&[Value::Float(3.0)]).unwrap()),
+            "asinh odd-symmetry",
+        );
+    }
+
+    #[test]
+    fn asinh_rejects_int() {
+        let err = builtin_asinh(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn asinh_arity_check() {
+        let err = builtin_asinh(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1074,6 +1074,8 @@ impl TypeChecker {
         env.set("cosh".to_string(), fn_float_to_float());
         // RES-898.
         env.set("tanh".to_string(), fn_float_to_float());
+        // RES-899.
+        env.set("asinh".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5358,6 +5360,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "sinh",
         "cosh",
         "tanh",
+        "asinh",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #986.

Inverse of `sinh` (RES-896): `asinh(x: Float) -> Float`, std-only, float-in / float-out per RES-130. Total domain — no NaN cases for any real input.

## Changes

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_asinh`, 3 unit tests covering `asinh(0)=0`, `sinh(asinh(x))=x` round-trip, and odd-symmetry.
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `asinh(x)`.
- `resilient/examples/asinh.rz` + `.expected.txt` — golden example exercising the inverse identity and odd-symmetry.

## Test plan

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_