### PR TITLE
feat: Curated playground examples — 5 showcase files + pinned dropdown ordering

### DIFF
--- a/playground/build.sh
+++ b/playground/build.sh
@@ -61,26 +61,75 @@ repo_root = sys.argv[1]
 out_path = sys.argv[2]
 
 examples_dir = os.path.join(repo_root, "resilient", "examples")
-items = []
-for name in sorted(os.listdir(examples_dir)):
-    if not (name.endswith(".rz") or name.endswith(".rz")):
-        continue
+
+# Pinned examples appear first in the dropdown, in this exact order.
+# They showcase the language's most distinctive features.
+PINNED = [
+    "sensor_monitor.rz",            # flagship: contracts + Result + live block
+    "showcase_contracts.rz",        # requires / ensures / loop invariant
+    "showcase_linear_types.rz",     # linear types: resource ownership tracking
+    "showcase_actors.rz",           # actor model: spawn / send / receive
+    "showcase_quantifiers.rz",      # forall / exists as runnable SMT proofs
+    "showcase_result.rz",           # Ok / Err pattern matching
+    "invariant_proven_demo.rz",     # SMT-discharged while-loop invariant
+    "termination_decreases.rz",     # termination checking with @decreases
+    "sum_types_match.rz",           # algebraic data types + exhaustive match
+    "actor_ping_pong.rz",           # two-actor message-passing
+    "actor_queue_safe.rz",          # actor with Z3-verified state invariant
+    "linear_demo.rz",               # linear types: FileHandle lifetime
+    "linear_closure_demo.rz",       # linear types captured in closures
+    "fault_model_demo.rz",          # fails + recovers_to annotations
+    "quantifier_assert.rz",         # quantifiers inside assert()
+    "operator_overload.rz",         # impl Add/Sub/Mul for custom structs
+    "pipe_operator.rz",             # |> chains without nesting
+    "optional_chaining.rz",         # ?. short-circuits on None
+    "result_patterns.rz",           # Ok(n) / Err(_) in match arms
+    "trait_printable.rz",           # trait declaration + impl block
+    "generic_bounds_with_traits.rz", # generics with trait bounds
+    "generic_monomorph.rz",         # monomorphised generics
+    "comprehension_demo.rz",        # [expr for x in xs if guard]
+    "for_tuple_binding.rz",         # for (a, b) in pairs { ... }
+    "effect_polymorphism.rz",       # -e-> effect-polymorphic HOFs
+    "newtype_units.rz",             # newtype Meters = Float (nominal wrapper)
+    "hello.rz",                     # hello world
+    "factorial.rz",                 # classic recursion
+]
+
+def load(name):
     path = os.path.join(examples_dir, name)
     try:
         with open(path, encoding="utf-8") as f:
             source = f.read()
+        if len(source) > 16 * 1024:
+            return None
+        return {"name": name, "source": source}
     except (UnicodeDecodeError, OSError):
+        return None
+
+items = []
+seen = set()
+
+# Pinned first — preserve the declared order, skip missing files silently.
+for name in PINNED:
+    entry = load(name)
+    if entry:
+        items.append(entry)
+        seen.add(name)
+
+# Remaining examples in alphabetical order.
+for name in sorted(os.listdir(examples_dir)):
+    if not name.endswith(".rz"):
         continue
-    # Skip the very large examples — the dropdown is not the place
-    # to scroll a 500-line snippet. Keeps the manifest under a few
-    # hundred KB.
-    if len(source) > 16 * 1024:
+    if name in seen:
         continue
-    items.append({"name": name, "source": source})
+    entry = load(name)
+    if entry:
+        items.append(entry)
+        seen.add(name)
 
 with open(out_path, "w", encoding="utf-8") as f:
     json.dump(items, f, indent=2)
-print(f"baked {len(items)} examples into {out_path}")
+print(f"baked {len(items)} examples into {out_path} ({len(PINNED)} pinned)")
 PYEOF
 
 if (( CHECK_SIZE )); then

--- a/playground/web/main.js
+++ b/playground/web/main.js
@@ -15,21 +15,391 @@ import init, {
   playground_version,
 } from "./pkg/resilient_playground.js";
 
+// Fallback examples shown when examples.json is not present (e.g., dev mode).
+// These are the curated top picks that best illustrate what makes Resilient
+// distinct. The full list (350+ examples) is baked into examples.json at
+// build time by playground/build.sh.
 const EXAMPLES_FALLBACK = [
   {
+    name: "sensor_monitor.rz",
+    source: `// Flagship example: contracts + Result + live self-healing block.
+// Classifies sensor readings into buckets and counts each category.
+
+struct Reading { int id, int value, }
+struct Counts { int low, int mid, int high, int alert, }
+
+fn bucket_of(int v) -> string
+    requires v >= 0
+{
+    if v < 25  { return "low"; }
+    if v < 75  { return "mid"; }
+    if v < 100 { return "high"; }
+    return "alert";
+}
+
+fn validate(int v) -> Result {
+    if v < 0    { return Err("negative reading"); }
+    if v > 1000 { return Err("overflow reading"); }
+    return Ok(v);
+}
+
+fn process(int v) -> Result {
+    let safe = validate(v)?;
+    return Ok(bucket_of(safe));
+}
+
+fn main() {
+    let readings = [
+        new Reading { id: 1, value: 10  },
+        new Reading { id: 2, value: 50  },
+        new Reading { id: 3, value: 90  },
+        new Reading { id: 4, value: 200 },
+        new Reading { id: 5, value: 0   },
+    ];
+    let counts = new Counts { low: 0, mid: 0, high: 0, alert: 0 };
+    let total = 0;
+    live invariant total >= 0 {
+        for r in readings {
+            let result = process(r.value);
+            if is_err(result) {
+                println("rejecting " + r.id + ": " + unwrap_err(result));
+            } else {
+                let label = unwrap(result);
+                if label == "low"   { counts.low   = counts.low   + 1; }
+                if label == "mid"   { counts.mid   = counts.mid   + 1; }
+                if label == "high"  { counts.high  = counts.high  + 1; }
+                if label == "alert" { counts.alert = counts.alert + 1; }
+                total = total + 1;
+            }
+        }
+    }
+    println("low:   " + counts.low);
+    println("mid:   " + counts.mid);
+    println("high:  " + counts.high);
+    println("alert: " + counts.alert);
+    println("processed: " + total);
+}
+main();
+`,
+  },
+  {
+    name: "showcase_contracts.rz",
+    source: `// Contracts: machine-checked pre/postconditions.
+// requires guards the caller; ensures guarantees the callee.
+// With --features z3, these discharge statically — zero runtime cost.
+
+fn safe_divide(int n, int d) -> int
+    requires d != 0
+{
+    return n / d;
+}
+
+fn clamp(int x, int lo, int hi) -> int
+    requires lo <= hi
+    ensures result >= lo
+    ensures result <= hi
+{
+    if x < lo { return lo; }
+    if x > hi { return hi; }
+    return x;
+}
+
+fn factorial(int n) -> int
+    requires n >= 0
+    ensures result >= 1
+{
+    if n <= 1 { return 1; }
+    return n * factorial(n - 1);
+}
+
+fn main() {
+    println(safe_divide(100, 7));   // 14
+    println(safe_divide(42, 6));    // 7
+
+    println(clamp(-5, 0, 10));     // 0  (below lo)
+    println(clamp(15, 0, 10));     // 10 (above hi)
+    println(clamp(5,  0, 10));     // 5  (in range)
+
+    println(factorial(5));          // 120
+    println(factorial(0));          // 1
+}
+main();
+`,
+  },
+  {
+    name: "showcase_linear_types.rz",
+    source: `// Linear types: the compiler tracks resource ownership.
+// A linear value must be consumed exactly once.
+// Double-close and use-after-close are compile-time errors.
+
+struct UartConn { int port }
+
+fn uart_open(int port) -> linear UartConn {
+    println("uart: opened port " + port);
+    return new UartConn { port: port };
+}
+
+fn uart_write(linear UartConn c, string msg) -> linear UartConn {
+    println("uart: tx " + msg);
+    return c;   // ownership returned — caller must consume it
+}
+
+fn uart_close(linear UartConn c) {
+    println("uart: closed port " + c.port);
+    // c consumed here; the compiler forbids any further use
+}
+
+fn main() {
+    let c  = uart_open(2);
+    let c2 = uart_write(c,  "boot ok");
+    let c3 = uart_write(c2, "sensor ready");
+    uart_close(c3);
+    println("handle released exactly once");
+}
+main();
+`,
+  },
+  {
+    name: "showcase_actors.rz",
+    source: `// Actor model: isolated processes communicate via messages.
+// spawn() creates an actor; send/receive pass values between them.
+// No shared state — data races are structurally impossible.
+
+fn summer() {
+    let a = receive();
+    let b = receive();
+    let c = receive();
+    println("sum = " + (a + b + c));
+}
+
+fn main() {
+    let pid = spawn(summer);
+    send(pid, 10);
+    send(pid, 20);
+    send(pid, 12);   // 10 + 20 + 12 = 42
+    println("messages sent");
+}
+main();
+`,
+  },
+  {
+    name: "showcase_quantifiers.rz",
+    source: `// Quantifiers as runnable code and static proofs.
+// forall / exists evaluate at runtime and, with --features z3,
+// discharge as SMT lemmas — no loop unrolling needed.
+
+fn is_even(int n) -> bool { return n % 2 == 0; }
+
+fn main() {
+    // Every square in 0..8 is non-negative.
+    println(forall i in 0..8: i * i >= 0);     // true
+
+    // There exists an even number in 1..10.
+    println(exists i in 1..10: is_even(i));    // true
+
+    // Not all numbers in 0..5 are even.
+    println(forall i in 0..5: is_even(i));     // false
+
+    // Vacuously true: empty range, no counterexample.
+    println(forall i in 5..5: false);          // true
+
+    // Embed quantifiers directly in assertions.
+    assert(forall i in 0..10: i * i >= 0);
+    assert(exists i in 0..10: i == 7);
+    println("all proofs passed");
+}
+main();
+`,
+  },
+  {
+    name: "showcase_result.rz",
+    source: `// Result<T>: principled error propagation without exceptions.
+// Ok(v) carries a success value; Err(e) carries a failure reason.
+// Pattern matching forces every caller to handle both cases.
+
+fn safe_div(int n, int d) -> Result {
+    if d == 0 { return Err("division by zero"); }
+    return Ok(n / d);
+}
+
+fn safe_sqrt(int n) -> Result {
+    if n < 0 { return Err("negative input"); }
+    return Ok(n);
+}
+
+fn main() {
+    let r1 = safe_div(100, 5);
+    let msg1 = match r1 {
+        Ok(v)  => "100 / 5 = " + v,
+        Err(e) => "error: " + e,
+    };
+    println(msg1);
+
+    let r2 = safe_div(42, 0);
+    let msg2 = match r2 {
+        Ok(v)  => "ok: " + v,
+        Err(e) => "caught: " + e,
+    };
+    println(msg2);
+
+    let r3 = safe_sqrt(-1);
+    let msg3 = match r3 {
+        Ok(v)  => "ok: " + v,
+        Err(e) => "caught: " + e,
+    };
+    println(msg3);
+}
+main();
+`,
+  },
+  {
+    name: "sum_types_match.rz",
+    source: `// Algebraic data types with exhaustive pattern matching.
+// Each variant carries its own fields; match enforces coverage.
+
+enum Shape {
+    Circle { r: int },
+    Square { side: int },
+    Rect   { w: int, h: int },
+}
+
+enum Color { Red, Green, Blue }
+
+fn area(Shape s) -> int {
+    return match s {
+        Shape::Circle { r }    => 3 * r * r,
+        Shape::Square { side } => side * side,
+        Shape::Rect   { w, h } => w * h,
+    };
+}
+
+fn name(Color c) -> string {
+    return match c {
+        Color::Red   => "red",
+        Color::Green => "green",
+        Color::Blue  => "blue",
+    };
+}
+
+fn main() -> int {
+    println(area(new Shape::Circle { r: 2 }));       // 12
+    println(area(new Shape::Square { side: 4 }));    // 16
+    println(area(new Shape::Rect { w: 3, h: 5 }));  // 15
+    println(name(Color::Red));                        // red
+    println(name(Color::Green));                      // green
+    println(name(Color::Blue));                       // blue
+    return 0;
+}
+main();
+`,
+  },
+  {
+    name: "operator_overload.rz",
+    source: `// Operator overloading: implement Add, Sub, Mul for a custom type.
+
+struct Vec2 { float x, float y, }
+
+impl Add for Vec2 {
+    fn add(Vec2 self, Vec2 other) -> Vec2 {
+        return new Vec2 { x: self.x + other.x, y: self.y + other.y };
+    }
+}
+
+impl Sub for Vec2 {
+    fn sub(Vec2 self, Vec2 other) -> Vec2 {
+        return new Vec2 { x: self.x - other.x, y: self.y - other.y };
+    }
+}
+
+impl Mul for Vec2 {
+    fn mul(Vec2 self, Vec2 other) -> Vec2 {
+        return new Vec2 { x: self.x * other.x, y: self.y * other.y };
+    }
+}
+
+fn main() -> int {
+    let a = new Vec2 { x: 1.0, y: 2.0 };
+    let b = new Vec2 { x: 3.0, y: 4.0 };
+    let sum  = a + b;  println(sum.x);   println(sum.y);   // 4, 6
+    let diff = b - a;  println(diff.x);  println(diff.y);  // 2, 2
+    let prod = a * b;  println(prod.x);  println(prod.y);  // 3, 8
+    return 0;
+}
+main();
+`,
+  },
+  {
+    name: "pipe_operator.rz",
+    source: `// The |> pipe operator: x |> f desugars to f(x).
+// Chains read top-to-bottom instead of inside-out.
+
+fn double(int n) -> int  { return n * 2; }
+fn add_one(int n) -> int { return n + 1; }
+
+fn main(int _d) {
+    // Without pipes: nested calls read inside-out.
+    println(add_one(double(add_one(3))));        // 9
+
+    // With pipes: reads left-to-right.
+    println(3 |> add_one |> double |> add_one);  // 9
+
+    // String pipeline: trim then uppercase.
+    println("  resilient  " |> trim |> to_upper);  // RESILIENT
+
+    // Pipe with stdlib.
+    println(-42 |> abs);    // 42
+    println("ab" |> repeat(3));  // ababab
+    return 0;
+}
+main(0);
+`,
+  },
+  {
+    name: "invariant_proven_demo.rz",
+    source: `// SMT-discharged loop invariant.
+// The verifier statically proves both base case and inductive step
+// without executing the loop — no runtime check needed.
+
+fn main() {
+    let i = 0;
+    let n = 5;
+    while i < n {
+        invariant i >= 0;
+        invariant i <= n;
+        i = i + 1;
+    }
+    println("ok");
+}
+main();
+`,
+  },
+  {
+    name: "comprehension_demo.rz",
+    source: `// Array comprehensions: [expr for x in xs (if guard)?]
+
+fn main(int _d) {
+    let xs = [1, 2, 3, 4, 5, 6];
+
+    // Map: double each element.
+    let doubled = [x * 2 for x in xs];
+    println(doubled);               // [2, 4, 6, 8, 10, 12]
+
+    // Filter-map: square the even numbers only.
+    let even_sq = [x * x for x in xs if x % 2 == 0];
+    println(even_sq);               // [4, 16, 36]
+
+    return 0;
+}
+main(0);
+`,
+  },
+  {
     name: "hello.rz",
-    source:
-      'fn main() {\n    println("Hello, Resilient world!");\n}\nmain();\n',
-  },
-  {
-    name: "factorial.rz",
-    source:
-      "fn fact(int n) {\n    if n <= 1 { return 1; }\n    return n * fact(n - 1);\n}\nprintln(fact(7));\n",
-  },
-  {
-    name: "loop_invariant.rz",
-    source:
-      "fn sum_to(int n)\n  requires n >= 0\n  ensures result >= 0\n{\n    let total = 0;\n    let i = 0;\n    while i < n\n      invariant total >= 0\n      invariant i >= 0\n    {\n        total = total + i;\n        i = i + 1;\n    }\n    return total;\n}\nprintln(sum_to(10));\n",
+    source: `fn main() {
+    println("Hello, Resilient world!");
+}
+main();
+`,
   },
 ];
 
@@ -41,7 +411,7 @@ const clearBtn = document.getElementById("clear-btn");
 const select = document.getElementById("example-select");
 const banner = document.getElementById("scaffold-banner");
 
-editorEl.value = EXAMPLES_FALLBACK[0].source;
+editorEl.value = EXAMPLES_FALLBACK[0].source; // sensor_monitor — first pinned example
 
 const cm = CodeMirror.fromTextArea(editorEl, {
   mode: "rust",

--- a/resilient/examples/showcase_actors.expected.txt
+++ b/resilient/examples/showcase_actors.expected.txt
@@ -1,0 +1,3 @@
+messages sent
+sum = 42
+Program executed successfully

--- a/resilient/examples/showcase_actors.rz
+++ b/resilient/examples/showcase_actors.rz
@@ -1,0 +1,19 @@
+// Actor model: isolated processes communicate via messages.
+// spawn() creates an actor; send/receive pass values between them.
+// No shared state — data races are structurally impossible.
+
+fn summer() {
+    let a = receive();
+    let b = receive();
+    let c = receive();
+    println("sum = " + (a + b + c));
+}
+
+fn main() {
+    let pid = spawn(summer);
+    send(pid, 10);
+    send(pid, 20);
+    send(pid, 12);   // 10 + 20 + 12 = 42
+    println("messages sent");
+}
+main();

--- a/resilient/examples/showcase_contracts.expected.txt
+++ b/resilient/examples/showcase_contracts.expected.txt
@@ -1,0 +1,8 @@
+14
+7
+0
+10
+5
+120
+1
+Program executed successfully

--- a/resilient/examples/showcase_contracts.rz
+++ b/resilient/examples/showcase_contracts.rz
@@ -1,0 +1,42 @@
+// Contracts: machine-checked pre/postconditions.
+// `requires` is enforced at every call site;
+// `ensures` is a guarantee the callee must prove.
+// With --features z3, the compiler discharges these statically
+// — the division-by-zero check below has zero runtime cost.
+
+fn safe_divide(int n, int d) -> int
+    requires d != 0
+{
+    return n / d;
+}
+
+fn clamp(int x, int lo, int hi) -> int
+    requires lo <= hi
+    ensures result >= lo
+    ensures result <= hi
+{
+    if x < lo { return lo; }
+    if x > hi { return hi; }
+    return x;
+}
+
+fn factorial(int n) -> int
+    requires n >= 0
+    ensures result >= 1
+{
+    if n <= 1 { return 1; }
+    return n * factorial(n - 1);
+}
+
+fn main() {
+    println(safe_divide(100, 7));   // 14  (integer division)
+    println(safe_divide(42, 6));    // 7
+
+    println(clamp(-5, 0, 10));      // 0   (below lo → returns lo)
+    println(clamp(15, 0, 10));      // 10  (above hi → returns hi)
+    println(clamp(5,  0, 10));      // 5   (in range → unchanged)
+
+    println(factorial(5));          // 120
+    println(factorial(0));          // 1
+}
+main();

--- a/resilient/examples/showcase_linear_types.expected.txt
+++ b/resilient/examples/showcase_linear_types.expected.txt
@@ -1,0 +1,6 @@
+uart: opened port 2
+uart: tx boot ok
+uart: tx sensor ready
+uart: closed port 2
+handle released exactly once
+Program executed successfully

--- a/resilient/examples/showcase_linear_types.rz
+++ b/resilient/examples/showcase_linear_types.rz
@@ -1,0 +1,30 @@
+// Linear types: the compiler tracks resource ownership.
+// A linear value must be consumed exactly once —
+// double-close and use-after-close are compile-time errors,
+// not runtime crashes. Ideal for MMIO, file handles, sockets.
+
+struct UartConn { int port }
+
+fn uart_open(int port) -> linear UartConn {
+    println("uart: opened port " + port);
+    return new UartConn { port: port };
+}
+
+fn uart_write(linear UartConn c, string msg) -> linear UartConn {
+    println("uart: tx " + msg);
+    return c;   // ownership returned — caller must consume it
+}
+
+fn uart_close(linear UartConn c) {
+    println("uart: closed port " + c.port);
+    // c is consumed here; the compiler forbids any further use
+}
+
+fn main() {
+    let c  = uart_open(2);
+    let c2 = uart_write(c,  "boot ok");
+    let c3 = uart_write(c2, "sensor ready");
+    uart_close(c3);
+    println("handle released exactly once");
+}
+main();

--- a/resilient/examples/showcase_quantifiers.expected.txt
+++ b/resilient/examples/showcase_quantifiers.expected.txt
@@ -1,0 +1,7 @@
+true
+true
+false
+true
+true
+all proofs passed
+Program executed successfully

--- a/resilient/examples/showcase_quantifiers.rz
+++ b/resilient/examples/showcase_quantifiers.rz
@@ -1,0 +1,29 @@
+// Quantifiers as runnable code and static proofs.
+// `forall i in lo..hi: P(i)` evaluates true if P holds for every i.
+// `exists i in lo..hi: P(i)` is true if any witness satisfies P.
+// With --features z3, bounded-range forms discharge as SMT lemmas.
+
+fn is_even(int n) -> bool { return n % 2 == 0; }
+
+fn main() {
+    // Every square in 0..8 is non-negative.
+    println(forall i in 0..8: i * i >= 0);     // true
+
+    // There exists an even number in 1..10.
+    println(exists i in 1..10: is_even(i));    // true
+
+    // Not all numbers in 0..5 are even.
+    println(forall i in 0..5: is_even(i));     // false
+
+    // Every number in 1..6 is positive.
+    println(forall i in 1..6: i > 0);          // true
+
+    // Vacuously true: empty range, no counterexample.
+    println(forall i in 5..5: false);          // true
+
+    // Embed quantifiers directly in assertions.
+    assert(forall i in 0..10: i * i >= 0);
+    assert(exists i in 0..10: i == 7);
+    println("all proofs passed");
+}
+main();

--- a/resilient/examples/showcase_result.expected.txt
+++ b/resilient/examples/showcase_result.expected.txt
@@ -1,0 +1,5 @@
+100 / 5 = 20
+caught: division by zero
+sqrt input: 9
+caught: negative input
+Program executed successfully

--- a/resilient/examples/showcase_result.rz
+++ b/resilient/examples/showcase_result.rz
@@ -1,0 +1,45 @@
+// Result<T>: principled error propagation without exceptions.
+// Ok(v) carries a success value; Err(e) carries a failure reason.
+// Pattern matching forces every caller to handle both cases.
+// The `?` operator propagates Err out of the current function.
+
+fn safe_div(int n, int d) -> Result {
+    if d == 0 { return Err("division by zero"); }
+    return Ok(n / d);
+}
+
+fn safe_sqrt(int n) -> Result {
+    if n < 0 { return Err("negative input"); }
+    return Ok(n);
+}
+
+fn main() {
+    let r1 = safe_div(100, 5);
+    let msg1 = match r1 {
+        Ok(v)  => "100 / 5 = " + v,
+        Err(e) => "error: " + e,
+    };
+    println(msg1);
+
+    let r2 = safe_div(42, 0);
+    let msg2 = match r2 {
+        Ok(v)  => "ok: " + v,
+        Err(e) => "caught: " + e,
+    };
+    println(msg2);
+
+    let r3 = safe_sqrt(9);
+    let msg3 = match r3 {
+        Ok(v)  => "sqrt input: " + v,
+        Err(e) => "error: " + e,
+    };
+    println(msg3);
+
+    let r4 = safe_sqrt(-1);
+    let msg4 = match r4 {
+        Ok(v)  => "ok: " + v,
+        Err(e) => "caught: " + e,
+    };
+    println(msg4);
+}
+main();


### PR DESCRIPTION
## What

Adds five new `showcase_*.rz` examples that highlight Resilient's most distinctive features, pins 28 curated entries to the top of the playground dropdown, and expands the inline `EXAMPLES_FALLBACK` in `main.js` so the playground is compelling even in dev mode.

## Why

The previous dropdown started with `hello.rz`, `factorial.rz`, and a loop-invariant stub — none of which show what makes Resilient different from any other language. A first-time visitor had to scroll through 360+ alphabetically-sorted files to find the features worth demoing. The pinned ordering and new showcase examples fix the first-impression problem.

## Changes

**New example files** (all with golden `.expected.txt` sidecars, all passing):
- `resilient/examples/showcase_contracts.rz` — `requires`/`ensures` contracts preventing divide-by-zero and proving clamp bounds statically
- `resilient/examples/showcase_linear_types.rz` — UART connection handle tracked by the compiler; double-close is a compile-time error, not a runtime crash
- `resilient/examples/showcase_actors.rz` — `spawn`/`send`/`receive` with no shared state; data races structurally impossible
- `resilient/examples/showcase_quantifiers.rz` — `forall`/`exists` as runnable code that also discharges as SMT lemmas with `--features z3`
- `resilient/examples/showcase_result.rz` — `Ok`/`Err` pattern matching forcing callers to handle both cases explicitly

**`playground/build.sh`**
- Python script now has a `PINNED` list of 28 examples; these appear first in `examples.json` in the declared order, remainder alphabetical
- Refactored into a `load()` helper to deduplicate the size-limit check

**`playground/web/main.js`**
- `EXAMPLES_FALLBACK` expanded from 3 generic entries to 12 curated inline examples covering: contracts, linear types, actors, quantifiers, Result, algebraic data types, operator overloading, pipe operator, SMT loop invariants, and array comprehensions
- Initial editor content is the flagship `sensor_monitor.rz` (first pinned entry)

## Test plan

- [ ] All 5 new golden files verified: `showcase_{contracts,linear_types,actors,quantifiers,result}` produce output matching their `.expected.txt` exactly
- [ ] `cargo test --test examples_golden golden_outputs_match` — new files pass (pre-existing `asin`/`asinh`/`atanh` float-precision failures are unrelated and pre-date this PR)
- [ ] Build script Python logic validated: 28/28 pinned examples resolve, 366 total entries, correct ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)