### PR TITLE
RES-901: Add atanh builtin (inverse hyperbolic tangent)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -53,6 +53,7 @@ This document is a human-facing summary grouped by category.
 | `tanh(x)` | float → float | RES-898: hyperbolic tangent; std-only; mirror of `tan`; saturates to ±1 |
 | `asinh(x)` | float → float | RES-899: inverse hyperbolic sine; std-only; total domain (no NaN cases) |
 | `acosh(x)` | float → float | RES-900: inverse hyperbolic cosine; std-only; domain `x ≥ 1` (NaN otherwise) |
+| `atanh(x)` | float → float | RES-901: inverse hyperbolic tangent; std-only; domain `(-1, 1)`; `±1` → ±∞; `|x|>1` → NaN |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/atanh.expected.txt
+++ b/resilient/examples/atanh.expected.txt
@@ -1,0 +1,5 @@
+0
+0
+true
+true
+Program executed successfully

--- a/resilient/examples/atanh.rz
+++ b/resilient/examples/atanh.rz
@@ -1,0 +1,15 @@
+// RES-901 demo: atanh(x) is the inverse hyperbolic tangent. Inverse of
+// tanh (RES-898). std-only; float-in / float-out per RES-130. Domain
+// is (-1, 1); |x|=1 yields ±∞; |x|>1 yields NaN.
+
+fn main(int _d) {
+    println(atanh(0.0));                  // 0
+    // atanh is odd: atanh(x) + atanh(-x) cancels exactly.
+    println(atanh(0.5) + atanh(-0.5));    // 0
+    println(atanh(0.5) > 0.0);            // true
+    println(atanh(-0.5) < 0.0);           // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8914,6 +8914,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("asinh", builtin_asinh),
     // RES-900.
     ("acosh", builtin_acosh),
+    // RES-901.
+    ("atanh", builtin_atanh),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9865,6 +9867,20 @@ fn builtin_acosh(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("acosh: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-901: `atanh(x: Float) -> Float` — inverse hyperbolic tangent. Inverse
+/// of `tanh`; domain is `(-1, 1)`. `|x| = 1` yields ±∞; `|x| > 1` yields NaN
+/// per `f64::atanh`.
+fn builtin_atanh(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.atanh())),
+        [other] => Err(format!(
+            "atanh: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("atanh: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27499,6 +27515,47 @@ mod tests {
     #[test]
     fn acosh_arity_check() {
         let err = builtin_acosh(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn atanh_basic() {
+        // atanh(0) = 0.
+        close(
+            as_float(builtin_atanh(&[Value::Float(0.0)]).unwrap()),
+            0.0,
+            "atanh(0)",
+        );
+        // tanh(atanh(x)) = x for x in (-1, 1) — round-trip identity.
+        close(
+            as_float(builtin_tanh(&[builtin_atanh(&[Value::Float(0.5)]).unwrap()]).unwrap()),
+            0.5,
+            "tanh(atanh(0.5))",
+        );
+        // atanh is odd: atanh(-x) = -atanh(x).
+        close(
+            as_float(builtin_atanh(&[Value::Float(-0.7)]).unwrap()),
+            -as_float(builtin_atanh(&[Value::Float(0.7)]).unwrap()),
+            "atanh odd-symmetry",
+        );
+        // |x| > 1 → NaN.
+        let nan = as_float(builtin_atanh(&[Value::Float(1.5)]).unwrap());
+        assert!(nan.is_nan(), "atanh(1.5) was {}", nan);
+        // |x| = 1 → ±∞.
+        let inf = as_float(builtin_atanh(&[Value::Float(1.0)]).unwrap());
+        assert!(inf.is_infinite() && inf > 0.0, "atanh(1) was {}", inf);
+    }
+
+    #[test]
+    fn atanh_rejects_int() {
+        let err = builtin_atanh(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn atanh_arity_check() {
+        let err = builtin_atanh(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1078,6 +1078,8 @@ impl TypeChecker {
         env.set("asinh".to_string(), fn_float_to_float());
         // RES-900.
         env.set("acosh".to_string(), fn_float_to_float());
+        // RES-901.
+        env.set("atanh".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5364,6 +5366,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "tanh",
         "asinh",
         "acosh",
+        "atanh",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #990.

**Stacked on #987 (asinh) → #989 (acosh).** Will rebase to a single commit once those land on main.

Completes the inverse-hyperbolic trio (`asinh` RES-899, `acosh` RES-900, `atanh` RES-901). Inverse of `tanh` (RES-898): `atanh(x: Float) -> Float`, std-only, float-in / float-out per RES-130. Domain is `(-1, 1)`; `|x|=1` yields ±∞; `|x|>1` yields NaN per `f64::atanh`.

## Changes (atanh-only)

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_atanh`, 3 unit tests covering `atanh(0)=0`, `tanh(atanh(x))=x` round-trip, odd-symmetry, NaN on out-of-domain, and ±∞ at boundary.
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `atanh(x)` with domain note.
- `resilient/examples/atanh.rz` + `.expected.txt` — golden example.

## Test plan

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_