### PR TITLE
RES-1146: array_sort_float / array_sort_string + array_is_sorted family — 5 new builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,12 +5,12 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
-      "branch": "res-1140-ascii-predicates",
-      "claimed_at": "2026-05-11T15:25:00Z"
+      "branch": "res-1146-array-sort-extra",
+      "claimed_at": "2026-05-11T15:52:00Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1140-ascii-predicates",
-      "claimed_at": "2026-05-11T15:25:00Z"
+      "branch": "res-1146-array-sort-extra",
+      "claimed_at": "2026-05-11T15:52:00Z"
     }
   }
 }

--- a/resilient/examples/array_sort_extra.expected.txt
+++ b/resilient/examples/array_sort_extra.expected.txt
@@ -1,0 +1,12 @@
+-1
+3
+true
+Bob
+alice
+carol
+true
+true
+false
+true
+true
+Program executed successfully

--- a/resilient/examples/array_sort_extra.rz
+++ b/resilient/examples/array_sort_extra.rz
@@ -1,0 +1,30 @@
+// RES-1146 demo: array_sort_float / array_sort_string + the
+// array_is_sorted predicate family.
+
+fn main(int _d) {
+    // Float sort handles NaN-safe ordering via IEEE 754 total order.
+    let nums = array_sort_float([3.0, 1.5, -1.0, 2.5]);
+    println(nums[0]);                       // -1.0
+    println(nums[3]);                       // 3.0
+    println(array_is_sorted_float(nums));   // true
+
+    // String sort is byte-wise lex (uppercase < lowercase).
+    let names = array_sort_string(["carol", "alice", "Bob"]);
+    println(names[0]);                      // Bob
+    println(names[1]);                      // alice
+    println(names[2]);                      // carol
+    println(array_is_sorted_string(names)); // true
+
+    // is_sorted predicates on already-sorted vs unsorted input.
+    println(array_is_sorted([1, 2, 3, 4]));   // true
+    println(array_is_sorted([1, 3, 2]));      // false
+    println(array_is_sorted([]));             // true (vacuous)
+
+    // Sorting any input always produces is_sorted output.
+    let already = array_sort_float([0.0, -0.0]);
+    println(array_is_sorted_float(already)); // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/array_sort_extra.rs
+++ b/resilient/src/array_sort_extra.rs
@@ -1,0 +1,426 @@
+//! RES-1146: float / string array sort + the `array_is_sorted` predicate
+//! family.
+//!
+//! `array_sort` and `array_sort_desc` only accept int arrays; this
+//! ticket adds the float / string variants and the "is this already
+//! sorted?" predicate over all three element types.
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `array_sort_float(arr)`      | `(Array) -> Array` | Ascending float sort (NaN-safe via IEEE 754 total order) |
+//! | `array_sort_string(arr)`     | `(Array) -> Array` | Ascending lex string sort |
+//! | `array_is_sorted(arr)`       | `(Array) -> Bool`  | Int array is ascending |
+//! | `array_is_sorted_float(arr)` | `(Array) -> Bool`  | Float array is ascending (NaN-safe) |
+//! | `array_is_sorted_string(arr)`| `(Array) -> Bool`  | String array is lex-ascending |
+//!
+//! All five are pure leaf builtins. `_float` variants use
+//! `f64::total_cmp` so NaN and `±0` are well-ordered. Empty and
+//! singleton arrays are always sorted (vacuously).
+
+use crate::{RResult, Value};
+
+fn collect_floats(name: &str, items: &[Value]) -> RResult<Vec<f64>> {
+    let mut nums: Vec<f64> = Vec::with_capacity(items.len());
+    for v in items {
+        match v {
+            Value::Float(f) => nums.push(*f),
+            other => {
+                return Err(format!(
+                    "{}: expected all float elements, got {}",
+                    name, other
+                ));
+            }
+        }
+    }
+    Ok(nums)
+}
+
+fn collect_strings(name: &str, items: &[Value]) -> RResult<Vec<String>> {
+    let mut out: Vec<String> = Vec::with_capacity(items.len());
+    for v in items {
+        match v {
+            Value::String(s) => out.push(s.clone()),
+            other => {
+                return Err(format!(
+                    "{}: expected all string elements, got {}",
+                    name, other
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn collect_ints(name: &str, items: &[Value]) -> RResult<Vec<i64>> {
+    let mut out: Vec<i64> = Vec::with_capacity(items.len());
+    for v in items {
+        match v {
+            Value::Int(n) => out.push(*n),
+            other => {
+                return Err(format!(
+                    "{}: expected all int elements, got {}",
+                    name, other
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// `array_sort_float(arr) -> Array` — sort a float array ascending using
+/// IEEE 754 total order (`f64::total_cmp`). NaN, `±0`, and signed-NaN
+/// payloads are placed in a well-defined position; the result is always
+/// a strict total order, unlike `<` which is undefined on NaN.
+pub(crate) fn builtin_array_sort_float(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let mut nums = collect_floats("array_sort_float", items)?;
+            nums.sort_by(|a, b| a.total_cmp(b));
+            Ok(Value::Array(nums.into_iter().map(Value::Float).collect()))
+        }
+        [other] => Err(format!("array_sort_float: expected array, got {}", other)),
+        _ => Err(format!(
+            "array_sort_float: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_sort_string(arr) -> Array` — sort a string array ascending
+/// lexicographically (byte-wise on the UTF-8 representation, matching
+/// `String::cmp`).
+pub(crate) fn builtin_array_sort_string(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let mut strings = collect_strings("array_sort_string", items)?;
+            strings.sort();
+            Ok(Value::Array(
+                strings.into_iter().map(Value::String).collect(),
+            ))
+        }
+        [other] => Err(format!("array_sort_string: expected array, got {}", other)),
+        _ => Err(format!(
+            "array_sort_string: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_is_sorted(arr) -> Bool` — true iff every consecutive pair of
+/// int elements is non-decreasing. Empty and singleton arrays are
+/// vacuously sorted.
+pub(crate) fn builtin_array_is_sorted(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let nums = collect_ints("array_is_sorted", items)?;
+            Ok(Value::Bool(nums.windows(2).all(|w| w[0] <= w[1])))
+        }
+        [other] => Err(format!("array_is_sorted: expected array, got {}", other)),
+        _ => Err(format!(
+            "array_is_sorted: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_is_sorted_float(arr) -> Bool` — true iff every consecutive
+/// pair is `<=` under IEEE 754 total order. Same NaN-safety as
+/// `array_sort_float`.
+pub(crate) fn builtin_array_is_sorted_float(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let nums = collect_floats("array_is_sorted_float", items)?;
+            Ok(Value::Bool(nums.windows(2).all(|w| {
+                w[0].total_cmp(&w[1]) != std::cmp::Ordering::Greater
+            })))
+        }
+        [other] => Err(format!(
+            "array_is_sorted_float: expected array, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "array_is_sorted_float: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_is_sorted_string(arr) -> Bool` — true iff every consecutive
+/// pair is lex-ordered.
+pub(crate) fn builtin_array_is_sorted_string(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let strings = collect_strings("array_is_sorted_string", items)?;
+            Ok(Value::Bool(strings.windows(2).all(|w| w[0] <= w[1])))
+        }
+        [other] => Err(format!(
+            "array_is_sorted_string: expected array, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "array_is_sorted_string: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn floats(xs: &[f64]) -> Value {
+        Value::Array(xs.iter().map(|&f| Value::Float(f)).collect())
+    }
+
+    fn strings(xs: &[&str]) -> Value {
+        Value::Array(xs.iter().map(|s| Value::String(s.to_string())).collect())
+    }
+
+    fn ints(xs: &[i64]) -> Value {
+        Value::Array(xs.iter().map(|&n| Value::Int(n)).collect())
+    }
+
+    fn as_float_vec(v: Value) -> Vec<f64> {
+        match v {
+            Value::Array(items) => items
+                .into_iter()
+                .map(|x| match x {
+                    Value::Float(f) => f,
+                    other => panic!("expected Float, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    fn as_string_vec(v: Value) -> Vec<String> {
+        match v {
+            Value::Array(items) => items
+                .into_iter()
+                .map(|x| match x {
+                    Value::String(s) => s,
+                    other => panic!("expected String, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    fn as_bool(v: Value) -> bool {
+        match v {
+            Value::Bool(b) => b,
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    // --- sort_float -------------------------------------------------------
+
+    #[test]
+    fn sort_float_basic() {
+        let r = builtin_array_sort_float(&[floats(&[3.0, 1.5, 2.5, -1.0])]).unwrap();
+        assert_eq!(as_float_vec(r), vec![-1.0, 1.5, 2.5, 3.0]);
+    }
+
+    #[test]
+    fn sort_float_empty() {
+        let r = builtin_array_sort_float(&[floats(&[])]).unwrap();
+        assert_eq!(as_float_vec(r), Vec::<f64>::new());
+    }
+
+    #[test]
+    fn sort_float_handles_nan_under_total_order() {
+        // NaN sorts after +inf under IEEE 754 total order.
+        let r = builtin_array_sort_float(&[floats(&[1.0, f64::NAN, -1.0, f64::INFINITY, 0.0])])
+            .unwrap();
+        let v = as_float_vec(r);
+        assert_eq!(v.len(), 5);
+        assert_eq!(v[0], -1.0);
+        assert_eq!(v[1], 0.0);
+        assert_eq!(v[2], 1.0);
+        assert_eq!(v[3], f64::INFINITY);
+        // Last is NaN — can't use ==, check classify.
+        assert!(v[4].is_nan());
+    }
+
+    #[test]
+    fn sort_float_distinguishes_signed_zero() {
+        // -0.0 < +0.0 under total order.
+        let r = builtin_array_sort_float(&[floats(&[0.0, -0.0, 0.0])]).unwrap();
+        let v = as_float_vec(r);
+        assert!(v[0].is_sign_negative());
+        assert!(!v[1].is_sign_negative());
+        assert!(!v[2].is_sign_negative());
+    }
+
+    #[test]
+    fn sort_float_rejects_non_float() {
+        let err = builtin_array_sort_float(&[ints(&[1, 2, 3])]).unwrap_err();
+        assert!(err.contains("expected all float elements"));
+    }
+
+    #[test]
+    fn sort_float_rejects_non_array() {
+        let err = builtin_array_sort_float(&[Value::Int(7)]).unwrap_err();
+        assert!(err.contains("expected array"));
+    }
+
+    // --- sort_string ------------------------------------------------------
+
+    #[test]
+    fn sort_string_basic() {
+        let r = builtin_array_sort_string(&[strings(&["carol", "alice", "bob"])]).unwrap();
+        assert_eq!(as_string_vec(r), vec!["alice", "bob", "carol"]);
+    }
+
+    #[test]
+    fn sort_string_empty() {
+        let r = builtin_array_sort_string(&[strings(&[])]).unwrap();
+        assert_eq!(as_string_vec(r), Vec::<String>::new());
+    }
+
+    #[test]
+    fn sort_string_lex_byte_order() {
+        // Uppercase < lowercase under byte-wise UTF-8 comparison.
+        let r = builtin_array_sort_string(&[strings(&["b", "A", "a", "B"])]).unwrap();
+        assert_eq!(as_string_vec(r), vec!["A", "B", "a", "b"]);
+    }
+
+    #[test]
+    fn sort_string_stable_on_duplicates() {
+        let r = builtin_array_sort_string(&[strings(&["x", "a", "x", "a"])]).unwrap();
+        assert_eq!(as_string_vec(r), vec!["a", "a", "x", "x"]);
+    }
+
+    #[test]
+    fn sort_string_rejects_non_string() {
+        let err = builtin_array_sort_string(&[floats(&[1.0])]).unwrap_err();
+        assert!(err.contains("expected all string elements"));
+    }
+
+    // --- is_sorted (int) --------------------------------------------------
+
+    #[test]
+    fn is_sorted_int_basic() {
+        assert!(as_bool(
+            builtin_array_is_sorted(&[ints(&[1, 2, 3, 4, 5])]).unwrap()
+        ));
+        assert!(!as_bool(
+            builtin_array_is_sorted(&[ints(&[1, 3, 2])]).unwrap()
+        ));
+        // Equal-adjacent counts as sorted.
+        assert!(as_bool(
+            builtin_array_is_sorted(&[ints(&[1, 1, 1])]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn is_sorted_int_vacuous() {
+        assert!(as_bool(builtin_array_is_sorted(&[ints(&[])]).unwrap()));
+        assert!(as_bool(builtin_array_is_sorted(&[ints(&[42])]).unwrap()));
+    }
+
+    #[test]
+    fn is_sorted_int_rejects_non_int_elements() {
+        let err = builtin_array_is_sorted(&[Value::Array(vec![Value::Int(1), Value::Float(2.0)])])
+            .unwrap_err();
+        assert!(err.contains("expected all int elements"));
+    }
+
+    // --- is_sorted_float --------------------------------------------------
+
+    #[test]
+    fn is_sorted_float_basic() {
+        assert!(as_bool(
+            builtin_array_is_sorted_float(&[floats(&[-1.0, 0.0, 1.5, 2.5])]).unwrap()
+        ));
+        assert!(!as_bool(
+            builtin_array_is_sorted_float(&[floats(&[1.0, 0.5])]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn is_sorted_float_nan_sorts_last_under_total_order() {
+        // Under total order, NaN > +inf — so [-inf, 0, NaN] is sorted.
+        assert!(as_bool(
+            builtin_array_is_sorted_float(&[floats(&[
+                f64::NEG_INFINITY,
+                0.0,
+                f64::INFINITY,
+                f64::NAN
+            ])])
+            .unwrap()
+        ));
+        // [NaN, 0] is NOT sorted (NaN > 0).
+        assert!(!as_bool(
+            builtin_array_is_sorted_float(&[floats(&[f64::NAN, 0.0])]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn is_sorted_float_signed_zero() {
+        // -0.0 < +0.0 under total order, so [-0.0, +0.0] IS sorted.
+        assert!(as_bool(
+            builtin_array_is_sorted_float(&[floats(&[-0.0, 0.0])]).unwrap()
+        ));
+        // [+0.0, -0.0] is NOT sorted.
+        assert!(!as_bool(
+            builtin_array_is_sorted_float(&[floats(&[0.0, -0.0])]).unwrap()
+        ));
+    }
+
+    // --- is_sorted_string -------------------------------------------------
+
+    #[test]
+    fn is_sorted_string_basic() {
+        assert!(as_bool(
+            builtin_array_is_sorted_string(&[strings(&["a", "b", "c"])]).unwrap()
+        ));
+        assert!(!as_bool(
+            builtin_array_is_sorted_string(&[strings(&["c", "b", "a"])]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn is_sorted_string_vacuous() {
+        assert!(as_bool(
+            builtin_array_is_sorted_string(&[strings(&[])]).unwrap()
+        ));
+        assert!(as_bool(
+            builtin_array_is_sorted_string(&[strings(&["only"])]).unwrap()
+        ));
+    }
+
+    // --- composite property -----------------------------------------------
+
+    #[test]
+    fn sort_produces_sorted_output() {
+        // Sorting any input should produce something is_sorted accepts.
+        let inputs = [floats(&[3.0, 1.0, 2.0, 0.5, -1.0])];
+        for input in inputs {
+            let sorted = builtin_array_sort_float(&[input]).unwrap();
+            assert!(as_bool(builtin_array_is_sorted_float(&[sorted]).unwrap()));
+        }
+
+        let inputs = [strings(&["banana", "apple", "cherry"])];
+        for input in inputs {
+            let sorted = builtin_array_sort_string(&[input]).unwrap();
+            assert!(as_bool(builtin_array_is_sorted_string(&[sorted]).unwrap()));
+        }
+    }
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        for f in [
+            builtin_array_sort_float,
+            builtin_array_sort_string,
+            builtin_array_is_sorted,
+            builtin_array_is_sorted_float,
+            builtin_array_is_sorted_string,
+        ] {
+            let err = f(&[]).unwrap_err();
+            assert!(err.contains("expected 1"), "got {}", err);
+            let err = f(&[Value::Int(5)]).unwrap_err();
+            assert!(err.contains("expected array"), "got {}", err);
+        }
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -15,6 +15,9 @@ mod alignment_helpers;
 // RES-1142: array chunking + striding + rotation primitives.
 // Pure leaf builtins; module-isolated.
 mod array_chunking;
+// RES-1146: float / string sort + array_is_sorted predicates.
+// Pure leaf builtins; module-isolated.
+mod array_sort_extra;
 // RES-1140: ASCII char-class predicates — rounds out the RES-459 family.
 // Pure leaf builtins; module-isolated.
 mod ascii_predicates;
@@ -11101,6 +11104,29 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     (
         "is_ascii_control",
         crate::ascii_predicates::builtin_is_ascii_control,
+    ),
+    // RES-1146: float / string sort + array_is_sorted predicates.
+    // Pure leaf builtins; module-isolated in `array_sort_extra.rs`.
+    // Appended at the end of BUILTINS per the perf rule from PR #1125.
+    (
+        "array_sort_float",
+        crate::array_sort_extra::builtin_array_sort_float,
+    ),
+    (
+        "array_sort_string",
+        crate::array_sort_extra::builtin_array_sort_string,
+    ),
+    (
+        "array_is_sorted",
+        crate::array_sort_extra::builtin_array_is_sorted,
+    ),
+    (
+        "array_is_sorted_float",
+        crate::array_sort_extra::builtin_array_is_sorted_float,
+    ),
+    (
+        "array_is_sorted_string",
+        crate::array_sort_extra::builtin_array_is_sorted_string,
     ),
 ];
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1354,6 +1354,20 @@ impl TypeChecker {
         env.set("is_ascii_lowercase".to_string(), fn_string_to_bool());
         env.set("is_ascii_punctuation".to_string(), fn_string_to_bool());
         env.set("is_ascii_control".to_string(), fn_string_to_bool());
+        // RES-1146: float / string sort + array_is_sorted predicates.
+        let fn_array_to_array = || Type::Function {
+            params: vec![Type::Array],
+            return_type: Box::new(Type::Array),
+        };
+        let fn_array_to_bool = || Type::Function {
+            params: vec![Type::Array],
+            return_type: Box::new(Type::Bool),
+        };
+        env.set("array_sort_float".to_string(), fn_array_to_array());
+        env.set("array_sort_string".to_string(), fn_array_to_array());
+        env.set("array_is_sorted".to_string(), fn_array_to_bool());
+        env.set("array_is_sorted_float".to_string(), fn_array_to_bool());
+        env.set("array_is_sorted_string".to_string(), fn_array_to_bool());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6138,6 +6152,12 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "is_ascii_lowercase",
         "is_ascii_punctuation",
         "is_ascii_control",
+        // RES-1146: float / string sort + array_is_sorted predicates.
+        "array_sort_float",
+        "array_sort_string",
+        "array_is_sorted",
+        "array_is_sorted_float",
+        "array_is_sorted_string",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1146.

`array_sort` and `array_sort_desc` accepted only int arrays; sorting a
`Float[]` or `String[]` required a hand-rolled comparator which got
the float case wrong (`<` is undefined on NaN). And there was no
"is this already sorted" predicate.

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| `array_sort_float(arr)`      | `(Array) -> Array` | Ascending float sort, NaN-safe via `f64::total_cmp` |
| `array_sort_string(arr)`     | `(Array) -> Array` | Ascending lex string sort |
| `array_is_sorted(arr)`       | `(Array) -> Bool`  | Int array is ascending |
| `array_is_sorted_float(arr)` | `(Array) -> Bool`  | Float array is ascending (NaN-safe) |
| `array_is_sorted_string(arr)`| `(Array) -> Bool`  | String array is lex-ascending |

### Design notes

- `_float` variants use the IEEE 754 total order shipped in RES-1138.
  NaN, `±0`, and signed-NaN payloads sort to deterministic positions.
- `_string` variants delegate to `String::cmp` (byte-wise UTF-8).
- Empty / singleton arrays are vacuously sorted.
- Mixed-type arrays produce a typed error rather than a panic.
- Module-isolated in `array_sort_extra.rs` per CLAUDE.md feature
  isolation.

### Tests

- 21 unit tests + 1 golden example.
- Composite property covered: `array_is_sorted_*(array_sort_*(arr))`
  is always true.

### Local gates

All four clean: build, test, clippy, fmt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>