### PR TITLE
RES-929: Add `lib.rs` to the auto-resolver allowlist (workflow speedup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,18 +138,24 @@ Include a `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` trailer.
 
 **This is the single most important rule for parallel agent work.**
 
+> **Heads up (RES-929):** historical references in this file say
+> `src/main.rs` for the big core file. The actual file is now
+> `src/lib.rs` (1.8 MB; `main.rs` is a 463-byte binary entry).
+> The append-only allowlist in `agent-scripts/auto-resolve-extensions.sh`
+> and `agent-scripts/sync-integration.sh` covers both.
+
 Every language feature MUST follow this layout:
 
 ```
 resilient/src/my_feature.rs   ← ALL feature logic lives here
-resilient/src/main.rs         ← minimal: token + AST variant + dispatch call (~5 lines total)
+resilient/src/lib.rs          ← minimal: token + AST variant + dispatch call (~5 lines total)
 resilient/src/typechecker.rs  ← minimal: one function call in the <EXTENSION_PASSES> block
 resilient/src/lexer_logos.rs  ← minimal: one token arm
 ```
 
 ### Core files have designated extension points
 
-`main.rs`, `typechecker.rs`, and `lexer_logos.rs` contain comment markers:
+`lib.rs`, `typechecker.rs`, and `lexer_logos.rs` contain comment markers:
 
 ```rust
 // <EXTENSION_TOKENS>    ← add Token variants here

--- a/agent-scripts/auto-resolve-extensions.sh
+++ b/agent-scripts/auto-resolve-extensions.sh
@@ -33,6 +33,10 @@ if [[ $# -eq 0 ]]; then
 fi
 
 ALLOWED=(
+    # RES-929: lib.rs is the real extension-block file (1.8 MB);
+    # main.rs is a 463-byte binary entry. Keep main.rs allowlisted
+    # for legacy compatibility; lib.rs is now the primary path.
+    "resilient/src/lib.rs"
     "resilient/src/main.rs"
     "resilient/src/typechecker.rs"
     "resilient/src/lexer_logos.rs"

--- a/agent-scripts/sync-integration.sh
+++ b/agent-scripts/sync-integration.sh
@@ -83,6 +83,10 @@ else
     printf '  %s\n' $unresolved
 
     allowlist=(
+        # RES-929: lib.rs is the real extension-block file (1.8 MB);
+        # main.rs is a 463-byte binary entry that doesn't see overlaps.
+        # Keep main.rs allowlisted for legacy paths; lib.rs is primary.
+        "resilient/src/lib.rs"
         "resilient/src/main.rs"
         "resilient/src/typechecker.rs"
         "resilient/src/lexer_logos.rs"


### PR DESCRIPTION
Closes #1045.

**Workflow speedup.** Both `auto-resolve-extensions.sh` and `sync-integration.sh` listed `src/main.rs` in their allowed-conflict allowlist, but the real extension-block file is `src/lib.rs` (1.8 MB; `main.rs` is a 463-byte binary entry). Every ticket in this session that touched the `BUILTINS` table or `parse_pattern_atom` dispatch needed a manual rebase because the auto-resolver refused to touch `lib.rs`.

Adding `lib.rs` to both allowlists lets the auto-resolver collapse trivial "keep both" cases — drops a CI cycle per overlap.

## What changed

- `agent-scripts/auto-resolve-extensions.sh`: `lib.rs` added to the `ALLOWED` array.
- `agent-scripts/sync-integration.sh`: same.
- `CLAUDE.md`: short heads-up note in the "Feature isolation pattern" section explaining the rename so future agents reading the historical `main.rs` text aren't tripped up.

`main.rs` stays in both allowlists for legacy compatibility (zero risk; it's tiny).

## Why now

Per the user's "fix anything slow in our workflow" directive — this was the single biggest paper cut hitting every overlap in this session.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_