### PR TITLE
RES-1142: array chunking + striding + rotation — 5 new builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,12 +5,12 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
-      "branch": "res-1138-float-predicates",
-      "claimed_at": "2026-05-11T15:15:00Z"
+      "branch": "res-1142-array-chunking",
+      "claimed_at": "2026-05-11T15:32:00Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1138-float-predicates",
-      "claimed_at": "2026-05-11T15:15:00Z"
+      "branch": "res-1142-array-chunking",
+      "claimed_at": "2026-05-11T15:32:00Z"
     }
   }
 }

--- a/resilient/examples/array_chunking.expected.txt
+++ b/resilient/examples/array_chunking.expected.txt
@@ -1,0 +1,13 @@
+3
+2
+1
+2
+3
+10
+70
+3
+2
+3
+1
+5
+Program executed successfully

--- a/resilient/examples/array_chunking.rz
+++ b/resilient/examples/array_chunking.rz
@@ -1,0 +1,39 @@
+// RES-1142 demo: array_chunks, array_chunks_exact, array_step,
+// array_rotate_left, array_rotate_right.
+
+fn main(int _d) {
+    // Non-overlapping chunks; last may be shorter.
+    let arr = [1, 2, 3, 4, 5];
+    let cs = array_chunks(arr, 2);
+    println(len(cs));               // 3
+    println(len(cs[0]));             // 2
+    println(len(cs[2]));             // 1 (remainder)
+
+    // Strict version drops the remainder.
+    let ex = array_chunks_exact(arr, 2);
+    println(len(ex));               // 2
+
+    // Every-nth element.
+    let stepped = array_step([10, 20, 30, 40, 50, 60, 70], 3);
+    println(len(stepped));          // 3
+    println(stepped[0]);            // 10
+    println(stepped[2]);            // 70
+
+    // Rotation: rotate-left by 2 on [1..5] → [3,4,5,1,2].
+    let rl = array_rotate_left([1, 2, 3, 4, 5], 2);
+    println(rl[0]);                 // 3
+    println(rl[4]);                 // 2
+
+    // Rotation taken modulo length.
+    let rl_mod = array_rotate_left([1, 2, 3, 4, 5], 7);
+    println(rl_mod[0]);             // 3 (7 mod 5 = 2)
+
+    // Round-trip: rotate left then right by same amount.
+    let back = array_rotate_right(array_rotate_left([1, 2, 3, 4, 5], 3), 3);
+    println(back[0]);               // 1
+    println(back[4]);               // 5
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/array_chunking.rs
+++ b/resilient/src/array_chunking.rs
@@ -1,0 +1,375 @@
+//! RES-1142: array chunking + striding + rotation primitives.
+//!
+//! Five pure leaf builtins that round out the `Array` slicing surface
+//! alongside the existing `array_window` (RES-455) and `array_repeat`
+//! (RES-456). `array_window` exposes overlapping sliding windows; this
+//! ticket adds the disjoint / strided / cyclic variants:
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `array_chunks(arr, n)`       | `(Array, Int) -> Array` | Non-overlapping chunks; last chunk may be shorter |
+//! | `array_chunks_exact(arr, n)` | `(Array, Int) -> Array` | Strict version — drops remainder |
+//! | `array_step(arr, n)`         | `(Array, Int) -> Array` | Every nth element starting at index 0 |
+//! | `array_rotate_left(arr, n)`  | `(Array, Int) -> Array` | Rotate left by `n` positions (`n` is taken mod `len`) |
+//! | `array_rotate_right(arr, n)` | `(Array, Int) -> Array` | Rotate right by `n` positions |
+//!
+//! All five require `n > 0` and return a fresh `Array`. Input never
+//! mutated. `n` larger than `len` is allowed for chunks / step (returns
+//! a single full chunk / single-element / empty result) and rotation
+//! (taken modulo `len`).
+
+use crate::{RResult, Value};
+
+/// `array_chunks(arr, n) -> Array[Array]` — split `arr` into
+/// non-overlapping sub-arrays of length `n`. If `len` is not divisible
+/// by `n`, the last chunk is shorter. `n` must be positive.
+pub(crate) fn builtin_array_chunks(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::Int(n)] => {
+            if *n <= 0 {
+                return Err(format!(
+                    "array_chunks: chunk size must be positive, got {}",
+                    n
+                ));
+            }
+            let size = *n as usize;
+            let chunks: Vec<Value> = items
+                .chunks(size)
+                .map(|c| Value::Array(c.to_vec()))
+                .collect();
+            Ok(Value::Array(chunks))
+        }
+        [a, b] => Err(format!(
+            "array_chunks: expected (array, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_chunks: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_chunks_exact(arr, n) -> Array[Array]` — like `array_chunks`
+/// but drops the final partial chunk when `len % n != 0`. Useful when
+/// every chunk must be exactly `n` elements (SIMD lanes, fixed-size
+/// frames). `n` must be positive.
+pub(crate) fn builtin_array_chunks_exact(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::Int(n)] => {
+            if *n <= 0 {
+                return Err(format!(
+                    "array_chunks_exact: chunk size must be positive, got {}",
+                    n
+                ));
+            }
+            let size = *n as usize;
+            let chunks: Vec<Value> = items
+                .chunks_exact(size)
+                .map(|c| Value::Array(c.to_vec()))
+                .collect();
+            Ok(Value::Array(chunks))
+        }
+        [a, b] => Err(format!(
+            "array_chunks_exact: expected (array, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_chunks_exact: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_step(arr, n) -> Array` — every nth element starting at
+/// index 0. `n` must be positive. `n = 1` returns a clone; `n >= len`
+/// returns just the first element (or empty if input is empty).
+pub(crate) fn builtin_array_step(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::Int(n)] => {
+            if *n <= 0 {
+                return Err(format!("array_step: stride must be positive, got {}", n));
+            }
+            let stride = *n as usize;
+            let stepped: Vec<Value> = items.iter().step_by(stride).cloned().collect();
+            Ok(Value::Array(stepped))
+        }
+        [a, b] => Err(format!(
+            "array_step: expected (array, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_step: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_rotate_left(arr, n) -> Array` — rotate `arr` left by `n`
+/// positions. `n` must be non-negative. Effective rotation is taken
+/// modulo `len`, so `n >= len` is well-defined. Empty array returns
+/// empty regardless of `n`. Element at index `i` ends up at
+/// `(i - n + len) mod len`.
+pub(crate) fn builtin_array_rotate_left(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "array_rotate_left: count must be non-negative, got {}",
+                    n
+                ));
+            }
+            if items.is_empty() {
+                return Ok(Value::Array(Vec::new()));
+            }
+            let len = items.len();
+            let shift = (*n as usize) % len;
+            let mut out = Vec::with_capacity(len);
+            out.extend_from_slice(&items[shift..]);
+            out.extend_from_slice(&items[..shift]);
+            Ok(Value::Array(out))
+        }
+        [a, b] => Err(format!(
+            "array_rotate_left: expected (array, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_rotate_left: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_rotate_right(arr, n) -> Array` — rotate `arr` right by `n`
+/// positions. Same contract as `array_rotate_left`, in the opposite
+/// direction. Element at index `i` ends up at `(i + n) mod len`.
+pub(crate) fn builtin_array_rotate_right(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "array_rotate_right: count must be non-negative, got {}",
+                    n
+                ));
+            }
+            if items.is_empty() {
+                return Ok(Value::Array(Vec::new()));
+            }
+            let len = items.len();
+            let shift = (*n as usize) % len;
+            // Right-by-shift = left-by-(len - shift).
+            let split = len - shift;
+            let mut out = Vec::with_capacity(len);
+            out.extend_from_slice(&items[split..]);
+            out.extend_from_slice(&items[..split]);
+            Ok(Value::Array(out))
+        }
+        [a, b] => Err(format!(
+            "array_rotate_right: expected (array, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "array_rotate_right: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ints(xs: &[i64]) -> Value {
+        Value::Array(xs.iter().map(|&n| Value::Int(n)).collect())
+    }
+
+    fn as_ints(v: Value) -> Vec<i64> {
+        match v {
+            Value::Array(items) => items
+                .into_iter()
+                .map(|x| match x {
+                    Value::Int(n) => n,
+                    other => panic!("expected Int, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    fn as_nested_ints(v: Value) -> Vec<Vec<i64>> {
+        match v {
+            Value::Array(outer) => outer.into_iter().map(as_ints).collect(),
+            other => panic!("expected Array of Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn chunks_evenly_divisible() {
+        let r = builtin_array_chunks(&[ints(&[1, 2, 3, 4, 5, 6]), Value::Int(2)]).unwrap();
+        assert_eq!(as_nested_ints(r), vec![vec![1, 2], vec![3, 4], vec![5, 6]]);
+    }
+
+    #[test]
+    fn chunks_with_remainder() {
+        let r = builtin_array_chunks(&[ints(&[1, 2, 3, 4, 5]), Value::Int(2)]).unwrap();
+        assert_eq!(as_nested_ints(r), vec![vec![1, 2], vec![3, 4], vec![5]]);
+    }
+
+    #[test]
+    fn chunks_n_greater_than_len_returns_one_full_chunk() {
+        let r = builtin_array_chunks(&[ints(&[1, 2, 3]), Value::Int(10)]).unwrap();
+        assert_eq!(as_nested_ints(r), vec![vec![1, 2, 3]]);
+    }
+
+    #[test]
+    fn chunks_empty_array_is_empty() {
+        let r = builtin_array_chunks(&[ints(&[]), Value::Int(3)]).unwrap();
+        assert_eq!(as_nested_ints(r), Vec::<Vec<i64>>::new());
+    }
+
+    #[test]
+    fn chunks_n_one_returns_singletons() {
+        let r = builtin_array_chunks(&[ints(&[1, 2, 3]), Value::Int(1)]).unwrap();
+        assert_eq!(as_nested_ints(r), vec![vec![1], vec![2], vec![3]]);
+    }
+
+    #[test]
+    fn chunks_rejects_zero_and_negative() {
+        let err = builtin_array_chunks(&[ints(&[1, 2]), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("must be positive"));
+        let err = builtin_array_chunks(&[ints(&[1, 2]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("must be positive"));
+    }
+
+    #[test]
+    fn chunks_exact_drops_remainder() {
+        let r = builtin_array_chunks_exact(&[ints(&[1, 2, 3, 4, 5]), Value::Int(2)]).unwrap();
+        assert_eq!(as_nested_ints(r), vec![vec![1, 2], vec![3, 4]]);
+    }
+
+    #[test]
+    fn chunks_exact_even_split_matches_chunks() {
+        let r = builtin_array_chunks_exact(&[ints(&[1, 2, 3, 4, 5, 6]), Value::Int(3)]).unwrap();
+        assert_eq!(as_nested_ints(r), vec![vec![1, 2, 3], vec![4, 5, 6]]);
+    }
+
+    #[test]
+    fn chunks_exact_n_greater_than_len_is_empty() {
+        let r = builtin_array_chunks_exact(&[ints(&[1, 2, 3]), Value::Int(10)]).unwrap();
+        assert_eq!(as_nested_ints(r), Vec::<Vec<i64>>::new());
+    }
+
+    #[test]
+    fn step_basic() {
+        let r = builtin_array_step(&[ints(&[1, 2, 3, 4, 5, 6, 7]), Value::Int(2)]).unwrap();
+        assert_eq!(as_ints(r), vec![1, 3, 5, 7]);
+        let r = builtin_array_step(&[ints(&[1, 2, 3, 4, 5, 6, 7]), Value::Int(3)]).unwrap();
+        assert_eq!(as_ints(r), vec![1, 4, 7]);
+    }
+
+    #[test]
+    fn step_one_is_identity() {
+        let r = builtin_array_step(&[ints(&[1, 2, 3]), Value::Int(1)]).unwrap();
+        assert_eq!(as_ints(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn step_larger_than_len_returns_first_element() {
+        let r = builtin_array_step(&[ints(&[1, 2, 3]), Value::Int(10)]).unwrap();
+        assert_eq!(as_ints(r), vec![1]);
+    }
+
+    #[test]
+    fn step_empty_yields_empty() {
+        let r = builtin_array_step(&[ints(&[]), Value::Int(5)]).unwrap();
+        assert_eq!(as_ints(r), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn step_rejects_zero_and_negative() {
+        let err = builtin_array_step(&[ints(&[1, 2]), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("must be positive"));
+        let err = builtin_array_step(&[ints(&[1, 2]), Value::Int(-3)]).unwrap_err();
+        assert!(err.contains("must be positive"));
+    }
+
+    #[test]
+    fn rotate_left_basic() {
+        let r = builtin_array_rotate_left(&[ints(&[1, 2, 3, 4, 5]), Value::Int(2)]).unwrap();
+        assert_eq!(as_ints(r), vec![3, 4, 5, 1, 2]);
+    }
+
+    #[test]
+    fn rotate_left_by_zero_is_identity() {
+        let r = builtin_array_rotate_left(&[ints(&[1, 2, 3]), Value::Int(0)]).unwrap();
+        assert_eq!(as_ints(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn rotate_left_by_len_is_identity() {
+        let r = builtin_array_rotate_left(&[ints(&[1, 2, 3]), Value::Int(3)]).unwrap();
+        assert_eq!(as_ints(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn rotate_left_modulo_len() {
+        let r = builtin_array_rotate_left(&[ints(&[1, 2, 3, 4, 5]), Value::Int(7)]).unwrap();
+        // 7 mod 5 = 2 → same as rotate-left-by-2
+        assert_eq!(as_ints(r), vec![3, 4, 5, 1, 2]);
+    }
+
+    #[test]
+    fn rotate_left_empty_yields_empty() {
+        let r = builtin_array_rotate_left(&[ints(&[]), Value::Int(7)]).unwrap();
+        assert_eq!(as_ints(r), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn rotate_left_rejects_negative() {
+        let err = builtin_array_rotate_left(&[ints(&[1]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"));
+    }
+
+    #[test]
+    fn rotate_right_basic() {
+        let r = builtin_array_rotate_right(&[ints(&[1, 2, 3, 4, 5]), Value::Int(2)]).unwrap();
+        assert_eq!(as_ints(r), vec![4, 5, 1, 2, 3]);
+    }
+
+    #[test]
+    fn rotate_right_modulo_len() {
+        let r = builtin_array_rotate_right(&[ints(&[1, 2, 3, 4, 5]), Value::Int(12)]).unwrap();
+        // 12 mod 5 = 2
+        assert_eq!(as_ints(r), vec![4, 5, 1, 2, 3]);
+    }
+
+    #[test]
+    fn rotate_left_then_right_is_identity() {
+        let original = ints(&[1, 2, 3, 4, 5, 6, 7]);
+        let left = builtin_array_rotate_left(&[original.clone(), Value::Int(3)]).unwrap();
+        let back = builtin_array_rotate_right(&[left, Value::Int(3)]).unwrap();
+        assert_eq!(as_ints(back), as_ints(original));
+    }
+
+    #[test]
+    fn rotate_right_rejects_negative() {
+        let err = builtin_array_rotate_right(&[ints(&[1]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"));
+    }
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        for f in [
+            builtin_array_chunks,
+            builtin_array_chunks_exact,
+            builtin_array_step,
+            builtin_array_rotate_left,
+            builtin_array_rotate_right,
+        ] {
+            let err = f(&[ints(&[1])]).unwrap_err();
+            assert!(err.contains("expected 2"), "got {}", err);
+            let err = f(&[Value::Int(5), Value::Int(1)]).unwrap_err();
+            assert!(err.contains("expected (array, int)"), "got {}", err);
+        }
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -12,6 +12,9 @@ use std::rc::Rc;
 // Pure leaf builtins; module-isolated so adding new bytes/int helpers
 // doesn't have to dodge each other inside lib.rs.
 mod alignment_helpers;
+// RES-1142: array chunking + striding + rotation primitives.
+// Pure leaf builtins; module-isolated.
+mod array_chunking;
 mod bytecode;
 // RES-1134: bitwise + construction ops on `Value::Bytes` —
 // xor / and / or / not / fill / reverse. Pure leaf builtins; wires
@@ -11050,6 +11053,23 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     (
         "float_sign_bit",
         crate::float_predicates::builtin_float_sign_bit,
+    ),
+    // RES-1142: array chunking + striding + rotation primitives.
+    // Pure leaf builtins; module-isolated in `array_chunking.rs`.
+    // Appended at the end of BUILTINS per the perf rule from PR #1125.
+    ("array_chunks", crate::array_chunking::builtin_array_chunks),
+    (
+        "array_chunks_exact",
+        crate::array_chunking::builtin_array_chunks_exact,
+    ),
+    ("array_step", crate::array_chunking::builtin_array_step),
+    (
+        "array_rotate_left",
+        crate::array_chunking::builtin_array_rotate_left,
+    ),
+    (
+        "array_rotate_right",
+        crate::array_chunking::builtin_array_rotate_right,
     ),
 ];
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1332,6 +1332,16 @@ impl TypeChecker {
         env.set("float_is_normal".to_string(), fn_float_to_bool());
         env.set("float_is_subnormal".to_string(), fn_float_to_bool());
         env.set("float_sign_bit".to_string(), fn_float_to_bool());
+        // RES-1142: array chunking + striding + rotation primitives.
+        let fn_array_int_to_array = || Type::Function {
+            params: vec![Type::Array, Type::Int],
+            return_type: Box::new(Type::Array),
+        };
+        env.set("array_chunks".to_string(), fn_array_int_to_array());
+        env.set("array_chunks_exact".to_string(), fn_array_int_to_array());
+        env.set("array_step".to_string(), fn_array_int_to_array());
+        env.set("array_rotate_left".to_string(), fn_array_int_to_array());
+        env.set("array_rotate_right".to_string(), fn_array_int_to_array());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6102,6 +6112,12 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "float_is_normal",
         "float_is_subnormal",
         "float_sign_bit",
+        // RES-1142: array chunking + striding + rotation.
+        "array_chunks",
+        "array_chunks_exact",
+        "array_step",
+        "array_rotate_left",
+        "array_rotate_right",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1142.

\`array_window\` (RES-455) gives overlapping sliding windows, but the
disjoint / strided / cyclic variants weren't exposed — every batching /
pagination / SIMD-prep / ring-buffer workload had to hand-roll them and
risk getting the boundary conditions wrong.

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| \`array_chunks(arr, n)\`       | \`(Array, Int) -> Array\` | Non-overlapping chunks; last chunk may be shorter |
| \`array_chunks_exact(arr, n)\` | \`(Array, Int) -> Array\` | Strict version — drops remainder when \`len % n != 0\` |
| \`array_step(arr, n)\`         | \`(Array, Int) -> Array\` | Every nth element starting at index 0 |
| \`array_rotate_left(arr, n)\`  | \`(Array, Int) -> Array\` | Rotate left by \`n\` positions (\`n\` taken mod \`len\`) |
| \`array_rotate_right(arr, n)\` | \`(Array, Int) -> Array\` | Rotate right by \`n\` positions |

### Semantics

- \`array_chunks*\` and \`array_step\` require \`n > 0\`. \`n > len\` returns
  one full chunk / a single-element step / empty exact-chunk.
- \`array_rotate_*\` require \`n >= 0\`. \`n\` is taken modulo \`len\` so
  \`n > len\` is well-defined. Empty arrays return empty regardless of \`n\`.
- All five return fresh arrays; input is never mutated.

### Design notes

- Module-isolated in \`resilient/src/array_chunking.rs\` per CLAUDE.md
  feature isolation. Minimal touches:
  - \`lib.rs\`: 1 \`mod\` decl + 5 \`BUILTINS\` entries appended (perf rule
    from [PR #1125](https://github.com/EricSpencer00/Resilient/pull/1125)).
  - \`typechecker.rs\`: 5 env-seed entries + 5 \`PURE_BUILTINS\` entries.
- All five are pure leaf builtins — no I/O, no allocation beyond the
  fresh result \`Vec<Value>\`, never panic. Listed in \`PURE_BUILTINS\`.
- Delegates to \`slice::chunks\`, \`slice::chunks_exact\`, \`Iterator::step_by\`,
  and manual cyclic-shift for rotation (avoids \`Vec::rotate_left\`'s
  in-place mutation since the contract is *fresh-allocation*).

### Tests

- **25 unit tests** in \`array_chunking.rs\` covering: evenly-divisible
  / remainder / oversize / empty cases for each builtin, n-of-one
  identity cases, modulo-len rotation, rotate-left-then-right
  round-trip identity, and consistent type / arity rejection.
- **1 new golden example** (\`array_chunking.rz\`) exercising the full
  surface from \`.rz\` source through the compiled \`rz\` binary.

### Local gates

- \`cargo build --locked\` — clean
- \`cargo test --locked\` — clean (25 new + all 39 targets green)
- \`cargo clippy --locked --all-targets -- -D warnings\` — clean
- \`cargo fmt --check\` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>