### PR TITLE
RES-1154: set_is_empty / set_from_array / result_and / option_and — 4 new builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,21 +5,12 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
-<<<<<<< HEAD
-      "branch": "res-1150-array-stats",
-      "claimed_at": "2026-05-11T16:12:00Z"
+      "branch": "res-1154-set-result-option",
+      "claimed_at": "2026-05-11T16:32:00Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1150-array-stats",
-      "claimed_at": "2026-05-11T16:12:00Z"
-=======
-      "branch": "res-1152-bytes-helpers",
-      "claimed_at": "2026-05-11T16:22:00Z"
-    },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1152-bytes-helpers",
-      "claimed_at": "2026-05-11T16:22:00Z"
->>>>>>> 50e33d1 (RES-1152: bytes_repeat / bytes_count_byte / bytes_replace_byte)
+      "branch": "res-1154-set-result-option",
+      "claimed_at": "2026-05-11T16:32:00Z"
     }
   }
 }

--- a/resilient/examples/set_result_option.expected.txt
+++ b/resilient/examples/set_result_option.expected.txt
@@ -1,0 +1,14 @@
+true
+false
+3
+true
+false
+2
+true
+Ok(2)
+Err("nope")
+Err("late")
+Some(2)
+None
+None
+Program executed successfully

--- a/resilient/examples/set_result_option.rz
+++ b/resilient/examples/set_result_option.rz
@@ -1,0 +1,33 @@
+// RES-1154 demo: set_is_empty / set_from_array / result_and / option_and.
+
+fn main(int _d) {
+    // set_is_empty
+    println(set_is_empty(set_new()));   // true
+    let s = set_insert(set_new(), 42);
+    println(set_is_empty(s));            // false
+
+    // set_from_array — deduplicates and reorders into set semantics.
+    let s2 = set_from_array([1, 2, 3, 2, 1]);
+    println(set_len(s2));                // 3
+    println(set_has(s2, 1));             // true
+    println(set_has(s2, 5));             // false
+
+    // Mixed hashable types in one set.
+    let s3 = set_from_array(["a", "b"]);
+    println(set_len(s3));                // 2
+    println(set_has(s3, "a"));           // true
+
+    // result_and: short-circuits on first Err, otherwise returns second.
+    println(result_and(Ok(1), Ok(2)));        // Ok(2)
+    println(result_and(Err("nope"), Ok(2)));  // Err(nope) — first wins
+    println(result_and(Ok(1), Err("late")));  // Err(late)
+
+    // option_and: short-circuits on first None.
+    println(option_and(Some(1), Some(2)));    // Some(2)
+    println(option_and(None, Some(2)));       // None
+    println(option_and(Some(1), None));       // None
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -41,6 +41,9 @@ mod bytes_helpers;
 mod compiler;
 mod const_fold;
 mod disasm;
+// RES-1154: set_is_empty / set_from_array / result_and / option_and.
+// Pure leaf builtins; module-isolated.
+mod set_result_option;
 // RES-1138: IEEE 754 classification + total order + sign-bit predicates.
 // Pure leaf builtins; module-isolated so the predicate surface can
 // grow without bloating lib.rs.
@@ -11216,6 +11219,19 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
         "bytes_replace_byte",
         crate::bytes_helpers::builtin_bytes_replace_byte,
     ),
+    // RES-1154: set_is_empty / set_from_array / result_and / option_and.
+    // Pure leaf builtins; module-isolated in `set_result_option.rs`.
+    // Appended at the end of BUILTINS per the perf rule from PR #1125.
+    (
+        "set_is_empty",
+        crate::set_result_option::builtin_set_is_empty,
+    ),
+    (
+        "set_from_array",
+        crate::set_result_option::builtin_set_from_array,
+    ),
+    ("result_and", crate::set_result_option::builtin_result_and),
+    ("option_and", crate::set_result_option::builtin_option_and),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/set_result_option.rs
+++ b/resilient/src/set_result_option.rs
@@ -1,0 +1,320 @@
+//! RES-1154: small gap-filling builtins for Set / Result / Option.
+//!
+//! - `set_is_empty`: parallel to RES-1144's `map_is_empty`.
+//! - `set_from_array`: build a Set from an Array of hashable values.
+//! - `result_and` / `option_and`: short-circuit combinators that
+//!   complete the `_or` / `_and` pair (the `_or` variants already
+//!   ship — see RES-939).
+//!
+//! All four are pure leaf builtins.
+
+use crate::{MapKey, RResult, Value};
+use std::collections::HashSet;
+
+/// `set_is_empty(s) -> Bool` — true iff the set has zero items.
+pub(crate) fn builtin_set_is_empty(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Set(s)] => Ok(Value::Bool(s.is_empty())),
+        [a] => Err(format!("set_is_empty: expected a Set, got {}", a)),
+        _ => Err(format!(
+            "set_is_empty: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `set_from_array(arr) -> Set` — build a Set from an Array. Each
+/// element must be Int / String / Bool (the hashable subset that
+/// `MapKey` accepts). Duplicates collapse to one entry.
+pub(crate) fn builtin_set_from_array(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let mut s = HashSet::new();
+            for v in items {
+                let k = MapKey::from_value(v)?;
+                s.insert(k);
+            }
+            Ok(Value::Set(s))
+        }
+        [a] => Err(format!("set_from_array: expected an Array, got {}", a)),
+        _ => Err(format!(
+            "set_from_array: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `result_and(a, b) -> Result` — return `a` if it is `Err`, otherwise
+/// return `b`. Matches Rust's `Result::and` short-circuit semantics:
+/// once the first error appears, propagate it instead of running the
+/// rest of the chain.
+pub(crate) fn builtin_result_and(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Result { ok: false, .. }, _] => Ok(args[0].clone()),
+        [Value::Result { ok: true, .. }, Value::Result { .. }] => Ok(args[1].clone()),
+        [Value::Result { .. }, other] => Err(format!(
+            "result_and: second argument must be Result, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "result_and: first argument must be Result, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "result_and: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `option_and(a, b) -> Option` — return `None` if `a` is `None`,
+/// otherwise return `b`. Matches Rust's `Option::and`.
+pub(crate) fn builtin_option_and(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Option(None), _] => Ok(Value::Option(None)),
+        [Value::Option(Some(_)), Value::Option(_)] => Ok(args[1].clone()),
+        [Value::Option(_), other] => Err(format!(
+            "option_and: second argument must be Option, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "option_and: first argument must be Option, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "option_and: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_with(keys: &[MapKey]) -> Value {
+        let mut s = HashSet::new();
+        for k in keys {
+            s.insert(k.clone());
+        }
+        Value::Set(s)
+    }
+
+    fn ok(v: Value) -> Value {
+        Value::Result {
+            ok: true,
+            payload: Box::new(v),
+        }
+    }
+
+    fn err(v: Value) -> Value {
+        Value::Result {
+            ok: false,
+            payload: Box::new(v),
+        }
+    }
+
+    fn some(v: Value) -> Value {
+        Value::Option(Some(Box::new(v)))
+    }
+
+    fn none() -> Value {
+        Value::Option(None)
+    }
+
+    // --- set_is_empty ---
+
+    #[test]
+    fn set_is_empty_basic() {
+        assert!(matches!(
+            builtin_set_is_empty(&[set_with(&[])]).unwrap(),
+            Value::Bool(true)
+        ));
+        assert!(matches!(
+            builtin_set_is_empty(&[set_with(&[MapKey::Int(1)])]).unwrap(),
+            Value::Bool(false)
+        ));
+    }
+
+    #[test]
+    fn set_is_empty_rejects_non_set() {
+        let err = builtin_set_is_empty(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected a Set"));
+    }
+
+    #[test]
+    fn set_is_empty_rejects_wrong_arity() {
+        let err = builtin_set_is_empty(&[]).unwrap_err();
+        assert!(err.contains("expected 1"));
+    }
+
+    // --- set_from_array ---
+
+    #[test]
+    fn set_from_array_basic() {
+        let arr = Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+        let s = builtin_set_from_array(&[arr]).unwrap();
+        match s {
+            Value::Set(set) => {
+                assert_eq!(set.len(), 3);
+                assert!(set.contains(&MapKey::Int(1)));
+                assert!(set.contains(&MapKey::Int(2)));
+                assert!(set.contains(&MapKey::Int(3)));
+            }
+            _ => panic!("expected Set"),
+        }
+    }
+
+    #[test]
+    fn set_from_array_deduplicates() {
+        let arr = Value::Array(vec![
+            Value::Int(1),
+            Value::Int(2),
+            Value::Int(1),
+            Value::Int(2),
+        ]);
+        let s = builtin_set_from_array(&[arr]).unwrap();
+        match s {
+            Value::Set(set) => assert_eq!(set.len(), 2),
+            _ => panic!("expected Set"),
+        }
+    }
+
+    #[test]
+    fn set_from_array_empty() {
+        let s = builtin_set_from_array(&[Value::Array(vec![])]).unwrap();
+        match s {
+            Value::Set(set) => assert_eq!(set.len(), 0),
+            _ => panic!("expected Set"),
+        }
+    }
+
+    #[test]
+    fn set_from_array_mixed_hashable_types() {
+        let arr = Value::Array(vec![
+            Value::Int(1),
+            Value::String("hello".to_string()),
+            Value::Bool(true),
+        ]);
+        let s = builtin_set_from_array(&[arr]).unwrap();
+        match s {
+            Value::Set(set) => {
+                assert_eq!(set.len(), 3);
+                assert!(set.contains(&MapKey::Int(1)));
+                assert!(set.contains(&MapKey::Str("hello".to_string())));
+                assert!(set.contains(&MapKey::Bool(true)));
+            }
+            _ => panic!("expected Set"),
+        }
+    }
+
+    #[test]
+    fn set_from_array_rejects_non_hashable_element() {
+        let arr = Value::Array(vec![Value::Int(1), Value::Float(2.0)]);
+        let err = builtin_set_from_array(&[arr]).unwrap_err();
+        assert!(err.contains("Map key must be Int, String, or Bool"));
+    }
+
+    #[test]
+    fn set_from_array_rejects_non_array() {
+        let err = builtin_set_from_array(&[Value::Int(5)]).unwrap_err();
+        assert!(err.contains("expected an Array"));
+    }
+
+    // --- result_and ---
+
+    #[test]
+    fn result_and_short_circuits_on_first_err() {
+        let r = builtin_result_and(&[err(Value::String("first".to_string())), ok(Value::Int(2))])
+            .unwrap();
+        match r {
+            Value::Result { ok, payload } => {
+                assert!(!ok);
+                match *payload {
+                    Value::String(s) => assert_eq!(s, "first"),
+                    _ => panic!("expected String payload"),
+                }
+            }
+            _ => panic!("expected Result"),
+        }
+    }
+
+    #[test]
+    fn result_and_returns_second_when_first_is_ok() {
+        let r = builtin_result_and(&[ok(Value::Int(1)), ok(Value::Int(2))]).unwrap();
+        match r {
+            Value::Result { ok, payload } => {
+                assert!(ok);
+                match *payload {
+                    Value::Int(n) => assert_eq!(n, 2),
+                    _ => panic!("expected Int payload"),
+                }
+            }
+            _ => panic!("expected Result"),
+        }
+    }
+
+    #[test]
+    fn result_and_propagates_second_err() {
+        let r = builtin_result_and(&[ok(Value::Int(1)), err(Value::String("second".to_string()))])
+            .unwrap();
+        match r {
+            Value::Result { ok, .. } => assert!(!ok),
+            _ => panic!("expected Result"),
+        }
+    }
+
+    #[test]
+    fn result_and_rejects_non_result() {
+        let err = builtin_result_and(&[ok(Value::Int(1)), Value::Int(2)]).unwrap_err();
+        assert!(err.contains("second argument must be Result"));
+        let err = builtin_result_and(&[Value::Int(1), ok(Value::Int(2))]).unwrap_err();
+        assert!(err.contains("first argument must be Result"));
+    }
+
+    // --- option_and ---
+
+    #[test]
+    fn option_and_short_circuits_on_first_none() {
+        let r = builtin_option_and(&[none(), some(Value::Int(2))]).unwrap();
+        assert!(matches!(r, Value::Option(None)));
+    }
+
+    #[test]
+    fn option_and_returns_second_when_first_is_some() {
+        let r = builtin_option_and(&[some(Value::Int(1)), some(Value::Int(2))]).unwrap();
+        match r {
+            Value::Option(Some(inner)) => match *inner {
+                Value::Int(n) => assert_eq!(n, 2),
+                _ => panic!("expected Int payload"),
+            },
+            _ => panic!("expected Some"),
+        }
+    }
+
+    #[test]
+    fn option_and_propagates_second_none() {
+        let r = builtin_option_and(&[some(Value::Int(1)), none()]).unwrap();
+        assert!(matches!(r, Value::Option(None)));
+    }
+
+    #[test]
+    fn option_and_rejects_non_option() {
+        let err = builtin_option_and(&[some(Value::Int(1)), Value::Int(2)]).unwrap_err();
+        assert!(err.contains("second argument must be Option"));
+        let err = builtin_option_and(&[Value::Int(1), some(Value::Int(2))]).unwrap_err();
+        assert!(err.contains("first argument must be Option"));
+    }
+
+    // --- general ---
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        for f in [builtin_result_and, builtin_option_and] {
+            let err = f(&[]).unwrap_err();
+            assert!(err.contains("expected 2"), "got {}", err);
+            let err = f(&[Value::Int(1)]).unwrap_err();
+            assert!(err.contains("expected 2"), "got {}", err);
+        }
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2904,6 +2904,35 @@ impl TypeChecker {
                 return_type: Box::new(Type::Bool),
             },
         );
+        // RES-1154: set_is_empty / set_from_array / result_and / option_and.
+        env.set(
+            "set_is_empty".to_string(),
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Bool),
+            },
+        );
+        env.set(
+            "set_from_array".to_string(),
+            Type::Function {
+                params: vec![Type::Array],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "result_and".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
+        env.set(
+            "option_and".to_string(),
+            Type::Function {
+                params: vec![Type::Any, Type::Any],
+                return_type: Box::new(Type::Any),
+            },
+        );
 
         // RES-149: Set builtins. Same permissive-Any convention as
         // Map — no dedicated `Type::Set<T>` until inference lands.
@@ -6658,6 +6687,11 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "hashmap_entries",
         "hashmap_merge",
         "hashmap_is_empty",
+        // RES-1154: set_is_empty / set_from_array / result_and / option_and.
+        "set_is_empty",
+        "set_from_array",
+        "result_and",
+        "option_and",
         "set_new",
         "set_insert",
         "set_remove",


### PR DESCRIPTION
Closes #1154.

Four small gap-filling builtins:

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| `set_is_empty(s)`        | `(Set) -> Bool`             | True iff zero items |
| `set_from_array(arr)`    | `(Array) -> Set`            | Fresh Set with deduplicated elements |
| `result_and(a, b)`       | `(Result, Result) -> Result`| `a` if `a` is Err; else `b` |
| `option_and(a, b)`       | `(Option, Option) -> Option`| `None` if `a` is None; else `b` |

### Why now

- `set_is_empty` parallels RES-1144's `map_is_empty`.
- `set_from_array` saves the `set_new` + fold-insert idiom.
- `result_and` / `option_and` are the short-circuit partners of the
  existing `result_or` / `option_or` (RES-939). Together they cover the
  Rust `Result::and` / `::or` / `Option::and` / `::or` quartet.

### Design notes

- `set_from_array` accepts the same hashable subset as `MapKey`
  (`Int` / `String` / `Bool`); non-hashable elements are a typed error.
- All four pure leaf builtins, module-isolated in
  `set_result_option.rs` per CLAUDE.md feature isolation.

### Tests

- 18 unit tests + 1 golden example.

### Local gates

All four clean: build, test, clippy, fmt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>