### PR TITLE
RES-903: Add acos builtin (inverse cosine)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -55,6 +55,7 @@ This document is a human-facing summary grouped by category.
 | `acosh(x)` | float → float | RES-900: inverse hyperbolic cosine; std-only; domain `x ≥ 1` (NaN otherwise) |
 | `atanh(x)` | float → float | RES-901: inverse hyperbolic tangent; std-only; domain `(-1, 1)`; `±1` → ±∞; `|x|>1` → NaN |
 | `asin(x)` | float → float | RES-902: inverse sine (radians); std-only; domain `[-1, 1]`; `|x|>1` → NaN; range `[-π/2, π/2]` |
+| `acos(x)` | float → float | RES-903: inverse cosine (radians); std-only; domain `[-1, 1]`; `|x|>1` → NaN; range `[0, π]` |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/acos.expected.txt
+++ b/resilient/examples/acos.expected.txt
@@ -1,0 +1,5 @@
+0
+true
+true
+true
+Program executed successfully

--- a/resilient/examples/acos.rz
+++ b/resilient/examples/acos.rz
@@ -1,0 +1,16 @@
+// RES-903 demo: acos(x) is the inverse cosine (radians). Inverse of
+// cos (RES-146). std-only; float-in / float-out per RES-130. Domain
+// is [-1, 1]; |x|>1 yields NaN. Range [0, π].
+
+fn main(int _d) {
+    println(acos(1.0));                  // 0
+    // cos(acos(x)) = x for x in [-1, 1].
+    println(cos(acos(0.5)) > 0.49);      // true
+    println(cos(acos(0.5)) < 0.51);      // true
+    // acos(-1) = π > 3.14.
+    println(acos(-1.0) > 3.14);          // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8918,6 +8918,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("atanh", builtin_atanh),
     // RES-902.
     ("asin", builtin_asin),
+    // RES-903.
+    ("acos", builtin_acos),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9896,6 +9898,19 @@ fn builtin_asin(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("asin: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-903: `acos(x: Float) -> Float` — inverse cosine (radians). Inverse of
+/// `cos`; domain is `[-1, 1]`; `|x| > 1` yields NaN. Range `[0, π]`.
+fn builtin_acos(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.acos())),
+        [other] => Err(format!(
+            "acos: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("acos: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27609,6 +27624,44 @@ mod tests {
     #[test]
     fn asin_arity_check() {
         let err = builtin_asin(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn acos_basic() {
+        // acos(1) = 0.
+        close(
+            as_float(builtin_acos(&[Value::Float(1.0)]).unwrap()),
+            0.0,
+            "acos(1)",
+        );
+        // acos(0) = π/2.
+        close(
+            as_float(builtin_acos(&[Value::Float(0.0)]).unwrap()),
+            std::f64::consts::FRAC_PI_2,
+            "acos(0)",
+        );
+        // acos(-1) = π.
+        close(
+            as_float(builtin_acos(&[Value::Float(-1.0)]).unwrap()),
+            std::f64::consts::PI,
+            "acos(-1)",
+        );
+        // |x| > 1 → NaN.
+        let nan = as_float(builtin_acos(&[Value::Float(1.5)]).unwrap());
+        assert!(nan.is_nan(), "acos(1.5) was {}", nan);
+    }
+
+    #[test]
+    fn acos_rejects_int() {
+        let err = builtin_acos(&[Value::Int(1)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn acos_arity_check() {
+        let err = builtin_acos(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1082,6 +1082,8 @@ impl TypeChecker {
         env.set("atanh".to_string(), fn_float_to_float());
         // RES-902.
         env.set("asin".to_string(), fn_float_to_float());
+        // RES-903.
+        env.set("acos".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5370,6 +5372,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "acosh",
         "atanh",
         "asin",
+        "acos",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #994.

Inverse of `cos` (RES-146): `acos(x: Float) -> Float`, std-only, float-in / float-out per RES-130. Domain `[-1, 1]`; `|x|>1` yields NaN per `f64::acos`. Range `[0, π]`.

## Changes

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_acos`, 3 unit tests covering `acos(1)=0`, `acos(0)=π/2`, `acos(-1)=π`, and NaN on out-of-domain.
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `acos(x)`.
- `resilient/examples/acos.rz` + `.expected.txt` — golden example. Uses comparisons because `cos(acos(0.5))` has subtle fp rounding.

## Test plan

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_