### PR TITLE
RES-1138: 5 IEEE 754 float predicates — classify, total_cmp, is_normal, is_subnormal, sign_bit

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,12 +5,12 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
-      "branch": "res-1136-alignment-helpers",
-      "claimed_at": "2026-05-11T15:08:45Z"
+      "branch": "res-1138-float-predicates",
+      "claimed_at": "2026-05-11T15:15:00Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1136-alignment-helpers",
-      "claimed_at": "2026-05-11T15:08:45Z"
+      "branch": "res-1138-float-predicates",
+      "claimed_at": "2026-05-11T15:15:00Z"
     }
   }
 }

--- a/resilient/examples/float_classify.expected.txt
+++ b/resilient/examples/float_classify.expected.txt
@@ -1,0 +1,16 @@
+normal
+zero
+zero
+infinite
+nan
+true
+false
+false
+false
+true
+true
+-1
+1
+0
+-1
+Program executed successfully

--- a/resilient/examples/float_classify.rz
+++ b/resilient/examples/float_classify.rz
@@ -1,0 +1,30 @@
+// RES-1138 demo: IEEE 754 classification + sign-bit + total-order ops.
+
+fn main(int _d) {
+    // Classify each category.
+    println(float_classify(1.0));          // normal
+    println(float_classify(0.0));          // zero
+    println(float_classify(-0.0));         // zero (same category)
+    println(float_classify(1.0 / 0.0));    // infinite
+    println(float_classify(0.0 / 0.0));    // nan
+
+    // Specific predicates.
+    println(float_is_normal(1.0));         // true
+    println(float_is_normal(0.0));         // false
+    println(float_is_subnormal(1.0));      // false
+
+    // Sign bit distinguishes -0 from +0 — the < operator cannot.
+    println(float_sign_bit(0.0));          // false
+    println(float_sign_bit(-0.0));         // true
+    println(float_sign_bit(-1.0));         // true
+
+    // Total order: -0.0 < +0.0 under IEEE 754 total order.
+    println(float_total_cmp(-0.0, 0.0));   // -1
+    println(float_total_cmp(0.0, -0.0));   // 1
+    println(float_total_cmp(1.0, 1.0));    // 0
+    println(float_total_cmp(1.0, 2.0));    // -1
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/float_predicates.rs
+++ b/resilient/src/float_predicates.rs
@@ -1,0 +1,359 @@
+//! RES-1138: IEEE 754 classification + total order + sign-bit predicates.
+//!
+//! Five pure leaf builtins that complete the float-predicate surface
+//! alongside the existing `is_nan`, `is_inf`, `is_finite` (RES-130) and
+//! the `float_to_bits` / `float_from_bits` bit-reinterpret pair
+//! (RES-1130). Each delegates to the corresponding `f64::*` stdlib
+//! method, so behaviour matches Rust exactly.
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `float_classify(x)`     | `(Float) -> String` | `"normal"` / `"subnormal"` / `"zero"` / `"infinite"` / `"nan"` |
+//! | `float_total_cmp(a, b)` | `(Float, Float) -> Int` | IEEE 754 total order: `-1` / `0` / `1` |
+//! | `float_is_normal(x)`    | `(Float) -> Bool` | Normal (finite, non-zero, non-subnormal) |
+//! | `float_is_subnormal(x)` | `(Float) -> Bool` | Subnormal (denormal) |
+//! | `float_sign_bit(x)`     | `(Float) -> Bool` | Sign bit set — distinguishes `-0` from `+0` |
+//!
+//! `float_total_cmp` is the only IEEE 754 total order available in the
+//! language; `<` returns false for any comparison involving NaN, which
+//! makes sorting `Float[]` arrays containing NaNs undefined behaviour.
+
+use crate::{RResult, Value};
+use std::num::FpCategory;
+
+/// `float_classify(x) -> String` — IEEE 754 number classification.
+/// Returns one of `"normal"`, `"subnormal"`, `"zero"`, `"infinite"`,
+/// `"nan"`. Mirrors `f64::classify()`.
+pub(crate) fn builtin_float_classify(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(x)] => {
+            let kind = match x.classify() {
+                FpCategory::Nan => "nan",
+                FpCategory::Infinite => "infinite",
+                FpCategory::Zero => "zero",
+                FpCategory::Subnormal => "subnormal",
+                FpCategory::Normal => "normal",
+            };
+            Ok(Value::String(kind.to_string()))
+        }
+        [other] => Err(format!("float_classify: expected float, got {}", other)),
+        _ => Err(format!(
+            "float_classify: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `float_total_cmp(a, b) -> Int` — IEEE 754 total order: returns `-1`
+/// if `a < b`, `0` if `a == b`, `1` if `a > b`. Unlike `<`, this orders
+/// NaN values, distinguishes `-0.0` from `+0.0`, and orders negative
+/// NaN payloads before positive ones. Delegates to `f64::total_cmp`.
+pub(crate) fn builtin_float_total_cmp(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(a), Value::Float(b)] => {
+            let ord = a.total_cmp(b) as i64;
+            Ok(Value::Int(ord))
+        }
+        [a, b] => Err(format!(
+            "float_total_cmp: expected (float, float), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "float_total_cmp: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `float_is_normal(x) -> Bool` — true iff `x` is a *normal* IEEE 754
+/// double: finite, non-zero, and non-subnormal. Mirrors `f64::is_normal`.
+pub(crate) fn builtin_float_is_normal(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(x)] => Ok(Value::Bool(x.is_normal())),
+        [other] => Err(format!("float_is_normal: expected float, got {}", other)),
+        _ => Err(format!(
+            "float_is_normal: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `float_is_subnormal(x) -> Bool` — true iff `x` is subnormal
+/// (a.k.a. denormal). Mirrors `f64::is_subnormal`.
+pub(crate) fn builtin_float_is_subnormal(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(x)] => Ok(Value::Bool(x.is_subnormal())),
+        [other] => Err(format!("float_is_subnormal: expected float, got {}", other)),
+        _ => Err(format!(
+            "float_is_subnormal: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `float_sign_bit(x) -> Bool` — true iff the IEEE 754 sign bit is set.
+/// Distinguishes `-0.0` (returns `true`) from `+0.0` (returns `false`),
+/// which the `<` operator cannot. Mirrors `f64::is_sign_negative`.
+pub(crate) fn builtin_float_sign_bit(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Float(x)] => Ok(Value::Bool(x.is_sign_negative())),
+        [other] => Err(format!("float_sign_bit: expected float, got {}", other)),
+        _ => Err(format!(
+            "float_sign_bit: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn classify(x: f64) -> String {
+        match builtin_float_classify(&[Value::Float(x)]).unwrap() {
+            Value::String(s) => s,
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    fn total_cmp(a: f64, b: f64) -> i64 {
+        match builtin_float_total_cmp(&[Value::Float(a), Value::Float(b)]).unwrap() {
+            Value::Int(v) => v,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    fn is_normal(x: f64) -> bool {
+        match builtin_float_is_normal(&[Value::Float(x)]).unwrap() {
+            Value::Bool(v) => v,
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    fn is_subnormal(x: f64) -> bool {
+        match builtin_float_is_subnormal(&[Value::Float(x)]).unwrap() {
+            Value::Bool(v) => v,
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    fn sign_bit(x: f64) -> bool {
+        match builtin_float_sign_bit(&[Value::Float(x)]).unwrap() {
+            Value::Bool(v) => v,
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_each_category() {
+        assert_eq!(classify(1.0), "normal");
+        assert_eq!(classify(-1.0), "normal");
+        assert_eq!(classify(0.0), "zero");
+        assert_eq!(classify(-0.0), "zero");
+        assert_eq!(classify(f64::INFINITY), "infinite");
+        assert_eq!(classify(f64::NEG_INFINITY), "infinite");
+        assert_eq!(classify(f64::NAN), "nan");
+        assert_eq!(classify(f64::MIN_POSITIVE / 2.0), "subnormal");
+    }
+
+    #[test]
+    fn classify_rejects_int_and_other_types() {
+        let err = builtin_float_classify(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected float"));
+        let err = builtin_float_classify(&[Value::Bool(true)]).unwrap_err();
+        assert!(err.contains("expected float"));
+    }
+
+    #[test]
+    fn classify_arity_check() {
+        let err = builtin_float_classify(&[]).unwrap_err();
+        assert!(err.contains("expected 1"));
+        let err = builtin_float_classify(&[Value::Float(0.0), Value::Float(0.0)]).unwrap_err();
+        assert!(err.contains("expected 1"));
+    }
+
+    #[test]
+    fn total_cmp_basic_ordering() {
+        assert_eq!(total_cmp(1.0, 2.0), -1);
+        assert_eq!(total_cmp(2.0, 1.0), 1);
+        assert_eq!(total_cmp(1.0, 1.0), 0);
+    }
+
+    #[test]
+    fn total_cmp_distinguishes_negative_zero() {
+        // IEEE 754 total order: -0.0 < +0.0
+        assert_eq!(total_cmp(-0.0, 0.0), -1);
+        assert_eq!(total_cmp(0.0, -0.0), 1);
+        // self comparisons are equal
+        assert_eq!(total_cmp(0.0, 0.0), 0);
+        assert_eq!(total_cmp(-0.0, -0.0), 0);
+    }
+
+    #[test]
+    fn total_cmp_orders_nan() {
+        // Negative NaN < every finite < positive NaN. We test that
+        // total order is strict (transitivity is property of f64::total_cmp).
+        let nan = f64::NAN;
+        // self-comparison: NaN totalCmp NaN must be 0 (unlike `<`)
+        assert_eq!(total_cmp(nan, nan), 0);
+        // ordering with infinities — positive NaN sorts after +inf
+        assert_eq!(total_cmp(f64::INFINITY, nan), -1);
+        // negative-NaN bit-pattern sorts before -inf
+        let neg_nan = f64::from_bits(f64::NAN.to_bits() | (1 << 63));
+        assert_eq!(total_cmp(neg_nan, f64::NEG_INFINITY), -1);
+    }
+
+    #[test]
+    fn total_cmp_orders_infinities() {
+        assert_eq!(total_cmp(f64::NEG_INFINITY, f64::INFINITY), -1);
+        assert_eq!(total_cmp(f64::INFINITY, f64::NEG_INFINITY), 1);
+        assert_eq!(total_cmp(f64::INFINITY, f64::INFINITY), 0);
+    }
+
+    #[test]
+    fn total_cmp_rejects_wrong_arity_and_types() {
+        let err = builtin_float_total_cmp(&[Value::Float(0.0)]).unwrap_err();
+        assert!(err.contains("expected 2"));
+        let err = builtin_float_total_cmp(&[Value::Float(0.0), Value::Int(1)]).unwrap_err();
+        assert!(err.contains("expected (float, float)"));
+    }
+
+    #[test]
+    fn is_normal_basic() {
+        assert!(is_normal(1.0));
+        assert!(is_normal(-1.0));
+        assert!(is_normal(1e300));
+        // zero is NOT normal
+        assert!(!is_normal(0.0));
+        assert!(!is_normal(-0.0));
+        // subnormals are not normal
+        assert!(!is_normal(f64::MIN_POSITIVE / 2.0));
+        // inf and nan are not normal
+        assert!(!is_normal(f64::INFINITY));
+        assert!(!is_normal(f64::NEG_INFINITY));
+        assert!(!is_normal(f64::NAN));
+    }
+
+    #[test]
+    fn is_subnormal_basic() {
+        assert!(is_subnormal(f64::MIN_POSITIVE / 2.0));
+        // 1.0 is normal, not subnormal
+        assert!(!is_subnormal(1.0));
+        // zero is not subnormal
+        assert!(!is_subnormal(0.0));
+        assert!(!is_subnormal(-0.0));
+        // inf / nan are not subnormal
+        assert!(!is_subnormal(f64::INFINITY));
+        assert!(!is_subnormal(f64::NAN));
+    }
+
+    #[test]
+    fn classification_is_partition() {
+        // Every float falls into exactly one of: normal, subnormal,
+        // zero, infinite, nan.
+        for &x in &[
+            1.0,
+            -1.0,
+            0.0,
+            -0.0,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::NAN,
+            f64::MIN_POSITIVE / 2.0,
+            1e-300,
+            1e300,
+            f64::MIN_POSITIVE,
+            f64::MAX,
+        ] {
+            let cat = classify(x);
+            let count = [
+                cat == "normal",
+                cat == "subnormal",
+                cat == "zero",
+                cat == "infinite",
+                cat == "nan",
+            ]
+            .iter()
+            .filter(|b| **b)
+            .count();
+            assert_eq!(count, 1, "{} got category {}", x, cat);
+        }
+    }
+
+    #[test]
+    fn sign_bit_distinguishes_zeros() {
+        assert!(!sign_bit(0.0));
+        assert!(sign_bit(-0.0));
+    }
+
+    #[test]
+    fn sign_bit_finite_values() {
+        assert!(!sign_bit(1.0));
+        assert!(sign_bit(-1.0));
+        assert!(!sign_bit(f64::INFINITY));
+        assert!(sign_bit(f64::NEG_INFINITY));
+        assert!(!sign_bit(f64::MAX));
+        assert!(sign_bit(f64::MIN));
+    }
+
+    #[test]
+    fn sign_bit_on_negative_nan() {
+        // Positive NaN has sign bit clear; negative NaN (different
+        // bit pattern) has it set.
+        assert!(!sign_bit(f64::NAN));
+        let neg_nan = f64::from_bits(f64::NAN.to_bits() | (1 << 63));
+        assert!(sign_bit(neg_nan));
+    }
+
+    #[test]
+    fn classify_total_cmp_compose_for_sort() {
+        // Building block: sorting a Vec<f64> with total_cmp as the
+        // comparator should always produce a well-defined order even
+        // with NaNs and -0.0 in the input.
+        let mut values = [
+            f64::NAN,
+            1.0,
+            -0.0,
+            f64::INFINITY,
+            -1.0,
+            0.0,
+            f64::NEG_INFINITY,
+        ];
+        values.sort_by(|a, b| {
+            let ord = total_cmp(*a, *b);
+            if ord < 0 {
+                std::cmp::Ordering::Less
+            } else if ord > 0 {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        });
+        // Expected total order (with positive NaN): -inf, -1, -0, 0, 1, +inf, nan
+        assert_eq!(classify(values[0]), "infinite");
+        assert!(sign_bit(values[0]));
+        assert_eq!(values[1], -1.0);
+        assert!(sign_bit(values[2]));
+        assert_eq!(classify(values[2]), "zero");
+        assert!(!sign_bit(values[3]));
+        assert_eq!(classify(values[3]), "zero");
+        assert_eq!(values[4], 1.0);
+        assert_eq!(classify(values[5]), "infinite");
+        assert!(!sign_bit(values[5]));
+        assert_eq!(classify(values[6]), "nan");
+    }
+
+    #[test]
+    fn float_predicate_arity_diagnostics_consistent() {
+        for f in [
+            builtin_float_is_normal,
+            builtin_float_is_subnormal,
+            builtin_float_sign_bit,
+        ] {
+            let err = f(&[]).unwrap_err();
+            assert!(err.contains("expected 1"), "got {}", err);
+            let err = f(&[Value::Int(0)]).unwrap_err();
+            assert!(err.contains("expected float"), "got {}", err);
+        }
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -20,6 +20,10 @@ mod bytes_bitwise;
 mod compiler;
 mod const_fold;
 mod disasm;
+// RES-1138: IEEE 754 classification + total order + sign-bit predicates.
+// Pure leaf builtins; module-isolated so the predicate surface can
+// grow without bloating lib.rs.
+mod float_predicates;
 // RES-510 PR 3: REPL is CLI-only — uses rustyline (termios) which
 // doesn't compile to wasm32. Gated so the playground can depend on
 // the lib without dragging it in.
@@ -11022,6 +11026,30 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     (
         "is_multiple_of",
         crate::alignment_helpers::builtin_is_multiple_of,
+    ),
+    // RES-1138: IEEE 754 classification + total order + sign-bit
+    // predicates. Pure leaf builtins; module-isolated in
+    // `float_predicates.rs`. Appended at the end of BUILTINS per
+    // the perf rule established in PR #1125.
+    (
+        "float_classify",
+        crate::float_predicates::builtin_float_classify,
+    ),
+    (
+        "float_total_cmp",
+        crate::float_predicates::builtin_float_total_cmp,
+    ),
+    (
+        "float_is_normal",
+        crate::float_predicates::builtin_float_is_normal,
+    ),
+    (
+        "float_is_subnormal",
+        crate::float_predicates::builtin_float_is_subnormal,
+    ),
+    (
+        "float_sign_bit",
+        crate::float_predicates::builtin_float_sign_bit,
     ),
 ];
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1309,6 +1309,29 @@ impl TypeChecker {
                 return_type: Box::new(Type::Bool),
             },
         );
+        // RES-1138: IEEE 754 classification + total order + sign-bit
+        // predicates.
+        let fn_float_to_bool = || Type::Function {
+            params: vec![Type::Float],
+            return_type: Box::new(Type::Bool),
+        };
+        env.set(
+            "float_classify".to_string(),
+            Type::Function {
+                params: vec![Type::Float],
+                return_type: Box::new(Type::String),
+            },
+        );
+        env.set(
+            "float_total_cmp".to_string(),
+            Type::Function {
+                params: vec![Type::Float, Type::Float],
+                return_type: Box::new(Type::Int),
+            },
+        );
+        env.set("float_is_normal".to_string(), fn_float_to_bool());
+        env.set("float_is_subnormal".to_string(), fn_float_to_bool());
+        env.set("float_sign_bit".to_string(), fn_float_to_bool());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6073,6 +6096,12 @@ fn is_known_pure_builtin(name: &str) -> bool {
         // RES-1136: alignment helpers.
         "next_multiple_of",
         "is_multiple_of",
+        // RES-1138: IEEE 754 classification + total order + sign-bit.
+        "float_classify",
+        "float_total_cmp",
+        "float_is_normal",
+        "float_is_subnormal",
+        "float_sign_bit",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1138.

Round out the float-predicate surface with the five IEEE 754 primitives
that the existing `is_nan` / `is_inf` / `is_finite` trio (RES-130) leaves
out. Companion to RES-1130's `float_to_bits` / `float_from_bits` — that
ticket opened bit-level inspection; these are the high-level predicates
that pair with it.

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| `float_classify(x)`     | `(Float) -> String` | `\"normal\"` / `\"subnormal\"` / `\"zero\"` / `\"infinite\"` / `\"nan\"` |
| `float_total_cmp(a, b)` | `(Float, Float) -> Int` | IEEE 754 total order: `-1` / `0` / `1` |
| `float_is_normal(x)`    | `(Float) -> Bool` | Finite, non-zero, non-subnormal |
| `float_is_subnormal(x)` | `(Float) -> Bool` | Subnormal (a.k.a. denormal) |
| `float_sign_bit(x)`     | `(Float) -> Bool` | Sign bit set (distinguishes `-0` from `+0`) |

Each delegates to the corresponding `f64::*` stdlib method
(`f64::classify`, `f64::total_cmp`, `f64::is_normal`, `f64::is_subnormal`,
`f64::is_sign_negative`), so behaviour matches Rust exactly.

### Why now

- **Sorting**: `<` returns `false` for any comparison involving NaN,
  which makes sorting `Float[]` arrays containing NaNs undefined.
  `float_total_cmp` gives a strict total order — NaN self-compare is
  `0`, negative NaNs sort before negative infinity, positive NaNs after
  positive infinity, and `-0.0 < +0.0`.
- **Diagnostics / denormal-flushing**: `float_classify` returns the
  IEEE 754 category as a `String`, suitable for printing or branching.
- **`-0.0` detection**: `float_sign_bit` is the only way to distinguish
  `-0.0` from `+0.0`; `< 0` returns `false` for both. Same goes for
  signed NaN payloads.
- **Cleaner predicates**: `float_is_normal` saves the user from writing
  `!is_nan(x) && !is_inf(x) && x != 0.0 && !is_subnormal(x)` by hand,
  which is easy to get wrong.

### Design notes

- Float-only signatures (unlike `is_nan` / `is_inf` / `is_finite`, which
  accept Int as well). Ints have no IEEE 754 category, no sign bit
  separate from the value, and no subnormal representation — accepting
  them in these new predicates would just propagate confusion.
- Module-isolated in `resilient/src/float_predicates.rs` per CLAUDE.md
  feature isolation. Minimal touches:
  - `lib.rs`: 1 `mod` decl + 5 `BUILTINS` entries appended (per the
    perf rule established in [PR #1125](https://github.com/EricSpencer00/Resilient/pull/1125)).
  - `typechecker.rs`: 5 env-seed entries + 5 `PURE_BUILTINS` entries.
- No `unsafe`, no panics, no new dependencies.

### Tests

- **16 unit tests** covering: every IEEE 754 category, total-order
  rules (NaN self-compare `= 0`, `-0 < +0`, signed-NaN ordering),
  partition property (every float in *exactly one* category), sign-bit
  distinguishing `±0` and `±NaN`, type / arity errors, and a composite
  property — sorting a vector containing NaN, `±0`, `±inf`, and finite
  values via `total_cmp` produces a well-defined order.
- **1 new golden example** (`float_classify.rz`) exercising the full
  surface from `.rz` source through the compiled `rz` binary. Named
  `float_classify` rather than `float_predicates` to avoid colliding
  with the existing RES-411 `float_predicates.rz` example.

### Local gates

- `cargo build --locked` — clean
- `cargo test --locked` — clean (16 new + all 39 test targets green)
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>