### PR TITLE
RES-934: `as` cast operator

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -575,6 +575,39 @@ let value = "Pi: " + 3.14;              // "Pi: 3.14"
 | Array index | `arr[i]` — single element |
 | Array slice | `arr[lo..hi]`, `arr[lo..=hi]`, `arr[lo..]`, `arr[..hi]`, `arr[..]` (RES-911) — returns a fresh array |
 | Compound assign | `+= -= *= /= %= &= \|= ^= <<= >>=` (RES-912) — `x OP= rhs` desugars to `x = x OP rhs` for plain identifiers |
+| Cast | `<expr> as int` / `as float` / `as string` (RES-934) — postfix sugar over `to_int`, `to_float`, `to_string` builtins; high precedence (`1 + 2 as float` is `1 + (2 as float)`) |
+
+## `as` cast (RES-934)
+
+`as` is a postfix cast that desugars to the matching numeric/string
+conversion builtin:
+
+```rust
+let n = 3.7 as int;           // to_int(3.7)   → 3 (truncates)
+let f = 42 as float;          // to_float(42)  → 42.0
+let s = true as string;       // to_string(true) → "true"
+
+let chained = 3.5 as int as float as string;   // "3"
+let sum_cast = (1 + 2) as float;               // parens to cast a sum
+```
+
+Supported targets are `int` (also `Int` / `Int64`), `float` (also
+`Float`), and `string` (also `String`). An unsupported target name
+(`as MyStruct`) is a parse error: *"Cannot cast to `MyStruct` — `as`
+supports int / float / string"*. The runtime semantics match the
+underlying builtin, including its error policy — `to_int(NaN)`,
+`to_int(∞)`, and out-of-range floats raise runtime errors rather
+than silently saturating.
+
+`as` binds tightly (precedence 11, same as `.`/`?`), mirroring Rust:
+
+```rust
+let x = 1 + 2 as float;       // means 1 + (2 as float)
+let y = (1 + 2) as float;     // explicit parens cast the whole sum
+```
+
+`use "file" as alias;` (RES-360) continues to parse — the postfix-cast
+form only fires in expression position.
 
 ## Array slicing (RES-911)
 

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,8 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-933-for-tuple-binding",
-      "claimed_at": "2026-05-06T05:57:42Z"
+      "branch": "res-934-as-cast",
+      "claimed_at": "2026-05-06T06:31:27Z"
     }
   }
 }

--- a/resilient/examples/as_cast.expected.txt
+++ b/resilient/examples/as_cast.expected.txt
@@ -1,0 +1,6 @@
+3
+42
+true
+3
+3
+Program executed successfully

--- a/resilient/examples/as_cast.rz
+++ b/resilient/examples/as_cast.rz
@@ -1,0 +1,28 @@
+// RES-934 demo: `as` cast operator. Sugar over the existing
+// `to_int` / `to_float` / `to_string` builtins; produces clean,
+// idiomatic conversions in expression position.
+
+fn main(int _d) -> int {
+    // Float → int truncates toward zero.
+    let f = 3.7;
+    println(f as int);                  // 3
+
+    // Int → float widens.
+    let n = 42;
+    println(n as float);                // 42
+
+    // Anything → string.
+    println(true as string);            // true
+
+    // Chains compose left-to-right.
+    let s = 3.5 as int as float as string;
+    println(s);                         // 3
+
+    // Cast binds tightly — parens needed to cast a sum.
+    let sum_cast = (1 + 2) as float;
+    println(sum_cast);                  // 3
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -7347,6 +7347,52 @@ impl Parser {
                         span: q_span,
                     })
                 }
+                // RES-934: postfix `as TYPE` cast — desugar to the
+                // matching `to_<type>` builtin call so the rest of the
+                // pipeline (typechecker, interpreter, JIT) sees a plain
+                // `CallExpression` and needs no per-feature knowledge.
+                // High precedence (11) mirrors Rust: `1 + 2 as float`
+                // means `1 + (2 as float)`.
+                Token::As => {
+                    let as_span = self.span_at_current();
+                    self.next_token(); // current = `as`
+                    self.next_token(); // current = type identifier
+                    let type_name = match &self.current_token {
+                        Token::Identifier(n) => n.clone(),
+                        // `as int` / `as float` / etc. lex `int` as a
+                        // bare identifier already, but if a future
+                        // change introduces a Token::IntKw or similar,
+                        // accept it via display_syntax fallback.
+                        other => {
+                            let tok = other.clone();
+                            self.record_error(format!(
+                                "Expected target type after `as`, found {}",
+                                tok
+                            ));
+                            return Some(current_left);
+                        }
+                    };
+                    let builtin = match type_name.as_str() {
+                        "int" | "Int" | "Int64" => "to_int",
+                        "float" | "Float" => "to_float",
+                        "string" | "String" => "to_string",
+                        other => {
+                            self.record_error(format!(
+                                "Cannot cast to `{}` — `as` supports int / float / string",
+                                other
+                            ));
+                            return Some(current_left);
+                        }
+                    };
+                    Some(Node::CallExpression {
+                        function: Box::new(Node::Identifier {
+                            name: builtin.to_string(),
+                            span: as_span,
+                        }),
+                        arguments: vec![current_left],
+                        span: as_span,
+                    })
+                }
                 Token::QuestionDot => {
                     // RES-363: `?.` — optional chaining. `peek_token` is
                     // `QuestionDot`. Advance twice: first to make `?.` the
@@ -9198,6 +9244,10 @@ impl Parser {
             Token::Dot => 11,
             Token::Question => 12,
             Token::QuestionDot => 12,
+            // RES-934: `as` postfix cast binds tightly, mirroring Rust —
+            // `1 + 2 as float` parses as `1 + (2 as float)`. Use parens
+            // around the sum to cast the whole expression.
+            Token::As => 11,
             _ => 0,
         }
     }
@@ -27776,6 +27826,81 @@ mod tests {
             Value::Int(n) => assert_eq!(n, 300),
             other => panic!("expected Int(300), got {:?}", other),
         }
+    }
+
+    /// RES-934: `as int` desugars to `to_int(_)` and truncates floats.
+    #[test]
+    fn as_cast_float_to_int_truncates() {
+        let src = "\
+            fn main(int _d) -> int {\n\
+                let f = 3.7;\n\
+                return f as int;\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::Int(n) => assert_eq!(n, 3),
+            other => panic!("expected Int(3), got {:?}", other),
+        }
+    }
+
+    /// RES-934: `as float` widens an int.
+    #[test]
+    fn as_cast_int_to_float_widens() {
+        let src = "\
+            fn main(int _d) -> float {\n\
+                return 42 as float;\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::Float(f) => assert!((f - 42.0).abs() < 1e-9),
+            other => panic!("expected Float(42.0), got {:?}", other),
+        }
+    }
+
+    /// RES-934: `as string` formats any value to its string repr.
+    #[test]
+    fn as_cast_to_string() {
+        let src = "\
+            fn main(int _d) -> string {\n\
+                return 7 as string;\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        match interp.eval(&program).unwrap() {
+            Value::String(s) => assert_eq!(s, "7"),
+            other => panic!("expected String(\"7\"), got {:?}", other),
+        }
+    }
+
+    /// RES-934: an unsupported target type produces a parse-time
+    /// "cannot cast" diagnostic.
+    #[test]
+    fn as_cast_unsupported_type_errors() {
+        let src = "\
+            fn main(int _d) -> int {\n\
+                let n = 3.5 as foo;\n\
+                return 0;\n\
+            }\n\
+            main(0);\n\
+        ";
+        let (_program, errs) = parse(src);
+        let combined = errs.join("\n");
+        assert!(
+            combined.contains("Cannot cast to `foo`"),
+            "expected cast diagnostic, got: {}",
+            combined
+        );
     }
 
     /// RES-928: out-of-range positional index errors with a clear


### PR DESCRIPTION
Closes #1055.

`x as int` / `as float` / `as string` is now parser-level sugar over the existing `to_int` / `to_float` / `to_string` builtins.

```resilient
let n = 3.7 as int;            // to_int(3.7)   → 3 (truncates)
let f = 42 as float;           // to_float(42)  → 42.0
let s = true as string;        // to_string(true) → "true"
let chained = 3.5 as int as float as string;   // "3"
```

## Implementation

Postfix arm in the expression-tail loop — when the peek token is `Token::As`, consume it, read the target type identifier, and rewrite into a `CallExpression` of the matching builtin. No new AST node; the rest of the pipeline (typechecker, interpreter, JIT) is untouched.

Precedence 11 (same as `.` / `?`), mirroring Rust — `1 + 2 as float` is `1 + (2 as float)`. Existing `use "file" as alias;` continues to parse: it's at statement position, not expression position, so the postfix-cast arm never fires there.

Unsupported targets (`as MyStruct`) raise a parse-time "Cannot cast to `MyStruct` — `as` supports int / float / string" diagnostic.

## Tests

- `as_cast_float_to_int_truncates` — `3.7 as int → 3`
- `as_cast_int_to_float_widens` — `42 as float → 42.0`
- `as_cast_to_string` — `7 as string → "7"`
- `as_cast_unsupported_type_errors` — diagnostic surface
- Golden `examples/as_cast.rz` covers all three targets, chains, and parenthesized casts.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWjYtQ1V3gHkpgvub2WMkt)_