### PR TITLE
RES-1134: bytes_xor/and/or/not/fill/reverse — 6 new builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -3,6 +3,14 @@
     "resilient/src/feature_attrs.rs": {
       "branch": "res-1132-feature-attrs-test-race",
       "claimed_at": "2026-05-11T14:34:56Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "res-1134-bytes-bitwise-ops",
+      "claimed_at": "2026-05-11T14:57:42Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1134-bytes-bitwise-ops",
+      "claimed_at": "2026-05-11T14:57:42Z"
     }
   }
 }

--- a/resilient/examples/bytes_and_or_not.expected.txt
+++ b/resilient/examples/bytes_and_or_not.expected.txt
@@ -1,0 +1,5 @@
+0b0d0f
+1f2f3f
+ff0055aa
+true
+Program executed successfully

--- a/resilient/examples/bytes_and_or_not.rz
+++ b/resilient/examples/bytes_and_or_not.rz
@@ -1,0 +1,24 @@
+// RES-1134 demo: bytes_and / bytes_or / bytes_not — bitwise mask ops.
+// AND clears bits, OR sets bits, NOT flips every bit (involution).
+
+fn main(int _d) {
+    // Mask off the high nibble of every byte (clear top 4 bits).
+    let lo = bytes_and(b"\xAB\xCD\xEF", b"\x0F\x0F\x0F");
+    println(bytes_to_hex(lo));         // 0b0d0f
+
+    // Set the low nibble of every byte to 0xF.
+    let hi = bytes_or(b"\x10\x20\x30", b"\x0F\x0F\x0F");
+    println(bytes_to_hex(hi));         // 1f2f3f
+
+    // NOT flips every bit.
+    let flipped = bytes_not(b"\x00\xFF\xAA\x55");
+    println(bytes_to_hex(flipped));    // ff0055aa
+
+    // NOT(NOT(b)) == b — involution.
+    let back = bytes_not(bytes_not(b"hello"));
+    println(bytes_eq(back, b"hello")); // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/examples/bytes_fill_reverse.expected.txt
+++ b/resilient/examples/bytes_fill_reverse.expected.txt
@@ -1,0 +1,6 @@
+00000000
+cccccccccc
+0504030201
+deadbeef
+0
+Program executed successfully

--- a/resilient/examples/bytes_fill_reverse.rz
+++ b/resilient/examples/bytes_fill_reverse.rz
@@ -1,0 +1,24 @@
+// RES-1134 demo: bytes_fill(n, byte) builds a uniform buffer;
+// bytes_reverse(b) flips byte order (involution).
+
+fn main(int _d) {
+    // Zero buffer of length 4 — classic IV / padding seed.
+    println(bytes_to_hex(bytes_fill(4, 0)));    // 00000000
+
+    // Sentinel buffer of length 5 with byte 0xCC.
+    println(bytes_to_hex(bytes_fill(5, 204)));  // cccccccccc
+
+    // Reverse a 5-byte sequence.
+    println(bytes_to_hex(bytes_reverse(b"\x01\x02\x03\x04\x05")));  // 0504030201
+
+    // Reversing twice is identity.
+    let back = bytes_reverse(bytes_reverse(b"\xDE\xAD\xBE\xEF"));
+    println(bytes_to_hex(back));                // deadbeef
+
+    // Empty fill produces empty bytes.
+    println(bytes_len(bytes_fill(0, 0)));       // 0
+
+    return 0;
+}
+
+main(0);

--- a/resilient/examples/bytes_xor.expected.txt
+++ b/resilient/examples/bytes_xor.expected.txt
@@ -1,0 +1,5 @@
+55a500
+0000000000
+deadbeef
+0
+Program executed successfully

--- a/resilient/examples/bytes_xor.rz
+++ b/resilient/examples/bytes_xor.rz
@@ -1,0 +1,26 @@
+// RES-1134 demo: bytes_xor(a, b) — element-wise XOR of two equal-length
+// Bytes. Classic one-time-pad / stream-cipher mask helper.
+
+fn main(int _d) {
+    // Basic XOR — masking bits with 0xAA toggles every other bit.
+    let masked = bytes_xor(b"\xFF\x0F\xAA", b"\xAA\xAA\xAA");
+    println(bytes_to_hex(masked));     // 55a500
+
+    // Self-XOR yields all zeros (idempotent erase).
+    let zeros = bytes_xor(b"hello", b"hello");
+    println(bytes_to_hex(zeros));      // 0000000000
+
+    // Round-trip: encrypt then decrypt with the same key.
+    let msg = b"\xDE\xAD\xBE\xEF";
+    let key = b"\x12\x34\x56\x78";
+    let ct = bytes_xor(msg, key);
+    let back = bytes_xor(ct, key);
+    println(bytes_to_hex(back));       // deadbeef
+
+    // Empty XOR empty is empty.
+    println(bytes_len(bytes_xor(b"", b"")));   // 0
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/bytes_bitwise.rs
+++ b/resilient/src/bytes_bitwise.rs
@@ -1,0 +1,391 @@
+//! RES-1134: bitwise + construction ops on `Value::Bytes`.
+//!
+//! Six pure, side-effect-free builtins that round out the byte-buffer
+//! surface alongside the existing `bytes_len`, `bytes_slice`,
+//! `bytes_concat`, `bytes_eq`, `bytes_starts_with`, `bytes_ends_with`,
+//! `bytes_index_of`, `bytes_to_hex`, and `bytes_from_hex`. They cover
+//! the gap that crypto / protocol / mask-and-merge work hits as soon
+//! as the existing accessors aren't enough:
+//!
+//! | Builtin | Purpose |
+//! |---|---|
+//! | `bytes_xor(a, b) -> Bytes` | One-time-pad / stream-cipher mask / parity |
+//! | `bytes_and(a, b) -> Bytes` | Selective bit clear (mask AND) |
+//! | `bytes_or(a, b) -> Bytes`  | Selective bit set (mask OR) |
+//! | `bytes_not(b) -> Bytes`    | Bit complement / parity helper |
+//! | `bytes_fill(n, byte) -> Bytes` | Zero / sentinel buffer of length n |
+//! | `bytes_reverse(b) -> Bytes` | Endianness flip, palindrome checks |
+//!
+//! All six are deterministic, allocate exactly one fresh `Vec<u8>` per
+//! call, and never panic — every error path returns a typed `RResult`
+//! diagnostic the interpreter wraps with the call-site span.
+
+use crate::{RResult, Value};
+
+/// `bytes_xor(a, b) -> Bytes` — element-wise XOR of two equal-length
+/// `Bytes`. Errors on length mismatch — XOR of differing-length buffers
+/// is almost always a bug (truncating one side hides the surprise).
+pub(crate) fn builtin_bytes_xor(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(a), Value::Bytes(b)] => {
+            if a.len() != b.len() {
+                return Err(format!(
+                    "bytes_xor: length mismatch — left={}, right={}",
+                    a.len(),
+                    b.len()
+                ));
+            }
+            let out: Vec<u8> = a.iter().zip(b.iter()).map(|(x, y)| x ^ y).collect();
+            Ok(Value::Bytes(out))
+        }
+        [Value::Bytes(_), other] => Err(format!(
+            "bytes_xor: second argument must be Bytes, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "bytes_xor: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_xor: expected 2 arguments (bytes, bytes), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_and(a, b) -> Bytes` — element-wise AND of two equal-length
+/// `Bytes`. Same length contract as `bytes_xor`.
+pub(crate) fn builtin_bytes_and(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(a), Value::Bytes(b)] => {
+            if a.len() != b.len() {
+                return Err(format!(
+                    "bytes_and: length mismatch — left={}, right={}",
+                    a.len(),
+                    b.len()
+                ));
+            }
+            let out: Vec<u8> = a.iter().zip(b.iter()).map(|(x, y)| x & y).collect();
+            Ok(Value::Bytes(out))
+        }
+        [Value::Bytes(_), other] => Err(format!(
+            "bytes_and: second argument must be Bytes, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "bytes_and: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_and: expected 2 arguments (bytes, bytes), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_or(a, b) -> Bytes` — element-wise OR of two equal-length
+/// `Bytes`. Same length contract as `bytes_xor`.
+pub(crate) fn builtin_bytes_or(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(a), Value::Bytes(b)] => {
+            if a.len() != b.len() {
+                return Err(format!(
+                    "bytes_or: length mismatch — left={}, right={}",
+                    a.len(),
+                    b.len()
+                ));
+            }
+            let out: Vec<u8> = a.iter().zip(b.iter()).map(|(x, y)| x | y).collect();
+            Ok(Value::Bytes(out))
+        }
+        [Value::Bytes(_), other] => Err(format!(
+            "bytes_or: second argument must be Bytes, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "bytes_or: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_or: expected 2 arguments (bytes, bytes), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_not(b) -> Bytes` — bitwise complement of every byte. Round-trip
+/// holds: `bytes_not(bytes_not(b)) == b`.
+pub(crate) fn builtin_bytes_not(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b)] => {
+            let out: Vec<u8> = b.iter().map(|x| !x).collect();
+            Ok(Value::Bytes(out))
+        }
+        [other] => Err(format!("bytes_not: expected Bytes, got {}", other)),
+        _ => Err(format!(
+            "bytes_not: expected 1 argument (bytes), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_fill(n, byte) -> Bytes` — fresh `Bytes` of length `n` with every
+/// position set to `byte`. `n` must be non-negative; `byte` must fit in a
+/// `u8` (0..=255). Useful for zero buffers, sentinel fills, and padding.
+pub(crate) fn builtin_bytes_fill(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n), Value::Int(byte)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "bytes_fill: length must be non-negative, got {}",
+                    n
+                ));
+            }
+            if *byte < 0 || *byte > 255 {
+                return Err(format!("bytes_fill: byte must be in 0..=255, got {}", byte));
+            }
+            Ok(Value::Bytes(vec![*byte as u8; *n as usize]))
+        }
+        [a, b] => Err(format!(
+            "bytes_fill: expected (Int, Int), got ({:?}, {:?})",
+            a, b
+        )),
+        _ => Err(format!(
+            "bytes_fill: expected 2 arguments (length, byte), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_reverse(b) -> Bytes` — fresh `Bytes` with the byte order flipped.
+/// Involution: `bytes_reverse(bytes_reverse(b)) == b`. Useful for
+/// endianness conversion of opaque byte strings and palindrome checks.
+pub(crate) fn builtin_bytes_reverse(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b)] => {
+            let mut out = b.clone();
+            out.reverse();
+            Ok(Value::Bytes(out))
+        }
+        [other] => Err(format!("bytes_reverse: expected Bytes, got {}", other)),
+        _ => Err(format!(
+            "bytes_reverse: expected 1 argument (bytes), got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn val(v: &[u8]) -> Value {
+        Value::Bytes(v.to_vec())
+    }
+
+    fn bytes(v: Value) -> Vec<u8> {
+        match v {
+            Value::Bytes(b) => b,
+            other => panic!("expected Value::Bytes, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn xor_pair_known_vector() {
+        let r = builtin_bytes_xor(&[val(&[0xFF, 0x0F, 0xAA]), val(&[0xAA, 0xAA, 0xAA])]).unwrap();
+        assert_eq!(bytes(r), vec![0x55, 0xA5, 0x00]);
+    }
+
+    #[test]
+    fn xor_self_is_zero() {
+        let buf = val(&[1, 2, 3, 4, 5]);
+        let r = builtin_bytes_xor(&[buf.clone(), buf]).unwrap();
+        assert_eq!(bytes(r), vec![0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn xor_empty_yields_empty() {
+        let r = builtin_bytes_xor(&[val(&[]), val(&[])]).unwrap();
+        assert_eq!(bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn xor_length_mismatch_errors() {
+        let err = builtin_bytes_xor(&[val(&[1, 2]), val(&[1, 2, 3])]).unwrap_err();
+        assert!(err.contains("length mismatch"), "got {}", err);
+    }
+
+    #[test]
+    fn xor_round_trips_with_key() {
+        let msg = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let key = vec![0x12, 0x34, 0x56, 0x78];
+        let ct = builtin_bytes_xor(&[val(&msg), val(&key)]).unwrap();
+        let back = builtin_bytes_xor(&[ct, val(&key)]).unwrap();
+        assert_eq!(bytes(back), msg);
+    }
+
+    #[test]
+    fn xor_rejects_non_bytes() {
+        let err = builtin_bytes_xor(&[val(&[1]), Value::Int(7)]).unwrap_err();
+        assert!(err.contains("second argument must be Bytes"));
+        let err = builtin_bytes_xor(&[Value::Int(7), val(&[1])]).unwrap_err();
+        assert!(err.contains("first argument must be Bytes"));
+    }
+
+    #[test]
+    fn xor_arity_check() {
+        let err = builtin_bytes_xor(&[val(&[1])]).unwrap_err();
+        assert!(err.contains("expected 2"));
+    }
+
+    #[test]
+    fn and_clears_with_zero_mask() {
+        let r = builtin_bytes_and(&[val(&[0xFF, 0xFF, 0xFF]), val(&[0x00, 0x0F, 0xF0])]).unwrap();
+        assert_eq!(bytes(r), vec![0x00, 0x0F, 0xF0]);
+    }
+
+    #[test]
+    fn and_identity_with_all_ones() {
+        let r = builtin_bytes_and(&[val(&[0xAB, 0xCD, 0xEF]), val(&[0xFF, 0xFF, 0xFF])]).unwrap();
+        assert_eq!(bytes(r), vec![0xAB, 0xCD, 0xEF]);
+    }
+
+    #[test]
+    fn and_length_mismatch_errors() {
+        let err = builtin_bytes_and(&[val(&[1]), val(&[1, 2])]).unwrap_err();
+        assert!(err.contains("length mismatch"));
+    }
+
+    #[test]
+    fn or_sets_bits_with_mask() {
+        let r = builtin_bytes_or(&[val(&[0x10, 0x20, 0x30]), val(&[0x0F, 0x0F, 0x0F])]).unwrap();
+        assert_eq!(bytes(r), vec![0x1F, 0x2F, 0x3F]);
+    }
+
+    #[test]
+    fn or_identity_with_zero_mask() {
+        let r = builtin_bytes_or(&[val(&[0xAB, 0xCD, 0xEF]), val(&[0x00, 0x00, 0x00])]).unwrap();
+        assert_eq!(bytes(r), vec![0xAB, 0xCD, 0xEF]);
+    }
+
+    #[test]
+    fn or_length_mismatch_errors() {
+        let err = builtin_bytes_or(&[val(&[1, 2, 3]), val(&[1])]).unwrap_err();
+        assert!(err.contains("length mismatch"));
+    }
+
+    #[test]
+    fn not_flips_each_bit() {
+        let r = builtin_bytes_not(&[val(&[0x00, 0xFF, 0xAA, 0x55])]).unwrap();
+        assert_eq!(bytes(r), vec![0xFF, 0x00, 0x55, 0xAA]);
+    }
+
+    #[test]
+    fn not_is_involution() {
+        let original = vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF];
+        let once = builtin_bytes_not(&[val(&original)]).unwrap();
+        let twice = builtin_bytes_not(&[once]).unwrap();
+        assert_eq!(bytes(twice), original);
+    }
+
+    #[test]
+    fn not_empty_yields_empty() {
+        let r = builtin_bytes_not(&[val(&[])]).unwrap();
+        assert_eq!(bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn not_rejects_non_bytes() {
+        let err = builtin_bytes_not(&[Value::Int(7)]).unwrap_err();
+        assert!(err.contains("expected Bytes"));
+    }
+
+    #[test]
+    fn fill_basic() {
+        let r = builtin_bytes_fill(&[Value::Int(4), Value::Int(0x42)]).unwrap();
+        assert_eq!(bytes(r), vec![0x42, 0x42, 0x42, 0x42]);
+    }
+
+    #[test]
+    fn fill_zero_length_is_empty() {
+        let r = builtin_bytes_fill(&[Value::Int(0), Value::Int(0)]).unwrap();
+        assert_eq!(bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn fill_with_byte_zero_and_ff_boundaries() {
+        let r = builtin_bytes_fill(&[Value::Int(3), Value::Int(0)]).unwrap();
+        assert_eq!(bytes(r), vec![0, 0, 0]);
+        let r = builtin_bytes_fill(&[Value::Int(3), Value::Int(255)]).unwrap();
+        assert_eq!(bytes(r), vec![0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn fill_rejects_negative_length() {
+        let err = builtin_bytes_fill(&[Value::Int(-1), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("non-negative"));
+    }
+
+    #[test]
+    fn fill_rejects_out_of_range_byte() {
+        let err = builtin_bytes_fill(&[Value::Int(2), Value::Int(256)]).unwrap_err();
+        assert!(err.contains("0..=255"));
+        let err = builtin_bytes_fill(&[Value::Int(2), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("0..=255"));
+    }
+
+    #[test]
+    fn fill_rejects_wrong_types() {
+        let err = builtin_bytes_fill(&[Value::Bool(true), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected (Int, Int)"));
+    }
+
+    #[test]
+    fn reverse_known_vector() {
+        let r = builtin_bytes_reverse(&[val(&[1, 2, 3, 4, 5])]).unwrap();
+        assert_eq!(bytes(r), vec![5, 4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn reverse_is_involution() {
+        let original = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x42];
+        let once = builtin_bytes_reverse(&[val(&original)]).unwrap();
+        let twice = builtin_bytes_reverse(&[once]).unwrap();
+        assert_eq!(bytes(twice), original);
+    }
+
+    #[test]
+    fn reverse_palindrome_unchanged() {
+        let palindrome = vec![1, 2, 3, 2, 1];
+        let r = builtin_bytes_reverse(&[val(&palindrome)]).unwrap();
+        assert_eq!(bytes(r), palindrome);
+    }
+
+    #[test]
+    fn reverse_empty_and_single() {
+        let r = builtin_bytes_reverse(&[val(&[])]).unwrap();
+        assert_eq!(bytes(r), Vec::<u8>::new());
+        let r = builtin_bytes_reverse(&[val(&[0x42])]).unwrap();
+        assert_eq!(bytes(r), vec![0x42]);
+    }
+
+    #[test]
+    fn reverse_rejects_non_bytes() {
+        let err = builtin_bytes_reverse(&[Value::Int(7)]).unwrap_err();
+        assert!(err.contains("expected Bytes"));
+    }
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        for f in [builtin_bytes_xor, builtin_bytes_and, builtin_bytes_or] {
+            let err = f(&[val(&[1])]).unwrap_err();
+            assert!(err.contains("expected 2"), "got {}", err);
+        }
+        for f in [builtin_bytes_not, builtin_bytes_reverse] {
+            let err = f(&[]).unwrap_err();
+            assert!(err.contains("expected 1"), "got {}", err);
+        }
+        let err = builtin_bytes_fill(&[Value::Int(1)]).unwrap_err();
+        assert!(err.contains("expected 2"));
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9,6 +9,10 @@ use std::rc::Rc;
 
 // Import modules
 mod bytecode;
+// RES-1134: bitwise + construction ops on `Value::Bytes` —
+// xor / and / or / not / fill / reverse. Pure leaf builtins; wires
+// into BUILTINS, typechecker env-seed, and PURE_BUILTINS only.
+mod bytes_bitwise;
 mod compiler;
 mod const_fold;
 mod disasm;
@@ -10995,6 +10999,15 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     // RES-1130: IEEE 754 bit reinterpret cast.
     ("float_to_bits", builtin_float_to_bits),
     ("float_from_bits", builtin_float_from_bits),
+    // RES-1134: bitwise + construction ops on Bytes. Pure leaf
+    // builtins; module-isolated in `bytes_bitwise.rs`. Appended at
+    // the end of BUILTINS per the perf rule established in PR #1125.
+    ("bytes_xor", crate::bytes_bitwise::builtin_bytes_xor),
+    ("bytes_and", crate::bytes_bitwise::builtin_bytes_and),
+    ("bytes_or", crate::bytes_bitwise::builtin_bytes_or),
+    ("bytes_not", crate::bytes_bitwise::builtin_bytes_not),
+    ("bytes_fill", crate::bytes_bitwise::builtin_bytes_fill),
+    ("bytes_reverse", crate::bytes_bitwise::builtin_bytes_reverse),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1279,6 +1279,27 @@ impl TypeChecker {
                 return_type: Box::new(Type::Float),
             },
         );
+        // RES-1134: bitwise + construction ops on Bytes.
+        let fn_bytes_bytes_to_bytes = || Type::Function {
+            params: vec![Type::Bytes, Type::Bytes],
+            return_type: Box::new(Type::Bytes),
+        };
+        let fn_bytes_to_bytes = || Type::Function {
+            params: vec![Type::Bytes],
+            return_type: Box::new(Type::Bytes),
+        };
+        env.set("bytes_xor".to_string(), fn_bytes_bytes_to_bytes());
+        env.set("bytes_and".to_string(), fn_bytes_bytes_to_bytes());
+        env.set("bytes_or".to_string(), fn_bytes_bytes_to_bytes());
+        env.set("bytes_not".to_string(), fn_bytes_to_bytes());
+        env.set(
+            "bytes_fill".to_string(),
+            Type::Function {
+                params: vec![Type::Int, Type::Int],
+                return_type: Box::new(Type::Bytes),
+            },
+        );
+        env.set("bytes_reverse".to_string(), fn_bytes_to_bytes());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6033,6 +6054,13 @@ fn is_known_pure_builtin(name: &str) -> bool {
         // RES-1130: IEEE 754 bit reinterpret cast.
         "float_to_bits",
         "float_from_bits",
+        // RES-1134: bitwise + construction ops on Bytes.
+        "bytes_xor",
+        "bytes_and",
+        "bytes_or",
+        "bytes_not",
+        "bytes_fill",
+        "bytes_reverse",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1134.

Round out the Bytes builtin family with the bitwise + construction ops
that crypto / protocol / mask-and-merge workloads expect. The existing
surface covered length / read / search / hex codec, but every bit-level
operation on byte buffers currently has to detour through ints or
hand-rolled loops in user code.

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| `bytes_xor(a, b)` | `(Bytes, Bytes) -> Bytes` | One-time-pad / stream-cipher mask |
| `bytes_and(a, b)` | `(Bytes, Bytes) -> Bytes` | Selective bit clear |
| `bytes_or(a, b)`  | `(Bytes, Bytes) -> Bytes` | Selective bit set |
| `bytes_not(b)`    | `(Bytes) -> Bytes`        | Bit complement (involution) |
| `bytes_fill(n, byte)` | `(Int, Int) -> Bytes` | Uniform-byte buffer |
| `bytes_reverse(b)` | `(Bytes) -> Bytes`       | Byte-order flip (involution) |

### Design notes

- **Module-isolated** in `resilient/src/bytes_bitwise.rs` per CLAUDE.md
  feature-isolation pattern. Minimal touches to core files:
  - `lib.rs`: 1 `mod` decl + 6 `BUILTINS` entries appended at the END
    (per the perf rule established in [PR #1125](https://github.com/EricSpencer00/Resilient/pull/1125) — front-loading regressed fib(25) by ~23%).
  - `typechecker.rs`: 6 env-seed entries + 6 `PURE_BUILTINS` entries.
- **All six are pure** — no I/O, no mutation, exactly one fresh `Vec<u8>`
  allocated per call. Listed in `PURE_BUILTINS` so the effect analysis
  classifies them correctly.
- **Length-mismatch is a hard error** for the binary ops (`bytes_xor`,
  `bytes_and`, `bytes_or`). Silently truncating to the shorter input
  is almost always a bug — the diagnostic surfaces both sizes.
- **`bytes_fill`** rejects negative length and bytes outside `0..=255`
  with explicit diagnostics, matching the contract of the existing
  range-checked builtins (`byte_at`, `bytes_slice`).
- **No `unsafe`**, no panics, no new dependencies, no breaking changes
  to the existing surface.

### Tests

- **29 unit tests** in `bytes_bitwise.rs` (under `#[cfg(test)] mod tests`)
  covering: known-vector outputs, involution / round-trip properties
  (XOR with key, NOT∘NOT, REVERSE∘REVERSE), empty-input edge cases,
  length mismatch errors, type errors, and arity errors. All 29 pass.
- **3 new golden examples** under `resilient/examples/`:
  `bytes_xor.rz`, `bytes_and_or_not.rz`, `bytes_fill_reverse.rz`. Each
  has a sibling `.expected.txt` so the `examples_golden` harness runs
  them end-to-end through the compiled `rz` binary.

### Local gates

- `cargo build --locked` — clean
- `cargo test --locked` — clean (one flaky `refinement_types::refine_int_enforces_predicate` failure on first run that disappears on retry; pre-existing `feature_attrs` global-state race that PR #1133 partly addressed, unrelated to this change)
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

### Why one PR

All six builtins are leaf functions touching only the `BUILTINS` table,
the typechecker env-seed, and `PURE_BUILTINS`. Same precedent as
[PR #1125](https://github.com/EricSpencer00/Resilient/pull/1125) (19 builtins) and [PR #1131](https://github.com/EricSpencer00/Resilient/pull/1131) (9 builtins) — batching pure
leaf additions keeps the surface coherent and reviewable.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>