### PR TITLE
RES-1136: next_multiple_of / is_multiple_of — alignment helpers

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,12 +5,12 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
-      "branch": "res-1134-bytes-bitwise-ops",
-      "claimed_at": "2026-05-11T14:57:42Z"
+      "branch": "res-1136-alignment-helpers",
+      "claimed_at": "2026-05-11T15:08:45Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1134-bytes-bitwise-ops",
-      "claimed_at": "2026-05-11T14:57:42Z"
+      "branch": "res-1136-alignment-helpers",
+      "claimed_at": "2026-05-11T15:08:45Z"
     }
   }
 }

--- a/resilient/examples/alignment_helpers.expected.txt
+++ b/resilient/examples/alignment_helpers.expected.txt
@@ -1,0 +1,10 @@
+16
+128
+4096
+8192
+-4
+true
+false
+true
+true
+Program executed successfully

--- a/resilient/examples/alignment_helpers.rz
+++ b/resilient/examples/alignment_helpers.rz
@@ -1,0 +1,29 @@
+// RES-1136 demo: next_multiple_of(n, m) rounds n up to the next
+// multiple of m; is_multiple_of(a, b) tests divisibility.
+
+fn main(int _d) {
+    // Buffer-pad a 13-byte payload to an 8-byte boundary.
+    println(next_multiple_of(13, 8));         // 16
+
+    // 100 bytes rounded up to a 64-byte cache line.
+    println(next_multiple_of(100, 64));       // 128
+
+    // Already aligned — returns unchanged.
+    println(next_multiple_of(4096, 4096));    // 4096
+
+    // One byte past a page — bumps up to the next page.
+    println(next_multiple_of(4097, 4096));    // 8192
+
+    // Negative n: smallest multiple of 4 that is ≥ -5 is -4.
+    println(next_multiple_of(-5, 4));         // -4
+
+    // Divisibility checks.
+    println(is_multiple_of(64, 8));           // true
+    println(is_multiple_of(65, 8));           // false
+    println(is_multiple_of(-64, 8));          // true (sign of a is irrelevant)
+    println(is_multiple_of(0, 7));            // true (0 is a multiple of every nonzero b)
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/alignment_helpers.rs
+++ b/resilient/src/alignment_helpers.rs
@@ -1,0 +1,269 @@
+//! RES-1136: alignment helpers — `next_multiple_of` and `is_multiple_of`.
+//!
+//! Buffer padding, DMA descriptor alignment, SIMD lane sizing, and
+//! ring-buffer power-of-two indexing all need to round counts up to an
+//! alignment boundary or test divisibility. These two pure leaf builtins
+//! replace the inline `if n % m == 0 { n } else { n + (m - n % m) }`
+//! pattern with explicit, sign-correct, overflow-checked primitives.
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `next_multiple_of(n, m)` | `(Int, Int) -> Int` | Smallest multiple of `m` that is ≥ `n` |
+//! | `is_multiple_of(a, b)`   | `(Int, Int) -> Bool` | `true` iff `a` is an exact multiple of `b` |
+//!
+//! Both are deterministic, allocate nothing, and never panic — every
+//! error path returns a typed `RResult` diagnostic.
+
+use crate::{RResult, Value};
+
+/// `next_multiple_of(n, m) -> Int` — smallest multiple of `m` that is
+/// greater than or equal to `n`. `m` must be **positive**; `m ≤ 0` is
+/// a typed error (alignment is always positive in practice, and
+/// negative-`m` semantics would be ambiguous). On overflow, surfaces a
+/// typed error rather than wrapping silently.
+///
+/// Examples (all with `m = 4`):
+/// - `n = 0` → `0`
+/// - `n = 1` → `4`
+/// - `n = 4` → `4`
+/// - `n = 5` → `8`
+/// - `n = -1` → `0` (smallest multiple of 4 that is ≥ -1)
+/// - `n = -5` → `-4`
+pub(crate) fn builtin_next_multiple_of(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n), Value::Int(m)] => {
+            if *m <= 0 {
+                return Err(format!(
+                    "next_multiple_of: alignment must be positive, got {}",
+                    m
+                ));
+            }
+            // Rust's `%` returns a remainder with the sign of the
+            // dividend, so `(m - n%m) % m` gives the (non-negative)
+            // distance to the next multiple. Adding it to `n` lifts
+            // `n` up to (or keeps it at) that multiple.
+            let r = n.rem_euclid(*m);
+            if r == 0 {
+                return Ok(Value::Int(*n));
+            }
+            let bump = *m - r;
+            match n.checked_add(bump) {
+                Some(v) => Ok(Value::Int(v)),
+                None => Err(format!(
+                    "next_multiple_of: overflow — {} + {} exceeds i64::MAX",
+                    n, bump
+                )),
+            }
+        }
+        [a, b] => Err(format!(
+            "next_multiple_of: expected (int, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "next_multiple_of: expected 2 arguments (n, m), got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `is_multiple_of(a, b) -> Bool` — true iff `a` is an exact multiple
+/// of `b`. `b == 0` is a typed error (division by zero); negative `b`
+/// is fine and is treated the same as `|b|` — every nonzero integer
+/// divides the same multiples of itself as its negation.
+pub(crate) fn builtin_is_multiple_of(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(a), Value::Int(b)] => {
+            if *b == 0 {
+                return Err("is_multiple_of: divisor must be non-zero".to_string());
+            }
+            // i64::MIN % -1 would overflow if we used the operator,
+            // but i64::MIN IS a multiple of -1, so short-circuit.
+            if *a == i64::MIN && *b == -1 {
+                return Ok(Value::Bool(true));
+            }
+            Ok(Value::Bool(a % b == 0))
+        }
+        [a, b] => Err(format!(
+            "is_multiple_of: expected (int, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "is_multiple_of: expected 2 arguments (a, b), got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nm(n: i64, m: i64) -> Result<i64, String> {
+        match builtin_next_multiple_of(&[Value::Int(n), Value::Int(m)])? {
+            Value::Int(v) => Ok(v),
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    fn im(a: i64, b: i64) -> Result<bool, String> {
+        match builtin_is_multiple_of(&[Value::Int(a), Value::Int(b)])? {
+            Value::Bool(v) => Ok(v),
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn next_multiple_aligns_positive() {
+        assert_eq!(nm(0, 4).unwrap(), 0);
+        assert_eq!(nm(1, 4).unwrap(), 4);
+        assert_eq!(nm(3, 4).unwrap(), 4);
+        assert_eq!(nm(4, 4).unwrap(), 4);
+        assert_eq!(nm(5, 4).unwrap(), 8);
+        assert_eq!(nm(7, 4).unwrap(), 8);
+        assert_eq!(nm(8, 4).unwrap(), 8);
+    }
+
+    #[test]
+    fn next_multiple_handles_negative_n() {
+        // smallest multiple of 4 that is ≥ -1 is 0
+        assert_eq!(nm(-1, 4).unwrap(), 0);
+        // smallest multiple of 4 that is ≥ -5 is -4
+        assert_eq!(nm(-5, 4).unwrap(), -4);
+        // exact negative multiple — return n unchanged
+        assert_eq!(nm(-8, 4).unwrap(), -8);
+        // smallest multiple of 4 that is ≥ -7 is -4
+        assert_eq!(nm(-7, 4).unwrap(), -4);
+    }
+
+    #[test]
+    fn next_multiple_alignment_one_is_identity() {
+        // every integer is a multiple of 1.
+        assert_eq!(nm(0, 1).unwrap(), 0);
+        assert_eq!(nm(7, 1).unwrap(), 7);
+        assert_eq!(nm(-7, 1).unwrap(), -7);
+        assert_eq!(nm(i64::MAX, 1).unwrap(), i64::MAX);
+        assert_eq!(nm(i64::MIN, 1).unwrap(), i64::MIN);
+    }
+
+    #[test]
+    fn next_multiple_rejects_zero_alignment() {
+        let err = nm(5, 0).unwrap_err();
+        assert!(err.contains("alignment must be positive"));
+    }
+
+    #[test]
+    fn next_multiple_rejects_negative_alignment() {
+        let err = nm(5, -4).unwrap_err();
+        assert!(err.contains("alignment must be positive"));
+    }
+
+    #[test]
+    fn next_multiple_detects_overflow() {
+        // Anything just below i64::MAX that doesn't already align
+        // forces an overflow when bumped up to the next multiple.
+        let err = nm(i64::MAX, 4).unwrap_err();
+        assert!(err.contains("overflow"), "got {}", err);
+        let err = nm(i64::MAX - 1, 4).unwrap_err();
+        assert!(err.contains("overflow"));
+    }
+
+    #[test]
+    fn next_multiple_max_minus_three_aligned_to_four_works() {
+        // i64::MAX = 9223372036854775807. MAX-3 % 4 = ?
+        // 9223372036854775807 mod 4 = 3 (since MAX = 4q + 3).
+        // So MAX-3 mod 4 = 0 — already aligned, returns MAX-3.
+        assert_eq!(nm(i64::MAX - 3, 4).unwrap(), i64::MAX - 3);
+    }
+
+    #[test]
+    fn next_multiple_rejects_wrong_arity_and_types() {
+        let err = builtin_next_multiple_of(&[Value::Int(1)]).unwrap_err();
+        assert!(err.contains("expected 2"));
+        let err = builtin_next_multiple_of(&[Value::Int(1), Value::Bool(true)]).unwrap_err();
+        assert!(err.contains("expected (int, int)"));
+    }
+
+    #[test]
+    fn next_multiple_typical_alignment_values() {
+        // 8-byte alignment of a 13-byte payload.
+        assert_eq!(nm(13, 8).unwrap(), 16);
+        // 64-byte cache-line alignment of 100.
+        assert_eq!(nm(100, 64).unwrap(), 128);
+        // 4096-byte page alignment of a counter at exactly one page.
+        assert_eq!(nm(4096, 4096).unwrap(), 4096);
+        // Same counter, one byte further → next page.
+        assert_eq!(nm(4097, 4096).unwrap(), 8192);
+    }
+
+    #[test]
+    fn is_multiple_positive_cases() {
+        assert!(im(0, 5).unwrap());
+        assert!(im(10, 5).unwrap());
+        assert!(im(15, 5).unwrap());
+        assert!(!im(7, 5).unwrap());
+        assert!(!im(11, 5).unwrap());
+    }
+
+    #[test]
+    fn is_multiple_negative_a() {
+        assert!(im(-10, 5).unwrap());
+        assert!(im(-15, 5).unwrap());
+        assert!(!im(-7, 5).unwrap());
+    }
+
+    #[test]
+    fn is_multiple_negative_b_same_as_positive_b() {
+        // |b| works for membership in the multiples set.
+        assert!(im(10, -5).unwrap());
+        assert!(im(-10, -5).unwrap());
+        assert!(!im(7, -5).unwrap());
+    }
+
+    #[test]
+    fn is_multiple_b_eq_one_always_true() {
+        assert!(im(0, 1).unwrap());
+        assert!(im(42, 1).unwrap());
+        assert!(im(-42, 1).unwrap());
+        assert!(im(i64::MAX, 1).unwrap());
+        assert!(im(i64::MIN, 1).unwrap());
+    }
+
+    #[test]
+    fn is_multiple_b_eq_minus_one_always_true() {
+        assert!(im(0, -1).unwrap());
+        assert!(im(42, -1).unwrap());
+        assert!(im(-42, -1).unwrap());
+        assert!(im(i64::MAX, -1).unwrap());
+        // i64::MIN % -1 would overflow with the operator — must
+        // short-circuit. MIN is indeed a multiple of -1.
+        assert!(im(i64::MIN, -1).unwrap());
+    }
+
+    #[test]
+    fn is_multiple_rejects_zero_divisor() {
+        let err = im(5, 0).unwrap_err();
+        assert!(err.contains("non-zero"));
+        let err = im(0, 0).unwrap_err();
+        assert!(err.contains("non-zero"));
+    }
+
+    #[test]
+    fn is_multiple_rejects_wrong_arity_and_types() {
+        let err = builtin_is_multiple_of(&[Value::Int(1)]).unwrap_err();
+        assert!(err.contains("expected 2"));
+        let err = builtin_is_multiple_of(&[Value::Int(1), Value::Bool(true)]).unwrap_err();
+        assert!(err.contains("expected (int, int)"));
+    }
+
+    #[test]
+    fn round_trip_with_next_multiple_of() {
+        // next_multiple_of(n, m) is itself always a multiple of m.
+        for &(n, m) in &[(0i64, 4), (1, 4), (5, 4), (8, 4), (-3, 4), (100, 64)] {
+            let aligned = nm(n, m).unwrap();
+            assert!(
+                im(aligned, m).unwrap(),
+                "next_multiple_of({n}, {m}) = {aligned} is not a multiple of {m}"
+            );
+        }
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8,6 +8,10 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 // Import modules
+// RES-1136: alignment helpers — `next_multiple_of` and `is_multiple_of`.
+// Pure leaf builtins; module-isolated so adding new bytes/int helpers
+// doesn't have to dodge each other inside lib.rs.
+mod alignment_helpers;
 mod bytecode;
 // RES-1134: bitwise + construction ops on `Value::Bytes` —
 // xor / and / or / not / fill / reverse. Pure leaf builtins; wires
@@ -11008,6 +11012,17 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("bytes_not", crate::bytes_bitwise::builtin_bytes_not),
     ("bytes_fill", crate::bytes_bitwise::builtin_bytes_fill),
     ("bytes_reverse", crate::bytes_bitwise::builtin_bytes_reverse),
+    // RES-1136: alignment helpers. Pure leaf builtins; module-isolated
+    // in `alignment_helpers.rs`. Appended at the end of BUILTINS per
+    // the perf rule established in PR #1125.
+    (
+        "next_multiple_of",
+        crate::alignment_helpers::builtin_next_multiple_of,
+    ),
+    (
+        "is_multiple_of",
+        crate::alignment_helpers::builtin_is_multiple_of,
+    ),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1300,6 +1300,15 @@ impl TypeChecker {
             },
         );
         env.set("bytes_reverse".to_string(), fn_bytes_to_bytes());
+        // RES-1136: alignment helpers.
+        env.set("next_multiple_of".to_string(), fn_int_int_to_int());
+        env.set(
+            "is_multiple_of".to_string(),
+            Type::Function {
+                params: vec![Type::Int, Type::Int],
+                return_type: Box::new(Type::Bool),
+            },
+        );
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6061,6 +6070,9 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "bytes_not",
         "bytes_fill",
         "bytes_reverse",
+        // RES-1136: alignment helpers.
+        "next_multiple_of",
+        "is_multiple_of",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1136.

Buffer padding, DMA descriptor alignment, SIMD lane sizing, and ring-
buffer power-of-two indexing all need to round counts up to an alignment
boundary or test divisibility. Today both operations have to be hand-
rolled inline, and the sign rules are easy to get wrong once operands
can go negative.

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| `next_multiple_of(n, m)` | `(Int, Int) -> Int` | Smallest multiple of `m` that is ≥ `n` |
| `is_multiple_of(a, b)`   | `(Int, Int) -> Bool` | `true` iff `a` is an exact multiple of `b` |

### Design notes

- **`next_multiple_of`** requires `m > 0`. Alignment in real systems
  is always positive, and the negative-`m` semantics would be
  ambiguous (do we round toward `±∞`?). `m ≤ 0` is a typed error.
  For negative `n`, returns the smallest multiple of `m` that is `≥ n`
  (which may itself be negative or zero — e.g. `next_multiple_of(-5, 4) = -4`).
  Uses `rem_euclid` for sign-correct distance and `checked_add` to
  surface overflow at the `i64::MAX` boundary as a typed error rather
  than silently wrapping.
- **`is_multiple_of`** rejects `b == 0` (division by zero). Negative
  `b` is fine — every integer divides the same multiples as its
  negation. Short-circuits the `i64::MIN % -1` overflow case
  explicitly (`MIN` IS a multiple of `-1`, so return `true`).
- Module-isolated in `resilient/src/alignment_helpers.rs` per
  CLAUDE.md feature isolation. Minimal touches:
  - `lib.rs`: 1 `mod` decl + 2 `BUILTINS` entries appended (perf rule
    from [PR #1125](https://github.com/EricSpencer00/Resilient/pull/1125)).
  - `typechecker.rs`: 2 env-seed entries + 2 `PURE_BUILTINS` entries.
- Both builtins are pure leaf functions — no I/O, allocate nothing,
  never panic. Listed in `PURE_BUILTINS`.
- No `unsafe`, no new dependencies, no breaking changes.

### Tests

- **17 unit tests** in `alignment_helpers.rs` (`#[cfg(test)] mod tests`)
  covering: positive / negative / zero alignment, page-size boundaries
  (8 / 64 / 4096), overflow detection at `i64::MAX`, divisor-zero
  rejection, sign symmetry, the `i64::MIN / -1` edge case, type errors,
  arity errors, and a round-trip property
  (`is_multiple_of(next_multiple_of(n, m), m)` is always `true`).
- **1 new golden example** (`alignment_helpers.rz` +
  `.expected.txt`) exercising the whole surface end-to-end through the
  compiled `rz` binary.

### Local gates

- `cargo build --locked` — clean
- `cargo test --locked` — clean (2783 lib tests + 17 new + all integration suites green)
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

### Why one PR

Adjacent to the RES-1126..1128 family (`div_ceil` / `div_floor` /
`div_euclid` / `rem_euclid` / `midpoint`) that already shipped in
[PR #1131](https://github.com/EricSpencer00/Resilient/pull/1131). Same shape (int-int leaf), same wiring, same diagnostic
style. Bundling the two-builtin alignment pair into a single PR keeps
the surface coherent — they share semantics (`is_multiple_of` is the
predicate that `next_multiple_of` happens to satisfy).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>