### PR TITLE
RES-1156: set_bit / clear_bit / get_bit / flip_bit — 4 bit-manipulation builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,12 +5,21 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
+<<<<<<< HEAD
       "branch": "res-1154-set-result-option",
       "claimed_at": "2026-05-11T16:32:00Z"
     },
     "resilient/src/typechecker.rs": {
       "branch": "res-1154-set-result-option",
       "claimed_at": "2026-05-11T16:32:00Z"
+=======
+      "branch": "res-1156-bit-manipulation",
+      "claimed_at": "2026-05-11T16:42:00Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1156-bit-manipulation",
+      "claimed_at": "2026-05-11T16:42:00Z"
+>>>>>>> 92a172f (RES-1156: set_bit / clear_bit / get_bit / flip_bit — 4 bit-manipulation builtins)
     }
   }
 }

--- a/resilient/examples/bit_manipulation.expected.txt
+++ b/resilient/examples/bit_manipulation.expected.txt
@@ -1,0 +1,12 @@
+1
+8
+7
+254
+11
+false
+true
+true
+16
+0
+66045
+Program executed successfully

--- a/resilient/examples/bit_manipulation.rz
+++ b/resilient/examples/bit_manipulation.rz
@@ -1,0 +1,31 @@
+// RES-1156 demo: per-bit accessors — set_bit, clear_bit, get_bit, flip_bit.
+
+fn main(int _d) {
+    // set_bit: turn a bit on. 0 with bit 3 set = 8.
+    println(set_bit(0, 0));    // 1
+    println(set_bit(0, 3));    // 8
+    println(set_bit(5, 1));    // 7 (0b101 -> 0b111)
+
+    // clear_bit: turn a bit off. 0xFF clear bit 0 = 0xFE.
+    println(clear_bit(255, 0));  // 254
+    println(clear_bit(15, 2));   // 11 (0b1111 -> 0b1011)
+
+    // get_bit: read a bit. Bit 0 of 0b1010 is 0, bit 1 is 1.
+    println(get_bit(10, 0));   // false (bit 0 of 0b1010)
+    println(get_bit(10, 1));   // true  (bit 1 of 0b1010)
+    println(get_bit(10, 3));   // true  (bit 3 of 0b1010)
+
+    // flip_bit: toggle. Involution — calling twice is identity.
+    println(flip_bit(0, 4));   // 16
+    println(flip_bit(16, 4));  // 0
+
+    // Common use: GPIO-style register manipulation.
+    let reg = set_bit(set_bit(clear_bit(0xFF, 1), 8), 16);
+    // Started with 0xFF (low byte all set). Cleared bit 1 → 0xFD.
+    // Set bit 8 → 0x01FD. Set bit 16 → 0x101FD.
+    println(reg);              // 66045
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/bit_manipulation.rs
+++ b/resilient/src/bit_manipulation.rs
@@ -1,0 +1,308 @@
+//! RES-1156: per-bit accessors on i64.
+//!
+//! Four pure leaf builtins that complement the existing whole-word bit
+//! ops (`reverse_bits`, `swap_bytes`, `rotate_left_int`/`right`,
+//! `count_ones`/`zeros`, `leading_zeros`/`trailing_zeros`).
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `set_bit(n, idx)`   | `(Int, Int) -> Int`  | `n` with bit `idx` set to 1 |
+//! | `clear_bit(n, idx)` | `(Int, Int) -> Int`  | `n` with bit `idx` set to 0 |
+//! | `get_bit(n, idx)`   | `(Int, Int) -> Bool` | True iff bit `idx` of `n` is 1 |
+//! | `flip_bit(n, idx)`  | `(Int, Int) -> Int`  | `n` with bit `idx` XOR-toggled |
+//!
+//! `idx` is 0-based (LSB = 0). Out of `0..=63` is a typed error —
+//! masks the easy "shift count too large" bug.
+
+use crate::{RResult, Value};
+
+fn check_bit_idx(name: &str, idx: i64) -> Result<u32, String> {
+    if !(0..64).contains(&idx) {
+        return Err(format!(
+            "{}: bit index must be in 0..=63, got {}",
+            name, idx
+        ));
+    }
+    Ok(idx as u32)
+}
+
+/// `set_bit(n, idx) -> Int` — return `n` with bit `idx` set to 1.
+/// Idempotent (calling twice returns the same value).
+pub(crate) fn builtin_set_bit(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n), Value::Int(idx)] => {
+            let bit = check_bit_idx("set_bit", *idx)?;
+            Ok(Value::Int(*n | (1i64 << bit)))
+        }
+        [Value::Int(_), other] => Err(format!("set_bit: idx must be Int, got {}", other)),
+        [other, _] => Err(format!("set_bit: n must be Int, got {}", other)),
+        _ => Err(format!("set_bit: expected 2 arguments, got {}", args.len())),
+    }
+}
+
+/// `clear_bit(n, idx) -> Int` — return `n` with bit `idx` set to 0.
+/// Idempotent. Negative numbers have meaningful upper bits (i64 is
+/// two's complement); clearing bit 63 toggles sign.
+pub(crate) fn builtin_clear_bit(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n), Value::Int(idx)] => {
+            let bit = check_bit_idx("clear_bit", *idx)?;
+            Ok(Value::Int(*n & !(1i64 << bit)))
+        }
+        [Value::Int(_), other] => Err(format!("clear_bit: idx must be Int, got {}", other)),
+        [other, _] => Err(format!("clear_bit: n must be Int, got {}", other)),
+        _ => Err(format!(
+            "clear_bit: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `get_bit(n, idx) -> Bool` — true iff bit `idx` of `n` is 1.
+pub(crate) fn builtin_get_bit(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n), Value::Int(idx)] => {
+            let bit = check_bit_idx("get_bit", *idx)?;
+            Ok(Value::Bool((*n >> bit) & 1 == 1))
+        }
+        [Value::Int(_), other] => Err(format!("get_bit: idx must be Int, got {}", other)),
+        [other, _] => Err(format!("get_bit: n must be Int, got {}", other)),
+        _ => Err(format!("get_bit: expected 2 arguments, got {}", args.len())),
+    }
+}
+
+/// `flip_bit(n, idx) -> Int` — return `n` with bit `idx` XOR-toggled.
+/// Involution: `flip_bit(flip_bit(n, i), i) == n`.
+pub(crate) fn builtin_flip_bit(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(n), Value::Int(idx)] => {
+            let bit = check_bit_idx("flip_bit", *idx)?;
+            Ok(Value::Int(*n ^ (1i64 << bit)))
+        }
+        [Value::Int(_), other] => Err(format!("flip_bit: idx must be Int, got {}", other)),
+        [other, _] => Err(format!("flip_bit: n must be Int, got {}", other)),
+        _ => Err(format!(
+            "flip_bit: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn as_int(v: Value) -> i64 {
+        match v {
+            Value::Int(n) => n,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    fn as_bool(v: Value) -> bool {
+        match v {
+            Value::Bool(b) => b,
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    // --- set_bit ---
+
+    #[test]
+    fn set_bit_basic() {
+        assert_eq!(
+            as_int(builtin_set_bit(&[Value::Int(0), Value::Int(0)]).unwrap()),
+            1
+        );
+        assert_eq!(
+            as_int(builtin_set_bit(&[Value::Int(0), Value::Int(3)]).unwrap()),
+            8
+        );
+        assert_eq!(
+            as_int(builtin_set_bit(&[Value::Int(0b0101), Value::Int(1)]).unwrap()),
+            0b0111
+        );
+    }
+
+    #[test]
+    fn set_bit_idempotent() {
+        let v = builtin_set_bit(&[Value::Int(0xFF), Value::Int(3)]).unwrap();
+        let v2 = builtin_set_bit(&[v.clone(), Value::Int(3)]).unwrap();
+        assert_eq!(as_int(v), as_int(v2));
+    }
+
+    #[test]
+    fn set_bit_at_msb() {
+        let r = as_int(builtin_set_bit(&[Value::Int(0), Value::Int(63)]).unwrap());
+        assert_eq!(r, i64::MIN); // bit 63 in two's complement is the sign bit
+    }
+
+    #[test]
+    fn set_bit_rejects_out_of_range_idx() {
+        let err = builtin_set_bit(&[Value::Int(0), Value::Int(64)]).unwrap_err();
+        assert!(err.contains("0..=63"));
+        let err = builtin_set_bit(&[Value::Int(0), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("0..=63"));
+    }
+
+    // --- clear_bit ---
+
+    #[test]
+    fn clear_bit_basic() {
+        assert_eq!(
+            as_int(builtin_clear_bit(&[Value::Int(0xFF), Value::Int(0)]).unwrap()),
+            0xFE
+        );
+        assert_eq!(
+            as_int(builtin_clear_bit(&[Value::Int(0b1111), Value::Int(2)]).unwrap()),
+            0b1011
+        );
+    }
+
+    #[test]
+    fn clear_bit_idempotent() {
+        let v = builtin_clear_bit(&[Value::Int(0xFF), Value::Int(0)]).unwrap();
+        let v2 = builtin_clear_bit(&[v.clone(), Value::Int(0)]).unwrap();
+        assert_eq!(as_int(v), as_int(v2));
+    }
+
+    #[test]
+    fn clear_bit_at_msb_makes_positive() {
+        // i64::MIN has only bit 63 set. Clearing it gives 0.
+        let r = as_int(builtin_clear_bit(&[Value::Int(i64::MIN), Value::Int(63)]).unwrap());
+        assert_eq!(r, 0);
+    }
+
+    #[test]
+    fn clear_bit_already_zero_is_noop() {
+        let r = as_int(builtin_clear_bit(&[Value::Int(0), Value::Int(5)]).unwrap());
+        assert_eq!(r, 0);
+    }
+
+    // --- get_bit ---
+
+    #[test]
+    fn get_bit_basic() {
+        assert!(as_bool(
+            builtin_get_bit(&[Value::Int(1), Value::Int(0)]).unwrap()
+        ));
+        assert!(!as_bool(
+            builtin_get_bit(&[Value::Int(1), Value::Int(1)]).unwrap()
+        ));
+        assert!(as_bool(
+            builtin_get_bit(&[Value::Int(0b1010), Value::Int(1)]).unwrap()
+        ));
+        assert!(as_bool(
+            builtin_get_bit(&[Value::Int(0b1010), Value::Int(3)]).unwrap()
+        ));
+        assert!(!as_bool(
+            builtin_get_bit(&[Value::Int(0b1010), Value::Int(0)]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn get_bit_msb_of_min() {
+        // i64::MIN = -9223372036854775808 has bit 63 set, all others 0.
+        assert!(as_bool(
+            builtin_get_bit(&[Value::Int(i64::MIN), Value::Int(63)]).unwrap()
+        ));
+        assert!(!as_bool(
+            builtin_get_bit(&[Value::Int(i64::MIN), Value::Int(0)]).unwrap()
+        ));
+    }
+
+    #[test]
+    fn get_bit_negative_one_all_set() {
+        for idx in 0..64 {
+            assert!(as_bool(
+                builtin_get_bit(&[Value::Int(-1), Value::Int(idx)]).unwrap()
+            ));
+        }
+    }
+
+    // --- flip_bit ---
+
+    #[test]
+    fn flip_bit_basic() {
+        assert_eq!(
+            as_int(builtin_flip_bit(&[Value::Int(0), Value::Int(2)]).unwrap()),
+            4
+        );
+        assert_eq!(
+            as_int(builtin_flip_bit(&[Value::Int(0b101), Value::Int(0)]).unwrap()),
+            0b100
+        );
+        assert_eq!(
+            as_int(builtin_flip_bit(&[Value::Int(0b101), Value::Int(1)]).unwrap()),
+            0b111
+        );
+    }
+
+    #[test]
+    fn flip_bit_is_involution() {
+        for n in [0i64, 1, -1, 0x5A5A5A5A, i64::MAX, i64::MIN] {
+            for idx in [0i64, 7, 31, 63] {
+                let once = as_int(builtin_flip_bit(&[Value::Int(n), Value::Int(idx)]).unwrap());
+                let twice = as_int(builtin_flip_bit(&[Value::Int(once), Value::Int(idx)]).unwrap());
+                assert_eq!(
+                    twice, n,
+                    "flip_bit({}, {}) twice should be identity",
+                    n, idx
+                );
+            }
+        }
+    }
+
+    // --- general ---
+
+    #[test]
+    fn round_trip_set_clear_get() {
+        // For any input n and idx in 0..64:
+        //   get_bit(set_bit(n, i), i) == true
+        //   get_bit(clear_bit(n, i), i) == false
+        for n in [0i64, 0x1234_5678, -1, i64::MAX] {
+            for idx in [0i64, 1, 7, 31, 63] {
+                let set = as_int(builtin_set_bit(&[Value::Int(n), Value::Int(idx)]).unwrap());
+                assert!(as_bool(
+                    builtin_get_bit(&[Value::Int(set), Value::Int(idx)]).unwrap()
+                ));
+                let clr = as_int(builtin_clear_bit(&[Value::Int(n), Value::Int(idx)]).unwrap());
+                assert!(!as_bool(
+                    builtin_get_bit(&[Value::Int(clr), Value::Int(idx)]).unwrap()
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        for f in [
+            builtin_set_bit,
+            builtin_clear_bit,
+            builtin_get_bit,
+            builtin_flip_bit,
+        ] {
+            let err = f(&[]).unwrap_err();
+            assert!(err.contains("expected 2"), "got {}", err);
+            let err = f(&[Value::Int(0)]).unwrap_err();
+            assert!(err.contains("expected 2"), "got {}", err);
+            let err = f(&[Value::Bool(false), Value::Int(0)]).unwrap_err();
+            assert!(err.contains("n must be Int"), "got {}", err);
+            let err = f(&[Value::Int(0), Value::Bool(false)]).unwrap_err();
+            assert!(err.contains("idx must be Int"), "got {}", err);
+        }
+    }
+
+    #[test]
+    fn out_of_range_idx_diagnostics_consistent() {
+        for f in [
+            builtin_set_bit,
+            builtin_clear_bit,
+            builtin_get_bit,
+            builtin_flip_bit,
+        ] {
+            let err = f(&[Value::Int(0), Value::Int(64)]).unwrap_err();
+            assert!(err.contains("0..=63"), "got {}", err);
+        }
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -15,6 +15,9 @@ mod alignment_helpers;
 // RES-1148: binary search on sorted int / float / string arrays.
 // Pure leaf builtins; module-isolated.
 mod array_binary_search;
+// RES-1156: per-bit accessors on i64 — set / clear / get / flip.
+// Pure leaf builtins; module-isolated.
+mod bit_manipulation;
 // RES-1142: array chunking + striding + rotation primitives.
 // Pure leaf builtins; module-isolated.
 mod array_chunking;
@@ -11232,6 +11235,13 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ),
     ("result_and", crate::set_result_option::builtin_result_and),
     ("option_and", crate::set_result_option::builtin_option_and),
+    // RES-1156: per-bit accessors on i64 — set / clear / get / flip.
+    // Pure leaf builtins; module-isolated in `bit_manipulation.rs`.
+    // Appended at the end of BUILTINS per the perf rule from PR #1125.
+    ("set_bit", crate::bit_manipulation::builtin_set_bit),
+    ("clear_bit", crate::bit_manipulation::builtin_clear_bit),
+    ("get_bit", crate::bit_manipulation::builtin_get_bit),
+    ("flip_bit", crate::bit_manipulation::builtin_flip_bit),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1427,6 +1427,17 @@ impl TypeChecker {
                 return_type: Box::new(Type::Bytes),
             },
         );
+        // RES-1156: per-bit accessors on i64.
+        env.set("set_bit".to_string(), fn_int_int_to_int());
+        env.set("clear_bit".to_string(), fn_int_int_to_int());
+        env.set(
+            "get_bit".to_string(),
+            Type::Function {
+                params: vec![Type::Int, Type::Int],
+                return_type: Box::new(Type::Bool),
+            },
+        );
+        env.set("flip_bit".to_string(), fn_int_int_to_int());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6305,6 +6316,11 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "bytes_repeat",
         "bytes_count_byte",
         "bytes_replace_byte",
+        // RES-1156: per-bit accessors.
+        "set_bit",
+        "clear_bit",
+        "get_bit",
+        "flip_bit",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1156.

The four foundational per-bit accessors on i64. Every embedded
register / flag-word / bit-set workload reaches for these; the language
had whole-word bit ops (`reverse_bits`, `swap_bytes`, `rotate_*`,
`count_ones`, etc) but not the per-bit accessors.

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| `set_bit(n, idx)`   | `(Int, Int) -> Int`  | `n` with bit `idx` set to 1 |
| `clear_bit(n, idx)` | `(Int, Int) -> Int`  | `n` with bit `idx` set to 0 |
| `get_bit(n, idx)`   | `(Int, Int) -> Bool` | True iff bit `idx` of `n` is 1 |
| `flip_bit(n, idx)`  | `(Int, Int) -> Int`  | `n` with bit `idx` XOR-toggled |

### Design notes

- `idx` is 0-based (LSB = 0). Out of `0..=63` is a typed error,
  centralizing the bounds check that hand-rolled `n | (1 << idx)`
  gets wrong.
- Two's complement: `set_bit(0, 63) == i64::MIN`, etc.
- `set_bit` / `clear_bit` are idempotent; `flip_bit` is an involution.
- Module-isolated in `bit_manipulation.rs` per CLAUDE.md.

### Tests

- 16 unit tests + 1 golden example (with a GPIO-style register chain).
- Property: for every `n` and `idx`, `get_bit(set_bit(n, idx), idx) == true`
  and `get_bit(clear_bit(n, idx), idx) == false`.

### Local gates

All four clean: build, test, clippy, fmt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>