### PR TITLE
feat: showcase_live_invariant — exercise the rollback path for real

### DIFF
--- a/playground/build.sh
+++ b/playground/build.sh
@@ -66,6 +66,7 @@ examples_dir = os.path.join(repo_root, "resilient", "examples")
 # They showcase the language's most distinctive features.
 PINNED = [
     "sensor_monitor.rz",            # flagship: contracts + Result + live block
+    "showcase_live_invariant.rz",   # live invariant: atomic rollback + retry (THE differentiator)
     "showcase_contracts.rz",        # requires / ensures / loop invariant
     "showcase_linear_types.rz",     # linear types: resource ownership tracking
     "showcase_actors.rz",           # actor model: spawn / send / receive

--- a/playground/web/main.js
+++ b/playground/web/main.js
@@ -160,6 +160,42 @@ main();
 `,
   },
   {
+    name: "showcase_live_invariant.rz",
+    source: `// \`live invariant\` is atomic rollback-on-failure with bounded retry.
+// When the body's exit state violates the invariant (or the body
+// throws), the runtime restores the pre-block environment and
+// re-runs the body. On exhaustion the error propagates.
+//
+// This demo exercises the machinery for real:
+//   - the body is non-idempotent (a two-step money transfer),
+//   - a transient fault aborts mid-transfer, and
+//   - the invariant \`total funds preserved\` fails on partial state.
+// Without rollback, repeated debits would compound and corrupt the
+// books. live_retries() lets the simulated fault clear by attempt 3.
+
+fn main() {
+    let bal_a = 100;
+    let bal_b = 50;
+    let total_before = bal_a + bal_b;
+
+    println("before: a=" + bal_a + " b=" + bal_b);
+
+    live invariant bal_a + bal_b == total_before {
+        bal_a = bal_a - 50;                       // partial mutation
+        if live_retries() < 2 {
+            assert(false, "transient fault — must roll back");
+        }
+        bal_b = bal_b + 50;                       // completes transfer
+    }
+
+    println("after:  a=" + bal_a + " b=" + bal_b);
+    println("total preserved: " + (bal_a + bal_b));
+    println("retries used: " + live_total_retries());
+}
+main();
+`,
+  },
+  {
     name: "showcase_actors.rz",
     source: `// Actor model: isolated processes communicate via messages.
 // spawn() creates an actor; send/receive pass values between them.

--- a/resilient/examples/showcase_live_invariant.expected.txt
+++ b/resilient/examples/showcase_live_invariant.expected.txt
@@ -1,0 +1,5 @@
+before: a=100 b=50
+after:  a=50 b=100
+total preserved: 150
+retries used: 2
+Program executed successfully

--- a/resilient/examples/showcase_live_invariant.rz
+++ b/resilient/examples/showcase_live_invariant.rz
@@ -1,0 +1,45 @@
+// `live invariant` is atomic rollback-on-failure with bounded retry.
+// When the body's exit state violates the invariant (or the body
+// throws), the runtime restores the pre-block environment and
+// re-runs the body. On exhaustion the error propagates with a
+// "Live block failed after N attempts" prefix.
+//
+// This demo actually exercises the machinery:
+//
+//   - the body is non-idempotent (a two-step money transfer),
+//   - a transient fault aborts the body mid-transfer, and
+//   - the invariant `total funds preserved` fails on partial state.
+//
+// The rollback is what makes retries safe. Without it, the failed
+// debit would persist and the next attempt would debit again — the
+// invariant would never be restorable. `live_retries()` lets the
+// body see which attempt it's on, so the simulated fault clears
+// after two retries and the third attempt completes cleanly.
+
+fn main() {
+    let bal_a = 100;
+    let bal_b = 50;
+    let total_before = bal_a + bal_b;
+
+    println("before: a=" + bal_a + " b=" + bal_b);
+
+    live invariant bal_a + bal_b == total_before {
+        // Step 1: debit account A.
+        bal_a = bal_a - 50;
+
+        // Simulated transient fault on the first two attempts.
+        // Without rollback, the partial state (a=50, b=50, total=100)
+        // would leak out and a retry would debit again → corruption.
+        if live_retries() < 2 {
+            assert(false, "transient fault — must roll back");
+        }
+
+        // Step 2: credit account B. Reached only on the third attempt.
+        bal_b = bal_b + 50;
+    }
+
+    println("after:  a=" + bal_a + " b=" + bal_b);
+    println("total preserved: " + (bal_a + bal_b));
+    println("retries used: " + live_total_retries());
+}
+main();


### PR DESCRIPTION
## What

Adds `showcase_live_invariant.rz`, the first example that actually exercises `live invariant`'s rollback-and-retry machinery — and pins it second in the playground dropdown.

## Why

A reviewer pointed out that none of the existing showcase examples actually demonstrate `live invariant`. The flagship `sensor_monitor.rz` has `live invariant total >= 0`, but `total` starts at 0 and only increments — the invariant cannot fail, the runtime never rolls back, never retries, and the construct is decorative.

This was the strongest argument that Resilient has nothing distinctive: the language's most differentiated feature had no honest demo.

## What `live invariant` actually does

From reading `eval_live_block` in [`resilient/src/lib.rs`](resilient/src/lib.rs):

1. Deep-clones the local environment at block entry
2. Runs the body
3. Evaluates each `invariant` clause as a postcondition
4. If any returns false (or the body throws): restores the environment from the snapshot and re-runs the body
5. Repeats up to `max_retries` (default 3, configurable via `retries(N)`); supports a `within <duration>` wall-clock budget
6. On exhaustion: propagates an error with `"Live block failed after N attempts"`

It's speculative execution with atomic local-state rollback — closest analogy is STM `retry`. Note: rollback is locals-only; I/O, actor sends, and external side effects are not undone.

## The new example

A two-step transfer where rollback is load-bearing:

```rz
let bal_a = 100;
let bal_b = 50;
let total_before = bal_a + bal_b;

live invariant bal_a + bal_b == total_before {
    bal_a = bal_a - 50;                       // partial mutation
    if live_retries() < 2 {
        assert(false, "transient fault — must roll back");
    }
    bal_b = bal_b + 50;                       // completes transfer
}
```

- **Body is non-idempotent**: debiting A twice would corrupt state.
- **Fault is transient**: `live_retries()` lets the third attempt skip the fault.
- **Rollback is load-bearing**: without it, repeated debits would compound (100 → 50 → 0 → -50) and the invariant would never be restorable.
- Final output reports `retries used: 2`, confirming the retry path actually fired.

The `[LIVE BLOCK] ... Restoring environment to last known good state` trace lines on stderr show the rollback observably happening twice before the third attempt completes.

## Changes

- `resilient/examples/showcase_live_invariant.rz` — the new example
- `resilient/examples/showcase_live_invariant.expected.txt` — golden output
- `playground/build.sh` — pinned second in dropdown ordering (right after `sensor_monitor.rz`)
- `playground/web/main.js` — added inline source to `EXAMPLES_FALLBACK` so dev mode picks it up

## Test plan

- [x] Golden output matches: `bal_a=50, bal_b=100, total=150, retries used: 2`
- [x] Rollback is observable in stderr trace (two restore-and-retry cycles)
- [x] Pinned list integrity preserved (29 entries, all resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)