### PR TITLE
RES-1148: array_binary_search (int / float / string) — 3 new builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,12 +5,12 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
-      "branch": "res-1146-array-sort-extra",
-      "claimed_at": "2026-05-11T15:52:00Z"
+      "branch": "res-1148-binary-search",
+      "claimed_at": "2026-05-11T16:02:00Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1146-array-sort-extra",
-      "claimed_at": "2026-05-11T15:52:00Z"
+      "branch": "res-1148-binary-search",
+      "claimed_at": "2026-05-11T16:02:00Z"
     }
   }
 }

--- a/resilient/examples/array_binary_search.expected.txt
+++ b/resilient/examples/array_binary_search.expected.txt
@@ -1,0 +1,13 @@
+Ok(2)
+Ok(0)
+Ok(4)
+Err(0)
+Err(2)
+Err(5)
+Err(0)
+Ok(1)
+Ok(2)
+Err(4)
+Ok(2)
+Err(2)
+Program executed successfully

--- a/resilient/examples/array_binary_search.rz
+++ b/resilient/examples/array_binary_search.rz
@@ -1,0 +1,34 @@
+// RES-1148 demo: array_binary_search (int / float / string).
+// Returns Ok(index) when found, Err(insertion_position) when absent.
+
+fn main(int _d) {
+    let nums = [1, 3, 5, 7, 9];
+
+    // Found: returns Ok(index).
+    println(array_binary_search(nums, 5));    // Ok(2)
+    println(array_binary_search(nums, 1));    // Ok(0)
+    println(array_binary_search(nums, 9));    // Ok(4)
+
+    // Not found: returns Err(insertion-point).
+    println(array_binary_search(nums, 0));    // Err(0)
+    println(array_binary_search(nums, 4));    // Err(2)
+    println(array_binary_search(nums, 10));   // Err(5)
+
+    // Empty array: always Err(0).
+    println(array_binary_search([], 42));     // Err(0)
+
+    // Float variant uses IEEE 754 total order — NaN-safe.
+    let f = [-1.0, -0.0, 0.0, 1.0, 2.0];
+    println(array_binary_search_float(f, -0.0)); // Ok(1)
+    println(array_binary_search_float(f, 0.0));  // Ok(2)
+    println(array_binary_search_float(f, 1.5));  // Err(4)
+
+    // String variant uses lex byte-wise ordering.
+    let names = ["alice", "bob", "carol", "dave"];
+    println(array_binary_search_string(names, "carol")); // Ok(2)
+    println(array_binary_search_string(names, "bobby")); // Err(2)
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/array_binary_search.rs
+++ b/resilient/src/array_binary_search.rs
@@ -1,0 +1,374 @@
+//! RES-1148: `array_binary_search`, `_float`, `_string` — sorted-array
+//! lookup primitives that return `Result<Int, Int>`.
+//!
+//! Companions to RES-1146's float / string sort + `is_sorted` predicates.
+//! Without binary search, sorted arrays don't get their main benefit —
+//! every membership query falls back to O(N) `array_index_of`.
+//!
+//! | Builtin | Signature | Found / Not-found |
+//! |---|---|---|
+//! | `array_binary_search(arr, target)`        | `(Array, Int) -> Result<Int, Int>`    | `Ok(idx)` / `Err(insertion_pos)` |
+//! | `array_binary_search_float(arr, target)`  | `(Array, Float) -> Result<Int, Int>`  | NaN-safe via IEEE 754 total order |
+//! | `array_binary_search_string(arr, target)` | `(Array, String) -> Result<Int, Int>` | Lex byte-wise |
+//!
+//! Caller must pass a sorted array — the function does not verify
+//! sortedness, matching `slice::binary_search`. Unsorted input
+//! produces an unspecified `Ok` / `Err` index but never a panic.
+
+use crate::{RResult, Value};
+
+fn result_int(ok: bool, idx: usize) -> Value {
+    Value::Result {
+        ok,
+        payload: Box::new(Value::Int(idx as i64)),
+    }
+}
+
+/// `array_binary_search(arr, target) -> Result<Int, Int>` — lookup in a
+/// sorted int array. Array elements must all be ints; mixed types are
+/// rejected with a typed error.
+pub(crate) fn builtin_array_binary_search(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::Int(target)] => {
+            let mut nums: Vec<i64> = Vec::with_capacity(items.len());
+            for v in items {
+                match v {
+                    Value::Int(n) => nums.push(*n),
+                    other => {
+                        return Err(format!(
+                            "array_binary_search: expected all int elements, got {}",
+                            other
+                        ));
+                    }
+                }
+            }
+            match nums.binary_search(target) {
+                Ok(idx) => Ok(result_int(true, idx)),
+                Err(idx) => Ok(result_int(false, idx)),
+            }
+        }
+        [Value::Array(_), other] => Err(format!(
+            "array_binary_search: target must be Int, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "array_binary_search: first argument must be array, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "array_binary_search: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_binary_search_float(arr, target) -> Result<Int, Int>` —
+/// lookup in a sorted float array. Comparison uses `f64::total_cmp` so
+/// the search behaves correctly on NaN / `±0` / signed-NaN inputs,
+/// matching `array_sort_float`'s ordering.
+pub(crate) fn builtin_array_binary_search_float(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::Float(target)] => {
+            let mut nums: Vec<f64> = Vec::with_capacity(items.len());
+            for v in items {
+                match v {
+                    Value::Float(f) => nums.push(*f),
+                    other => {
+                        return Err(format!(
+                            "array_binary_search_float: expected all float elements, got {}",
+                            other
+                        ));
+                    }
+                }
+            }
+            match nums.binary_search_by(|x| x.total_cmp(target)) {
+                Ok(idx) => Ok(result_int(true, idx)),
+                Err(idx) => Ok(result_int(false, idx)),
+            }
+        }
+        [Value::Array(_), other] => Err(format!(
+            "array_binary_search_float: target must be Float, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "array_binary_search_float: first argument must be array, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "array_binary_search_float: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_binary_search_string(arr, target) -> Result<Int, Int>` —
+/// lookup in a sorted string array. Comparison is byte-wise on the
+/// UTF-8 representation, matching `array_sort_string`'s ordering.
+pub(crate) fn builtin_array_binary_search_string(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items), Value::String(target)] => {
+            let mut strings: Vec<&String> = Vec::with_capacity(items.len());
+            for v in items {
+                match v {
+                    Value::String(s) => strings.push(s),
+                    other => {
+                        return Err(format!(
+                            "array_binary_search_string: expected all string elements, got {}",
+                            other
+                        ));
+                    }
+                }
+            }
+            match strings.binary_search(&target) {
+                Ok(idx) => Ok(result_int(true, idx)),
+                Err(idx) => Ok(result_int(false, idx)),
+            }
+        }
+        [Value::Array(_), other] => Err(format!(
+            "array_binary_search_string: target must be String, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "array_binary_search_string: first argument must be array, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "array_binary_search_string: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ints(xs: &[i64]) -> Value {
+        Value::Array(xs.iter().map(|&n| Value::Int(n)).collect())
+    }
+
+    fn floats(xs: &[f64]) -> Value {
+        Value::Array(xs.iter().map(|&f| Value::Float(f)).collect())
+    }
+
+    fn strings(xs: &[&str]) -> Value {
+        Value::Array(xs.iter().map(|s| Value::String(s.to_string())).collect())
+    }
+
+    fn as_result(v: Value) -> (bool, i64) {
+        match v {
+            Value::Result { ok, payload } => match *payload {
+                Value::Int(n) => (ok, n),
+                other => panic!("expected Int payload, got {:?}", other),
+            },
+            other => panic!("expected Result, got {:?}", other),
+        }
+    }
+
+    // --- int ---
+
+    #[test]
+    fn binary_search_int_found() {
+        let arr = ints(&[1, 3, 5, 7, 9]);
+        assert_eq!(
+            as_result(builtin_array_binary_search(&[arr.clone(), Value::Int(1)]).unwrap()),
+            (true, 0)
+        );
+        assert_eq!(
+            as_result(builtin_array_binary_search(&[arr.clone(), Value::Int(5)]).unwrap()),
+            (true, 2)
+        );
+        assert_eq!(
+            as_result(builtin_array_binary_search(&[arr, Value::Int(9)]).unwrap()),
+            (true, 4)
+        );
+    }
+
+    #[test]
+    fn binary_search_int_not_found_returns_insertion_index() {
+        let arr = ints(&[1, 3, 5, 7, 9]);
+        // 0 would be inserted at the start.
+        assert_eq!(
+            as_result(builtin_array_binary_search(&[arr.clone(), Value::Int(0)]).unwrap()),
+            (false, 0)
+        );
+        // 4 would be inserted at index 2 (between 3 and 5).
+        assert_eq!(
+            as_result(builtin_array_binary_search(&[arr.clone(), Value::Int(4)]).unwrap()),
+            (false, 2)
+        );
+        // 10 would be appended at the end.
+        assert_eq!(
+            as_result(builtin_array_binary_search(&[arr, Value::Int(10)]).unwrap()),
+            (false, 5)
+        );
+    }
+
+    #[test]
+    fn binary_search_int_empty_returns_err_zero() {
+        let r = builtin_array_binary_search(&[ints(&[]), Value::Int(42)]).unwrap();
+        assert_eq!(as_result(r), (false, 0));
+    }
+
+    #[test]
+    fn binary_search_int_single_element() {
+        let arr = ints(&[5]);
+        assert_eq!(
+            as_result(builtin_array_binary_search(&[arr.clone(), Value::Int(5)]).unwrap()),
+            (true, 0)
+        );
+        assert_eq!(
+            as_result(builtin_array_binary_search(&[arr.clone(), Value::Int(3)]).unwrap()),
+            (false, 0)
+        );
+        assert_eq!(
+            as_result(builtin_array_binary_search(&[arr, Value::Int(7)]).unwrap()),
+            (false, 1)
+        );
+    }
+
+    #[test]
+    fn binary_search_int_rejects_non_int_target() {
+        let err = builtin_array_binary_search(&[ints(&[1, 2, 3]), Value::Float(2.0)]).unwrap_err();
+        assert!(err.contains("target must be Int"));
+    }
+
+    #[test]
+    fn binary_search_int_rejects_non_int_elements() {
+        let err = builtin_array_binary_search(&[
+            Value::Array(vec![Value::Int(1), Value::Float(2.0)]),
+            Value::Int(1),
+        ])
+        .unwrap_err();
+        assert!(err.contains("expected all int elements"));
+    }
+
+    // --- float ---
+
+    #[test]
+    fn binary_search_float_found() {
+        let arr = floats(&[1.0, 1.5, 2.0, 2.5, 3.0]);
+        let r = builtin_array_binary_search_float(&[arr, Value::Float(2.5)]).unwrap();
+        assert_eq!(as_result(r), (true, 3));
+    }
+
+    #[test]
+    fn binary_search_float_handles_total_order() {
+        // -0.0 < +0.0 under total order — they're distinct positions.
+        let arr = floats(&[-1.0, -0.0, 0.0, 1.0]);
+        let r = builtin_array_binary_search_float(&[arr.clone(), Value::Float(-0.0)]).unwrap();
+        assert_eq!(as_result(r), (true, 1));
+        let r = builtin_array_binary_search_float(&[arr, Value::Float(0.0)]).unwrap();
+        assert_eq!(as_result(r), (true, 2));
+    }
+
+    #[test]
+    fn binary_search_float_nan_search_in_nan_terminated_array() {
+        // Under total order NaN sorts after +inf.
+        let arr = floats(&[1.0, 2.0, f64::INFINITY, f64::NAN]);
+        let r = builtin_array_binary_search_float(&[arr, Value::Float(f64::NAN)]).unwrap();
+        assert_eq!(as_result(r), (true, 3));
+    }
+
+    #[test]
+    fn binary_search_float_not_found() {
+        let arr = floats(&[1.0, 2.0, 3.0]);
+        let r = builtin_array_binary_search_float(&[arr, Value::Float(2.5)]).unwrap();
+        assert_eq!(as_result(r), (false, 2));
+    }
+
+    #[test]
+    fn binary_search_float_rejects_non_float_target() {
+        let err = builtin_array_binary_search_float(&[floats(&[1.0]), Value::Int(1)]).unwrap_err();
+        assert!(err.contains("target must be Float"));
+    }
+
+    // --- string ---
+
+    #[test]
+    fn binary_search_string_found() {
+        let arr = strings(&["alice", "bob", "carol", "dave"]);
+        assert_eq!(
+            as_result(
+                builtin_array_binary_search_string(&[
+                    arr.clone(),
+                    Value::String("bob".to_string())
+                ])
+                .unwrap()
+            ),
+            (true, 1)
+        );
+        assert_eq!(
+            as_result(
+                builtin_array_binary_search_string(&[arr, Value::String("dave".to_string())])
+                    .unwrap()
+            ),
+            (true, 3)
+        );
+    }
+
+    #[test]
+    fn binary_search_string_not_found() {
+        let arr = strings(&["alice", "carol", "eve"]);
+        // "bob" sorts between "alice" and "carol".
+        let r =
+            builtin_array_binary_search_string(&[arr.clone(), Value::String("bob".to_string())])
+                .unwrap();
+        assert_eq!(as_result(r), (false, 1));
+        // "aardvark" sorts before "alice".
+        let r = builtin_array_binary_search_string(&[arr, Value::String("aardvark".to_string())])
+            .unwrap();
+        assert_eq!(as_result(r), (false, 0));
+    }
+
+    #[test]
+    fn binary_search_string_empty() {
+        let r = builtin_array_binary_search_string(&[strings(&[]), Value::String("x".to_string())])
+            .unwrap();
+        assert_eq!(as_result(r), (false, 0));
+    }
+
+    #[test]
+    fn binary_search_string_rejects_non_string_target() {
+        let err =
+            builtin_array_binary_search_string(&[strings(&["a", "b"]), Value::Int(1)]).unwrap_err();
+        assert!(err.contains("target must be String"));
+    }
+
+    // --- general ---
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        for f in [
+            builtin_array_binary_search,
+            builtin_array_binary_search_float,
+            builtin_array_binary_search_string,
+        ] {
+            let err = f(&[Value::Array(vec![])]).unwrap_err();
+            assert!(err.contains("expected 2"), "got {}", err);
+        }
+        let err = builtin_array_binary_search(&[Value::Int(5), Value::Int(1)]).unwrap_err();
+        assert!(err.contains("first argument must be array"));
+    }
+
+    #[test]
+    fn insertion_index_property() {
+        // For any miss, inserting at the returned index keeps the array sorted.
+        let arr = vec![1i64, 3, 5, 7, 9];
+        for target in [0, 2, 4, 6, 8, 10] {
+            let r = builtin_array_binary_search(&[ints(&arr), Value::Int(target)]).unwrap();
+            let (ok, idx) = as_result(r);
+            assert!(!ok, "expected Err for absent target {}", target);
+            // Simulate insertion.
+            let mut inserted = arr.clone();
+            inserted.insert(idx as usize, target);
+            assert!(
+                inserted.windows(2).all(|w| w[0] <= w[1]),
+                "inserting {} at {} broke sort: {:?}",
+                target,
+                idx,
+                inserted
+            );
+        }
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -12,6 +12,9 @@ use std::rc::Rc;
 // Pure leaf builtins; module-isolated so adding new bytes/int helpers
 // doesn't have to dodge each other inside lib.rs.
 mod alignment_helpers;
+// RES-1148: binary search on sorted int / float / string arrays.
+// Pure leaf builtins; module-isolated.
+mod array_binary_search;
 // RES-1142: array chunking + striding + rotation primitives.
 // Pure leaf builtins; module-isolated.
 mod array_chunking;
@@ -11127,6 +11130,21 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     (
         "array_is_sorted_string",
         crate::array_sort_extra::builtin_array_is_sorted_string,
+    ),
+    // RES-1148: binary search on sorted int / float / string arrays.
+    // Pure leaf builtins; module-isolated in `array_binary_search.rs`.
+    // Appended at the end of BUILTINS per the perf rule from PR #1125.
+    (
+        "array_binary_search",
+        crate::array_binary_search::builtin_array_binary_search,
+    ),
+    (
+        "array_binary_search_float",
+        crate::array_binary_search::builtin_array_binary_search_float,
+    ),
+    (
+        "array_binary_search_string",
+        crate::array_binary_search::builtin_array_binary_search_string,
     ),
 ];
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1368,6 +1368,31 @@ impl TypeChecker {
         env.set("array_is_sorted".to_string(), fn_array_to_bool());
         env.set("array_is_sorted_float".to_string(), fn_array_to_bool());
         env.set("array_is_sorted_string".to_string(), fn_array_to_bool());
+        // RES-1148: binary search on sorted int / float / string arrays.
+        // Return type is Result<Int, Int> — typed as `Any` since the type
+        // system has no generic Result<T, E> yet (same convention as the
+        // `checked_*` builtins in RES-1115).
+        env.set(
+            "array_binary_search".to_string(),
+            Type::Function {
+                params: vec![Type::Array, Type::Int],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "array_binary_search_float".to_string(),
+            Type::Function {
+                params: vec![Type::Array, Type::Float],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "array_binary_search_string".to_string(),
+            Type::Function {
+                params: vec![Type::Array, Type::String],
+                return_type: Box::new(Type::Any),
+            },
+        );
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6158,6 +6183,10 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_is_sorted",
         "array_is_sorted_float",
         "array_is_sorted_string",
+        // RES-1148: binary search on sorted arrays.
+        "array_binary_search",
+        "array_binary_search_float",
+        "array_binary_search_string",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1148.

[RES-1146](https://github.com/EricSpencer00/Resilient/pull/1147) shipped float / string sort + `array_is_sorted` predicates;
this PR adds the obvious complement — binary search lookup over the
three sorted-array types.

### Surface added

| Builtin | Signature | Contract |
|---|---|---|
| `array_binary_search(arr, target)`        | `(Array, Int) -> Result<Int, Int>` | `Ok(idx)` found / `Err(insertion)` absent |
| `array_binary_search_float(arr, target)`  | `(Array, Float) -> Result<Int, Int>` | NaN-safe via `f64::total_cmp` |
| `array_binary_search_string(arr, target)` | `(Array, String) -> Result<Int, Int>` | Lex byte-wise |

Return contract matches Rust's `Vec::binary_search` — `Ok(idx)` when
the target is present, `Err(idx)` where `idx` is the position the
target would be inserted to keep the array sorted.

### Design notes

- Caller must pass a sorted array; unsorted input yields an
  unspecified `Ok` / `Err` index (same as `slice::binary_search`)
  but never panics.
- Float variant uses the IEEE 754 total order from RES-1138, matching
  `array_sort_float`'s ordering.
- String variant uses byte-wise UTF-8 comparison, matching
  `array_sort_string`.
- Module-isolated in `array_binary_search.rs` per CLAUDE.md.

### Tests

- 17 unit tests + 1 golden example.
- Composite property: for any miss, inserting at the returned index
  keeps the array sorted.

### Local gates

All four clean: build, test, clippy, fmt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>