### PR TITLE
RES-931: Tuple-struct match patterns

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -818,6 +818,32 @@ match parse_int(input) {
 `None` for `Option`. Inner pattern can be a wildcard,
 identifier-binding, literal, range, or another nested pattern.
 
+### Tuple-struct patterns (RES-931)
+
+A tuple-struct value (declared with `struct Pair(int, string);`)
+destructures positionally — the pattern's sub-patterns line up with
+the struct's positional fields in declaration order:
+
+```rust
+struct Pair(int, string);
+
+let p = new Pair(42, "hi");
+match p {
+    Pair(0, _) => "zero",
+    Pair(n, s) => s + ":" + n,
+}
+```
+
+Sub-patterns can be any other pattern atom — wildcard, identifier,
+literal, range, nested `Some(_)` / `Ok(_)` / `Err(_)`, or another
+tuple-struct pattern. The arity must match the struct's declared
+field count; a mismatched count is a typecheck error
+(`tuple-struct pattern \`Pair\` expects 2 field(s), got 1`).
+
+`Pair(_, _)` is a catch-all for `Pair`-typed scrutinees and counts
+toward exhaustiveness; `Pair(0, _)` does not (it misses every
+non-zero `Pair`).
+
 ### Range patterns (RES-915)
 
 Match arms accept integer range patterns:

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-820-typechecker-associated-types",
-      "claimed_at": "2026-05-04T03:00:54Z"
+      "branch": "res-931-tuple-struct-patterns",
+      "claimed_at": "2026-05-06T05:25:02Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-820-typechecker-associated-types",
-      "claimed_at": "2026-05-04T03:00:54Z"
+      "branch": "res-931-tuple-struct-patterns",
+      "claimed_at": "2026-05-06T05:25:02Z"
     }
   }
 }

--- a/resilient/examples/tuple_struct_match.expected.txt
+++ b/resilient/examples/tuple_struct_match.expected.txt
@@ -1,0 +1,5 @@
+zero-key
+nonzero
+ninety-nine
+done
+Program executed successfully

--- a/resilient/examples/tuple_struct_match.rz
+++ b/resilient/examples/tuple_struct_match.rz
@@ -1,0 +1,37 @@
+// RES-931 demo: tuple-struct destructure patterns in `match`.
+// Pairs with RES-928 (tuple structs). The pattern `Pair(p1, p2)`
+// matches a `Value::Struct` with the same name and synthesized
+// positional field names "0", "1", ... — sub-patterns recurse.
+
+struct Pair(int, string);
+struct Wrapped(int);
+
+fn classify(int _d) -> string {
+    // Literal-then-bind sub-patterns work positionally.
+    let p1 = new Pair(0, "first");
+    let r1 = match p1 {
+        Pair(0, _) => "zero-key",
+        Pair(_, s) => s,
+    };
+    println(r1);                                  // zero-key
+
+    // Bare identifier sub-patterns bind by position.
+    let p2 = new Pair(7, "seven");
+    let r2 = match p2 {
+        Pair(0, _) => "zero-key",
+        Pair(n, _) => "nonzero",
+    };
+    println(r2);                                  // nonzero
+
+    // Single-field tuple struct; literal vs wildcard.
+    let w = new Wrapped(99);
+    let r3 = match w {
+        Wrapped(99) => "ninety-nine",
+        Wrapped(_) => "other",
+    };
+    println(r3);                                  // ninety-nine
+
+    return "done";
+}
+
+println(classify(0));

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -1291,6 +1291,18 @@ impl Formatter {
                     }
                 }
             }
+            // RES-931: tuple-struct destructure — `Pair(0, _)`.
+            Pattern::TupleStruct { name, fields } => {
+                self.write(name);
+                self.write("(");
+                for (i, sub) in fields.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.fmt_pattern(sub);
+                }
+                self.write(")");
+            }
         }
     }
 }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -563,6 +563,12 @@ fn bind_pattern(pat: &Pattern, bound: &mut BTreeSet<String>) {
                 }
             }
         },
+        // RES-931: tuple-struct destructure — recurse into each field pattern.
+        Pattern::TupleStruct { fields, .. } => {
+            for sub in fields {
+                bind_pattern(sub, bound);
+            }
+        }
     }
 }
 

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -1531,6 +1531,12 @@ pub(crate) enum Pattern {
         variant_name: String,
         payload: EnumPatternPayload,
     },
+    /// RES-931: tuple-struct destructure pattern — `Pair(0, _)`,
+    /// `Wrapped(Some(x))`, etc. Matches `Value::Struct` with the same
+    /// `name` and synthesized positional field names "0", "1", ...
+    /// The arity is checked against the struct registry by the
+    /// typechecker.
+    TupleStruct { name: String, fields: Vec<Pattern> },
 }
 
 /// RES-400: payload portion of a `Pattern::EnumVariant`. Mirrors the
@@ -8399,6 +8405,13 @@ impl Parser {
                 if self.peek_token == Token::LeftBrace {
                     return self.parse_match_struct_pattern(name);
                 }
+                // RES-931: tuple-struct destructure — `Pair(0, _)`.
+                // Bare `Identifier(...)` that isn't Some/Ok/Err and
+                // isn't a `::`-qualified enum variant is a tuple-struct
+                // pattern. Empty `Pair()` is also accepted (zero-field).
+                if self.peek_token == Token::LeftParen {
+                    return self.parse_tuple_struct_pattern(name);
+                }
                 // RES-161a: `name @ inner` bind-subpattern.
                 // peek_token tells us whether `@` follows. If so, consume
                 // it and parse the inner atom (not a full or-pattern — the
@@ -8418,6 +8431,50 @@ impl Parser {
                 Pattern::Wildcard
             }
         }
+    }
+
+    /// RES-931: parse a tuple-struct pattern body — `(p1, p2, ...)`.
+    /// On entry `current_token` is the struct-name identifier and
+    /// `peek_token == LeftParen`. On exit `current_token` is the
+    /// closing `)`.
+    fn parse_tuple_struct_pattern(&mut self, name: String) -> Pattern {
+        self.next_token(); // current = `(`
+        let mut fields: Vec<Pattern> = Vec::new();
+        if self.peek_token == Token::RightParen {
+            self.next_token(); // current = `)`
+            return Pattern::TupleStruct { name, fields };
+        }
+        self.next_token(); // current = start of first sub-pattern
+        let first = self.parse_pattern();
+        fields.push(first);
+        loop {
+            match self.peek_token {
+                Token::Comma => {
+                    self.next_token(); // current = `,`
+                    if self.peek_token == Token::RightParen {
+                        // Trailing comma allowed.
+                        self.next_token(); // current = `)`
+                        break;
+                    }
+                    self.next_token(); // current = start of next sub-pattern
+                    let p = self.parse_pattern();
+                    fields.push(p);
+                }
+                Token::RightParen => {
+                    self.next_token(); // current = `)`
+                    break;
+                }
+                _ => {
+                    let tok = self.peek_token.clone();
+                    self.record_error(format!(
+                        "Expected `,` or `)` in tuple-struct pattern, found {}",
+                        tok
+                    ));
+                    break;
+                }
+            }
+        }
+        Pattern::TupleStruct { name, fields }
     }
 
     /// Parse `.field`. current_token is `.` on entry; on exit current is `field`.
@@ -21641,6 +21698,40 @@ impl Interpreter {
                 Value::Result { ok: false, payload } => self.match_pattern(inner_pat, payload),
                 _ => Ok(None),
             },
+            // RES-931: tuple-struct destructure. The runtime stores
+            // tuple-struct values as Value::Struct with field names
+            // "0", "1", ... — so the match peels off positional
+            // sub-patterns and recurses against those synthesized
+            // field values. Name mismatch and arity mismatch are both
+            // a no-match (the typechecker raises a hard error on
+            // arity, but the interpreter stays defensive).
+            Pattern::TupleStruct { name, fields } => {
+                let Value::Struct {
+                    name: vname,
+                    fields: vfields,
+                } = value
+                else {
+                    return Ok(None);
+                };
+                if name != vname {
+                    return Ok(None);
+                }
+                if fields.len() != vfields.len() {
+                    return Ok(None);
+                }
+                let mut bindings = Vec::new();
+                for (i, sub) in fields.iter().enumerate() {
+                    let key = i.to_string();
+                    let Some((_, fv)) = vfields.iter().find(|(n, _)| n == &key) else {
+                        return Ok(None);
+                    };
+                    match self.match_pattern(sub, fv)? {
+                        None => return Ok(None),
+                        Some(mut b) => bindings.append(&mut b),
+                    }
+                }
+                Ok(Some(bindings))
+            }
             // RES-400: tagged-enum-variant pattern. Three shapes
             // dispatched off the value's payload kind. The pattern's
             // optional `type_name` qualifier must match the value's
@@ -27252,6 +27343,80 @@ mod tests {
             Value::Int(n) => assert_eq!(n, 42 + 5),
             other => panic!("expected Int(47), got {:?}", other),
         }
+    }
+
+    /// RES-931: tuple-struct destructure pattern matches positional
+    /// fields and threads bindings into the arm body.
+    #[test]
+    fn tuple_struct_match_pattern_binds_positionally() {
+        let src = "\
+            struct Pair(int, string);\n\
+            fn main(int _d) -> string {\n\
+                let p = new Pair(42, \"hello\");\n\
+                return match p {\n\
+                    Pair(0, _) => \"zero\",\n\
+                    Pair(_, s) => s,\n\
+                };\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::String(s) => assert_eq!(s, "hello"),
+            other => panic!("expected String(\"hello\"), got {:?}", other),
+        }
+    }
+
+    /// RES-931: tuple-struct pattern with literal positional sub-pattern
+    /// fires only when the literal matches.
+    #[test]
+    fn tuple_struct_match_pattern_literal_arm_fires() {
+        let src = "\
+            struct Pair(int, string);\n\
+            fn main(int _d) -> string {\n\
+                let p = new Pair(0, \"x\");\n\
+                return match p {\n\
+                    Pair(0, _) => \"zero\",\n\
+                    Pair(_, s) => s,\n\
+                };\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::String(s) => assert_eq!(s, "zero"),
+            other => panic!("expected String(\"zero\"), got {:?}", other),
+        }
+    }
+
+    /// RES-931: tuple-struct pattern with mismatched arity is rejected
+    /// by the typechecker with a clear diagnostic.
+    #[test]
+    fn tuple_struct_match_pattern_arity_mismatch_typechecks_err() {
+        let src = "\
+            struct Pair(int, string);\n\
+            fn main(int _d) -> int {\n\
+                let p = new Pair(1, \"x\");\n\
+                return match p {\n\
+                    Pair(n) => n,\n\
+                };\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut tc = crate::typechecker::TypeChecker::new();
+        let result = tc.check_program(&program);
+        let err = result.expect_err("arity mismatch should fail typecheck");
+        assert!(
+            err.contains("expects 2 field(s), got 1"),
+            "expected arity diagnostic, got: {}",
+            err
+        );
     }
 
     /// RES-928: out-of-range positional index errors with a clear

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -283,6 +283,14 @@ fn collect_pattern_bindings(pattern: &Pattern) -> Vec<String> {
                 names
             }
         },
+        // RES-931: tuple-struct destructure — recurse into each field pattern.
+        Pattern::TupleStruct { fields, .. } => {
+            let mut names = Vec::new();
+            for sub in fields {
+                names.extend(collect_pattern_bindings(sub));
+            }
+            names
+        }
     }
 }
 
@@ -647,6 +655,10 @@ fn pattern_is_default_for_lint(p: &Pattern) -> bool {
         // RES-400: enum-variant patterns are never catch-alls — each
         // matches one specific variant.
         Pattern::EnumVariant { .. } => false,
+        // RES-931: a tuple-struct pattern is a catch-all iff every
+        // positional sub-pattern is itself a default — `Pair(_, _)`
+        // catches every `Pair`, but `Pair(0, _)` does not.
+        Pattern::TupleStruct { fields, .. } => fields.iter().all(pattern_is_default_for_lint),
     }
 }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -209,6 +209,9 @@ fn pattern_bindings(p: &Pattern) -> Vec<String> {
                 subs.iter().flat_map(pattern_bindings).collect()
             }
         },
+        // RES-931: tuple-struct destructure binds whatever each
+        // positional sub-pattern binds.
+        Pattern::TupleStruct { fields, .. } => fields.iter().flat_map(pattern_bindings).collect(),
     }
 }
 
@@ -241,6 +244,12 @@ fn pattern_is_default(p: &Pattern) -> bool {
         // matches only one variant. Exhaustiveness over enums is
         // handled by enumerating variants in a future PR.
         Pattern::EnumVariant { .. } => false,
+        // RES-931: a tuple-struct pattern is a default iff every
+        // positional sub-pattern is a default. (`Pair(_, _)` is
+        // default; `Pair(0, _)` is not.) The struct itself is the
+        // sole inhabitant of the nominal type, so name-mismatch is
+        // caught upstream.
+        Pattern::TupleStruct { fields, .. } => fields.iter().all(pattern_is_default),
     }
 }
 
@@ -298,6 +307,12 @@ fn struct_pattern_matches_nominal_type(sname: &str, decl: &[(String, Type)], p: 
         Pattern::Some(_) | Pattern::None | Pattern::Ok(_) | Pattern::Err(_) => false,
         // RES-400: enum-variant patterns don't match struct-nominal types.
         Pattern::EnumVariant { .. } => false,
+        // RES-931: tuple-struct pattern covers the nominal type iff
+        // it names the same struct AND every positional sub-pattern
+        // is a default (`Pair(_, _)` covers; `Pair(0, _)` does not).
+        Pattern::TupleStruct { name, fields } => {
+            name == sname && fields.len() == decl.len() && fields.iter().all(pattern_is_default)
+        }
     }
 }
 
@@ -3120,6 +3135,49 @@ impl TypeChecker {
                     Ok(out)
                 }
             },
+            // RES-931: tuple-struct destructure. Verify the scrutinee
+            // is a struct with this name, the registered field count
+            // matches the pattern arity, then recurse with each
+            // declared field's type as the sub-scrutinee. Field names
+            // in the registry are "0", "1", ... ordered by index.
+            Pattern::TupleStruct { name, fields } => {
+                let Type::Struct(sname) = scrut_ty else {
+                    return Err(format!(
+                        "tuple-struct pattern `{}(..)` used where scrutinee is not a struct (got {})",
+                        name, scrut_ty
+                    ));
+                };
+                if name != sname {
+                    return Err(format!(
+                        "tuple-struct pattern `{}(..)` does not match scrutinee struct `{}`",
+                        name, sname
+                    ));
+                }
+                let decl = self.struct_fields.get(sname).cloned().ok_or_else(|| {
+                    format!("unknown struct `{}` in tuple-struct match pattern", sname)
+                })?;
+                if decl.len() != fields.len() {
+                    return Err(format!(
+                        "tuple-struct pattern `{}` expects {} field(s), got {}",
+                        name,
+                        decl.len(),
+                        fields.len()
+                    ));
+                }
+                let mut out = Vec::new();
+                for (i, sub) in fields.iter().enumerate() {
+                    let key = i.to_string();
+                    let Some((_, fty)) = decl.iter().find(|(n, _)| n == &key) else {
+                        return Err(format!(
+                            "tuple-struct `{}` has no positional field `.{}`",
+                            sname, i
+                        ));
+                    };
+                    let sub_bt = self.match_pattern_binding_types(sub, fty)?;
+                    out.extend(sub_bt);
+                }
+                Ok(out)
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1049.

RES-928 added tuple structs (`struct Pair(int, string);` + `new Pair(...)` + `p.0` access). This finishes the symmetry: tuple-struct values can now destructure in `match`.

```resilient
struct Pair(int, string);

let p = new Pair(42, "hello");
match p {
    Pair(0, _) => "zero",
    Pair(n, s) => s + ":" + n,
}
```

## Implementation

- New `Pattern::TupleStruct { name, fields }` variant.
- `parse_pattern_atom`: when an identifier is followed by `(` and isn't `Some`/`Ok`/`Err` (and isn't `::`-qualified), parse a positional sub-pattern list. Trailing comma allowed; empty `Pair()` accepted.
- Interpreter `match_pattern`: matches `Value::Struct` by name + arity, then recurses against the synthesized `"0"`, `"1"`, ... field values stored by the tuple-struct constructor.
- Typechecker: arity check against the `struct_fields` registry — `tuple-struct pattern \`Pair\` expects 2 field(s), got 1`. Sub-pattern bindings type as the declared field types.
- Exhaustiveness: `Pair(_, _)` is a catch-all; `Pair(0, _)` is not.
- Formatter, `free_vars`, lint: exhaustive arms added for the new variant.

## Tests

- `tuple_struct_match_pattern_binds_positionally` — first-arm-fails / second-arm-binds case.
- `tuple_struct_match_pattern_literal_arm_fires` — first-arm-with-literal hits.
- `tuple_struct_match_pattern_arity_mismatch_typechecks_err` — typecheck rejects arity mismatch with a clear diagnostic.
- Golden example `examples/tuple_struct_match.rz` exercises Pair (2 fields) and Wrapped (1 field) with literal, wildcard, and bound sub-patterns.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_