### PR TITLE
RES-918: Cap z3 CI job at 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
     name: build / test with --features z3
     needs: [changes]
     runs-on: ubuntu-latest
+    # RES-918: hard 30-minute cap so a stuck z3 query (or a runaway
+    # bindgen / linker cache miss) doesn't wedge the runner for the
+    # default 6 hours. Surfaces as a normal CI failure, so auto-merge
+    # continues to refuse the PR until the job is fixed.
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: resilient


### PR DESCRIPTION
Closes #1024.

User reported the z3 check has been timing out on GitHub Actions — in extreme cases consuming the full 6-hour default before the runner is reclaimed. Add a job-level `timeout-minutes: 30` cap so a stuck z3 query (or a runaway bindgen / linker cache miss) surfaces as a normal CI failure within half an hour rather than wedging the queue.

## Why job-level, not step-level

A step-level timeout would only catch one of `cargo build` / `cargo test` hanging, and leaves the other free to consume up to the default 6 hours. A 30-minute job cap is the simplest, most predictable fix and matches the user's explicit ask.

## Why 30 (not 15 or 60)

A typical successful z3 run completes in 1–3 min in this repo. 30 min gives 10× headroom for cache-cold runs and natural growth without being so loose that a stuck query goes unnoticed.

## Test plan

- The new YAML is syntactically valid (loaded the file in CI before).
- `actionlint` (if added later) will verify the field name.
- A real verification only happens when the next CI run lands; a stuck z3 in the future will surface within 30 min.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_