### PR TITLE
RES-909: Underscore separators in decimal int and float literals

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -506,12 +506,16 @@ The current trait system does not support:
 ## Data Types
 
 - `int`: 64-bit signed integer. Accepts decimal (`42`), hex (`0xFF`),
-  and binary (`0b1010`) literals. Underscore separators allowed:
-  `0xDEAD_BEEF`.
+  and binary (`0b1010`) literals. Underscore separators allowed in all
+  three forms: `0xDEAD_BEEF`, `0b1010_0001`, `1_000_000` (RES-909).
 - `float`: 64-bit floating point. Accepts decimal-point literals
-  (`1.5`, `42.`) and RES-906 scientific notation (`1e9`, `2E10`,
-  `1.5e-3`, `1.e3`). Exponent body (`+`/`-` optional, then ≥1 digit)
-  must follow `e`/`E` — bare `1e` lexes as `Int(1) Ident("e")`.
+  (`1.5`, `42.`), RES-906 scientific notation (`1e9`, `2E10`,
+  `1.5e-3`, `1.e3`), and RES-909 underscore separators in mantissa
+  and exponent body (`1_000.5e1_0`). Exponent body (`+`/`-` optional,
+  then ≥1 digit) must follow `e`/`E` — bare `1e` lexes as
+  `Int(1) Ident("e")`. An underscore must sit between two digits;
+  `1_a` lexes as `Int(1) Ident("_a")`, never silently swallowing the
+  separator.
 - `string`: UTF-8 text; `len(s)` returns scalar count
 - `bytes`: raw byte sequence, `b"\x00\x01abc"` literal (RES-152)
 - `bool`: `true` / `false`

--- a/resilient/examples/underscore_numerics.expected.txt
+++ b/resilient/examples/underscore_numerics.expected.txt
@@ -1,0 +1,5 @@
+1000000
+271828.182845
+12345
+3735928559
+Program executed successfully

--- a/resilient/examples/underscore_numerics.rz
+++ b/resilient/examples/underscore_numerics.rz
@@ -1,0 +1,26 @@
+// RES-909 demo: underscore separators in decimal int and float
+// literals. Already worked in hex / binary; this PR extends the same
+// rule to decimal mantissas and the RES-906 scientific-notation
+// exponent.
+
+fn main(int _d) {
+    // Decimal int with separators.
+    let million = 1_000_000;
+    println(million);                    // 1000000
+
+    // Float mantissa with separators.
+    let euler = 2_71828.18284_5;
+    println(euler);                      // 271828.182845
+
+    // Scientific notation with separators in BOTH mantissa and exponent.
+    let big = 1_234.5e0_1;
+    println(big);                        // 12345
+
+    // Hex / binary still work — separators were already accepted there.
+    let mask = 0xDEAD_BEEF;
+    println(mask);                       // 3735928559
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -140,16 +140,18 @@ enum Tok {
     #[regex(r"0[bB][01_]+", bin_int, priority = 3)]
     BinInt(i64),
     // Float literal — `1.2`, `1.`, plus RES-906 scientific notation
-    // `1e9`, `1.5e-3`, `2E+10`. Must outrank `Int` for inputs with
-    // a trailing `.` or an `[eE]±?[0-9]+` exponent so logos picks the
-    // float arm.
+    // `1e9`, `1.5e-3`, `2E+10`, plus RES-909 underscore separators
+    // (`1_000.5e1_0`). Must outrank `Int` for inputs with a trailing
+    // `.` or an `[eE]±?[0-9]+` exponent so logos picks the float arm.
+    // The `_`-stripping callback (`float_lit`) handles separators.
     #[regex(
-        r"[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+",
-        |lex| lex.slice().parse::<f64>().ok(),
+        r"[0-9][0-9_]*\.[0-9_]*([eE][+-]?[0-9][0-9_]*)?|[0-9][0-9_]*[eE][+-]?[0-9][0-9_]*",
+        float_lit,
         priority = 2
     )]
     Float(f64),
-    #[regex(r"[0-9]+", |lex| lex.slice().parse::<i64>().ok())]
+    // RES-909: decimal int literals also accept `_` between digits.
+    #[regex(r"[0-9][0-9_]*", int_lit)]
     Int(i64),
     // String literal — `"([^"\\]|\\[\s\S])*"` matches any non-quote
     // non-backslash char OR a backslash followed by any char
@@ -312,6 +314,27 @@ fn hex_int(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
 fn bin_int(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
     let body = lex.slice()[2..].replace('_', "");
     Some(i64::from_str_radix(&body, 2).unwrap_or(0))
+}
+
+/// RES-909: decimal int literal with optional `_` separators.
+fn int_lit(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
+    let slice = lex.slice();
+    if slice.contains('_') {
+        slice.replace('_', "").parse::<i64>().ok()
+    } else {
+        slice.parse::<i64>().ok()
+    }
+}
+
+/// RES-909: float literal with optional `_` separators in mantissa
+/// or exponent body (`1_000.5e1_0`).
+fn float_lit(lex: &mut logos::Lexer<Tok>) -> Option<f64> {
+    let slice = lex.slice();
+    if slice.contains('_') {
+        slice.replace('_', "").parse::<f64>().ok()
+    } else {
+        slice.parse::<f64>().ok()
+    }
 }
 
 fn bytes_lit(lex: &mut logos::Lexer<Tok>) -> Vec<u8> {

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -1121,7 +1121,14 @@ impl Lexer {
         let position = self.position;
         let mut is_float = false;
 
-        while self.is_digit(self.ch) || self.ch == '.' {
+        // RES-909: accept `_` *between* digits in decimal mantissas. The
+        // lookahead-protected rule keeps `1_a` lexing as `Int(1) Ident("_a")`
+        // — we only consume an underscore when a digit immediately follows,
+        // never one that should start an identifier.
+        while self.is_digit(self.ch)
+            || self.ch == '.'
+            || (self.ch == '_' && self.is_digit(self.peek_char()))
+        {
             if self.ch == '.' {
                 // RES-330: stop on the range operator `..` so quantifier
                 // ranges like `0..n` lex as IntLiteral(0), DotDot, IDENT.
@@ -1136,6 +1143,7 @@ impl Lexer {
         }
 
         // RES-906: scientific-notation exponent — `1e9`, `1.5e-3`, `2E+10`.
+        // RES-909: also accept `_` between exponent digits (`1e1_0`).
         // We only consume `[eE]` if a digit (optionally preceded by `+`/`-`)
         // follows; this avoids ambiguity with hex digits in non-prefixed
         // contexts and produces a clean lex error if the exponent body is
@@ -1154,13 +1162,21 @@ impl Lexer {
                 if self.ch == '+' || self.ch == '-' {
                     self.read_char();
                 }
-                while self.is_digit(self.ch) {
+                while self.is_digit(self.ch) || (self.ch == '_' && self.is_digit(self.peek_char()))
+                {
                     self.read_char();
                 }
             }
         }
 
-        let number_str: String = self.input[position..self.position].iter().collect();
+        // RES-909: f64::from_str / i64::from_str do not strip `_`; we
+        // collect the slice and remove separators before parsing.
+        let raw: String = self.input[position..self.position].iter().collect();
+        let number_str = if raw.contains('_') {
+            raw.replace('_', "")
+        } else {
+            raw
+        };
 
         if is_float {
             Token::FloatLiteral(number_str.parse::<f64>().unwrap_or(0.0))
@@ -29656,6 +29672,74 @@ mod tests {
         interp.eval(&p).unwrap();
         match interp.env.get("x").unwrap() {
             Value::Float(v) => assert!((v - 0.0015).abs() < 1e-9, "x = {}", v),
+            other => panic!("expected Float, got {:?}", other),
+        }
+    }
+
+    /// RES-909: `_` between digits in decimal int / float literals is
+    /// stripped before parsing. Hex / binary already had this; we extend
+    /// it to the decimal path and to the RES-906 exponent body.
+    #[test]
+    fn lexer_underscore_separators_in_decimals() {
+        // Plain int with separators.
+        let toks = tokenize("1_000_000");
+        assert!(
+            matches!(toks[0], Token::IntLiteral(1_000_000)),
+            "expected IntLiteral(1_000_000), got {:?}",
+            toks[0]
+        );
+        // Float mantissa with separators.
+        let toks = tokenize("1_000.5");
+        assert!(
+            matches!(toks[0], Token::FloatLiteral(f) if (f - 1000.5).abs() < 1e-9),
+            "expected FloatLiteral(1_000.5), got {:?}",
+            toks[0]
+        );
+        // Both mantissa and exponent with separators.
+        let toks = tokenize("1_000.5e1_0");
+        assert!(
+            matches!(toks[0], Token::FloatLiteral(f) if (f - 1.0005e13).abs() < 1.0),
+            "expected FloatLiteral(1.0005e13), got {:?}",
+            toks[0]
+        );
+    }
+
+    /// RES-909: an underscore that's NOT between two digits stays
+    /// available to start an identifier. `1_a` must lex as
+    /// `Int(1) Ident("_a")`, not as `Int(1_a)` and not as
+    /// `Int(1_) Ident("a")` (which would silently swallow the `_`).
+    #[test]
+    fn lexer_trailing_underscore_starts_identifier() {
+        let toks = tokenize("1_a");
+        assert!(matches!(toks[0], Token::IntLiteral(1)));
+        assert!(matches!(&toks[1], Token::Identifier(s) if s == "_a"));
+        // Trailing `_` at end of input — bare `_` is the wildcard token.
+        let toks = tokenize("42_");
+        assert!(matches!(toks[0], Token::IntLiteral(42)));
+        assert!(matches!(toks[1], Token::Underscore));
+        // Float mantissa: `1.5_` must end the float, leaving `_` as the
+        // start of the next token (the wildcard).
+        let toks = tokenize("1.5_");
+        assert!(matches!(toks[0], Token::FloatLiteral(f) if (f - 1.5).abs() < 1e-9));
+        assert!(matches!(toks[1], Token::Underscore));
+    }
+
+    /// RES-909 end-to-end: a program with `_`-separated literals
+    /// evaluates to the same value as the un-separated form.
+    #[test]
+    fn underscore_separators_evaluate_correctly() {
+        let (p, _e) = parse("let a = 1_000_000; let b = 1000000; let c = a - b;");
+        let mut interp = Interpreter::new();
+        interp.eval(&p).unwrap();
+        match interp.env.get("c").unwrap() {
+            Value::Int(n) => assert_eq!(n, 0),
+            other => panic!("expected Int, got {:?}", other),
+        }
+        let (p, _e) = parse("let f = 1_234.5e1_0;");
+        let mut interp = Interpreter::new();
+        interp.eval(&p).unwrap();
+        match interp.env.get("f").unwrap() {
+            Value::Float(v) => assert!((v - 1234.5e10).abs() < 1.0, "f = {}", v),
             other => panic!("expected Float, got {:?}", other),
         }
     }


### PR DESCRIPTION
Closes #1006.

Hex / binary already accepted `_` separators (`0xDEAD_BEEF`, `0b1010_0001`); this extends the same rule to decimal int literals, the mantissa of a float literal, and the exponent of a scientific-notation literal.

| Source | Lexed as | Value |
|---|---|---|
| `1_000_000` | IntLiteral | 1000000 |
| `1_000.5` | FloatLiteral | 1000.5 |
| `1_234.5e1_0` | FloatLiteral | 1.2345e13 |

The lookahead-protected rule keeps `1_a` lexing as `Int(1) Ident("_a")` — we only consume an underscore when a digit immediately follows, never one that should start an identifier or wildcard token. `42_` ends the int and leaves bare `_` for the next token (`Token::Underscore`, the wildcard).

## Files

- `resilient/src/lib.rs::read_number` — extended both the mantissa loop and the RES-906 exponent loop with the lookahead rule, and post-process the slice to strip `_` before `parse::<f64>` / `parse::<i64>`.
- `resilient/src/lexer_logos.rs` — `Float` regex extended to `[0-9][0-9_]*\.[0-9_]*([eE][+-]?[0-9][0-9_]*)?|[0-9][0-9_]*[eE][+-]?[0-9][0-9_]*`; `Int` regex to `[0-9][0-9_]*`. Two new callback helpers (`int_lit`, `float_lit`) strip `_` before parsing.
- `SYNTAX.md` — documented the new rule alongside the existing hex / binary support.
- `resilient/examples/underscore_numerics.rz` + `.expected.txt` — golden example covering all four numeric literal forms (decimal int, decimal float, scientific notation, hex).

## Test plan

- `cargo test --locked` (full suite + 3 new lexer unit tests covering happy path, the `_a`/`_` boundary, and end-to-end value equality)
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --check`

## Coming next in the queue (per the user's prompt)

The biggest core-language gap I've spotted while iterating: **`break` and `continue`** statements are missing entirely. That blocks `while let` desugaring, makes early-exit iteration awkward, and shows up in user code as boolean-flag workarounds. I'll file the issue and ship that next.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_