### PR TITLE
RES-932: Anonymous tuple match patterns

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -818,6 +818,34 @@ match parse_int(input) {
 `None` for `Option`. Inner pattern can be a wildcard,
 identifier-binding, literal, range, or another nested pattern.
 
+### Anonymous tuple patterns (RES-932)
+
+Anonymous tuple values destructure positionally inside a `match`:
+
+```rust
+let p = (10, 20);
+match p {
+    (1, 2) => 0,
+    (a, b) => a + b,
+}
+```
+
+Sub-patterns can be any other pattern (wildcard, identifier, literal,
+range, nested tuple, `Some(_)` / `Ok(_)`, ...) and recurse element by
+element. A length mismatch is a no-match (falls through to the next
+arm).
+
+Disambiguation rules:
+
+- `()` is the unit pattern; matches `Value::Tuple(vec![])`.
+- `(p)` (no trailing comma) is a parenthesized pattern — equivalent to
+  `p`. This lets you group an inner pattern (`(x | y) => ...`) without
+  forcing a 1-tuple match.
+- `(p,)` (trailing comma) is a 1-tuple pattern.
+
+`(_, _)` is a catch-all over 2-tuples; `(0, _)` is not (the literal
+sub-pattern is non-default).
+
 ### Tuple-struct patterns (RES-931)
 
 A tuple-struct value (declared with `struct Pair(int, string);`)

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-931-tuple-struct-patterns",
-      "claimed_at": "2026-05-06T05:25:02Z"
+      "branch": "res-932-tuple-match-patterns",
+      "claimed_at": "2026-05-06T05:41:25Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-931-tuple-struct-patterns",
-      "claimed_at": "2026-05-06T05:25:02Z"
+      "branch": "res-932-tuple-match-patterns",
+      "claimed_at": "2026-05-06T05:41:25Z"
     }
   }
 }

--- a/resilient/examples/tuple_pattern.expected.txt
+++ b/resilient/examples/tuple_pattern.expected.txt
@@ -1,0 +1,6 @@
+30
+500
+5
+3
+1
+Program executed successfully

--- a/resilient/examples/tuple_pattern.rz
+++ b/resilient/examples/tuple_pattern.rz
@@ -1,0 +1,51 @@
+// RES-932 demo: anonymous tuple match patterns.
+// Anonymous tuple values (RES-401) destructure positionally inside
+// `match` arms — `(p1, p2, ...)` matches a `Value::Tuple` of the
+// same length and recurses into each sub-pattern.
+
+fn classify(int _d) -> int {
+    // Pair: literal sub-pattern + identifier sub-pattern.
+    let p = (10, 20);
+    let r1 = match p {
+        (1, 2) => 0,
+        (a, b) => a + b,
+    };
+    println(r1);                    // 30
+
+    // Wildcard sub-patterns.
+    let q = (0, 5);
+    let r2 = match q {
+        (0, x) => x * 100,
+        (_, _) => -1,
+    };
+    println(r2);                    // 500
+
+    // Nested tuple — the inner pattern is just another tuple pattern.
+    let nested = (1, (2, 3));
+    let r3 = match nested {
+        (1, (a, b)) => a + b,
+        (_, _)      => 0,
+    };
+    println(r3);                    // 5
+
+    // 3-tuple.
+    let triple = (1, 2, 3);
+    let r4 = match triple {
+        (1, 2, n) => n,
+        (_, _, _) => 0,
+    };
+    println(r4);                    // 3
+
+    // 1-tuple uses a trailing comma to disambiguate from a
+    // parenthesized scalar pattern.
+    let one = (42,);
+    let r5 = match one {
+        (42,) => 1,
+        (_,)  => 0,
+    };
+    println(r5);                    // 1
+
+    return 0;
+}
+
+classify(0);

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -1303,6 +1303,22 @@ impl Formatter {
                 }
                 self.write(")");
             }
+            // RES-932: anonymous tuple pattern — `(1, 2)`, `(a, b)`,
+            // `()`. Single-element tuples emit a trailing comma to
+            // disambiguate from a parenthesized pattern.
+            Pattern::Tuple(items) => {
+                self.write("(");
+                for (i, sub) in items.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.fmt_pattern(sub);
+                }
+                if items.len() == 1 {
+                    self.write(",");
+                }
+                self.write(")");
+            }
         }
     }
 }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -569,6 +569,12 @@ fn bind_pattern(pat: &Pattern, bound: &mut BTreeSet<String>) {
                 bind_pattern(sub, bound);
             }
         }
+        // RES-932: anonymous tuple destructure — recurse positionally.
+        Pattern::Tuple(items) => {
+            for sub in items {
+                bind_pattern(sub, bound);
+            }
+        }
     }
 }
 

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -1537,6 +1537,11 @@ pub(crate) enum Pattern {
     /// The arity is checked against the struct registry by the
     /// typechecker.
     TupleStruct { name: String, fields: Vec<Pattern> },
+    /// RES-932: anonymous tuple destructure — `(1, 2)`, `(a, b)`,
+    /// `()`. Matches `Value::Tuple` of the same length; sub-patterns
+    /// match by position. A bare `(p)` parses to `p` (parenthesized
+    /// pattern); `(p,)` is a 1-tuple pattern.
+    Tuple(Vec<Pattern>),
 }
 
 /// RES-400: payload portion of a `Pattern::EnumVariant`. Mirrors the
@@ -8430,12 +8435,69 @@ impl Parser {
                     Pattern::Identifier(name)
                 }
             }
+            // RES-932: anonymous tuple pattern — `(1, 2)`, `(a, b)`,
+            // `()`. Single-element parens are parenthesized patterns
+            // (return the inner directly); a trailing comma `(p,)`
+            // forces a 1-tuple.
+            Token::LeftParen => self.parse_tuple_pattern(),
             other => {
                 let tok = other.clone();
                 self.record_error(format!("Unsupported match pattern starting with {:?}", tok));
                 Pattern::Wildcard
             }
         }
+    }
+
+    /// RES-932: parse `(p1, p2, ...)` or `()`. On entry
+    /// `current_token == LeftParen`. On exit `current_token == RightParen`.
+    /// Disambiguation: `(p)` (single inner with no trailing comma)
+    /// returns `p` directly (parenthesized pattern); `(p,)` returns
+    /// a 1-tuple `Pattern::Tuple([p])`; `()` returns the empty
+    /// tuple pattern.
+    fn parse_tuple_pattern(&mut self) -> Pattern {
+        debug_assert!(matches!(self.current_token, Token::LeftParen));
+        // Empty tuple `()`.
+        if self.peek_token == Token::RightParen {
+            self.next_token(); // current = `)`
+            return Pattern::Tuple(Vec::new());
+        }
+        self.next_token(); // current = start of first sub-pattern
+        let first = self.parse_pattern();
+        // Bare `(p)` — parenthesized pattern, no trailing comma.
+        if self.peek_token == Token::RightParen {
+            self.next_token(); // current = `)`
+            return first;
+        }
+        let mut items: Vec<Pattern> = vec![first];
+        loop {
+            match self.peek_token {
+                Token::Comma => {
+                    self.next_token(); // current = `,`
+                    if self.peek_token == Token::RightParen {
+                        // Trailing comma — single-element forces tuple,
+                        // multi-element keeps tuple.
+                        self.next_token(); // current = `)`
+                        break;
+                    }
+                    self.next_token(); // current = start of next sub-pattern
+                    let p = self.parse_pattern();
+                    items.push(p);
+                }
+                Token::RightParen => {
+                    self.next_token(); // current = `)`
+                    break;
+                }
+                _ => {
+                    let tok = self.peek_token.clone();
+                    self.record_error(format!(
+                        "Expected `,` or `)` in tuple pattern, found {}",
+                        tok
+                    ));
+                    break;
+                }
+            }
+        }
+        Pattern::Tuple(items)
     }
 
     /// RES-931: parse a tuple-struct pattern body — `(p1, p2, ...)`.
@@ -21703,6 +21765,25 @@ impl Interpreter {
                 Value::Result { ok: false, payload } => self.match_pattern(inner_pat, payload),
                 _ => Ok(None),
             },
+            // RES-932: anonymous tuple destructure. Matches
+            // `Value::Tuple` of the same length; sub-patterns match
+            // by position. Length mismatch is a no-match.
+            Pattern::Tuple(pat_items) => {
+                let Value::Tuple(val_items) = value else {
+                    return Ok(None);
+                };
+                if pat_items.len() != val_items.len() {
+                    return Ok(None);
+                }
+                let mut bindings = Vec::new();
+                for (sub, fv) in pat_items.iter().zip(val_items.iter()) {
+                    match self.match_pattern(sub, fv)? {
+                        None => return Ok(None),
+                        Some(mut b) => bindings.append(&mut b),
+                    }
+                }
+                Ok(Some(bindings))
+            }
             // RES-931: tuple-struct destructure. The runtime stores
             // tuple-struct values as Value::Struct with field names
             // "0", "1", ... — so the match peels off positional
@@ -27422,6 +27503,74 @@ mod tests {
             "expected arity diagnostic, got: {}",
             err
         );
+    }
+
+    /// RES-932: anonymous tuple match patterns destructure
+    /// positionally. Identifier sub-patterns bind the matched element.
+    #[test]
+    fn anonymous_tuple_match_pattern_binds_positionally() {
+        let src = "\
+            fn main(int _d) -> int {\n\
+                let p = (10, 20);\n\
+                return match p {\n\
+                    (1, 2) => 0,\n\
+                    (a, b) => a + b,\n\
+                };\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::Int(n) => assert_eq!(n, 30),
+            other => panic!("expected Int(30), got {:?}", other),
+        }
+    }
+
+    /// RES-932: nested tuple pattern recurses into the inner tuple.
+    #[test]
+    fn anonymous_tuple_match_pattern_nests() {
+        let src = "\
+            fn main(int _d) -> int {\n\
+                let nested = (1, (2, 3));\n\
+                return match nested {\n\
+                    (1, (a, b)) => a + b,\n\
+                    (_, _)      => 0,\n\
+                };\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::Int(n) => assert_eq!(n, 5),
+            other => panic!("expected Int(5), got {:?}", other),
+        }
+    }
+
+    /// RES-932: arity mismatch is a no-match (falls through to the
+    /// catch-all arm).
+    #[test]
+    fn anonymous_tuple_match_pattern_arity_mismatch_falls_through() {
+        let src = "\
+            fn main(int _d) -> int {\n\
+                let p = (1, 2, 3);\n\
+                return match p {\n\
+                    (a, b)    => a + b,\n\
+                    (_, _, c) => c,\n\
+                };\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::Int(n) => assert_eq!(n, 3),
+            other => panic!("expected Int(3), got {:?}", other),
+        }
     }
 
     /// RES-928: out-of-range positional index errors with a clear

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -291,6 +291,14 @@ fn collect_pattern_bindings(pattern: &Pattern) -> Vec<String> {
             }
             names
         }
+        // RES-932: anonymous tuple destructure — recurse positionally.
+        Pattern::Tuple(items) => {
+            let mut names = Vec::new();
+            for sub in items {
+                names.extend(collect_pattern_bindings(sub));
+            }
+            names
+        }
     }
 }
 
@@ -659,6 +667,9 @@ fn pattern_is_default_for_lint(p: &Pattern) -> bool {
         // positional sub-pattern is itself a default — `Pair(_, _)`
         // catches every `Pair`, but `Pair(0, _)` does not.
         Pattern::TupleStruct { fields, .. } => fields.iter().all(pattern_is_default_for_lint),
+        // RES-932: same shape — `(_, _)` is a catch-all over 2-tuples;
+        // `(0, _)` is not.
+        Pattern::Tuple(items) => items.iter().all(pattern_is_default_for_lint),
     }
 }
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -212,6 +212,8 @@ fn pattern_bindings(p: &Pattern) -> Vec<String> {
         // RES-931: tuple-struct destructure binds whatever each
         // positional sub-pattern binds.
         Pattern::TupleStruct { fields, .. } => fields.iter().flat_map(pattern_bindings).collect(),
+        // RES-932: anonymous tuple destructure — recurse positionally.
+        Pattern::Tuple(items) => items.iter().flat_map(pattern_bindings).collect(),
     }
 }
 
@@ -250,6 +252,10 @@ fn pattern_is_default(p: &Pattern) -> bool {
         // sole inhabitant of the nominal type, so name-mismatch is
         // caught upstream.
         Pattern::TupleStruct { fields, .. } => fields.iter().all(pattern_is_default),
+        // RES-932: an anonymous tuple pattern is a default iff every
+        // positional sub-pattern is a default. (`(_, _)` is default;
+        // `(0, _)` is not.)
+        Pattern::Tuple(items) => items.iter().all(pattern_is_default),
     }
 }
 
@@ -313,6 +319,8 @@ fn struct_pattern_matches_nominal_type(sname: &str, decl: &[(String, Type)], p: 
         Pattern::TupleStruct { name, fields } => {
             name == sname && fields.len() == decl.len() && fields.iter().all(pattern_is_default)
         }
+        // RES-932: anonymous tuple patterns don't match struct-nominal types.
+        Pattern::Tuple(_) => false,
     }
 }
 
@@ -3174,6 +3182,18 @@ impl TypeChecker {
                         ));
                     };
                     let sub_bt = self.match_pattern_binding_types(sub, fty)?;
+                    out.extend(sub_bt);
+                }
+                Ok(out)
+            }
+            // RES-932: anonymous tuple destructure. Each positional
+            // sub-pattern recurses against `Type::Any` — the dynamic
+            // typechecker doesn't track per-position tuple element
+            // types yet, mirroring how Some/Ok bindings are widened.
+            Pattern::Tuple(items) => {
+                let mut out = Vec::new();
+                for sub in items {
+                    let sub_bt = self.match_pattern_binding_types(sub, &Type::Any)?;
                     out.extend(sub_bt);
                 }
                 Ok(out)


### PR DESCRIPTION
Closes #1051.

`(a, b)` / `(1, 2)` / `()` now destructure anonymous tuple values inside `match`. RES-401 already handled `let (a, b) = pair;` and RES-931 just shipped `match p { Pair(a, b) => ... }` for tuple structs — this fills the missing case.

```resilient
let p = (10, 20);
match p {
    (1, 2)      => 0,
    (a, b)      => a + b,
}

let nested = (1, (2, 3));
match nested {
    (1, (a, b)) => a + b,
    _           => 0,
}
```

## Implementation

- New `Pattern::Tuple(Vec<Pattern>)` variant.
- `parse_pattern_atom`: `LeftParen` arm collects comma-separated sub-patterns until `RightParen`. `(p)` (no comma) is a parenthesized pattern — returns inner directly; `(p,)` (trailing comma) forces a 1-tuple; `()` is the unit pattern.
- Interpreter `match_pattern`: matches `Value::Tuple` by length, then recurses positionally. Length mismatch is a no-match (falls through to the next arm — consistent with how the existing tuple-struct pattern handles arity).
- Typechecker: tuple-element types widen to `Type::Any` (the dynamic checker doesn't track per-position tuple types yet, mirroring `Some`/`Ok` payload widening).
- Formatter / `free_vars` / lint: exhaustive arms.

## Tests

- `anonymous_tuple_match_pattern_binds_positionally`
- `anonymous_tuple_match_pattern_nests`
- `anonymous_tuple_match_pattern_arity_mismatch_falls_through`
- Golden `examples/tuple_pattern.rz` covers pair, wildcard, nested, 3-tuple, and 1-tuple.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_