### PR TITLE
RES-915: Range patterns in match arms (`1..=5 => "small"`)

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -756,6 +756,24 @@ identifier: `let default = 3;` is a parse error
 No other `_` synonyms (`otherwise`, `else`, ...) are planned
 — one alias is plenty.
 
+### Range patterns (RES-915)
+
+Match arms accept integer range patterns:
+
+```rust
+match n {
+    1..=5  => "small",        // inclusive: 1, 2, 3, 4, 5
+    6..10  => "medium",       // half-open: 6, 7, 8, 9
+    _      => "other",
+}
+```
+
+Both endpoints must be integer literals (negative `hi` allowed:
+`1..=-3` is degenerate and matches nothing). Range patterns only
+fire on `Int` scrutinees; non-Int values fall through to the
+wildcard. Range patterns bind no names today (`1..=5 @ x` binding
+is a future enhancement).
+
 ### `if let` (RES-908)
 
 `if let` is parser-level sugar over `match`. It is the idiomatic way

--- a/resilient/examples/range_patterns.expected.txt
+++ b/resilient/examples/range_patterns.expected.txt
@@ -1,0 +1,10 @@
+small
+medium
+large
+other
+other
+true
+true
+false
+false
+Program executed successfully

--- a/resilient/examples/range_patterns.rz
+++ b/resilient/examples/range_patterns.rz
@@ -1,0 +1,36 @@
+// RES-915 demo: integer range patterns in match arms.
+
+fn classify(int n) -> string {
+    return match n {
+        1..=5 => "small",
+        6..=10 => "medium",
+        11..=100 => "large",
+        _ => "other",
+    };
+}
+
+fn is_in_range(int n) -> bool {
+    // Half-open range — excludes upper bound.
+    return match n {
+        5..10 => true,
+        _ => false,
+    };
+}
+
+fn main(int _d) -> int {
+    println(classify(3));                // small
+    println(classify(8));                // medium
+    println(classify(50));               // large
+    println(classify(0));                // other
+    println(classify(101));              // other
+
+    // Half-open boundaries.
+    println(is_in_range(5));             // true   (5 is included)
+    println(is_in_range(9));             // true   (9 is included)
+    println(is_in_range(10));            // false  (10 is excluded)
+    println(is_in_range(4));             // false
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -1186,6 +1186,12 @@ impl Formatter {
             Pattern::Wildcard => self.write("_"),
             Pattern::Identifier(name) => self.write(name),
             Pattern::Literal(node) => self.fmt_expr(node),
+            // RES-915: range patterns — `lo..hi` / `lo..=hi`.
+            Pattern::Range { lo, hi, inclusive } => {
+                self.write(&lo.to_string());
+                self.write(if *inclusive { "..=" } else { ".." });
+                self.write(&hi.to_string());
+            }
             Pattern::Or(branches) => {
                 for (i, b) in branches.iter().enumerate() {
                     if i > 0 {

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -527,7 +527,8 @@ fn bind_pattern(pat: &Pattern, bound: &mut BTreeSet<String>) {
         Pattern::Identifier(name) => {
             bound.insert(name.clone());
         }
-        Pattern::Wildcard | Pattern::Literal(_) => {}
+        // RES-915: range patterns bind no names today.
+        Pattern::Wildcard | Pattern::Literal(_) | Pattern::Range { .. } => {}
         Pattern::Or(branches) => {
             for b in branches {
                 bind_pattern(b, bound);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -1481,6 +1481,11 @@ pub(crate) enum Pattern {
     /// reliably reference bindings regardless of which branch
     /// fired.
     Or(Vec<Pattern>),
+    /// RES-915: integer range pattern — `lo..hi` (half-open) or
+    /// `lo..=hi` (inclusive). Only Int scrutinees are supported at
+    /// MVP precision; `lo` and `hi` are stored as `i64` (after
+    /// parser-side resolution of optional `Minus` prefix).
+    Range { lo: i64, hi: i64, inclusive: bool },
     /// RES-161a: `name @ inner` — bind the whole scrutinee to `name`
     /// AND apply `inner` pattern. Both bindings are in scope in the
     /// guard and arm body. Inner pattern is restricted to atoms that
@@ -7949,6 +7954,48 @@ impl Parser {
     /// (RES-160). On exit, `current_token` is the last token of the
     /// last atom (so the caller's `next_token()` advances past the
     /// pattern as a whole).
+    /// RES-915: parse the tail of an integer range pattern after the
+    /// lower bound has been recognised. Caller's `current_token` is the
+    /// `IntLiteral` for `lo`; on entry `peek_token == Token::DotDot`.
+    /// On exit `current_token` sits on the upper bound's last token,
+    /// per the standard "leave on the last consumed token" invariant
+    /// of `parse_pattern_atom`.
+    fn parse_int_range_pattern_tail(&mut self, lo: i64) -> Pattern {
+        // Step past `lo` onto `..`.
+        self.next_token();
+        debug_assert!(matches!(self.current_token, Token::DotDot));
+        // Step past `..` onto either `=` (inclusive) or the upper bound.
+        self.next_token();
+        let inclusive = if matches!(self.current_token, Token::Assign) {
+            self.next_token(); // skip `=`
+            true
+        } else {
+            false
+        };
+        // Upper bound: optional unary minus then an integer literal.
+        let negate = if matches!(self.current_token, Token::Minus) {
+            self.next_token();
+            true
+        } else {
+            false
+        };
+        let hi = match &self.current_token {
+            Token::IntLiteral(v) => {
+                let v = *v;
+                if negate { -v } else { v }
+            }
+            other => {
+                let tok = other.clone();
+                self.record_error(format!(
+                    "Expected integer literal as range-pattern upper bound, found {}",
+                    tok
+                ));
+                lo // recover with a degenerate single-element range
+            }
+        };
+        Pattern::Range { lo, hi, inclusive }
+    }
+
     pub(crate) fn parse_pattern(&mut self) -> Pattern {
         let first = self.parse_pattern_atom();
         // RES-160: collect `| <pattern>` tails. `|` is
@@ -7981,10 +8028,19 @@ impl Parser {
             // unexpected-token error since `Token::Default` isn't
             // accepted anywhere else in the grammar.
             Token::Default => Pattern::Wildcard,
-            Token::IntLiteral(n) => Pattern::Literal(Node::IntegerLiteral {
-                value: *n,
-                span: tok_span,
-            }),
+            Token::IntLiteral(n) => {
+                let n = *n;
+                // RES-915: integer range pattern — `lo..hi` / `lo..=hi`.
+                // Detect by peeking past the literal for `..`. If absent
+                // we fall through to the plain literal-pattern case.
+                if self.peek_token == Token::DotDot {
+                    return self.parse_int_range_pattern_tail(n);
+                }
+                Pattern::Literal(Node::IntegerLiteral {
+                    value: n,
+                    span: tok_span,
+                })
+            }
             Token::FloatLiteral(f) => Pattern::Literal(Node::FloatLiteral {
                 value: *f,
                 span: tok_span,
@@ -21016,6 +21072,22 @@ impl Interpreter {
                 };
                 Ok(if is_equal { Some(vec![]) } else { None })
             }
+            // RES-915: integer range pattern. Half-open matches `lo
+            // <= x < hi`; inclusive matches `lo <= x <= hi`. Only Int
+            // scrutinees match — anything else falls through to no-match
+            // rather than erroring (consistent with the literal branch).
+            Pattern::Range { lo, hi, inclusive } => {
+                let matches = if let Value::Int(x) = value {
+                    if *inclusive {
+                        *x >= *lo && *x <= *hi
+                    } else {
+                        *x >= *lo && *x < *hi
+                    }
+                } else {
+                    false
+                };
+                Ok(if matches { Some(vec![]) } else { None })
+            }
             // RES-160: first-match wins.
             Pattern::Or(branches) => {
                 for b in branches {
@@ -26350,6 +26422,118 @@ mod tests {
         match interp.eval(&program).unwrap() {
             Value::Int(n) => assert_eq!(n, 3),
             other => panic!("expected Int(3), got {:?}", other),
+        }
+    }
+
+    /// RES-915: integer range patterns in match arms. Half-open
+    /// `lo..hi` matches `lo <= x < hi`; inclusive `lo..=hi` matches
+    /// `lo <= x <= hi`. The matcher is exact about endpoints so we
+    /// test both edges.
+    #[test]
+    fn match_range_pattern_inclusive() {
+        let src = "\
+            fn classify(int n) -> string {\n\
+                return match n {\n\
+                    1..=5 => \"small\",\n\
+                    6..=10 => \"medium\",\n\
+                    _ => \"other\",\n\
+                };\n\
+            }\n\
+            fn main(int _d) -> int {\n\
+                let a = classify(1);\n\
+                let b = classify(5);\n\
+                let c = classify(6);\n\
+                let d = classify(0);\n\
+                return len(a) + len(b) + len(c) + len(d);\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        // small(5) + small(5) + medium(6) + other(5) = 21
+        match interp.eval(&program).unwrap() {
+            Value::Int(n) => assert_eq!(n, 21),
+            other => panic!("expected Int(21), got {:?}", other),
+        }
+    }
+
+    /// RES-915: half-open range pattern excludes the upper bound. `5..10`
+    /// must match 5, 9 but NOT 10.
+    #[test]
+    fn match_range_pattern_half_open_excludes_upper() {
+        let src = "\
+            fn matches(int n) -> bool {\n\
+                return match n {\n\
+                    5..10 => true,\n\
+                    _ => false,\n\
+                };\n\
+            }\n\
+            fn main(int _d) -> int {\n\
+                let r = 0;\n\
+                if matches(5) { r += 1; }\n\
+                if matches(9) { r += 1; }\n\
+                if matches(10) { r += 100; }\n\
+                if matches(4) { r += 100; }\n\
+                return r;\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::Int(n) => assert_eq!(n, 2),
+            other => panic!("expected Int(2), got {:?}", other),
+        }
+    }
+
+    /// RES-915: negative upper bound — `1..=-3` is degenerate (lo > hi)
+    /// and matches nothing; the wildcard arm fires.
+    #[test]
+    fn match_range_pattern_with_negative_upper() {
+        let src = "\
+            fn main(int _d) -> string {\n\
+                return match 0 {\n\
+                    1..=-3 => \"hit\",\n\
+                    _ => \"miss\",\n\
+                };\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::String(s) => assert_eq!(s, "miss"),
+            other => panic!("expected String(\"miss\"), got {:?}", other),
+        }
+    }
+
+    /// RES-915: range pattern only fires on Int scrutinees. A Float or
+    /// String falls through to the wildcard.
+    #[test]
+    fn range_pattern_does_not_match_non_int() {
+        let src = "\
+            fn matches(string s) -> bool {\n\
+                return match s {\n\
+                    \"hi\" => true,\n\
+                    _ => false,\n\
+                };\n\
+            }\n\
+            fn main(int _d) -> bool {\n\
+                return matches(\"hi\");\n\
+            }\n\
+            main(0);\n\
+        ";
+        // Just make sure non-Int match still works, doesn't accidentally
+        // try to apply a range pattern.
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::Bool(b) => assert!(b),
+            other => panic!("expected Bool(true), got {:?}", other),
         }
     }
 

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -261,6 +261,8 @@ fn collect_pattern_bindings(pattern: &Pattern) -> Vec<String> {
         // RES-375: `Some(inner)` forwards to inner; `None` has no bindings.
         Pattern::Some(inner) => collect_pattern_bindings(inner.as_ref()),
         Pattern::None => vec![],
+        // RES-915: range patterns bind no names.
+        Pattern::Range { .. } => vec![],
         // RES-400: enum-variant pattern bindings.
         Pattern::EnumVariant { payload, .. } => match payload {
             crate::EnumPatternPayload::None => vec![],
@@ -630,7 +632,9 @@ fn collect_identifier_reads_in(node: &Node, out: &mut std::collections::HashSet<
 fn pattern_is_default_for_lint(p: &Pattern) -> bool {
     match p {
         Pattern::Wildcard | Pattern::Identifier(_) => true,
-        Pattern::Literal(_) => false,
+        // RES-915: range patterns never catch every Int (e.g. `1..=5`
+        // misses 0, 6, …).
+        Pattern::Literal(_) | Pattern::Range { .. } => false,
         Pattern::Or(branches) => branches.iter().any(pattern_is_default_for_lint),
         Pattern::Bind(_, inner) => pattern_is_default_for_lint(inner),
         Pattern::Struct { fields, .. } => fields

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -169,7 +169,9 @@ fn compatible(a: &Type, b: &Type) -> bool {
 fn pattern_bindings(p: &Pattern) -> Vec<String> {
     match p {
         Pattern::Identifier(n) => vec![n.clone()],
-        Pattern::Wildcard | Pattern::Literal(_) => Vec::new(),
+        // RES-915: range patterns bind no names (today; `1..=5 @ x`
+        // binding is queued as a follow-up).
+        Pattern::Wildcard | Pattern::Literal(_) | Pattern::Range { .. } => Vec::new(),
         Pattern::Or(branches) => {
             // By induction (checked at each arm) every branch
             // introduces the same names — pick the first branch's
@@ -215,7 +217,9 @@ fn pattern_bindings(p: &Pattern) -> Vec<String> {
 fn pattern_is_default(p: &Pattern) -> bool {
     match p {
         Pattern::Wildcard | Pattern::Identifier(_) => true,
-        Pattern::Literal(_) => false,
+        // RES-915: a range pattern does not match every Int — `1..=5`
+        // misses 0, 6, etc. — so it is never a default arm.
+        Pattern::Literal(_) | Pattern::Range { .. } => false,
         Pattern::Or(branches) => branches.iter().any(pattern_is_default),
         // `x @ inner` is default iff the inner pattern is default.
         Pattern::Bind(_, inner) => pattern_is_default(inner),
@@ -252,7 +256,8 @@ fn pattern_covers_bool(p: &Pattern, want: bool) -> bool {
 fn struct_pattern_matches_nominal_type(sname: &str, decl: &[(String, Type)], p: &Pattern) -> bool {
     match p {
         Pattern::Wildcard | Pattern::Identifier(_) => true,
-        Pattern::Literal(_) => false,
+        // RES-915: range patterns never match a struct; they're Int-only.
+        Pattern::Literal(_) | Pattern::Range { .. } => false,
         Pattern::Or(branches) => branches
             .iter()
             .any(|b| struct_pattern_matches_nominal_type(sname, decl, b)),
@@ -3015,7 +3020,8 @@ impl TypeChecker {
         scrut_ty: &Type,
     ) -> Result<Vec<(String, Type)>, String> {
         match pattern {
-            Pattern::Wildcard | Pattern::Literal(_) => Ok(vec![]),
+            // RES-915: range patterns bind no names today.
+            Pattern::Wildcard | Pattern::Literal(_) | Pattern::Range { .. } => Ok(vec![]),
             Pattern::Identifier(n) => Ok(vec![(n.clone(), scrut_ty.clone())]),
             Pattern::Or(branches) => {
                 let first = self.match_pattern_binding_types(&branches[0], scrut_ty)?;


### PR DESCRIPTION
Closes #1018.

Match arms now accept integer range patterns alongside the existing literal / identifier / wildcard / struct / tuple / variant / Or patterns.

```resilient
match n {
    1..=5  => "small",       // inclusive: 1..5 plus the upper bound
    6..10  => "medium",      // half-open: 6, 7, 8, 9
    _      => "other",
}
```

The natural form for "classify by bracket". Until now you had to spell out a chain of guards.

## Surface

- `Pattern::Range { lo, hi, inclusive }` AST variant.
- Parser: `parse_pattern_atom` peeks for `Token::DotDot` after the lower-bound `IntLiteral` and dispatches to a new `parse_int_range_pattern_tail` helper that handles `..=` (consumes a following `=`) and the optional `Minus` on the upper bound.
- Interpreter `match_pattern`: new arm dispatching on `inclusive`. Non-Int scrutinees fall through.
- Typechecker, lint, formatter, free-vars walker all updated for the new variant. Range patterns are **not** defaults / not exhaustive (e.g. `1..=5` misses 0, 6).
- SYNTAX.md match-expressions section.
- 4 unit tests + golden example.

## Tests

- `match_range_pattern_inclusive` — `lo..=hi` covers both endpoints.
- `match_range_pattern_half_open_excludes_upper` — half-open boundary semantics (5 in, 9 in, 10 out, 4 out).
- `match_range_pattern_with_negative_upper` — `1..=-3` is degenerate (lo > hi); matches nothing.
- `range_pattern_does_not_match_non_int` — sanity check that non-Int scrutinees still match through the existing path.

## Out of scope (queued)

- `char` and `string` range patterns.
- Open-ended ranges (`..5`, `5..`).
- Negative *lower* bound (`-5..=5`) — needs 2-token lookahead, queued.
- Range-pattern with binding (`1..=5 @ x`).

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_