### PR TITLE
RES-922: Accept `let mut x = ...` as syntactic sugar

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -5346,6 +5346,14 @@ impl Parser {
         let stmt_span = self.span_at_current();
         self.next_token(); // Skip 'let'
 
+        // RES-922: accept and ignore `let mut x = ...`. Resilient bindings
+        // are always reassignable today (`let x = 1; x = 2;` works);
+        // the `mut` marker is purely syntactic sugar for Rust users'
+        // muscle memory. Drop it silently — no AST change needed.
+        if self.current_token == Token::Mut {
+            self.next_token();
+        }
+
         // RES-401: tuple destructure form — `let (a, b, ...) = expr;`.
         // The `(` immediately after `let` is unambiguous: the
         // single-name and annotated forms both require an identifier
@@ -26773,6 +26781,29 @@ mod tests {
             "expected lo>hi error, got: {}",
             err
         );
+    }
+
+    /// RES-922: `let mut x = ...` is now accepted as syntactic sugar
+    /// for `let x = ...`. Resilient bindings have always been
+    /// reassignable, so the `mut` marker is purely for Rust-user
+    /// ergonomics — silently dropped at parse time.
+    #[test]
+    fn let_mut_keyword_is_accepted() {
+        let src = "\
+            fn main(int _d) -> int {\n\
+                let mut x = 5;\n\
+                x = 10;\n\
+                return x;\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::Int(n) => assert_eq!(n, 10),
+            other => panic!("expected Int(10), got {:?}", other),
+        }
     }
 
     /// RES-921: negative array indices wrap from the end. `arr[-1]` is


### PR DESCRIPTION
Closes #1031.

`let mut x = 5;` was a parse error. Resilient bindings have always been reassignable without any keyword (`let x = 1; x = 2;` works), so `mut` is redundant — but it's universal Rust muscle memory and the parse error was a paper cut for newcomers.

One-line parser fix: after consuming `let`, drop `Token::Mut` if present. No AST change, no semantic change.

```resilient
let mut x = 5;        // now accepted
let mut y: Int = 7;   // annotated form too
x = 10;
```

## Out of scope

- `let mut (a, b) = ...` tuple destructure form — track separately.

## Test plan

- One unit test asserting `let mut x = 5; x = 10; return x;` returns 10.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_