### PR TITLE
RES-904: Add atan builtin (single-argument inverse tangent)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -56,6 +56,7 @@ This document is a human-facing summary grouped by category.
 | `atanh(x)` | float → float | RES-901: inverse hyperbolic tangent; std-only; domain `(-1, 1)`; `±1` → ±∞; `|x|>1` → NaN |
 | `asin(x)` | float → float | RES-902: inverse sine (radians); std-only; domain `[-1, 1]`; `|x|>1` → NaN; range `[-π/2, π/2]` |
 | `acos(x)` | float → float | RES-903: inverse cosine (radians); std-only; domain `[-1, 1]`; `|x|>1` → NaN; range `[0, π]` |
+| `atan(x)` | float → float | RES-904: inverse tangent (radians, single arg); std-only; total domain; range `(-π/2, π/2)`; sibling of `atan2(y, x)` |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/atan.expected.txt
+++ b/resilient/examples/atan.expected.txt
@@ -1,0 +1,5 @@
+0
+0
+true
+true
+Program executed successfully

--- a/resilient/examples/atan.rz
+++ b/resilient/examples/atan.rz
@@ -1,0 +1,16 @@
+// RES-904 demo: atan(x) is the single-argument inverse tangent (radians).
+// Inverse of tan (RES-146). std-only; float-in / float-out per RES-130.
+// Total domain; range (-π/2, π/2). Use atan2(y, x) for the full circle.
+
+fn main(int _d) {
+    println(atan(0.0));                  // 0
+    // atan is odd: atan(x) + atan(-x) = 0.
+    println(atan(3.0) + atan(-3.0));     // 0
+    // |atan(x)| < π/2 (≈ 1.5707963…) for finite x.
+    println(atan(1000000000.0) < 1.58);   // true
+    println(atan(-1000000000.0) > -1.58); // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8920,6 +8920,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("asin", builtin_asin),
     // RES-903.
     ("acos", builtin_acos),
+    // RES-904.
+    ("atan", builtin_atan),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9911,6 +9913,20 @@ fn builtin_acos(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("acos: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-904: `atan(x: Float) -> Float` — inverse tangent (radians, single
+/// argument). Inverse of `tan`. Total domain; range `(-π/2, π/2)`. Sibling
+/// of `atan2(y, x)` (RES-295) — pick `atan2` when you need the full circle.
+fn builtin_atan(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.atan())),
+        [other] => Err(format!(
+            "atan: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("atan: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27662,6 +27678,48 @@ mod tests {
     #[test]
     fn acos_arity_check() {
         let err = builtin_acos(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn atan_basic() {
+        // atan(0) = 0.
+        close(
+            as_float(builtin_atan(&[Value::Float(0.0)]).unwrap()),
+            0.0,
+            "atan(0)",
+        );
+        // atan(1) = π/4.
+        close(
+            as_float(builtin_atan(&[Value::Float(1.0)]).unwrap()),
+            std::f64::consts::FRAC_PI_4,
+            "atan(1)",
+        );
+        // atan is odd: atan(-x) = -atan(x).
+        close(
+            as_float(builtin_atan(&[Value::Float(-3.0)]).unwrap()),
+            -as_float(builtin_atan(&[Value::Float(3.0)]).unwrap()),
+            "atan odd-symmetry",
+        );
+        // Saturates strictly below π/2 for finite x.
+        let large = as_float(builtin_atan(&[Value::Float(1e9)]).unwrap());
+        assert!(
+            large < std::f64::consts::FRAC_PI_2,
+            "atan(1e9) was {}",
+            large
+        );
+    }
+
+    #[test]
+    fn atan_rejects_int() {
+        let err = builtin_atan(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn atan_arity_check() {
+        let err = builtin_atan(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1084,6 +1084,8 @@ impl TypeChecker {
         env.set("asin".to_string(), fn_float_to_float());
         // RES-903.
         env.set("acos".to_string(), fn_float_to_float());
+        // RES-904.
+        env.set("atan".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5373,6 +5375,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "atanh",
         "asin",
         "acos",
+        "atan",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #996.

Inverse of `tan` (RES-146): `atan(x: Float) -> Float`, std-only, float-in / float-out per RES-130. Total domain; range `(-π/2, π/2)`. Sibling of `atan2(y, x)` (RES-295) — pick `atan2` when you need the full circle.

## Changes

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_atan`, 3 unit tests covering `atan(0)=0`, `atan(1)=π/4`, odd-symmetry, and saturation strictly below π/2 for large `|x|`.
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `atan(x)` cross-referencing `atan2`.
- `resilient/examples/atan.rz` + `.expected.txt` — golden example. Uses the literal `1000000000.0` for the saturation test because Resilient's parser doesn't accept `1e9` scientific notation.

## Test plan

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_