### PR TITLE
RES-902: Add asin builtin (inverse sine)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -54,6 +54,7 @@ This document is a human-facing summary grouped by category.
 | `asinh(x)` | float → float | RES-899: inverse hyperbolic sine; std-only; total domain (no NaN cases) |
 | `acosh(x)` | float → float | RES-900: inverse hyperbolic cosine; std-only; domain `x ≥ 1` (NaN otherwise) |
 | `atanh(x)` | float → float | RES-901: inverse hyperbolic tangent; std-only; domain `(-1, 1)`; `±1` → ±∞; `|x|>1` → NaN |
+| `asin(x)` | float → float | RES-902: inverse sine (radians); std-only; domain `[-1, 1]`; `|x|>1` → NaN; range `[-π/2, π/2]` |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/asin.expected.txt
+++ b/resilient/examples/asin.expected.txt
@@ -1,0 +1,5 @@
+0
+0.5
+0
+true
+Program executed successfully

--- a/resilient/examples/asin.rz
+++ b/resilient/examples/asin.rz
@@ -1,0 +1,16 @@
+// RES-902 demo: asin(x) is the inverse sine (radians). Inverse of
+// sin (RES-146). std-only; float-in / float-out per RES-130. Domain
+// is [-1, 1]; |x|>1 yields NaN. Range [-π/2, π/2].
+
+fn main(int _d) {
+    println(asin(0.0));                  // 0
+    // sin(asin(x)) = x for x in [-1, 1].
+    println(sin(asin(0.5)));             // 0.5
+    // asin is odd: asin(x) + asin(-x) cancels.
+    println(asin(0.7) + asin(-0.7));     // 0
+    println(asin(1.0) > 0.0);            // true (= π/2)
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8916,6 +8916,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("acosh", builtin_acosh),
     // RES-901.
     ("atanh", builtin_atanh),
+    // RES-902.
+    ("asin", builtin_asin),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9881,6 +9883,19 @@ fn builtin_atanh(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("atanh: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-902: `asin(x: Float) -> Float` — inverse sine (radians). Inverse of
+/// `sin`; domain is `[-1, 1]`; `|x| > 1` yields NaN. Range `[-π/2, π/2]`.
+fn builtin_asin(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.asin())),
+        [other] => Err(format!(
+            "asin: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("asin: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27556,6 +27571,44 @@ mod tests {
     #[test]
     fn atanh_arity_check() {
         let err = builtin_atanh(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn asin_basic() {
+        // asin(0) = 0.
+        close(
+            as_float(builtin_asin(&[Value::Float(0.0)]).unwrap()),
+            0.0,
+            "asin(0)",
+        );
+        // asin(1) = π/2.
+        close(
+            as_float(builtin_asin(&[Value::Float(1.0)]).unwrap()),
+            std::f64::consts::FRAC_PI_2,
+            "asin(1)",
+        );
+        // asin is odd: asin(-x) = -asin(x).
+        close(
+            as_float(builtin_asin(&[Value::Float(-0.5)]).unwrap()),
+            -as_float(builtin_asin(&[Value::Float(0.5)]).unwrap()),
+            "asin odd-symmetry",
+        );
+        // |x| > 1 → NaN.
+        let nan = as_float(builtin_asin(&[Value::Float(1.5)]).unwrap());
+        assert!(nan.is_nan(), "asin(1.5) was {}", nan);
+    }
+
+    #[test]
+    fn asin_rejects_int() {
+        let err = builtin_asin(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn asin_arity_check() {
+        let err = builtin_asin(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1080,6 +1080,8 @@ impl TypeChecker {
         env.set("acosh".to_string(), fn_float_to_float());
         // RES-901.
         env.set("atanh".to_string(), fn_float_to_float());
+        // RES-902.
+        env.set("asin".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5367,6 +5369,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "asinh",
         "acosh",
         "atanh",
+        "asin",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #992.

**Stacked on #991 (atanh) until that lands; rebased to drop merged predecessors.**

Inverse of `sin` (RES-146): `asin(x: Float) -> Float`, std-only, float-in / float-out per RES-130. Domain `[-1, 1]`; `|x|>1` yields NaN per `f64::asin`. Range `[-π/2, π/2]`.

## Changes (asin-only)

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_asin`, 3 unit tests covering `asin(0)=0`, `asin(1)=π/2`, `sin(asin(x))=x` round-trip, odd-symmetry, and NaN on out-of-domain.
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `asin(x)` with domain note.
- `resilient/examples/asin.rz` + `.expected.txt` — golden example.

## Test plan

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_