### PR TITLE
RES-1140: 7 ASCII char-class predicates — complete the RES-459 family

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,12 +5,12 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
-      "branch": "res-1142-array-chunking",
-      "claimed_at": "2026-05-11T15:32:00Z"
+      "branch": "res-1140-ascii-predicates",
+      "claimed_at": "2026-05-11T15:25:00Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1142-array-chunking",
-      "claimed_at": "2026-05-11T15:32:00Z"
+      "branch": "res-1140-ascii-predicates",
+      "claimed_at": "2026-05-11T15:25:00Z"
     }
   }
 }

--- a/resilient/examples/is_ascii_family.expected.txt
+++ b/resilient/examples/is_ascii_family.expected.txt
@@ -1,0 +1,16 @@
+true
+false
+true
+false
+true
+false
+true
+false
+true
+true
+false
+true
+false
+true
+true
+Program executed successfully

--- a/resilient/examples/is_ascii_family.rz
+++ b/resilient/examples/is_ascii_family.rz
@@ -1,0 +1,38 @@
+// RES-1140 demo: complete the ASCII char-class predicate surface.
+// is_ascii_alpha / digit / alnum already shipped in RES-459; this
+// example exercises the seven new predicates added in RES-1140.
+
+fn main(int _d) {
+    // Plain ASCII vs UTF-8.
+    println(is_ascii("hello"));            // true
+    println(is_ascii("café"));             // false (é is U+00E9)
+
+    // Whitespace recognition.
+    println(is_ascii_whitespace(" \t\n")); // true
+    println(is_ascii_whitespace("hi"));    // false
+
+    // Hex digit recognition — covers all three cases.
+    println(is_ascii_hexdigit("DeadBeef"));// true
+    println(is_ascii_hexdigit("0x12"));    // false (x is not hex)
+
+    // Case predicates.
+    println(is_ascii_uppercase("HELLO"));  // true
+    println(is_ascii_uppercase("Hello"));  // false
+    println(is_ascii_lowercase("hello"));  // true
+
+    // Punctuation.
+    println(is_ascii_punctuation("!@#")); // true
+    println(is_ascii_punctuation("a"));   // false
+
+    // Control chars — tab / newline / CR are all ASCII control.
+    println(is_ascii_control("\t\n\r")); // true
+    println(is_ascii_control("a"));      // false
+
+    // Empty input is vacuously true for the entire family.
+    println(is_ascii(""));                 // true
+    println(is_ascii_whitespace(""));      // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/ascii_predicates.rs
+++ b/resilient/src/ascii_predicates.rs
@@ -1,0 +1,242 @@
+//! RES-1140: complete the ASCII char-class predicate family.
+//!
+//! Seven new pure leaf builtins that round out the predicate surface
+//! alongside the existing `is_ascii_alpha` / `is_ascii_digit` /
+//! `is_ascii_alnum` (RES-459). Each delegates to the corresponding
+//! `char::is_ascii_*` method and returns `true` iff *every* char in the
+//! input string satisfies the predicate. Empty input returns `true`
+//! (vacuously), matching the existing family's contract.
+//!
+//! | Builtin | Stdlib analog |
+//! |---|---|
+//! | `is_ascii(s)`             | `char::is_ascii` |
+//! | `is_ascii_whitespace(s)`  | `char::is_ascii_whitespace` |
+//! | `is_ascii_hexdigit(s)`    | `char::is_ascii_hexdigit` |
+//! | `is_ascii_uppercase(s)`   | `char::is_ascii_uppercase` |
+//! | `is_ascii_lowercase(s)`   | `char::is_ascii_lowercase` |
+//! | `is_ascii_punctuation(s)` | `char::is_ascii_punctuation` |
+//! | `is_ascii_control(s)`     | `char::is_ascii_control` |
+//!
+//! All seven share the same dispatch shape — a tiny local helper applies
+//! the predicate to every char, returning the all-true conjunction. The
+//! helper is duplicated from `lib.rs::ascii_all` to keep this module
+//! self-contained; the call shape is small enough that the duplication
+//! is cheaper than threading a `pub(crate)` helper out of the giant
+//! `lib.rs` root.
+
+use crate::{RResult, Value};
+
+fn ascii_all<F: Fn(char) -> bool>(name: &str, args: &[Value], pred: F) -> RResult<Value> {
+    match args {
+        [Value::String(s)] => Ok(Value::Bool(s.chars().all(pred))),
+        [other] => Err(format!("{}: expected string, got {}", name, other)),
+        _ => Err(format!("{}: expected 1 argument, got {}", name, args.len())),
+    }
+}
+
+/// `is_ascii(s) -> Bool` — true iff every char is in the ASCII range
+/// (`0x00..=0x7F`). Empty string → true. Mirrors `char::is_ascii`.
+pub(crate) fn builtin_is_ascii(args: &[Value]) -> RResult<Value> {
+    ascii_all("is_ascii", args, |c| c.is_ascii())
+}
+
+/// `is_ascii_whitespace(s) -> Bool` — true iff every char is ASCII
+/// whitespace (space, tab, newline, carriage return, form feed).
+pub(crate) fn builtin_is_ascii_whitespace(args: &[Value]) -> RResult<Value> {
+    ascii_all("is_ascii_whitespace", args, |c| c.is_ascii_whitespace())
+}
+
+/// `is_ascii_hexdigit(s) -> Bool` — true iff every char is in
+/// `0..=9 | a..=f | A..=F`.
+pub(crate) fn builtin_is_ascii_hexdigit(args: &[Value]) -> RResult<Value> {
+    ascii_all("is_ascii_hexdigit", args, |c| c.is_ascii_hexdigit())
+}
+
+/// `is_ascii_uppercase(s) -> Bool` — true iff every char is in `A..=Z`.
+pub(crate) fn builtin_is_ascii_uppercase(args: &[Value]) -> RResult<Value> {
+    ascii_all("is_ascii_uppercase", args, |c| c.is_ascii_uppercase())
+}
+
+/// `is_ascii_lowercase(s) -> Bool` — true iff every char is in `a..=z`.
+pub(crate) fn builtin_is_ascii_lowercase(args: &[Value]) -> RResult<Value> {
+    ascii_all("is_ascii_lowercase", args, |c| c.is_ascii_lowercase())
+}
+
+/// `is_ascii_punctuation(s) -> Bool` — true iff every char is an ASCII
+/// punctuation character (the 32 characters in `!"#$%&'()*+,-./:;<=>?@[\\]^_\`{|}~`).
+pub(crate) fn builtin_is_ascii_punctuation(args: &[Value]) -> RResult<Value> {
+    ascii_all("is_ascii_punctuation", args, |c| c.is_ascii_punctuation())
+}
+
+/// `is_ascii_control(s) -> Bool` — true iff every char is an ASCII
+/// control character (`0x00..=0x1F` or `0x7F`).
+pub(crate) fn builtin_is_ascii_control(args: &[Value]) -> RResult<Value> {
+    ascii_all("is_ascii_control", args, |c| c.is_ascii_control())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b(f: fn(&[Value]) -> RResult<Value>, s: &str) -> bool {
+        match f(&[Value::String(s.to_string())]).unwrap() {
+            Value::Bool(v) => v,
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn is_ascii_basic() {
+        assert!(b(builtin_is_ascii, ""));
+        assert!(b(builtin_is_ascii, "hello"));
+        assert!(b(builtin_is_ascii, "Hello, World! 123"));
+        assert!(b(builtin_is_ascii, "\x00\x7F"));
+        // Non-ASCII (UTF-8) → false
+        assert!(!b(builtin_is_ascii, "café"));
+        assert!(!b(builtin_is_ascii, "日本"));
+        assert!(!b(builtin_is_ascii, "\u{0080}"));
+    }
+
+    #[test]
+    fn is_ascii_whitespace_basic() {
+        assert!(b(builtin_is_ascii_whitespace, ""));
+        assert!(b(builtin_is_ascii_whitespace, " "));
+        assert!(b(builtin_is_ascii_whitespace, "\t"));
+        assert!(b(builtin_is_ascii_whitespace, "\n"));
+        assert!(b(builtin_is_ascii_whitespace, "\r"));
+        assert!(b(builtin_is_ascii_whitespace, "\x0C")); // form feed
+        assert!(b(builtin_is_ascii_whitespace, " \t\n\r"));
+        assert!(!b(builtin_is_ascii_whitespace, "a"));
+        assert!(!b(builtin_is_ascii_whitespace, " a "));
+        assert!(!b(builtin_is_ascii_whitespace, "\u{00A0}")); // non-breaking space is NOT ASCII whitespace
+    }
+
+    #[test]
+    fn is_ascii_hexdigit_basic() {
+        assert!(b(builtin_is_ascii_hexdigit, ""));
+        assert!(b(builtin_is_ascii_hexdigit, "0123456789"));
+        assert!(b(builtin_is_ascii_hexdigit, "abcdef"));
+        assert!(b(builtin_is_ascii_hexdigit, "ABCDEF"));
+        assert!(b(builtin_is_ascii_hexdigit, "DeadBeef"));
+        assert!(!b(builtin_is_ascii_hexdigit, "g"));
+        assert!(!b(builtin_is_ascii_hexdigit, "0x123"));
+        assert!(!b(builtin_is_ascii_hexdigit, "12 34"));
+    }
+
+    #[test]
+    fn is_ascii_uppercase_basic() {
+        assert!(b(builtin_is_ascii_uppercase, ""));
+        assert!(b(builtin_is_ascii_uppercase, "ABC"));
+        assert!(b(builtin_is_ascii_uppercase, "HELLO"));
+        assert!(!b(builtin_is_ascii_uppercase, "Hello"));
+        assert!(!b(builtin_is_ascii_uppercase, "abc"));
+        assert!(!b(builtin_is_ascii_uppercase, "A1B"));
+        assert!(!b(builtin_is_ascii_uppercase, "A B"));
+    }
+
+    #[test]
+    fn is_ascii_lowercase_basic() {
+        assert!(b(builtin_is_ascii_lowercase, ""));
+        assert!(b(builtin_is_ascii_lowercase, "abc"));
+        assert!(b(builtin_is_ascii_lowercase, "hello"));
+        assert!(!b(builtin_is_ascii_lowercase, "Hello"));
+        assert!(!b(builtin_is_ascii_lowercase, "ABC"));
+        assert!(!b(builtin_is_ascii_lowercase, "a1b"));
+    }
+
+    #[test]
+    fn is_ascii_punctuation_basic() {
+        assert!(b(builtin_is_ascii_punctuation, ""));
+        assert!(b(builtin_is_ascii_punctuation, "!@#"));
+        assert!(b(builtin_is_ascii_punctuation, ".,;:"));
+        assert!(b(builtin_is_ascii_punctuation, "()[]{}"));
+        assert!(!b(builtin_is_ascii_punctuation, "a"));
+        assert!(!b(builtin_is_ascii_punctuation, "1"));
+        assert!(!b(builtin_is_ascii_punctuation, " "));
+        assert!(!b(builtin_is_ascii_punctuation, "Hello!"));
+    }
+
+    #[test]
+    fn is_ascii_control_basic() {
+        assert!(b(builtin_is_ascii_control, ""));
+        assert!(b(builtin_is_ascii_control, "\x00"));
+        assert!(b(builtin_is_ascii_control, "\x1F"));
+        assert!(b(builtin_is_ascii_control, "\x7F")); // DEL is control
+        assert!(b(builtin_is_ascii_control, "\x00\x01\x02"));
+        // Tab / newline / CR are also ASCII control chars
+        assert!(b(builtin_is_ascii_control, "\t\n\r"));
+        // Space (0x20) is NOT control
+        assert!(!b(builtin_is_ascii_control, " "));
+        assert!(!b(builtin_is_ascii_control, "a"));
+        assert!(!b(builtin_is_ascii_control, "\x00a"));
+    }
+
+    #[test]
+    fn rejects_non_string() {
+        for f in [
+            builtin_is_ascii,
+            builtin_is_ascii_whitespace,
+            builtin_is_ascii_hexdigit,
+            builtin_is_ascii_uppercase,
+            builtin_is_ascii_lowercase,
+            builtin_is_ascii_punctuation,
+            builtin_is_ascii_control,
+        ] {
+            let err = f(&[Value::Int(65)]).unwrap_err();
+            assert!(err.contains("expected string"), "got {}", err);
+        }
+    }
+
+    #[test]
+    fn rejects_wrong_arity() {
+        for f in [
+            builtin_is_ascii,
+            builtin_is_ascii_whitespace,
+            builtin_is_ascii_hexdigit,
+            builtin_is_ascii_uppercase,
+            builtin_is_ascii_lowercase,
+            builtin_is_ascii_punctuation,
+            builtin_is_ascii_control,
+        ] {
+            let err = f(&[]).unwrap_err();
+            assert!(err.contains("expected 1"), "got {}", err);
+            let err = f(&[
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+            ])
+            .unwrap_err();
+            assert!(err.contains("expected 1"), "got {}", err);
+        }
+    }
+
+    #[test]
+    fn family_consistency_on_empty_string() {
+        // Every "all chars satisfy P" predicate returns true on the
+        // empty string vacuously.
+        for f in [
+            builtin_is_ascii,
+            builtin_is_ascii_whitespace,
+            builtin_is_ascii_hexdigit,
+            builtin_is_ascii_uppercase,
+            builtin_is_ascii_lowercase,
+            builtin_is_ascii_punctuation,
+            builtin_is_ascii_control,
+        ] {
+            assert!(b(f, ""));
+        }
+    }
+
+    #[test]
+    fn family_partitions_a_single_alpha_lower_char() {
+        // 'a' is lowercase, alphabetic, ASCII — but not digit, not
+        // upper, not punctuation, not control, not whitespace,
+        // not hexdigit-only (well, 'a' IS a hexdigit).
+        assert!(b(builtin_is_ascii, "a"));
+        assert!(b(builtin_is_ascii_lowercase, "a"));
+        assert!(b(builtin_is_ascii_hexdigit, "a"));
+        assert!(!b(builtin_is_ascii_uppercase, "a"));
+        assert!(!b(builtin_is_ascii_punctuation, "a"));
+        assert!(!b(builtin_is_ascii_control, "a"));
+        assert!(!b(builtin_is_ascii_whitespace, "a"));
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -15,6 +15,9 @@ mod alignment_helpers;
 // RES-1142: array chunking + striding + rotation primitives.
 // Pure leaf builtins; module-isolated.
 mod array_chunking;
+// RES-1140: ASCII char-class predicates — rounds out the RES-459 family.
+// Pure leaf builtins; module-isolated.
+mod ascii_predicates;
 mod bytecode;
 // RES-1134: bitwise + construction ops on `Value::Bytes` —
 // xor / and / or / not / fill / reverse. Pure leaf builtins; wires
@@ -11070,6 +11073,34 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     (
         "array_rotate_right",
         crate::array_chunking::builtin_array_rotate_right,
+    ),
+    // RES-1140: ASCII char-class predicates. Pure leaf builtins;
+    // module-isolated in `ascii_predicates.rs`. Appended at the end
+    // of BUILTINS per the perf rule established in PR #1125.
+    ("is_ascii", crate::ascii_predicates::builtin_is_ascii),
+    (
+        "is_ascii_whitespace",
+        crate::ascii_predicates::builtin_is_ascii_whitespace,
+    ),
+    (
+        "is_ascii_hexdigit",
+        crate::ascii_predicates::builtin_is_ascii_hexdigit,
+    ),
+    (
+        "is_ascii_uppercase",
+        crate::ascii_predicates::builtin_is_ascii_uppercase,
+    ),
+    (
+        "is_ascii_lowercase",
+        crate::ascii_predicates::builtin_is_ascii_lowercase,
+    ),
+    (
+        "is_ascii_punctuation",
+        crate::ascii_predicates::builtin_is_ascii_punctuation,
+    ),
+    (
+        "is_ascii_control",
+        crate::ascii_predicates::builtin_is_ascii_control,
     ),
 ];
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1342,6 +1342,18 @@ impl TypeChecker {
         env.set("array_step".to_string(), fn_array_int_to_array());
         env.set("array_rotate_left".to_string(), fn_array_int_to_array());
         env.set("array_rotate_right".to_string(), fn_array_int_to_array());
+        // RES-1140: ASCII char-class predicates.
+        let fn_string_to_bool = || Type::Function {
+            params: vec![Type::String],
+            return_type: Box::new(Type::Bool),
+        };
+        env.set("is_ascii".to_string(), fn_string_to_bool());
+        env.set("is_ascii_whitespace".to_string(), fn_string_to_bool());
+        env.set("is_ascii_hexdigit".to_string(), fn_string_to_bool());
+        env.set("is_ascii_uppercase".to_string(), fn_string_to_bool());
+        env.set("is_ascii_lowercase".to_string(), fn_string_to_bool());
+        env.set("is_ascii_punctuation".to_string(), fn_string_to_bool());
+        env.set("is_ascii_control".to_string(), fn_string_to_bool());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6118,6 +6130,14 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_step",
         "array_rotate_left",
         "array_rotate_right",
+        // RES-1140: ASCII char-class predicates.
+        "is_ascii",
+        "is_ascii_whitespace",
+        "is_ascii_hexdigit",
+        "is_ascii_uppercase",
+        "is_ascii_lowercase",
+        "is_ascii_punctuation",
+        "is_ascii_control",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1140.

RES-459 shipped three ASCII predicates (`is_ascii_alpha`, `is_ascii_digit`,
`is_ascii_alnum`). The other seven `char::is_ascii_*` methods were missing,
which forced every parser / lexer / sanitiser to fall back to byte-level
range checks (one of those *looks-fine-fails-on-\\x7F* footgun patterns).

### Surface added

| Builtin | Stdlib analog |
|---|---|
| `is_ascii(s)`             | `char::is_ascii` |
| `is_ascii_whitespace(s)`  | `char::is_ascii_whitespace` |
| `is_ascii_hexdigit(s)`    | `char::is_ascii_hexdigit` |
| `is_ascii_uppercase(s)`   | `char::is_ascii_uppercase` |
| `is_ascii_lowercase(s)`   | `char::is_ascii_lowercase` |
| `is_ascii_punctuation(s)` | `char::is_ascii_punctuation` |
| `is_ascii_control(s)`     | `char::is_ascii_control` |

Same shape as the existing family — returns `true` iff every char in
`s` satisfies the predicate, with the empty string vacuously true.

### Design notes

- Module-isolated in `resilient/src/ascii_predicates.rs` per CLAUDE.md
  feature isolation. The `ascii_all` dispatch helper is duplicated from
  `lib.rs::ascii_all` (3 lines) rather than threaded out as
  `pub(crate)` — easier to follow than chasing a helper across the
  giant `lib.rs`.
- Minimal touches: 1 `mod` decl + 7 `BUILTINS` entries appended in
  `lib.rs` (perf rule from [PR #1125](https://github.com/EricSpencer00/Resilient/pull/1125)), 7 env-seed entries + 7
  `PURE_BUILTINS` entries in `typechecker.rs`.
- All seven are pure leaf builtins — no I/O, no allocation, never panic.

### Tests

- **10 unit tests** in `ascii_predicates.rs` (`#[cfg(test)] mod tests`)
  covering: known-true / known-false strings for each predicate,
  ASCII / UTF-8 boundary cases (`é`, `日本`, `\\u{0080}`), empty-string
  vacuous truth across all seven, an alpha-lower partition check
  (\`'a'\` is lowercase, alphabetic, hexdigit, ASCII — but not uppercase,
  digit-only, punctuation, control, whitespace), and consistent
  rejection of non-string / wrong-arity inputs.
- **1 new golden example** (`is_ascii_family.rz`) exercising the full
  surface through the compiled `rz` binary. Uses `\\t` / `\\n` / `\\r`
  for control-char tests (Resilient string literals don't process
  `\\xNN` hex escapes).

### Local gates

- `cargo build --locked` — clean
- `cargo test --locked` — clean (10 new + all 39 targets green)
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>