### PR TITLE
RES-1132: serialize feature_attrs tests to eliminate global-state race

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,8 @@
 {
   "claims": {
-    "resilient/src/lib.rs": {
-      "branch": "res-1126-1130-direction-rounded-div",
-      "claimed_at": "2026-05-11T14:25:23Z"
+    "resilient/src/feature_attrs.rs": {
+      "branch": "res-1132-feature-attrs-test-race",
+      "claimed_at": "2026-05-11T14:34:56Z"
     }
   }
 }

--- a/resilient/src/feature_attrs.rs
+++ b/resilient/src/feature_attrs.rs
@@ -182,9 +182,27 @@ pub fn is_known_attribute(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// RES-1132: `record_and_lookup` and `reset_clears_state` both
+    /// drive the global `ATTR_REGISTRY`. cargo runs tests in parallel
+    /// by default, so without serialization the two races: A's
+    /// `record` can be wiped by B's `reset` between A's `record` and
+    /// `find_kind` calls, intermittently failing `record_and_lookup`
+    /// with `len = 0`. A per-module mutex held for the entire test
+    /// makes the global-state writes serial without affecting any
+    /// other test in the binary.
+    fn serial_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: Mutex<()> = Mutex::new(());
+        // Poison-tolerant: if a prior test panicked while holding the
+        // lock, the registry isn't corrupted (reset() rebuilds it),
+        // so we recover the guard and proceed.
+        LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
 
     #[test]
     fn record_and_lookup() {
+        let _g = serial_lock();
         reset();
         record(
             "my_fn",
@@ -209,6 +227,7 @@ mod tests {
 
     #[test]
     fn reset_clears_state() {
+        let _g = serial_lock();
         reset();
         record(
             "f",


### PR DESCRIPTION
## Summary

Fixes a global-state race in two `feature_attrs::tests` that intermittently flakes `build / test / clippy` on CI.

Closes #1132.

### Root cause

`feature_attrs` keeps a process-wide `ATTR_REGISTRY` (a `RwLock<Option<AttrMap>>`). Two tests in the module write to it:
- `record_and_lookup` — calls `reset()`, then `record(...)`, then asserts `find_kind("wcet").len() == 1`.
- `reset_clears_state` — calls `reset()`, `record(...)`, `reset()`, asserts the second `find_kind` returns 0.

cargo runs tests in parallel by default. Without serialization, `reset_clears_state`'s `reset()` calls can land *between* `record_and_lookup`'s `record` and `find_kind`, intermittently producing the observed `len = 0`.

### Hit

PR #1131's first `build / test / clippy` job tripped on this race once. Rerunning the failed step passed without code changes — classic flakiness signal.

### Fix

Add a per-module `Mutex<()>` and lock it in each test that *writes* to the registry. `known_attributes` is read-only and doesn't need the guard. The lock is poison-tolerant — if a test panics while holding it, subsequent tests still acquire and `reset()` rebuilds the registry.

```rust
fn serial_lock() -> std::sync::MutexGuard<'static, ()> {
    static LOCK: Mutex<()> = Mutex::new(());
    LOCK.lock().unwrap_or_else(|p| p.into_inner())
}
```

No new dependency — a 5-line static mutex is sufficient and keeps the supply-chain footprint flat per the project's hygiene rule.

### Test changes

No tests added or removed. The two affected tests still run, just sequentially with respect to each other.

### CI gates verified locally

- `cargo test --manifest-path resilient/Cargo.toml --locked --lib -- feature_attrs::` ✓ (3/3 pass)
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo fmt --check` ✓

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --locked --lib -- feature_attrs::`
- [x] Repeat 10× — no flakes (would be impossible to reliably reproduce locally given thread-scheduling sensitivity; the lock makes the race structurally impossible)
