### PR TITLE
RES-905: Add cbrt builtin (cube root)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -57,6 +57,7 @@ This document is a human-facing summary grouped by category.
 | `asin(x)` | float → float | RES-902: inverse sine (radians); std-only; domain `[-1, 1]`; `|x|>1` → NaN; range `[-π/2, π/2]` |
 | `acos(x)` | float → float | RES-903: inverse cosine (radians); std-only; domain `[-1, 1]`; `|x|>1` → NaN; range `[0, π]` |
 | `atan(x)` | float → float | RES-904: inverse tangent (radians, single arg); std-only; total domain; range `(-π/2, π/2)`; sibling of `atan2(y, x)` |
+| `cbrt(x)` | float → float | RES-905: cube root; std-only; total domain (handles negatives, unlike `sqrt`); odd |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/cbrt.expected.txt
+++ b/resilient/examples/cbrt.expected.txt
@@ -1,0 +1,5 @@
+0
+2
+-3
+5
+Program executed successfully

--- a/resilient/examples/cbrt.rz
+++ b/resilient/examples/cbrt.rz
@@ -1,0 +1,15 @@
+// RES-905 demo: cbrt(x) is the cube root. Sibling of sqrt but with
+// total domain (defined for negative inputs). std-only; float-in /
+// float-out per RES-130.
+
+fn main(int _d) {
+    println(cbrt(0.0));                  // 0
+    println(cbrt(8.0));                  // 2
+    // cbrt is odd, unlike sqrt.
+    println(cbrt(-27.0));                // -3
+    println(cbrt(125.0));                // 5
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8922,6 +8922,8 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("acos", builtin_acos),
     // RES-904.
     ("atan", builtin_atan),
+    // RES-905.
+    ("cbrt", builtin_cbrt),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9927,6 +9929,19 @@ fn builtin_atan(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("atan: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-905: `cbrt(x: Float) -> Float` — cube root. Sibling of `sqrt` but with
+/// total domain (defined for negative inputs); `cbrt` is odd.
+fn builtin_cbrt(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(f)] => Ok(Value::Float(f.cbrt())),
+        [other] => Err(format!(
+            "cbrt: expected Float, got {} — call `to_float(x)` to widen an Int",
+            other
+        )),
+        _ => Err(format!("cbrt: expected 1 argument, got {}", args.len())),
     }
 }
 
@@ -27720,6 +27735,44 @@ mod tests {
     #[test]
     fn atan_arity_check() {
         let err = builtin_atan(&[]).unwrap_err();
+        assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    #[test]
+    fn cbrt_basic() {
+        // cbrt(0) = 0.
+        close(
+            as_float(builtin_cbrt(&[Value::Float(0.0)]).unwrap()),
+            0.0,
+            "cbrt(0)",
+        );
+        // cbrt(8) = 2.
+        close(
+            as_float(builtin_cbrt(&[Value::Float(8.0)]).unwrap()),
+            2.0,
+            "cbrt(8)",
+        );
+        // cbrt is odd: cbrt(-27) = -3.
+        close(
+            as_float(builtin_cbrt(&[Value::Float(-27.0)]).unwrap()),
+            -3.0,
+            "cbrt(-27)",
+        );
+        // cbrt(cbrt(x)^3) = x for x = 7.
+        let c = as_float(builtin_cbrt(&[Value::Float(7.0)]).unwrap());
+        close(c * c * c, 7.0, "cbrt(7)^3");
+    }
+
+    #[test]
+    fn cbrt_rejects_int() {
+        let err = builtin_cbrt(&[Value::Int(8)]).unwrap_err();
+        assert!(err.contains("expected Float"), "err was: {}", err);
+        assert!(err.contains("to_float"), "err was: {}", err);
+    }
+
+    #[test]
+    fn cbrt_arity_check() {
+        let err = builtin_cbrt(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
     }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1086,6 +1086,8 @@ impl TypeChecker {
         env.set("acos".to_string(), fn_float_to_float());
         // RES-904.
         env.set("atan".to_string(), fn_float_to_float());
+        // RES-905.
+        env.set("cbrt".to_string(), fn_float_to_float());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5376,6 +5378,7 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "asin",
         "acos",
         "atan",
+        "cbrt",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #998.

Sibling of `sqrt`: `cbrt(x: Float) -> Float`, std-only, float-in / float-out per RES-130. Unlike `sqrt`, `cbrt` has total domain (handles negative inputs); `cbrt` is odd.

## Changes

- `resilient/src/lib.rs` — `BUILTINS` table entry, `builtin_cbrt`, 3 unit tests covering `cbrt(0)=0`, `cbrt(8)=2`, `cbrt(-27)=-3` odd-symmetry, and `cbrt(7)^3 = 7`.
- `resilient/src/typechecker.rs` — `Float -> Float` typing entry and `is_known_pure_builtin` listing.
- `STDLIB.md` — row for `cbrt(x)` cross-referencing `sqrt`.
- `resilient/examples/cbrt.rz` + `.expected.txt` — golden example exercising the perfect cubes 0, 8, -27, 125.

## Test plan

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_