### PR TITLE
RES-1152: bytes_repeat / bytes_count_byte / bytes_replace_byte — 3 new builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,12 +5,21 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
+<<<<<<< HEAD
       "branch": "res-1150-array-stats",
       "claimed_at": "2026-05-11T16:12:00Z"
     },
     "resilient/src/typechecker.rs": {
       "branch": "res-1150-array-stats",
       "claimed_at": "2026-05-11T16:12:00Z"
+=======
+      "branch": "res-1152-bytes-helpers",
+      "claimed_at": "2026-05-11T16:22:00Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1152-bytes-helpers",
+      "claimed_at": "2026-05-11T16:22:00Z"
+>>>>>>> 50e33d1 (RES-1152: bytes_repeat / bytes_count_byte / bytes_replace_byte)
     }
   }
 }

--- a/resilient/examples/bytes_helpers.expected.txt
+++ b/resilient/examples/bytes_helpers.expected.txt
@@ -1,0 +1,9 @@
+00ff00ff00ff
+6
+0
+3
+2
+0
+ff01ff02
+aabb
+Program executed successfully

--- a/resilient/examples/bytes_helpers.rz
+++ b/resilient/examples/bytes_helpers.rz
@@ -1,0 +1,28 @@
+// RES-1152 demo: bytes_repeat / bytes_count_byte / bytes_replace_byte.
+
+fn main(int _d) {
+    // bytes_repeat: build a sentinel pattern.
+    let sig = bytes_repeat(b"\x00\xFF", 3);
+    println(bytes_to_hex(sig));            // 00ff00ff00ff
+    println(bytes_len(sig));               // 6
+
+    // bytes_repeat with n=0 is empty.
+    println(bytes_len(bytes_repeat(b"hi", 0))); // 0
+
+    // bytes_count_byte: tally a specific byte value.
+    let msg = b"hello world";
+    println(bytes_count_byte(msg, 108));   // 3 ('l' = 0x6C = 108)
+    println(bytes_count_byte(msg, 111));   // 2 ('o')
+    println(bytes_count_byte(msg, 99));    // 0 ('c' absent)
+
+    // bytes_replace_byte: rewrite one byte value to another.
+    let masked = bytes_replace_byte(b"\x00\x01\x00\x02", 0, 0xFF);
+    println(bytes_to_hex(masked));         // ff01ff02
+
+    // Identity when old == new.
+    println(bytes_to_hex(bytes_replace_byte(b"\xAA\xBB", 0xAA, 0xAA))); // aabb
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/bytes_helpers.rs
+++ b/resilient/src/bytes_helpers.rs
@@ -1,0 +1,313 @@
+//! RES-1152: `bytes_repeat`, `bytes_count_byte`, `bytes_replace_byte`.
+//!
+//! Three per-byte primitives that complement RES-1134's bitwise ops
+//! and the existing search / accessor / construction surface.
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `bytes_repeat(b, n)`         | `(Bytes, Int) -> Bytes` | Concatenate `b` to itself `n` times |
+//! | `bytes_count_byte(b, byte)`  | `(Bytes, Int) -> Int`   | Number of bytes equal to `byte` |
+//! | `bytes_replace_byte(b, old, new)` | `(Bytes, Int, Int) -> Bytes` | Fresh Bytes with every `old` replaced by `new` |
+//!
+//! Length cap on `bytes_repeat` is 1 GiB to match `array_cycle` and
+//! the other repeating builtins.
+
+use crate::{RResult, Value};
+
+const MAX_BYTES_REPEAT: usize = 1_000_000_000;
+
+fn check_byte(name: &str, n: i64) -> Result<u8, String> {
+    if !(0..=255).contains(&n) {
+        return Err(format!("{}: byte must be in 0..=255, got {}", name, n));
+    }
+    Ok(n as u8)
+}
+
+/// `bytes_repeat(b, n) -> Bytes` — concatenate `b` with itself `n`
+/// times. `n` must be non-negative. `n = 0` returns empty Bytes.
+/// Output length capped at 1 GiB to avoid runaway memory use.
+pub(crate) fn builtin_bytes_repeat(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "bytes_repeat: count must be non-negative, got {}",
+                    n
+                ));
+            }
+            let count = *n as usize;
+            let total = b.len().saturating_mul(count);
+            if total > MAX_BYTES_REPEAT {
+                return Err(format!(
+                    "bytes_repeat: total length {} would exceed cap of {}",
+                    total, MAX_BYTES_REPEAT
+                ));
+            }
+            let mut out = Vec::with_capacity(total);
+            for _ in 0..count {
+                out.extend_from_slice(b);
+            }
+            Ok(Value::Bytes(out))
+        }
+        [Value::Bytes(_), other] => Err(format!("bytes_repeat: count must be Int, got {}", other)),
+        [other, _] => Err(format!(
+            "bytes_repeat: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_repeat: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_count_byte(b, byte) -> Int` — count of bytes in `b` equal
+/// to `byte`. `byte` must be in `0..=255`.
+pub(crate) fn builtin_bytes_count_byte(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b), Value::Int(byte)] => {
+            let target = check_byte("bytes_count_byte", *byte)?;
+            let count = b.iter().filter(|&&x| x == target).count();
+            Ok(Value::Int(count as i64))
+        }
+        [Value::Bytes(_), other] => {
+            Err(format!("bytes_count_byte: byte must be Int, got {}", other))
+        }
+        [other, _] => Err(format!(
+            "bytes_count_byte: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_count_byte: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_replace_byte(b, old, new) -> Bytes` — fresh Bytes with every
+/// occurrence of `old` replaced by `new`. Both `old` and `new` must be
+/// in `0..=255`. Input is never mutated.
+pub(crate) fn builtin_bytes_replace_byte(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b), Value::Int(old), Value::Int(new)] => {
+            let from = check_byte("bytes_replace_byte", *old)?;
+            let to = check_byte("bytes_replace_byte", *new)?;
+            let out: Vec<u8> = b.iter().map(|&x| if x == from { to } else { x }).collect();
+            Ok(Value::Bytes(out))
+        }
+        [Value::Bytes(_), Value::Int(_), other] => Err(format!(
+            "bytes_replace_byte: new byte must be Int, got {}",
+            other
+        )),
+        [Value::Bytes(_), other, _] => Err(format!(
+            "bytes_replace_byte: old byte must be Int, got {}",
+            other
+        )),
+        [other, _, _] => Err(format!(
+            "bytes_replace_byte: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_replace_byte: expected 3 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bytes(xs: &[u8]) -> Value {
+        Value::Bytes(xs.to_vec())
+    }
+
+    fn as_bytes(v: Value) -> Vec<u8> {
+        match v {
+            Value::Bytes(b) => b,
+            other => panic!("expected Bytes, got {:?}", other),
+        }
+    }
+
+    fn as_int(v: Value) -> i64 {
+        match v {
+            Value::Int(n) => n,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    // --- bytes_repeat ---
+
+    #[test]
+    fn repeat_basic() {
+        let r = builtin_bytes_repeat(&[bytes(&[1, 2]), Value::Int(3)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 1, 2, 1, 2]);
+    }
+
+    #[test]
+    fn repeat_zero_is_empty() {
+        let r = builtin_bytes_repeat(&[bytes(&[1, 2, 3]), Value::Int(0)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn repeat_empty_input_stays_empty() {
+        let r = builtin_bytes_repeat(&[bytes(&[]), Value::Int(5)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn repeat_one_is_identity() {
+        let r = builtin_bytes_repeat(&[bytes(&[7, 8, 9]), Value::Int(1)]).unwrap();
+        assert_eq!(as_bytes(r), vec![7, 8, 9]);
+    }
+
+    #[test]
+    fn repeat_rejects_negative() {
+        let err = builtin_bytes_repeat(&[bytes(&[1]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"));
+    }
+
+    #[test]
+    fn repeat_caps_total_length() {
+        // Length 1, count 2B → exceeds 1 GiB cap.
+        let err = builtin_bytes_repeat(&[bytes(&[1]), Value::Int(2_000_000_000)]).unwrap_err();
+        assert!(err.contains("exceed cap"));
+    }
+
+    #[test]
+    fn repeat_rejects_wrong_arg_types() {
+        let err = builtin_bytes_repeat(&[bytes(&[1]), Value::Bool(true)]).unwrap_err();
+        assert!(err.contains("count must be Int"));
+        let err = builtin_bytes_repeat(&[Value::Int(5), Value::Int(2)]).unwrap_err();
+        assert!(err.contains("first argument must be Bytes"));
+    }
+
+    // --- bytes_count_byte ---
+
+    #[test]
+    fn count_byte_basic() {
+        let b = bytes(&[1, 2, 1, 3, 1, 4]);
+        assert_eq!(
+            as_int(builtin_bytes_count_byte(&[b.clone(), Value::Int(1)]).unwrap()),
+            3
+        );
+        assert_eq!(
+            as_int(builtin_bytes_count_byte(&[b.clone(), Value::Int(2)]).unwrap()),
+            1
+        );
+        assert_eq!(
+            as_int(builtin_bytes_count_byte(&[b, Value::Int(99)]).unwrap()),
+            0
+        );
+    }
+
+    #[test]
+    fn count_byte_in_empty_bytes_is_zero() {
+        let r = builtin_bytes_count_byte(&[bytes(&[]), Value::Int(0)]).unwrap();
+        assert_eq!(as_int(r), 0);
+    }
+
+    #[test]
+    fn count_byte_zero_byte() {
+        let r = builtin_bytes_count_byte(&[bytes(&[0, 1, 0, 0, 2]), Value::Int(0)]).unwrap();
+        assert_eq!(as_int(r), 3);
+    }
+
+    #[test]
+    fn count_byte_full_byte_range() {
+        let r = builtin_bytes_count_byte(&[bytes(&[255, 255, 0]), Value::Int(255)]).unwrap();
+        assert_eq!(as_int(r), 2);
+    }
+
+    #[test]
+    fn count_byte_rejects_out_of_range() {
+        let err = builtin_bytes_count_byte(&[bytes(&[1]), Value::Int(256)]).unwrap_err();
+        assert!(err.contains("0..=255"));
+        let err = builtin_bytes_count_byte(&[bytes(&[1]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("0..=255"));
+    }
+
+    #[test]
+    fn count_byte_rejects_non_int_target() {
+        let err = builtin_bytes_count_byte(&[bytes(&[1]), Value::Bool(false)]).unwrap_err();
+        assert!(err.contains("byte must be Int"));
+    }
+
+    // --- bytes_replace_byte ---
+
+    #[test]
+    fn replace_byte_basic() {
+        let r = builtin_bytes_replace_byte(&[bytes(&[1, 2, 1, 3]), Value::Int(1), Value::Int(99)])
+            .unwrap();
+        assert_eq!(as_bytes(r), vec![99, 2, 99, 3]);
+    }
+
+    #[test]
+    fn replace_byte_no_match_unchanged() {
+        let r = builtin_bytes_replace_byte(&[bytes(&[1, 2, 3]), Value::Int(99), Value::Int(0)])
+            .unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn replace_byte_identity_when_old_equals_new() {
+        let r =
+            builtin_bytes_replace_byte(&[bytes(&[1, 2, 3]), Value::Int(2), Value::Int(2)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn replace_byte_empty_input_stays_empty() {
+        let r = builtin_bytes_replace_byte(&[bytes(&[]), Value::Int(0), Value::Int(1)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn replace_byte_does_not_mutate_input() {
+        let original = bytes(&[1, 2, 1]);
+        let _ =
+            builtin_bytes_replace_byte(&[original.clone(), Value::Int(1), Value::Int(9)]).unwrap();
+        // Original still has 1s in place.
+        match original {
+            Value::Bytes(b) => assert_eq!(b, vec![1, 2, 1]),
+            _ => panic!("expected Bytes"),
+        }
+    }
+
+    #[test]
+    fn replace_byte_rejects_out_of_range() {
+        let err =
+            builtin_bytes_replace_byte(&[bytes(&[1]), Value::Int(256), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("0..=255"));
+        let err =
+            builtin_bytes_replace_byte(&[bytes(&[1]), Value::Int(0), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("0..=255"));
+    }
+
+    // --- arity / type ---
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        let err = builtin_bytes_repeat(&[]).unwrap_err();
+        assert!(err.contains("expected 2"));
+        let err = builtin_bytes_count_byte(&[bytes(&[])]).unwrap_err();
+        assert!(err.contains("expected 2"));
+        let err = builtin_bytes_replace_byte(&[bytes(&[]), Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected 3"));
+    }
+
+    // --- composite property ---
+
+    #[test]
+    fn repeat_then_count_matches() {
+        // bytes_count_byte(bytes_repeat([0xAA], n), 0xAA) == n.
+        for &n in &[0, 1, 5, 100] {
+            let r = builtin_bytes_repeat(&[bytes(&[0xAA]), Value::Int(n)]).unwrap();
+            assert_eq!(
+                as_int(builtin_bytes_count_byte(&[r, Value::Int(0xAA)]).unwrap()),
+                n
+            );
+        }
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -35,6 +35,9 @@ mod map_entries_merge;
 // xor / and / or / not / fill / reverse. Pure leaf builtins; wires
 // into BUILTINS, typechecker env-seed, and PURE_BUILTINS only.
 mod bytes_bitwise;
+// RES-1152: per-byte helpers — repeat / count_byte / replace_byte.
+// Pure leaf builtins; module-isolated.
+mod bytes_helpers;
 mod compiler;
 mod const_fold;
 mod disasm;
@@ -11200,6 +11203,18 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     (
         "array_range_float",
         crate::array_stats::builtin_array_range_float,
+    ),
+    // RES-1152: per-byte helpers — repeat / count_byte / replace_byte.
+    // Pure leaf builtins; module-isolated in `bytes_helpers.rs`.
+    // Appended at the end of BUILTINS per the perf rule from PR #1125.
+    ("bytes_repeat", crate::bytes_helpers::builtin_bytes_repeat),
+    (
+        "bytes_count_byte",
+        crate::bytes_helpers::builtin_bytes_count_byte,
+    ),
+    (
+        "bytes_replace_byte",
+        crate::bytes_helpers::builtin_bytes_replace_byte,
     ),
 ];
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1405,6 +1405,28 @@ impl TypeChecker {
         env.set("array_stddev_float".to_string(), fn_array_to_float());
         env.set("array_median_float".to_string(), fn_array_to_float());
         env.set("array_range_float".to_string(), fn_array_to_float());
+        // RES-1152: per-byte helpers — repeat / count_byte / replace_byte.
+        env.set(
+            "bytes_repeat".to_string(),
+            Type::Function {
+                params: vec![Type::Bytes, Type::Int],
+                return_type: Box::new(Type::Bytes),
+            },
+        );
+        env.set(
+            "bytes_count_byte".to_string(),
+            Type::Function {
+                params: vec![Type::Bytes, Type::Int],
+                return_type: Box::new(Type::Int),
+            },
+        );
+        env.set(
+            "bytes_replace_byte".to_string(),
+            Type::Function {
+                params: vec![Type::Bytes, Type::Int, Type::Int],
+                return_type: Box::new(Type::Bytes),
+            },
+        );
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6250,6 +6272,10 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "array_stddev_float",
         "array_median_float",
         "array_range_float",
+        // RES-1152: per-byte helpers.
+        "bytes_repeat",
+        "bytes_count_byte",
+        "bytes_replace_byte",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1152.

Three per-byte primitives that complement RES-1134's bitwise ops:

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| `bytes_repeat(b, n)`              | `(Bytes, Int) -> Bytes`      | Concatenate `b` to itself `n` times |
| `bytes_count_byte(b, byte)`       | `(Bytes, Int) -> Int`        | Number of bytes equal to `byte` |
| `bytes_replace_byte(b, old, new)` | `(Bytes, Int, Int) -> Bytes` | Fresh Bytes with every `old` replaced by `new` |

### Semantics

- `bytes_repeat`: `n >= 0`, `n = 0` returns empty Bytes, output capped
  at 1 GiB.
- `bytes_count_byte` / `bytes_replace_byte`: byte values must be in
  `0..=255`.
- All pure leaf builtins, never mutate input.
- Module-isolated in `bytes_helpers.rs`.

### Tests

- 21 unit tests + 1 golden example.
- Composite property: `bytes_count_byte(bytes_repeat([0xAA], n), 0xAA) == n`.

### Local gates

All four clean: build, test, clippy, fmt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>