### PR TITLE
RES-900: Add acosh builtin (inverse hyperbolic cosine)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -52,6 +52,7 @@ This document is a human-facing summary grouped by category.
 | `cosh(x)` | float → float | RES-897: hyperbolic cosine; std-only; mirror of `cos` |
 | `tanh(x)` | float → float | RES-898: hyperbolic tangent; std-only; mirror of `tan`; saturates to ±1 |
 | `asinh(x)` | float → float | RES-899: inverse hyperbolic sine; std-only; total domain (no NaN cases) |
+| `acosh(x)` | float → float | RES-900: inverse hyperbolic cosine; std-only; domain `x ≥ 1` (NaN otherwise) |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/acosh.expected.txt
+++ b/resilient/examples/acosh.expected.txt
@@ -1,0 +1,5 @@
+0
+true
+true
+true
+Program executed successfully

--- a/resilient/examples/acosh.rz
+++ b/resilient/examples/acosh.rz
@@ -1,0 +1,15 @@
+// RES-900 demo: acosh(x) is the inverse hyperbolic cosine. Inverse of
+// cosh (RES-897). std-only; float-in / float-out per RES-130. Domain
+// is x >= 1; out-of-domain yields NaN.
+
+fn main(int _d) {
+    println(acosh(1.0));                  // 0
+    // cosh(acosh(x)) ≈ x for x >= 1 (subject to fp rounding).
+    println(cosh(acosh(2.5)) > 2.49);     // true
+    println(cosh(acosh(2.5)) < 2.51);     // true
+    println(acosh(2.0) > 0.0);            // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8912,6 +8912,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("tanh", builtin_tanh),
     // RES-899.
     ("asinh", builtin_asinh),
+    // RES-900.
+    ("acosh", builtin_acosh),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9850,6 +9852,19 @@ fn builtin_asinh(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("asinh: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-900: `acosh(x: Float) -> Float` — inverse hyperbolic cosine. Inverse
+/// of `cosh`; domain is `x >= 1` (returns NaN for `x < 1` per `f64::acosh`).
+fn builtin_acosh(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.acosh())),
+        [other] => Err(format!(
+            "acosh: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("acosh: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27452,6 +27467,38 @@ mod tests {
     #[test]
     fn asinh_arity_check() {
         let err = builtin_asinh(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn acosh_basic() {
+        // acosh(1) = 0.
+        close(
+            as_float(builtin_acosh(&[Value::Float(1.0)]).unwrap()),
+            0.0,
+            "acosh(1)",
+        );
+        // cosh(acosh(x)) = x for x >= 1 — round-trip identity.
+        close(
+            as_float(builtin_cosh(&[builtin_acosh(&[Value::Float(2.5)]).unwrap()]).unwrap()),
+            2.5,
+            "cosh(acosh(2.5))",
+        );
+        // x < 1 is out of domain — NaN.
+        let nan = as_float(builtin_acosh(&[Value::Float(0.5)]).unwrap());
+        assert!(nan.is_nan(), "acosh(0.5) was {}", nan);
+    }
+
+    #[test]
+    fn acosh_rejects_int() {
+        let err = builtin_acosh(&[Value::Int(1)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn acosh_arity_check() {
+        let err = builtin_acosh(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1076,6 +1076,8 @@ impl TypeChecker {
         env.set("tanh".to_string(), fn_float_to_float());
         // RES-899.
         env.set("asinh".to_string(), fn_float_to_float());
+        // RES-900.
+        env.set("acosh".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5361,6 +5363,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "cosh",
         "tanh",
         "asinh",
+        "acosh",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #988.

**Stacked on #987 (asinh).** Will rebase to a single commit once #987 lands on main.

Inverse of `cosh` (RES-897): `acosh(x: Float) -> Float`, std-only, float-in / float-out per RES-130. Domain `x ≥ 1`; out-of-domain yields NaN per `f64::acosh`.

## Changes (acosh-only)

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_acosh`, 3 unit tests covering `acosh(1)=0`, `cosh(acosh(x))=x` round-trip, and NaN on out-of-domain.
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `acosh(x)`.
- `resilient/examples/acosh.rz` + `.expected.txt` — golden example. Uses comparisons rather than printing the round-trip directly because `cosh(acosh(2.5)) = 2.499999999999999` in f64.

## Test plan

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_