### PR TITLE
RES-924: String * Int repetition operator

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -570,6 +570,7 @@ let value = "Pi: " + 3.14;              // "Pi: 3.14"
 | Bitwise | `&` `\|` `^` `<<` `>>` |
 | Prefix | `!x` (logical-not), `-x` (negate) |
 | String | `+` (concat); int/float/bool coerce to string when concatenated |
+| String × Int | `*` (RES-924) — `"-" * 10` repeats the string; both operand orders work |
 | Array index | `arr[i]` — single element |
 | Array slice | `arr[lo..hi]`, `arr[lo..=hi]`, `arr[lo..]`, `arr[..hi]`, `arr[..]` (RES-911) — returns a fresh array |
 | Compound assign | `+= -= *= /= %= &= \|= ^= <<= >>=` (RES-912) — `x OP= rhs` desugars to `x = x OP rhs` for plain identifiers |

--- a/resilient/examples/string_repetition.expected.txt
+++ b/resilient/examples/string_repetition.expected.txt
@@ -1,0 +1,13 @@
+--------------------
+ababab
+hi hi hi
+
+==============================
+Important section
+==============================
+*
+ *
+  *
+   *
+    *
+Program executed successfully

--- a/resilient/examples/string_repetition.rz
+++ b/resilient/examples/string_repetition.rz
@@ -1,0 +1,25 @@
+// RES-924 demo: `String * Int` (and `Int * String`) repeats the
+// string. Equivalent to the existing `repeat(s, n)` builtin / the
+// RES-920 `s.repeat(n)` method, but in operator form.
+
+fn main(int _d) {
+    println("-" * 20);                   // --------------------
+    println(3 * "ab");                   // ababab
+    println("hi " * 3);                  // hi hi hi
+    println("x" * 0);                    // (empty)
+
+    // Common patterns: aligned section headers.
+    let header = "=" * 30;
+    println(header);
+    println("Important section");
+    println(header);
+
+    // Stairs: lines of increasing indentation.
+    for i in 0..5 {
+        println(" " * i + "*");
+    }
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -20886,6 +20886,24 @@ impl Interpreter {
             return Ok(Value::Array(l));
         }
 
+        // RES-924: `"-" * 3` → `"---"` and `3 * "-"` → `"---"`.
+        // Repetition only fires for `*` with one String and one Int
+        // operand. Negative `n` errors per the existing `repeat`
+        // builtin policy.
+        if operator == "*" {
+            let str_int = match (&left, &right) {
+                (Value::String(s), Value::Int(n)) => Some((s.clone(), *n)),
+                (Value::Int(n), Value::String(s)) => Some((s.clone(), *n)),
+                _ => None,
+            };
+            if let Some((s, n)) = str_int {
+                if n < 0 {
+                    return Err(format!("string repetition count must be >= 0, got {}", n));
+                }
+                return Ok(Value::String(s.repeat(n as usize)));
+            }
+        }
+
         match (left.clone(), right.clone()) {
             (Value::Int(l), Value::Int(r)) => self.eval_integer_infix_expression(operator, l, r),
             (Value::Float(l), Value::Float(r)) => self.eval_float_infix_expression(operator, l, r),
@@ -26909,6 +26927,39 @@ mod tests {
             Value::Int(n) => assert_eq!(n, 0),
             other => panic!("expected Int(0), got {:?}", other),
         }
+    }
+
+    /// RES-924: `String * Int` repetition operator. Both operand
+    /// orders work; negative count errors at runtime.
+    #[test]
+    fn string_repetition_operator() {
+        let cases = [
+            ("\"-\" * 10", "----------"),
+            ("3 * \"ab\"", "ababab"),
+            ("\"x\" * 0", ""),
+        ];
+        for (expr, expected) in cases {
+            let src = format!("fn main(int _d) -> string {{ return {}; }} main(0);", expr);
+            let (program, errs) = parse(&src);
+            assert!(errs.is_empty(), "{}: parse errors: {:?}", expr, errs);
+            let mut interp = Interpreter::new();
+            match interp.eval(&program).unwrap() {
+                Value::String(s) => assert_eq!(s, expected, "{}", expr),
+                other => panic!("{}: expected String({:?}), got {:?}", expr, expected, other),
+            }
+        }
+    }
+
+    /// RES-924: negative repetition count is a runtime error matching
+    /// the `repeat` builtin's existing policy.
+    #[test]
+    fn string_repetition_negative_count_errors() {
+        let src = "fn main(int _d) -> string { return \"x\" * -1; } main(0);";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        let err = interp.eval(&program).unwrap_err();
+        assert!(err.contains(">= 0"), "got: {}", err);
     }
 
     /// RES-922: `let mut x = ...` is now accepted as syntactic sugar


### PR DESCRIPTION
Closes #1035.

`"-" * 10` was a `Type mismatch` error. The `repeat(s, n)` builtin and `s.repeat(n)` method already worked, but the operator form is universally expected (Python, Ruby, Java's StringBuilder).

```resilient
"-" * 10        // "----------"
3 * "ab"        // "ababab"
"x" * 0         // ""
"x" * -1        // runtime error: count must be >= 0
```

Both operand orders accept: `"x" * 3` and `3 * "x"` both produce `"xxx"`.

## Implementation

- `eval_infix_expression`: new branch handling `*` with one `String` and one `Int` operand. Reuses `String::repeat`. Negative count is a runtime error matching the existing `repeat` builtin's policy.

## Tests

2 unit tests:
- `string_repetition_operator` — table-driven over both operand orders + zero count.
- `string_repetition_negative_count_errors` — negative count clean-error.

Golden example demonstrates separators, banner headers, and indentation stairs.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_