### PR TITLE
RES-906: Scientific-notation float literals (1e9, 1.5e-3, 2E10)

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -508,7 +508,10 @@ The current trait system does not support:
 - `int`: 64-bit signed integer. Accepts decimal (`42`), hex (`0xFF`),
   and binary (`0b1010`) literals. Underscore separators allowed:
   `0xDEAD_BEEF`.
-- `float`: 64-bit floating point
+- `float`: 64-bit floating point. Accepts decimal-point literals
+  (`1.5`, `42.`) and RES-906 scientific notation (`1e9`, `2E10`,
+  `1.5e-3`, `1.e3`). Exponent body (`+`/`-` optional, then ≥1 digit)
+  must follow `e`/`E` — bare `1e` lexes as `Int(1) Ident("e")`.
 - `string`: UTF-8 text; `len(s)` returns scalar count
 - `bytes`: raw byte sequence, `b"\x00\x01abc"` literal (RES-152)
 - `bool`: `true` / `false`

--- a/resilient/examples/scientific_notation.expected.txt
+++ b/resilient/examples/scientific_notation.expected.txt
@@ -1,0 +1,7 @@
+1000
+20000000000
+0.0015
+250
+1000
+1001
+Program executed successfully

--- a/resilient/examples/scientific_notation.rz
+++ b/resilient/examples/scientific_notation.rz
@@ -1,0 +1,23 @@
+// RES-906 demo: scientific-notation float literals. The lexer accepts
+// `[mantissa][eE][+-]?digits` where mantissa is an integer or a regular
+// decimal-point float. Embedded code routinely needs constants like
+// 1e6 (clock dividers, sensor scaling) — without this rule the
+// workaround was the awkward `1000000.0`.
+
+fn main(int _d) {
+    // Bare integer mantissa.
+    println(1e3);                // 1000
+    println(2E10);               // 20000000000
+    // Decimal mantissa, signed exponent.
+    println(1.5e-3);             // 0.0015
+    println(2.5e+2);             // 250
+    // Trailing-dot mantissa.
+    println(1.e3);               // 1000
+
+    // Scientific notation flows through arithmetic just like any float.
+    println(1e3 + 1.0);          // 1001
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -139,9 +139,15 @@ enum Tok {
     HexInt(i64),
     #[regex(r"0[bB][01_]+", bin_int, priority = 3)]
     BinInt(i64),
-    // Float literal — `1.2`, `1.`. Must outrank `Int` for inputs with
-    // a trailing `.` so logos picks the float arm.
-    #[regex(r"[0-9]+\.[0-9]*", |lex| lex.slice().parse::<f64>().ok(), priority = 2)]
+    // Float literal — `1.2`, `1.`, plus RES-906 scientific notation
+    // `1e9`, `1.5e-3`, `2E+10`. Must outrank `Int` for inputs with
+    // a trailing `.` or an `[eE]±?[0-9]+` exponent so logos picks the
+    // float arm.
+    #[regex(
+        r"[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+",
+        |lex| lex.slice().parse::<f64>().ok(),
+        priority = 2
+    )]
     Float(f64),
     #[regex(r"[0-9]+", |lex| lex.slice().parse::<i64>().ok())]
     Int(i64),

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -1135,6 +1135,31 @@ impl Lexer {
             self.read_char();
         }
 
+        // RES-906: scientific-notation exponent — `1e9`, `1.5e-3`, `2E+10`.
+        // We only consume `[eE]` if a digit (optionally preceded by `+`/`-`)
+        // follows; this avoids ambiguity with hex digits in non-prefixed
+        // contexts and produces a clean lex error if the exponent body is
+        // empty.
+        if self.ch == 'e' || self.ch == 'E' {
+            let next = self.peek_char();
+            let exp_starts_here = self.is_digit(next)
+                || ((next == '+' || next == '-') && {
+                    // Look one further: only consume `e±` if a digit follows.
+                    let after_sign_idx = self.position + 2;
+                    after_sign_idx < self.input.len() && self.is_digit(self.input[after_sign_idx])
+                });
+            if exp_starts_here {
+                is_float = true;
+                self.read_char(); // consume `e`/`E`
+                if self.ch == '+' || self.ch == '-' {
+                    self.read_char();
+                }
+                while self.is_digit(self.ch) {
+                    self.read_char();
+                }
+            }
+        }
+
         let number_str: String = self.input[position..self.position].iter().collect();
 
         if is_float {
@@ -29138,6 +29163,99 @@ mod tests {
         match interp.env.get("n").unwrap() {
             Value::Int(n) => assert_eq!(n, 3),
             other => panic!("expected Int(3), got {:?}", other),
+        }
+    }
+
+    /// RES-906: scientific notation (`1e9`, `1.5e-3`, `2E+10`) lexes as
+    /// `FloatLiteral`, never as `Int` followed by an identifier. This
+    /// is the user-facing fix that lets safety-critical embedded code
+    /// write clock-divider and sensor-scaling constants directly.
+    #[test]
+    fn lexer_scientific_notation_floats() {
+        // Bare integer mantissa.
+        let toks = tokenize("1e9");
+        assert!(
+            matches!(toks[0], Token::FloatLiteral(f) if (f - 1.0e9).abs() < 1e-3),
+            "expected FloatLiteral(1e9), got {:?}",
+            toks[0]
+        );
+        // Capital E.
+        let toks = tokenize("2E10");
+        assert!(
+            matches!(toks[0], Token::FloatLiteral(f) if (f - 2.0e10).abs() < 1e-2),
+            "expected FloatLiteral(2e10), got {:?}",
+            toks[0]
+        );
+        // Mantissa with decimal + signed exponent.
+        let toks = tokenize("1.5e-3");
+        assert!(
+            matches!(toks[0], Token::FloatLiteral(f) if (f - 1.5e-3).abs() < 1e-9),
+            "expected FloatLiteral(1.5e-3), got {:?}",
+            toks[0]
+        );
+        let toks = tokenize("1.5e+3");
+        assert!(
+            matches!(toks[0], Token::FloatLiteral(f) if (f - 1500.0).abs() < 1e-6),
+            "expected FloatLiteral(1.5e+3), got {:?}",
+            toks[0]
+        );
+        // Trailing `.` mantissa with exponent.
+        let toks = tokenize("1.e3");
+        assert!(
+            matches!(toks[0], Token::FloatLiteral(f) if (f - 1000.0).abs() < 1e-6),
+            "expected FloatLiteral(1.e3), got {:?}",
+            toks[0]
+        );
+    }
+
+    /// RES-906: a bare `e` not followed by a digit (or signed digit) must
+    /// not be consumed by the number scanner — it has to remain available
+    /// as the start of an identifier so `1` ` ` `e` lexes as int / ident.
+    #[test]
+    fn lexer_bare_e_after_int_is_not_exponent() {
+        // `1e` (no digits after `e`) — the `e` is not consumed; lexes as
+        // `IntLiteral(1) Ident("e")`.
+        let toks = tokenize("1e");
+        assert!(
+            matches!(toks[0], Token::IntLiteral(1)),
+            "expected IntLiteral(1), got {:?}",
+            toks[0]
+        );
+        assert!(
+            matches!(&toks[1], Token::Identifier(s) if s == "e"),
+            "expected Identifier(\"e\"), got {:?}",
+            toks[1]
+        );
+        // `1ea` — `e` followed by a non-digit. Same split.
+        let toks = tokenize("1ea");
+        assert!(matches!(toks[0], Token::IntLiteral(1)));
+        assert!(matches!(&toks[1], Token::Identifier(s) if s == "ea"));
+        // `1e+` — `e+` without trailing digit; `e` stays an identifier.
+        let toks = tokenize("1e+");
+        assert!(matches!(toks[0], Token::IntLiteral(1)));
+        assert!(matches!(&toks[1], Token::Identifier(s) if s == "e"));
+        assert!(matches!(toks[2], Token::Plus));
+    }
+
+    /// RES-906 end-to-end: a program using scientific notation parses,
+    /// type-checks, and evaluates to the same value as the long-form
+    /// literal, proving the new lexer rule plumbed through the rest of
+    /// the pipeline correctly.
+    #[test]
+    fn scientific_notation_evaluates_correctly() {
+        let (p, _e) = parse("let a = 1e3; let b = 1000.0; let c = a - b;");
+        let mut interp = Interpreter::new();
+        interp.eval(&p).unwrap();
+        match interp.env.get("c").unwrap() {
+            Value::Float(v) => assert!((v - 0.0).abs() < 1e-9, "c = {}", v),
+            other => panic!("expected Float, got {:?}", other),
+        }
+        let (p, _e) = parse("let x = 1.5e-3;");
+        let mut interp = Interpreter::new();
+        interp.eval(&p).unwrap();
+        match interp.env.get("x").unwrap() {
+            Value::Float(v) => assert!((v - 0.0015).abs() < 1e-9, "x = {}", v),
+            other => panic!("expected Float, got {:?}", other),
         }
     }
 


### PR DESCRIPTION
Closes #1000.

Embedded code routinely needs constants like `1e6` (clock dividers, sensor scaling). The lexer used to reject `1e9` with a confusing `Expected ')' after call arguments, found identifier 'e9'` error, forcing the awkward `1000000.0` workaround. This was a real ergonomics gap I hit while writing the `atan` example for #997.

## Lexer changes

Both lexers now accept `mantissa[eE][+-]?digits` for both integer and decimal-point mantissas:

| Source | Lexed as | Value |
|---|---|---|
| `1e9` | FloatLiteral | 1.0e9 |
| `1E9` | FloatLiteral | 1.0e9 |
| `1.5e3` | FloatLiteral | 1500.0 |
| `1.5e+3` | FloatLiteral | 1500.0 |
| `1.5e-3` | FloatLiteral | 0.0015 |
| `1.e3` | FloatLiteral | 1000.0 |

The exponent body is required to be ≥1 digit (after the optional sign), so malformed forms still lex cleanly as int + identifier:

| Source | Token stream |
|---|---|
| `1e` | `Int(1) Ident("e")` |
| `1ea` | `Int(1) Ident("ea")` |
| `1e+` | `Int(1) Ident("e") Plus` |

This avoids silently consuming a stray `e` that should have started an identifier.

## Files

- `resilient/src/lib.rs::read_number` — hand-rolled lexer; consumes `[eE][+-]?[0-9]+` only when a digit (after the optional sign) actually follows.
- `resilient/src/lexer_logos.rs` — `Float` regex extended to `[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+`. Pure-digit (no `.`, no exponent) inputs still hit the `Int` arm.
- `SYNTAX.md` — documented the new literal form and the bare-`e` fallback rule.
- `resilient/examples/scientific_notation.rz` + `.expected.txt` — golden example covering integer mantissa, signed exponent, trailing-dot mantissa, and arithmetic flow-through.
- 3 new lexer unit tests in `lib.rs::tests`:
  - `lexer_scientific_notation_floats` — happy path across all forms.
  - `lexer_bare_e_after_int_is_not_exponent` — malformed-exponent fallback to int + ident.
  - `scientific_notation_evaluates_correctly` — end-to-end value equality with the long-form literal through the parser + interpreter.

## Test plan

- `cargo test --locked` (2429+ unit tests)
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`
- Golden suite (`examples_golden::golden_outputs_match`) includes the new sidecar.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_