### PR TITLE
RES-907: Add bit-counting integer builtins (count_ones, count_zeros, leading_zeros, trailing_zeros)

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -58,6 +58,8 @@ This document is a human-facing summary grouped by category.
 | `acos(x)` | float → float | RES-903: inverse cosine (radians); std-only; domain `[-1, 1]`; `|x|>1` → NaN; range `[0, π]` |
 | `atan(x)` | float → float | RES-904: inverse tangent (radians, single arg); std-only; total domain; range `(-π/2, π/2)`; sibling of `atan2(y, x)` |
 | `cbrt(x)` | float → float | RES-905: cube root; std-only; total domain (handles negatives, unlike `sqrt`); odd |
+| `count_ones(x)` `count_zeros(x)` | int → int | RES-907: 64-bit two's-complement bit population / complement |
+| `leading_zeros(x)` `trailing_zeros(x)` | int → int | RES-907: count of leading / trailing zero bits; both return `64` for input `0` |
 | `to_float(x)` | int → float | explicit coercion |
 | `to_int(x)` | float → int | explicit coercion |
 | `as_int8/16/32/64(x)` | int → int | wrapping truncation to signed width |

--- a/resilient/examples/bit_counting.expected.txt
+++ b/resilient/examples/bit_counting.expected.txt
@@ -1,0 +1,12 @@
+0
+3
+64
+64
+0
+64
+63
+8
+64
+0
+5
+Program executed successfully

--- a/resilient/examples/bit_counting.rz
+++ b/resilient/examples/bit_counting.rz
@@ -1,0 +1,29 @@
+// RES-907 demo: bit-counting integer builtins. All four operate on the
+// 64-bit two's-complement representation, so negative inputs are
+// well-defined.
+
+fn main(int _d) {
+    // count_ones is the population count (Hamming weight).
+    println(count_ones(0));               // 0
+    println(count_ones(7));               // 3   (0b111)
+    println(count_ones(-1));              // 64  (all bits set)
+
+    // count_zeros + count_ones = 64 for every input.
+    println(count_zeros(0));              // 64
+    println(count_zeros(-1));             // 0
+
+    // leading_zeros: log₂-of-power-of-two probe. 63 - leading_zeros(x)
+    // gives the bit index of the highest set bit.
+    println(leading_zeros(0));            // 64
+    println(leading_zeros(1));            // 63
+    println(63 - leading_zeros(256));     // 8   (256 = 1 << 8)
+
+    // trailing_zeros: lowest set bit. Bit-mask iteration primitive.
+    println(trailing_zeros(0));           // 64
+    println(trailing_zeros(1));           // 0
+    println(trailing_zeros(160));         // 5   (0b10100000)
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8949,6 +8949,12 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("atan", builtin_atan),
     // RES-905.
     ("cbrt", builtin_cbrt),
+    // RES-907: bit-counting integer builtins. Useful for register-bit
+    // decoding, bit-mask iteration, and log₂-of-power-of-two probes.
+    ("count_ones", builtin_count_ones),
+    ("count_zeros", builtin_count_zeros),
+    ("leading_zeros", builtin_leading_zeros),
+    ("trailing_zeros", builtin_trailing_zeros),
     // RES-147: monotonic ms clock, std-only.
     ("clock_ms", builtin_clock_ms),
     // RES-358: monotonic ns clock builtins. @io (non-pure).
@@ -9967,6 +9973,60 @@ fn builtin_cbrt(args: &[Value]) -> RResult<Value> {
             other
         )),
         _ => Err(format!("cbrt: expected 1 argument, got {}", args.len())),
+    }
+}
+
+/// RES-907: `count_ones(x: Int) -> Int` — population count (Hamming weight)
+/// of the 64-bit two's-complement representation. `count_ones(-1) == 64`.
+fn builtin_count_ones(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(i)] => Ok(Value::Int(i.count_ones() as i64)),
+        [other] => Err(format!("count_ones: expected Int, got {}", other)),
+        _ => Err(format!(
+            "count_ones: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-907: `count_zeros(x: Int) -> Int` — bits **not** set in the 64-bit
+/// representation. Equivalent to `64 - count_ones(x)`. `count_zeros(0) == 64`.
+fn builtin_count_zeros(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(i)] => Ok(Value::Int(i.count_zeros() as i64)),
+        [other] => Err(format!("count_zeros: expected Int, got {}", other)),
+        _ => Err(format!(
+            "count_zeros: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-907: `leading_zeros(x: Int) -> Int` — count of leading-zero bits in
+/// the 64-bit representation; `leading_zeros(0) == 64`. Useful as a fast
+/// log₂-of-power-of-two probe (`63 - leading_zeros(x)`).
+fn builtin_leading_zeros(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(i)] => Ok(Value::Int(i.leading_zeros() as i64)),
+        [other] => Err(format!("leading_zeros: expected Int, got {}", other)),
+        _ => Err(format!(
+            "leading_zeros: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// RES-907: `trailing_zeros(x: Int) -> Int` — count of trailing-zero bits;
+/// `trailing_zeros(0) == 64`. Useful for bit-mask iteration (find lowest
+/// set bit).
+fn builtin_trailing_zeros(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(i)] => Ok(Value::Int(i.trailing_zeros() as i64)),
+        [other] => Err(format!("trailing_zeros: expected Int, got {}", other)),
+        _ => Err(format!(
+            "trailing_zeros: expected 1 argument, got {}",
+            args.len()
+        )),
     }
 }
 
@@ -27799,6 +27859,125 @@ mod tests {
     fn cbrt_arity_check() {
         let err = builtin_cbrt(&[]).unwrap_err();
         assert!(err.contains("expected 1 argument"), "err was: {}", err);
+    }
+
+    /// RES-907: bit-counting builtins map to i64 two's-complement, so all
+    /// edge cases (zero, all-ones, single-bit) are well-defined.
+    #[test]
+    fn count_ones_basic() {
+        let f = |x: i64| match builtin_count_ones(&[Value::Int(x)]).unwrap() {
+            Value::Int(i) => i,
+            _ => panic!(),
+        };
+        assert_eq!(f(0), 0);
+        assert_eq!(f(1), 1);
+        assert_eq!(f(0b1011), 3);
+        // -1 in two's-complement is all 64 bits set.
+        assert_eq!(f(-1), 64);
+        // Population count is symmetric across i64::MAX vs MIN+1: both
+        // have exactly 63 set bits (sign bit differs only on i64::MIN).
+        assert_eq!(f(i64::MAX), 63);
+        assert_eq!(f(i64::MIN), 1);
+    }
+
+    #[test]
+    fn count_zeros_complements_count_ones() {
+        let ones = match builtin_count_ones(&[Value::Int(0b1011)]).unwrap() {
+            Value::Int(i) => i,
+            _ => panic!(),
+        };
+        let zeros = match builtin_count_zeros(&[Value::Int(0b1011)]).unwrap() {
+            Value::Int(i) => i,
+            _ => panic!(),
+        };
+        assert_eq!(ones + zeros, 64);
+        // count_zeros(0) is all 64 bits.
+        assert_eq!(
+            match builtin_count_zeros(&[Value::Int(0)]).unwrap() {
+                Value::Int(i) => i,
+                _ => panic!(),
+            },
+            64
+        );
+        // count_zeros(-1) is 0.
+        assert_eq!(
+            match builtin_count_zeros(&[Value::Int(-1)]).unwrap() {
+                Value::Int(i) => i,
+                _ => panic!(),
+            },
+            0
+        );
+    }
+
+    #[test]
+    fn leading_zeros_basic() {
+        let f = |x: i64| match builtin_leading_zeros(&[Value::Int(x)]).unwrap() {
+            Value::Int(i) => i,
+            _ => panic!(),
+        };
+        // Zero is all leading zeros.
+        assert_eq!(f(0), 64);
+        // 1 has 63 leading zeros.
+        assert_eq!(f(1), 63);
+        // High bit set (i64::MIN) has 0 leading zeros.
+        assert_eq!(f(i64::MIN), 0);
+        // log₂-of-power-of-two probe: 63 - leading_zeros(x) for x > 0.
+        for shift in 0..63 {
+            let x = 1i64 << shift;
+            assert_eq!(63 - f(x), shift, "x = 1 << {}", shift);
+        }
+    }
+
+    #[test]
+    fn trailing_zeros_basic() {
+        let f = |x: i64| match builtin_trailing_zeros(&[Value::Int(x)]).unwrap() {
+            Value::Int(i) => i,
+            _ => panic!(),
+        };
+        // Zero is all trailing zeros.
+        assert_eq!(f(0), 64);
+        // 1 has 0 trailing zeros.
+        assert_eq!(f(1), 0);
+        // Bit-mask iteration: trailing_zeros isolates the lowest set bit.
+        assert_eq!(f(0b1010_0000), 5);
+        // i64::MIN: only the sign bit is set → 63 trailing zeros.
+        assert_eq!(f(i64::MIN), 63);
+    }
+
+    #[test]
+    fn bit_counting_rejects_non_int() {
+        for (name, builder) in [
+            ("count_ones", builtin_count_ones as fn(&[Value]) -> _),
+            ("count_zeros", builtin_count_zeros),
+            ("leading_zeros", builtin_leading_zeros),
+            ("trailing_zeros", builtin_trailing_zeros),
+        ] {
+            let err = builder(&[Value::Float(0.5)]).unwrap_err();
+            assert!(
+                err.starts_with(name) && err.contains("expected Int"),
+                "{}: err was: {}",
+                name,
+                err
+            );
+        }
+    }
+
+    #[test]
+    fn bit_counting_arity_check() {
+        for (name, builder) in [
+            ("count_ones", builtin_count_ones as fn(&[Value]) -> _),
+            ("count_zeros", builtin_count_zeros),
+            ("leading_zeros", builtin_leading_zeros),
+            ("trailing_zeros", builtin_trailing_zeros),
+        ] {
+            let err = builder(&[]).unwrap_err();
+            assert!(
+                err.starts_with(name) && err.contains("expected 1 argument"),
+                "{}: err was: {}",
+                name,
+                err
+            );
+        }
     }
 
     #[test]

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1088,6 +1088,15 @@ impl TypeChecker {
         env.set("atan".to_string(), fn_float_to_float());
         // RES-905.
         env.set("cbrt".to_string(), fn_float_to_float());
+        // RES-907: bit-counting integer builtins (Int -> Int).
+        let fn_int_to_int = || Type::Function {
+            params: vec![Type::Int],
+            return_type: Box::new(Type::Int),
+        };
+        env.set("count_ones".to_string(), fn_int_to_int());
+        env.set("count_zeros".to_string(), fn_int_to_int());
+        env.set("leading_zeros".to_string(), fn_int_to_int());
+        env.set("trailing_zeros".to_string(), fn_int_to_int());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5379,6 +5388,10 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "acos",
         "atan",
         "cbrt",
+        "count_ones",
+        "count_zeros",
+        "leading_zeros",
+        "trailing_zeros",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1002.

Adds four bit-counting builtins for `Int`. All operate on the 64-bit two's-complement representation, so negative inputs are well-defined.

| Builtin | Behaviour | Embedded use |
|---|---|---|
| `count_ones(x)` | Hamming weight | bit-flag accumulators |
| `count_zeros(x)` | `64 - count_ones(x)` | mask coverage |
| `leading_zeros(x)` | leading-zero bits; `0 → 64` | log₂-of-power-of-two via `63 - leading_zeros(x)` |
| `trailing_zeros(x)` | trailing-zero bits; `0 → 64` | bit-mask iteration (find lowest set bit) |

## Files

- `resilient/src/lib.rs` — `BUILTINS` table entries, four `builtin_*` functions, 6 unit tests.
- `resilient/src/typechecker.rs` — new `fn_int_to_int` helper, four registry entries, four `is_known_pure_builtin` listings.
- `STDLIB.md` — two rows pairing the related builtins.
- `resilient/examples/bit_counting.rz` + `.expected.txt` — golden example demonstrating all four (edge cases: 0, all-ones, single-bit, multi-bit pattern).

## Notes on the design

- The reject-non-Int and arity-check tests use a function-pointer table to exercise all four builtins from a single test, keeping the test suite tight without copy-paste.
- `count_ones(-1) == 64`, `count_zeros(-1) == 0` — two's-complement is the natural choice for embedded register decoding, where a signed-vs-unsigned distinction would just create a footgun.
- Both `leading_zeros` and `trailing_zeros` return **64** for input `0`, matching `i64::leading_zeros` / `i64::trailing_zeros` (rather than the alternative undefined / `i64::BITS - 1` conventions some libraries use).

## Test plan

- `cargo test --locked` (full lib + integration suite)
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_