### PR TITLE
RES-916: String slicing — s[lo..hi] (Unicode-scalar indices)

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -587,7 +587,23 @@ xs[..];       // [10, 20, 30, 40, 50] — full copy
 
 Bounds clamp against `len(xs)` so `xs[..99]` returns the whole
 array, **not** an error. `lo > hi` and negative endpoints **are**
-runtime errors. String slicing is not yet supported.
+runtime errors.
+
+## String slicing (RES-916)
+
+Same five forms as array slicing, but indices are **Unicode-scalar
+indices** (matching `len(s)` semantics) so multi-byte UTF-8 strings
+slice on codepoint boundaries:
+
+```rust
+let s = "héllo";
+s[0..3];     // "hél"     — 3 scalars, 4 bytes
+s[2..=4];   // "llo"
+s[..]; s[..3]; s[3..];
+```
+
+Out-of-range upper bound clamps to scalar length. `lo > hi` and
+negative endpoints are runtime errors.
 
 ## Control Flow
 

--- a/resilient/examples/string_slicing.expected.txt
+++ b/resilient/examples/string_slicing.expected.txt
@@ -1,0 +1,9 @@
+hel
+llo
+he
+lo
+hello
+hé
+llo
+hi
+Program executed successfully

--- a/resilient/examples/string_slicing.rz
+++ b/resilient/examples/string_slicing.rz
@@ -1,0 +1,23 @@
+// RES-916 demo: string slicing — same five forms as array slicing,
+// but indices are Unicode-scalar (codepoint) indices, not bytes.
+
+fn main(int _d) {
+    let s = "hello";
+    println(s[0..3]);                    // hel  — half-open
+    println(s[2..=4]);                   // llo  — inclusive
+    println(s[..2]);                     // he   — open lower
+    println(s[3..]);                     // lo   — open upper
+    println(s[..]);                      // hello — full copy
+
+    // UTF-8: each `é` is 2 bytes but counts as 1 scalar.
+    let utf = "héllo";
+    println(utf[0..2]);                  // hé   — 2 scalars
+    println(utf[2..]);                   // llo
+
+    // Out-of-range upper bound clamps to scalar length.
+    println("hi"[..99]);                 // hi
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -19652,9 +19652,12 @@ impl Interpreter {
                     (other, _) => Err(format!("Cannot index {:?}", other)),
                 }
             }
-            // RES-911: array slicing — `target[lo..hi]` (etc.) returns a
-            // fresh `Value::Array`. Bounds clamp against `0..=len`; `lo
-            // > hi` and negative endpoints are runtime errors.
+            // RES-911 / RES-916: slicing — `target[lo..hi]` (etc.) returns
+            // a fresh `Value::Array` for array targets and a fresh
+            // `Value::String` for string targets. Bounds clamp against
+            // `0..=len`; `lo > hi` and negative endpoints are runtime
+            // errors. String slicing operates on **Unicode-scalar
+            // indices**, not bytes — matches `len(s)` semantics.
             Node::Slice {
                 target,
                 lo,
@@ -19663,11 +19666,6 @@ impl Interpreter {
                 ..
             } => {
                 let target_val = self.eval(target)?;
-                let items = match target_val {
-                    Value::Array(v) => v,
-                    other => return Err(format!("Cannot slice non-array: {}", other)),
-                };
-                let len = items.len() as i64;
                 let lo_i: i64 = match lo {
                     Some(n) => match self.eval(n)? {
                         Value::Int(i) => i,
@@ -19677,35 +19675,61 @@ impl Interpreter {
                     },
                     None => 0,
                 };
-                let hi_raw: i64 = match hi {
+                let hi_raw_opt: Option<i64> = match hi {
                     Some(n) => match self.eval(n)? {
-                        Value::Int(i) => i,
+                        Value::Int(i) => Some(i),
                         other => {
                             return Err(format!("slice upper bound must be Int, got {}", other));
                         }
                     },
-                    None => len,
+                    None => None,
                 };
                 if lo_i < 0 {
                     return Err(format!("slice lower bound must be >= 0, got {}", lo_i));
                 }
-                if hi_raw < 0 {
+                if let Some(hi_raw) = hi_raw_opt
+                    && hi_raw < 0
+                {
                     return Err(format!("slice upper bound must be >= 0, got {}", hi_raw));
                 }
-                // RES-911: convert inclusive-end into the half-open form
-                // `[lo, hi+1)`. We do this BEFORE clamping so `arr[..=hi]`
-                // with `hi == len-1` yields the full array.
-                let hi_excl = if *inclusive { hi_raw + 1 } else { hi_raw };
-                if lo_i > hi_excl {
-                    return Err(format!(
-                        "slice lower bound {} exceeds upper bound {}",
-                        lo_i, hi_raw
-                    ));
+                match target_val {
+                    Value::Array(items) => {
+                        let len = items.len() as i64;
+                        let hi_raw = hi_raw_opt.unwrap_or(len);
+                        let hi_excl = if *inclusive { hi_raw + 1 } else { hi_raw };
+                        if lo_i > hi_excl {
+                            return Err(format!(
+                                "slice lower bound {} exceeds upper bound {}",
+                                lo_i, hi_raw
+                            ));
+                        }
+                        let lo_clamp = lo_i.min(len) as usize;
+                        let hi_clamp = hi_excl.min(len) as usize;
+                        Ok(Value::Array(items[lo_clamp..hi_clamp].to_vec()))
+                    }
+                    Value::String(s) => {
+                        // RES-916: index by Unicode scalar, not bytes.
+                        // Materialize the scalar list once so both bounds
+                        // and the slice itself agree on the same units.
+                        let scalars: Vec<char> = s.chars().collect();
+                        let len = scalars.len() as i64;
+                        let hi_raw = hi_raw_opt.unwrap_or(len);
+                        let hi_excl = if *inclusive { hi_raw + 1 } else { hi_raw };
+                        if lo_i > hi_excl {
+                            return Err(format!(
+                                "slice lower bound {} exceeds upper bound {}",
+                                lo_i, hi_raw
+                            ));
+                        }
+                        let lo_clamp = lo_i.min(len) as usize;
+                        let hi_clamp = hi_excl.min(len) as usize;
+                        Ok(Value::String(scalars[lo_clamp..hi_clamp].iter().collect()))
+                    }
+                    other => Err(format!(
+                        "Cannot slice {}: only Array and String supported",
+                        other
+                    )),
                 }
-                // Clamp both endpoints against the array length.
-                let lo_clamp = lo_i.min(len) as usize;
-                let hi_clamp = hi_excl.min(len) as usize;
-                Ok(Value::Array(items[lo_clamp..hi_clamp].to_vec()))
             }
             Node::IndexAssignment {
                 target,
@@ -26423,6 +26447,101 @@ mod tests {
             Value::Int(n) => assert_eq!(n, 3),
             other => panic!("expected Int(3), got {:?}", other),
         }
+    }
+
+    /// RES-916: string slicing returns a fresh String built from the
+    /// matching scalar range. ASCII path — same shape as array slicing
+    /// but on string targets.
+    #[test]
+    fn string_slice_ascii_basic() {
+        let cases = [
+            ("\"hello\"[0..3]", "hel"),
+            ("\"hello\"[2..=4]", "llo"),
+            ("\"hello\"[..2]", "he"),
+            ("\"hello\"[3..]", "lo"),
+            ("\"hello\"[..]", "hello"),
+        ];
+        for (slice_expr, expected) in cases {
+            let src = format!(
+                "fn main(int _d) -> string {{ return {}; }} main(0);",
+                slice_expr
+            );
+            let (program, errs) = parse(&src);
+            assert!(
+                errs.is_empty(),
+                "parse errors for {}: {:?}",
+                slice_expr,
+                errs
+            );
+            let mut interp = Interpreter::new();
+            match interp.eval(&program).unwrap() {
+                Value::String(s) => assert_eq!(s, expected, "{}", slice_expr),
+                other => panic!(
+                    "{}: expected String({:?}), got {:?}",
+                    slice_expr, expected, other
+                ),
+            }
+        }
+    }
+
+    /// RES-916: indices are by Unicode scalar, not bytes. `"héllo"[0..2]`
+    /// must yield `"hé"` (2 scalars), not `"h\xc3"` (2 bytes).
+    #[test]
+    fn string_slice_is_unicode_scalar_aware() {
+        let src = "\
+            fn main(int _d) -> string {\n\
+                let utf = \"héllo\";\n\
+                return utf[0..2];\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::String(s) => assert_eq!(s, "hé"),
+            other => panic!("expected String(\"hé\"), got {:?}", other),
+        }
+    }
+
+    /// RES-916: out-of-range upper bound clamps to scalar length —
+    /// `"hi"[..99]` returns `"hi"`, not an error.
+    #[test]
+    fn string_slice_upper_bound_clamps() {
+        let src = "\
+            fn main(int _d) -> string {\n\
+                return \"hi\"[..99];\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::String(s) => assert_eq!(s, "hi"),
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    /// RES-916: `lo > hi` is a runtime error, same as the array-slice
+    /// path.
+    #[test]
+    fn string_slice_lo_greater_than_hi_is_runtime_error() {
+        let src = "\
+            fn main(int _d) -> string {\n\
+                return \"hello\"[3..1];\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        let err = interp.eval(&program).unwrap_err();
+        assert!(
+            err.contains("lower bound") && err.contains("exceeds"),
+            "expected lo>hi error, got: {}",
+            err
+        );
     }
 
     /// RES-915: integer range patterns in match arms. Half-open

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4314,19 +4314,21 @@ impl TypeChecker {
                 Ok(Type::Any)
             }
 
-            // RES-911: slicing — `target[lo..hi]` returns `Array` with
-            // the same element type as `target`. Endpoints must be `Int`.
-            // The MVP `Type::Array` is unparameterized, so the result is
-            // a plain `Array` regardless of element type.
+            // RES-911 / RES-916: slicing — `target[lo..hi]` returns
+            // `Array` for array targets and `String` for string targets.
+            // Endpoints must be `Int`.
             Node::Slice { target, lo, hi, .. } => {
-                let _ = self.check_node(target)?;
+                let target_ty = self.check_node(target)?;
                 if let Some(lo) = lo {
                     let _ = self.check_node(lo)?;
                 }
                 if let Some(hi) = hi {
                     let _ = self.check_node(hi)?;
                 }
-                Ok(Type::Array)
+                match target_ty {
+                    Type::String => Ok(Type::String),
+                    _ => Ok(Type::Array),
+                }
             }
 
             Node::IndexAssignment {


### PR DESCRIPTION
Closes #1020.

RES-911 introduced array slicing but the parser-level `Node::Slice` rejected non-Array targets at runtime. This extends the evaluator to also accept `Value::String`, returning a fresh `Value::String` built from the matching scalar range. All five slice forms (`lo..hi`, `lo..=hi`, `lo..`, `..hi`, `..`) work on strings.

Indices are **Unicode-scalar indices** (matching `len(s)` semantics), so `"héllo"[0..2]` yields `"hé"` (2 scalars, 4 bytes), never a half-codepoint slice.

## Surface

- `Node::Slice` interpreter branch: dispatch on `Value::Array` vs `Value::String`. The string path collects scalars via `chars()`, slices, then re-collects into a `String`. Reuses all the bound-clamp / `lo > hi` / negative-bound logic from RES-911.
- Typechecker: `Type::String` target preserves `Type::String` result; everything else still returns `Type::Array`.
- SYNTAX.md adds a string-slicing section after array-slicing.
- 4 unit tests + golden example.

## Tests

- `string_slice_ascii_basic` — table-driven test exercising all five slice forms on `"hello"`.
- `string_slice_is_unicode_scalar_aware` — `"héllo"[0..2] == "hé"` (codepoint index, not byte).
- `string_slice_upper_bound_clamps` — out-of-range upper bound returns the whole string.
- `string_slice_lo_greater_than_hi_is_runtime_error` — same error policy as array slicing.

## Out of scope

- Byte-index slicing (separate API, not in this PR).
- `Bytes` literal slicing (orthogonal, already works via existing `bytes_slice` paths).

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_