### PR TITLE
feat: Operator overloading + accurate MISSING_FEATURES audit

### DIFF
--- a/MISSING_FEATURES.md
+++ b/MISSING_FEATURES.md
@@ -1,162 +1,102 @@
-# 10 Major Missing Features in Resilient
+# Major Language Features Status
 
-Based on analysis of the current compiler implementation and git history, these are the highest-impact language features that would unlock significant new capabilities:
+A roadmap of what's implemented, partially implemented, and genuinely missing in Resilient. This was originally a "10 missing features" list; the audit found most are already in the compiler. The remaining genuinely missing pieces are listed below.
 
-## 1. Closures & Lambda Expressions
+## Already Implemented
 
-**Status**: Skeleton code exists (RES-164/169a) but incomplete  
-**Impact**: Essential for functional programming, callbacks, method chains  
-**Current state**: `free_vars` analysis exists but no lambda syntax  
-**Examples**:
-```rust
-let double = |x: int| { x * 2 };
-let doubled = array_map([1, 2, 3], |v| v * 2);
-```
+| Feature | Ticket | Status |
+|--------|--------|--------|
+| `?` operator (Result/Option propagation) | RES-086, RES-375 | Full — in `Node::TryExpression` eval |
+| String interpolation `"x = {x}"` | RES-221 | Full — `string_interp.rs` module |
+| Anonymous fn literals `fn(int x) -> int { ... }` | RES-403 | Full — `Node::FunctionLiteral` |
+| Function-type annotations `fn(int) -> int` | RES-403 | Full — parser accepts in param position |
+| Higher-order functions (`map`, `filter`, `reduce`) | RES-927 | Full — method-call form on arrays |
+| Generic type parameters `fn id<T>(x: T) -> T` | RES-405 PR1-4 | Full with monomorphization |
+| Variadic FFI (`extern fn printf(string, ...)`) | RES-316 | Full for FFI bindings |
+| Pipe operator `\|>` | RES-926 | Full |
+| `as` cast operator | RES-934 | Full |
+| Closure captures (immutable) | RES-164 | Full |
+| Tuple structs and tuple destructuring | RES-928, RES-933 | Full |
+| `if let` / `while let` / `else if let` | RES-908, RES-914, RES-930 | Full |
+| Range patterns / array slicing | RES-915, RES-911 | Full |
+| Compound assignment `+=` etc. | RES-912, RES-917 | Full |
+| Operator overloading via traits | (this PR) | Full at runtime |
 
-## 2. Complete Enum/Sum Types
+## Partially Implemented
 
-**Status**: RES-400 PR1 complete (payload-less variants), needs PR2-5  
-**Impact**: Core language feature for type-safe alternatives  
-**Current state**: Can't store data in variants, no pattern matching, no exhaustiveness checking  
-**Examples**:
-```rust
-enum Shape {
-    Circle { r: float },
-    Rect { w: float, h: float },
-}
-match s {
-    Shape::Circle { r } => 3.14 * r * r,
-    Shape::Rect { w, h } => w * h,
-}
-```
+| Feature | Ticket | Status |
+|--------|--------|--------|
+| Sum type / enum payloads | RES-400 PR1 | Parser scaffold for payload-less variants only; PR2-5 (payloads, matching, exhaustiveness, eval) remain |
+| Mutable closure capture | RES-328 | In progress — cell-based shared mutation works; auto-capture sugar deferred |
+| Module system | RES-116 | Textual splicing + namespacing primitives; full `mod`/`use` graph deferred |
+| Default function parameters | RES-118 | MVP for top-level fns; not for anonymous fn literals |
 
-## 3. Function Types as First-Class Values
+## Genuinely Missing
 
-**Status**: Not implemented  
-**Impact**: Higher-order functions, callbacks, dependency injection  
-**Current state**: Can pass functions by reference only through trait dispatch  
-**Examples**:
-```rust
-fn apply(callback: fn(int) -> int, x: int) -> int {
-    return callback(x);
-}
-```
+These have no in-flight scaffold and would each be substantial multi-PR work:
 
-## 4. Generic Functions
+### 1. Macros (Compile-Time Code Generation)
 
-**Status**: Only traits have generics (RES-783+)  
-**Impact**: Type-safe generic containers and algorithms  
-**Current state**: `fn foo<T>(x: T) -> T` syntax not supported  
-**Examples**:
-```rust
-fn swap<T>(a: T, b: T) -> (T, T) { return (b, a); }
-fn bsearch<T>(arr: Array<T>, target: T) -> Option<int> { ... }
-```
+No metaprogramming facilities exist. `assert_eq!`, `println!`-style format-string compile-time checking, and DSL macros all require an AST-at-compile-time representation, an expansion phase, and hygiene rules.
 
-## 5. Variadic Functions
+**Approximate scope**: 4-6 PRs (lexer for macro_rules!, parser for invocations, expansion engine, hygiene/scoping, error reporting, docs).
 
-**Status**: Not implemented  
-**Impact**: Functions with variable argument counts (print, format, sum)  
-**Current state**: All functions have fixed arity  
-**Examples**:
-```rust
-fn sum(int ...args) -> int { ... }
-fn format(string fmt, ...args) -> string { ... }
-```
+### 2. Async / Await
 
-## 6. Macros (Compile-Time Code Generation)
+Embedded I/O and actor-style cooperative scheduling currently use the live-block / actor primitives, but there's no `async fn` or `await` syntax. Adding it would unlock more conventional non-blocking I/O patterns.
 
-**Status**: Not implemented  
-**Impact**: DSLs, assertion macros, reducing boilerplate  
-**Current state**: No metaprogramming facilities  
-**Examples**:
-```rust
-#[macro]
-fn assert_eq(a, b) {
-    if a != b {
-        panic("assertion failed: {a} != {b}");
-    }
-}
-```
+**Approximate scope**: 5-8 PRs (parser, type representation, state-machine transform, scheduler integration, examples).
 
-## 7. Module System
+### 3. Const Functions / Compile-Time Evaluation
 
-**Status**: Basic textual include/import only  
-**Impact**: Code organization, namespacing, visibility control  
-**Current state**: Files are spliced inline; no `mod` keyword, no visibility modifiers  
-**Examples**:
-```rust
-mod math { fn sin(float x) -> float { ... } }
-mod graphics { use math::sin; }
-use graphics::draw;
-```
+Currently constants are limited to literals and a few folded expressions. A `const fn` keyword that lets the typechecker fully evaluate user code at compile time would enable better array sizes, lookup tables, and compile-time invariants.
 
-## 8. Operator Overloading
+**Approximate scope**: 3-4 PRs (parser, evaluator separation, typechecker integration, docs).
 
-**Status**: Not implemented  
-**Impact**: Custom types can define operators (Vector + Vector, Complex * Complex)  
-**Current state**: Only built-in operators work on built-in types  
-**Examples**:
-```rust
-struct Vector { float x, float y, }
-impl Add for Vector { fn add(self, other: Vector) -> Vector { ... } }
-let v3 = v1 + v2;
-```
+### 4. Trait Default Methods
 
-## 9. String Interpolation
+Trait declarations can only contain method *signatures*. Adding a default body (so impls can omit methods that have a default) is a real ergonomic gap for trait-heavy code.
 
-**Status**: Not implemented  
-**Impact**: Readable string formatting without verbose concatenation  
-**Current state**: Must concatenate or use separate string parts  
-**Examples**:
-```rust
-let x = 42;
-let msg = f"The answer is {x}";
-let formatted = "x={x}, y={y}";
-```
+**Approximate scope**: 1-2 PRs (parser change + trait registry update).
 
-## 10. Error Propagation Operator (?)
+### 5. Pattern-Matching Exhaustiveness for Structs
 
-**Status**: Not implemented  
-**Impact**: Ergonomic Result/Option handling  
-**Current state**: Manual unwrap/unwrap_or calls required  
-**Examples**:
-```rust
-fn risky() -> Result<int, string> {
-    let x = fallible()?;
-    let y = another_risky_call()?;
-    return ok(x + y);
-}
-```
+Match patterns over enums get exhaustiveness checks; match over plain structs and primitives don't. Closing this gap surfaces a class of bugs that typechecking misses today.
+
+**Approximate scope**: 2-3 PRs (extend the existing exhaustiveness pass, golden-file diagnostics).
+
+### 6. Type Classes / Implicit Parameters
+
+For ergonomic generic numeric code (`fn sum<T: Num>(arr: Array<T>) -> T`), some kind of bounded-instance lookup mechanism beyond the current trait-bound substitution would help. Today users must wrap operations in trait method calls.
+
+**Approximate scope**: 4-5 PRs (design + parser + typechecker + monomorphizer + docs).
+
+### 7. Recursive Type Definitions
+
+Self-referential structs like `struct Tree { Tree left, Tree right, }` would need a Box / indirection abstraction. Currently the type system treats this as an unbounded size error.
+
+**Approximate scope**: 2-3 PRs (Box type, parser sugar, typechecker, runtime indirection).
+
+### 8. Destructuring in Function Parameters
+
+`fn rotate((int x, int y)) -> (int, int)` is a small ergonomic win that would parallel the existing `let` destructuring.
+
+**Approximate scope**: 1 PR (parser change, typechecker, eval).
+
+### 9. Custom Derive Attributes
+
+`#[derive(Debug, Eq)]` on structs would auto-generate trait impls. Manual `impl` for boilerplate traits is currently the only option.
+
+**Approximate scope**: 2-3 PRs (attribute parser already exists; generator + per-derive logic).
+
+### 10. Associated Constants on Traits
+
+`trait Bounded { const MIN: int; const MAX: int; }` — useful for numeric trait bounds and embedded constants.
+
+**Approximate scope**: 2-3 PRs (parser, type representation, monomorphization).
 
 ---
 
-## Honorable Mentions
+## Footprint Reality Check
 
-**Lower priority but also valuable**:
-- Recursive type definitions (current limitation prevents recursive structs/enums)
-- Async/await (for I/O and long-running operations)
-- Const functions (compile-time evaluation, `const fn`)
-- Pattern matching improvements (struct/record patterns, guard clauses)
-- Better type inference (full Hindley-Milner; RES-120 WIP, gated on `infer` feature)
-- Destructuring in function parameters (`fn foo((int x, int y)) { ... }`)
-- Default trait methods (trait implementations can provide default bodies)
-- Attributes and derives (`#[derive(Debug)]`, custom attributes)
-
----
-
-## Estimated Complexity & Multi-PR Scope
-
-| Feature | Estimated PRs | Complexity | Core Blocker |
-|---------|---------------|-----------|--------------|
-| Closures | 3-4 | High | Free variable analysis exists; needs syntax + values + typechecker |
-| Complete enums | 5 | High | Payloads, matching, exhaustiveness (RES-400 PR2-5) |
-| Function types | 2-3 | Medium | Type representation + application syntax |
-| Generic functions | 3-4 | High | Parser + typechecker + monomorphization |
-| Variadic functions | 2 | Medium | Parser + VM support |
-| Macros | 4-5 | Very high | Need AST-at-compile-time + expansion framework |
-| Module system | 4-5 | High | Parser + visibility + resolution + scoping |
-| Operator overloading | 2-3 | Medium | Typechecker dispatch + trait integration |
-| String interpolation | 2 | Low | Parser + runtime formatting |
-| Error propagation (?) | 1-2 | Low | Syntactic sugar; desugar to match/unwrap |
-
+Resilient at ~1,800 KB of `lib.rs` is a much more complete language than the original "10 missing features" pass suggested. The genuinely-missing list above is what's left after auditing the actual implementation. Each item is decomposable into a small chain of PRs per the project's "ship-to-merge" workflow.

--- a/MISSING_FEATURES.md
+++ b/MISSING_FEATURES.md
@@ -1,0 +1,162 @@
+# 10 Major Missing Features in Resilient
+
+Based on analysis of the current compiler implementation and git history, these are the highest-impact language features that would unlock significant new capabilities:
+
+## 1. Closures & Lambda Expressions
+
+**Status**: Skeleton code exists (RES-164/169a) but incomplete  
+**Impact**: Essential for functional programming, callbacks, method chains  
+**Current state**: `free_vars` analysis exists but no lambda syntax  
+**Examples**:
+```rust
+let double = |x: int| { x * 2 };
+let doubled = array_map([1, 2, 3], |v| v * 2);
+```
+
+## 2. Complete Enum/Sum Types
+
+**Status**: RES-400 PR1 complete (payload-less variants), needs PR2-5  
+**Impact**: Core language feature for type-safe alternatives  
+**Current state**: Can't store data in variants, no pattern matching, no exhaustiveness checking  
+**Examples**:
+```rust
+enum Shape {
+    Circle { r: float },
+    Rect { w: float, h: float },
+}
+match s {
+    Shape::Circle { r } => 3.14 * r * r,
+    Shape::Rect { w, h } => w * h,
+}
+```
+
+## 3. Function Types as First-Class Values
+
+**Status**: Not implemented  
+**Impact**: Higher-order functions, callbacks, dependency injection  
+**Current state**: Can pass functions by reference only through trait dispatch  
+**Examples**:
+```rust
+fn apply(callback: fn(int) -> int, x: int) -> int {
+    return callback(x);
+}
+```
+
+## 4. Generic Functions
+
+**Status**: Only traits have generics (RES-783+)  
+**Impact**: Type-safe generic containers and algorithms  
+**Current state**: `fn foo<T>(x: T) -> T` syntax not supported  
+**Examples**:
+```rust
+fn swap<T>(a: T, b: T) -> (T, T) { return (b, a); }
+fn bsearch<T>(arr: Array<T>, target: T) -> Option<int> { ... }
+```
+
+## 5. Variadic Functions
+
+**Status**: Not implemented  
+**Impact**: Functions with variable argument counts (print, format, sum)  
+**Current state**: All functions have fixed arity  
+**Examples**:
+```rust
+fn sum(int ...args) -> int { ... }
+fn format(string fmt, ...args) -> string { ... }
+```
+
+## 6. Macros (Compile-Time Code Generation)
+
+**Status**: Not implemented  
+**Impact**: DSLs, assertion macros, reducing boilerplate  
+**Current state**: No metaprogramming facilities  
+**Examples**:
+```rust
+#[macro]
+fn assert_eq(a, b) {
+    if a != b {
+        panic("assertion failed: {a} != {b}");
+    }
+}
+```
+
+## 7. Module System
+
+**Status**: Basic textual include/import only  
+**Impact**: Code organization, namespacing, visibility control  
+**Current state**: Files are spliced inline; no `mod` keyword, no visibility modifiers  
+**Examples**:
+```rust
+mod math { fn sin(float x) -> float { ... } }
+mod graphics { use math::sin; }
+use graphics::draw;
+```
+
+## 8. Operator Overloading
+
+**Status**: Not implemented  
+**Impact**: Custom types can define operators (Vector + Vector, Complex * Complex)  
+**Current state**: Only built-in operators work on built-in types  
+**Examples**:
+```rust
+struct Vector { float x, float y, }
+impl Add for Vector { fn add(self, other: Vector) -> Vector { ... } }
+let v3 = v1 + v2;
+```
+
+## 9. String Interpolation
+
+**Status**: Not implemented  
+**Impact**: Readable string formatting without verbose concatenation  
+**Current state**: Must concatenate or use separate string parts  
+**Examples**:
+```rust
+let x = 42;
+let msg = f"The answer is {x}";
+let formatted = "x={x}, y={y}";
+```
+
+## 10. Error Propagation Operator (?)
+
+**Status**: Not implemented  
+**Impact**: Ergonomic Result/Option handling  
+**Current state**: Manual unwrap/unwrap_or calls required  
+**Examples**:
+```rust
+fn risky() -> Result<int, string> {
+    let x = fallible()?;
+    let y = another_risky_call()?;
+    return ok(x + y);
+}
+```
+
+---
+
+## Honorable Mentions
+
+**Lower priority but also valuable**:
+- Recursive type definitions (current limitation prevents recursive structs/enums)
+- Async/await (for I/O and long-running operations)
+- Const functions (compile-time evaluation, `const fn`)
+- Pattern matching improvements (struct/record patterns, guard clauses)
+- Better type inference (full Hindley-Milner; RES-120 WIP, gated on `infer` feature)
+- Destructuring in function parameters (`fn foo((int x, int y)) { ... }`)
+- Default trait methods (trait implementations can provide default bodies)
+- Attributes and derives (`#[derive(Debug)]`, custom attributes)
+
+---
+
+## Estimated Complexity & Multi-PR Scope
+
+| Feature | Estimated PRs | Complexity | Core Blocker |
+|---------|---------------|-----------|--------------|
+| Closures | 3-4 | High | Free variable analysis exists; needs syntax + values + typechecker |
+| Complete enums | 5 | High | Payloads, matching, exhaustiveness (RES-400 PR2-5) |
+| Function types | 2-3 | Medium | Type representation + application syntax |
+| Generic functions | 3-4 | High | Parser + typechecker + monomorphization |
+| Variadic functions | 2 | Medium | Parser + VM support |
+| Macros | 4-5 | Very high | Need AST-at-compile-time + expansion framework |
+| Module system | 4-5 | High | Parser + visibility + resolution + scoping |
+| Operator overloading | 2-3 | Medium | Typechecker dispatch + trait integration |
+| String interpolation | 2 | Low | Parser + runtime formatting |
+| Error propagation (?) | 1-2 | Low | Syntactic sugar; desugar to match/unwrap |
+

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -403,6 +403,45 @@ The impl block must provide all methods declared in the trait, with matching
 names and arities. Method implementations use the same `fn` syntax as top-level
 functions, and can access struct fields via `self`.
 
+### Operator Overloading
+
+Infix operators dispatch through method names that follow Rust's
+`core::ops` convention. When a struct has a method with the matching
+mangled name (e.g. `Vec2$add` for `+`), `lhs <op> rhs` evaluates that
+method with `lhs` as `self` and `rhs` as the second argument:
+
+```rust
+struct Vec2 { float x, float y, }
+
+impl Add for Vec2 {
+    fn add(Vec2 self, Vec2 other) -> Vec2 {
+        return new Vec2 { x: self.x + other.x, y: self.y + other.y };
+    }
+}
+
+let a = new Vec2 { x: 1.0, y: 2.0 };
+let b = new Vec2 { x: 3.0, y: 4.0 };
+let c = a + b;  // dispatches to Vec2$add(a, b)
+```
+
+The dispatch table:
+
+| Operator | Method  | | Operator | Method  |
+|---------|----------|-|----------|---------|
+| `+`     | `add`    | | `==`     | `eq`    |
+| `-`     | `sub`    | | `!=`     | `ne`    |
+| `*`     | `mul`    | | `<`      | `lt`    |
+| `/`     | `div`    | | `<=`     | `le`    |
+| `%`     | `rem`    | | `>`      | `gt`    |
+| `&`     | `bitand` | | `>=`     | `ge`    |
+| `\|`    | `bitor`  | | `<<`     | `shl`   |
+| `^`     | `bitxor` | | `>>`     | `shr`   |
+
+Logical `&&` / `||` and the `??` Option-coalescing operator do not
+overload (their short-circuit semantics make method dispatch
+inappropriate). When neither operand is a struct, behaviour is the
+built-in primitive dispatch with no change.
+
 ### Generic Bounds with Traits
 
 Use trait bounds to constrain generic type parameters:

--- a/resilient/examples/operator_overload.expected.txt
+++ b/resilient/examples/operator_overload.expected.txt
@@ -1,0 +1,7 @@
+4
+6
+2
+2
+3
+8
+Program executed successfully

--- a/resilient/examples/operator_overload.rz
+++ b/resilient/examples/operator_overload.rz
@@ -1,0 +1,42 @@
+// Operator overloading: define `+`, `-`, `*` on a custom struct.
+
+struct Vec2 { float x, float y, }
+
+impl Add for Vec2 {
+    fn add(Vec2 self, Vec2 other) -> Vec2 {
+        return new Vec2 { x: self.x + other.x, y: self.y + other.y };
+    }
+}
+
+impl Sub for Vec2 {
+    fn sub(Vec2 self, Vec2 other) -> Vec2 {
+        return new Vec2 { x: self.x - other.x, y: self.y - other.y };
+    }
+}
+
+impl Mul for Vec2 {
+    fn mul(Vec2 self, Vec2 other) -> Vec2 {
+        return new Vec2 { x: self.x * other.x, y: self.y * other.y };
+    }
+}
+
+fn main() -> int {
+    let a = new Vec2 { x: 1.0, y: 2.0 };
+    let b = new Vec2 { x: 3.0, y: 4.0 };
+
+    let sum = a + b;
+    println(sum.x);
+    println(sum.y);
+
+    let diff = b - a;
+    println(diff.x);
+    println(diff.y);
+
+    let prod = a * b;
+    println(prod.x);
+    println(prod.y);
+
+    return 0;
+}
+
+main();

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -167,6 +167,12 @@ mod assume_false_checker;
 // the main module only touches the extension-point blocks.
 mod try_catch;
 
+// Operator overloading for structs — dispatches `lhs <op> rhs` to a
+// trait-impl method (`Vec2$add`) when the LHS or RHS is a struct.
+// All logic lives in this module; lib.rs only calls into it from
+// `eval_infix_expression` before the type-mismatch fallthrough.
+mod operator_overload;
+
 // RES-330: `forall` / `exists` quantifier expressions in assertions.
 // All parser, interpreter, typechecker, and Z3 logic for quantifiers
 // lives here; the main module only touches the extension-point blocks
@@ -22048,7 +22054,17 @@ impl Interpreter {
                 self.eval_string_infix_expression(operator, l, r)
             }
             (Value::Bool(l), Value::Bool(r)) => self.eval_boolean_infix_expression(operator, l, r),
-            _ => Err(format!("Type mismatch: {} {} {}", left, operator, right)),
+            _ => {
+                // Operator overloading: when one operand is a struct
+                // and a `<StructName>$<op_method>` exists in the env,
+                // dispatch through it instead of erroring out.
+                if let Some(v) =
+                    crate::operator_overload::try_dispatch(self, operator, &left, &right)?
+                {
+                    return Ok(v);
+                }
+                Err(format!("Type mismatch: {} {} {}", left, operator, right))
+            }
         }
     }
 

--- a/resilient/src/operator_overload.rs
+++ b/resilient/src/operator_overload.rs
@@ -1,0 +1,124 @@
+//! Operator overloading for structs via trait method dispatch.
+//!
+//! When an arithmetic, comparison, or bitwise operator is applied to a
+//! `Value::Struct` and the host environment contains a method with the
+//! mangled name `<StructName>$<op_method>`, the operator dispatches to
+//! that method as if the user had written `lhs.op_method(rhs)`. The
+//! method is expected to receive `self` as the first parameter and the
+//! right-hand operand as the second.
+//!
+//! The mapping from operator → method name follows Rust's `core::ops`
+//! convention so a Resilient `impl Add for Vec2 { fn add(self, other) }`
+//! plays nicely with `+`. No new tokens, no parser changes — this is a
+//! pure runtime dispatch enrichment that fires before the legacy
+//! `Type mismatch` error.
+//!
+//! ## Example
+//!
+//! ```text
+//! struct Vec2 { float x, float y, }
+//! impl Add for Vec2 {
+//!     fn add(Vec2 self, Vec2 other) -> Vec2 {
+//!         return new Vec2 { x: self.x + other.x, y: self.y + other.y };
+//!     }
+//! }
+//! let c = a + b;  // dispatches to Vec2$add(a, b)
+//! ```
+
+use crate::{Interpreter, RResult, Value};
+
+/// Map an infix operator string to the conventional trait-method name.
+/// Returns `None` for operators that don't have an overloadable method
+/// (logical `&&` / `||`, `??`, etc.).
+pub(crate) fn op_method_name(op: &str) -> Option<&'static str> {
+    Some(match op {
+        "+" => "add",
+        "-" => "sub",
+        "*" => "mul",
+        "/" => "div",
+        "%" => "rem",
+        "==" => "eq",
+        "!=" => "ne",
+        "<" => "lt",
+        "<=" => "le",
+        ">" => "gt",
+        ">=" => "ge",
+        "&" => "bitand",
+        "|" => "bitor",
+        "^" => "bitxor",
+        "<<" => "shl",
+        ">>" => "shr",
+        _ => return None,
+    })
+}
+
+/// Try to dispatch `left <op> right` to a struct method.
+///
+/// Returns `Ok(Some(value))` if dispatch succeeded, `Ok(None)` if no
+/// matching method was found (caller should fall through to the
+/// built-in type dispatch / type-mismatch error), and `Err` if dispatch
+/// fired but the method itself raised a runtime error.
+pub(crate) fn try_dispatch(
+    interp: &mut Interpreter,
+    operator: &str,
+    left: &Value,
+    right: &Value,
+) -> RResult<Option<Value>> {
+    let Some(method) = op_method_name(operator) else {
+        return Ok(None);
+    };
+
+    let struct_name = match left {
+        Value::Struct { name, .. } => name.clone(),
+        _ => match right {
+            Value::Struct { name, .. } => name.clone(),
+            _ => return Ok(None),
+        },
+    };
+
+    let mangled = format!("{}${}", struct_name, method);
+    let Some(method_val) = interp.env.get(&mangled) else {
+        return Ok(None);
+    };
+
+    let args = vec![left.clone(), right.clone()];
+    interp.apply_function(method_val, args).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::op_method_name;
+
+    #[test]
+    fn op_method_name_covers_arithmetic() {
+        assert_eq!(op_method_name("+"), Some("add"));
+        assert_eq!(op_method_name("-"), Some("sub"));
+        assert_eq!(op_method_name("*"), Some("mul"));
+        assert_eq!(op_method_name("/"), Some("div"));
+        assert_eq!(op_method_name("%"), Some("rem"));
+    }
+
+    #[test]
+    fn op_method_name_covers_comparisons() {
+        assert_eq!(op_method_name("=="), Some("eq"));
+        assert_eq!(op_method_name("!="), Some("ne"));
+        assert_eq!(op_method_name("<"), Some("lt"));
+        assert_eq!(op_method_name(">="), Some("ge"));
+    }
+
+    #[test]
+    fn op_method_name_covers_bitwise() {
+        assert_eq!(op_method_name("&"), Some("bitand"));
+        assert_eq!(op_method_name("|"), Some("bitor"));
+        assert_eq!(op_method_name("^"), Some("bitxor"));
+        assert_eq!(op_method_name("<<"), Some("shl"));
+        assert_eq!(op_method_name(">>"), Some("shr"));
+    }
+
+    #[test]
+    fn op_method_name_returns_none_for_logical() {
+        assert_eq!(op_method_name("&&"), None);
+        assert_eq!(op_method_name("||"), None);
+        assert_eq!(op_method_name("??"), None);
+    }
+}


### PR DESCRIPTION
## Summary

**1. Implements operator overloading for structs.** When an arithmetic, comparison, or bitwise operator is applied to a `Value::Struct` and the env contains a method with the conventional name (`<Struct>$add` for `+`, `<Struct>$sub` for `-`, etc.), the operator dispatches through the method. Logical `&&`/`||` and `??` keep their short-circuit primitive semantics.

The mapping follows Rust's `core::ops` convention:

| Op | Method | | Op | Method |
|----|--------|-|----|--------|
| `+` | `add` | | `==` | `eq` |
| `-` | `sub` | | `!=` | `ne` |
| `*` | `mul` | | `<` | `lt` |
| `/` | `div` | | `<=` | `le` |
| `%` | `rem` | | `>` | `gt` |
| `&` | `bitand` | | `>=` | `ge` |
| `\|` | `bitor` | | `<<` | `shl` |
| `^` | `bitxor` | | `>>` | `shr` |

Implementation:
- New `operator_overload.rs` module owns the dispatch (per feature-isolation pattern).
- `lib.rs` only adds 8-line hook in `eval_infix_expression` before the existing `Type mismatch` fallthrough.
- 4 unit tests + golden-file example (`examples/operator_overload.rz`).

**2. Replaces `MISSING_FEATURES.md` with an accurate audit.** The previous "10 missing features" doc was wrong on 8 of 10 items — `?`, string interpolation, function literals, function-type annotations, higher-order functions, generics, variadic FFI, and pipe operator are all already implemented. The revised doc separates "implemented", "partial", and "genuinely missing" into three buckets with ticket numbers and scope estimates.

The genuinely missing list (no scaffold today): macros, async/await, const fn, trait default methods, struct-pattern exhaustiveness, type classes, recursive types, parameter destructuring, custom derives, associated constants.

## Test plan

- [x] `cargo test --lib` — 2571 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run -- run examples/operator_overload.rz` — produces expected output
- [x] Golden test (`tests/examples_golden.rs`) accepts new example

🤖 Generated with [Claude Code](https://claude.com/claude-code)