### PR TITLE
RES-1160: array_argmax_float / _string + array_argmin_float / _string — 4 new builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -5,12 +5,21 @@
       "claimed_at": "2026-05-11T14:34:56Z"
     },
     "resilient/src/lib.rs": {
+<<<<<<< HEAD
       "branch": "res-1162-hash-builtins",
       "claimed_at": "2026-05-11T17:12:00Z"
     },
     "resilient/src/typechecker.rs": {
       "branch": "res-1162-hash-builtins",
       "claimed_at": "2026-05-11T17:12:00Z"
+=======
+      "branch": "res-1160-array-argmin-argmax",
+      "claimed_at": "2026-05-11T17:02:00Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1160-array-argmin-argmax",
+      "claimed_at": "2026-05-11T17:02:00Z"
+>>>>>>> fe1909d (RES-1160: array_argmax_float / argmin_float / argmax_string / argmin_string)
     }
   }
 }

--- a/resilient/examples/array_argminmax.expected.txt
+++ b/resilient/examples/array_argminmax.expected.txt
@@ -1,0 +1,9 @@
+3
+1
+0
+0
+2
+1
+1
+1
+Program executed successfully

--- a/resilient/examples/array_argminmax.rz
+++ b/resilient/examples/array_argminmax.rz
@@ -1,0 +1,25 @@
+// RES-1160 demo: array_argmax / array_argmin for float and string.
+
+fn main(int _d) {
+    // argmax_float: index of the maximum element.
+    println(array_argmax_float([1.0, 3.0, 2.0, 5.0, 4.0]));  // 3
+    println(array_argmin_float([3.0, 1.0, 5.0, 2.0]));       // 1
+
+    // Ties: first match wins.
+    println(array_argmax_float([3.0, 1.0, 3.0, 2.0]));       // 0
+    println(array_argmin_float([1.0, 3.0, 1.0]));            // 0
+
+    // -inf is the minimum under total order.
+    println(array_argmin_float([0.0, -1.0, 0.0 - 1.0 / 0.0, 1.0]));  // 2
+
+    // Strings: lex byte order.
+    println(array_argmax_string(["a", "c", "b"]));            // 1
+    println(array_argmin_string(["carol", "alice", "bob"])); // 1
+
+    // Byte-wise lex puts uppercase < lowercase.
+    println(array_argmax_string(["Z", "a", "B"]));            // 1
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/array_argminmax.rs
+++ b/resilient/src/array_argminmax.rs
@@ -1,0 +1,316 @@
+//! RES-1160: argmax / argmin for float and string arrays.
+//!
+//! Complements the existing `array_argmax_int` / `array_argmin_int`
+//! (RES-???). Argmin / argmax returns the index of the (first)
+//! min/max element — the standard primitive for peak detection,
+//! feature ranking, and tournament selection.
+//!
+//! | Builtin | Signature | Notes |
+//! |---|---|---|
+//! | `array_argmax_float(arr)`  | `(Array) -> Int` | NaN-safe via IEEE 754 total order |
+//! | `array_argmin_float(arr)`  | `(Array) -> Int` | Same |
+//! | `array_argmax_string(arr)` | `(Array) -> Int` | Lex byte-wise |
+//! | `array_argmin_string(arr)` | `(Array) -> Int` | Same |
+//!
+//! Empty array → typed error. First match wins on ties.
+
+use crate::{RResult, Value};
+
+fn collect_floats(name: &str, items: &[Value]) -> RResult<Vec<f64>> {
+    if items.is_empty() {
+        return Err(format!("{}: empty array has no argmax/argmin", name));
+    }
+    let mut out: Vec<f64> = Vec::with_capacity(items.len());
+    for v in items {
+        match v {
+            Value::Float(f) => out.push(*f),
+            other => {
+                return Err(format!(
+                    "{}: expected all float elements, got {}",
+                    name, other
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn collect_strings<'a>(name: &str, items: &'a [Value]) -> RResult<Vec<&'a String>> {
+    if items.is_empty() {
+        return Err(format!("{}: empty array has no argmax/argmin", name));
+    }
+    let mut out: Vec<&String> = Vec::with_capacity(items.len());
+    for v in items {
+        match v {
+            Value::String(s) => out.push(s),
+            other => {
+                return Err(format!(
+                    "{}: expected all string elements, got {}",
+                    name, other
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// `array_argmax_float(arr) -> Int` — index of the maximum element
+/// under IEEE 754 total order. First match wins on ties.
+pub(crate) fn builtin_array_argmax_float(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let nums = collect_floats("array_argmax_float", items)?;
+            let mut best_idx = 0usize;
+            for (i, &v) in nums.iter().enumerate().skip(1) {
+                if v.total_cmp(&nums[best_idx]) == std::cmp::Ordering::Greater {
+                    best_idx = i;
+                }
+            }
+            Ok(Value::Int(best_idx as i64))
+        }
+        [other] => Err(format!("array_argmax_float: expected array, got {}", other)),
+        _ => Err(format!(
+            "array_argmax_float: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_argmin_float(arr) -> Int` — index of the minimum element
+/// under IEEE 754 total order.
+pub(crate) fn builtin_array_argmin_float(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let nums = collect_floats("array_argmin_float", items)?;
+            let mut best_idx = 0usize;
+            for (i, &v) in nums.iter().enumerate().skip(1) {
+                if v.total_cmp(&nums[best_idx]) == std::cmp::Ordering::Less {
+                    best_idx = i;
+                }
+            }
+            Ok(Value::Int(best_idx as i64))
+        }
+        [other] => Err(format!("array_argmin_float: expected array, got {}", other)),
+        _ => Err(format!(
+            "array_argmin_float: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_argmax_string(arr) -> Int` — index of the lex-maximum string.
+pub(crate) fn builtin_array_argmax_string(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let strings = collect_strings("array_argmax_string", items)?;
+            let mut best_idx = 0usize;
+            for (i, s) in strings.iter().enumerate().skip(1) {
+                if *s > strings[best_idx] {
+                    best_idx = i;
+                }
+            }
+            Ok(Value::Int(best_idx as i64))
+        }
+        [other] => Err(format!(
+            "array_argmax_string: expected array, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "array_argmax_string: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_argmin_string(arr) -> Int` — index of the lex-minimum string.
+pub(crate) fn builtin_array_argmin_string(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let strings = collect_strings("array_argmin_string", items)?;
+            let mut best_idx = 0usize;
+            for (i, s) in strings.iter().enumerate().skip(1) {
+                if *s < strings[best_idx] {
+                    best_idx = i;
+                }
+            }
+            Ok(Value::Int(best_idx as i64))
+        }
+        [other] => Err(format!(
+            "array_argmin_string: expected array, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "array_argmin_string: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn floats(xs: &[f64]) -> Value {
+        Value::Array(xs.iter().map(|&f| Value::Float(f)).collect())
+    }
+
+    fn strings(xs: &[&str]) -> Value {
+        Value::Array(xs.iter().map(|s| Value::String(s.to_string())).collect())
+    }
+
+    fn as_int(v: Value) -> i64 {
+        match v {
+            Value::Int(n) => n,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    // --- argmax_float ---
+
+    #[test]
+    fn argmax_float_basic() {
+        let r = builtin_array_argmax_float(&[floats(&[1.0, 3.0, 2.0, 5.0, 4.0])]).unwrap();
+        assert_eq!(as_int(r), 3);
+    }
+
+    #[test]
+    fn argmax_float_single_element_is_zero() {
+        let r = builtin_array_argmax_float(&[floats(&[42.0])]).unwrap();
+        assert_eq!(as_int(r), 0);
+    }
+
+    #[test]
+    fn argmax_float_ties_pick_first() {
+        let r = builtin_array_argmax_float(&[floats(&[3.0, 1.0, 3.0, 2.0])]).unwrap();
+        assert_eq!(as_int(r), 0);
+    }
+
+    #[test]
+    fn argmax_float_handles_nan_under_total_order() {
+        // NaN is the maximum under IEEE 754 total order.
+        let r = builtin_array_argmax_float(&[floats(&[1.0, f64::NAN, 100.0])]).unwrap();
+        assert_eq!(as_int(r), 1);
+    }
+
+    #[test]
+    fn argmax_float_signed_zero() {
+        // +0 > -0 under total order, so [+0, -0] argmax is 0.
+        let r = builtin_array_argmax_float(&[floats(&[0.0, -0.0])]).unwrap();
+        assert_eq!(as_int(r), 0);
+        // [-0, +0] argmax is 1.
+        let r = builtin_array_argmax_float(&[floats(&[-0.0, 0.0])]).unwrap();
+        assert_eq!(as_int(r), 1);
+    }
+
+    #[test]
+    fn argmax_float_empty_errors() {
+        let err = builtin_array_argmax_float(&[floats(&[])]).unwrap_err();
+        assert!(err.contains("empty array"));
+    }
+
+    // --- argmin_float ---
+
+    #[test]
+    fn argmin_float_basic() {
+        let r = builtin_array_argmin_float(&[floats(&[3.0, 1.0, 5.0, 2.0])]).unwrap();
+        assert_eq!(as_int(r), 1);
+    }
+
+    #[test]
+    fn argmin_float_ties_pick_first() {
+        let r = builtin_array_argmin_float(&[floats(&[1.0, 3.0, 1.0])]).unwrap();
+        assert_eq!(as_int(r), 0);
+    }
+
+    #[test]
+    fn argmin_float_handles_neg_inf() {
+        // -inf is minimum.
+        let r =
+            builtin_array_argmin_float(&[floats(&[0.0, -1.0, f64::NEG_INFINITY, 1.0])]).unwrap();
+        assert_eq!(as_int(r), 2);
+    }
+
+    #[test]
+    fn argmin_float_empty_errors() {
+        let err = builtin_array_argmin_float(&[floats(&[])]).unwrap_err();
+        assert!(err.contains("empty array"));
+    }
+
+    // --- argmax_string ---
+
+    #[test]
+    fn argmax_string_basic() {
+        let r = builtin_array_argmax_string(&[strings(&["a", "c", "b"])]).unwrap();
+        assert_eq!(as_int(r), 1);
+    }
+
+    #[test]
+    fn argmax_string_lex_byte_order() {
+        // Uppercase < lowercase in byte order, so "a" > "Z".
+        let r = builtin_array_argmax_string(&[strings(&["Z", "a", "B"])]).unwrap();
+        assert_eq!(as_int(r), 1);
+    }
+
+    #[test]
+    fn argmax_string_ties_pick_first() {
+        let r = builtin_array_argmax_string(&[strings(&["b", "a", "b"])]).unwrap();
+        assert_eq!(as_int(r), 0);
+    }
+
+    // --- argmin_string ---
+
+    #[test]
+    fn argmin_string_basic() {
+        let r = builtin_array_argmin_string(&[strings(&["carol", "alice", "bob"])]).unwrap();
+        assert_eq!(as_int(r), 1);
+    }
+
+    #[test]
+    fn argmin_string_empty_errors() {
+        let err = builtin_array_argmin_string(&[strings(&[])]).unwrap_err();
+        assert!(err.contains("empty array"));
+    }
+
+    // --- general ---
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        for f in [
+            builtin_array_argmax_float,
+            builtin_array_argmin_float,
+            builtin_array_argmax_string,
+            builtin_array_argmin_string,
+        ] {
+            let err = f(&[]).unwrap_err();
+            assert!(err.contains("expected 1"), "got {}", err);
+            let err = f(&[Value::Int(5)]).unwrap_err();
+            assert!(err.contains("expected array"), "got {}", err);
+        }
+    }
+
+    #[test]
+    fn rejects_mixed_element_types() {
+        let err =
+            builtin_array_argmax_float(&[Value::Array(vec![Value::Float(1.0), Value::Int(2)])])
+                .unwrap_err();
+        assert!(err.contains("expected all float elements"));
+
+        let err = builtin_array_argmax_string(&[Value::Array(vec![
+            Value::String("a".to_string()),
+            Value::Int(0),
+        ])])
+        .unwrap_err();
+        assert!(err.contains("expected all string elements"));
+    }
+
+    #[test]
+    fn argmax_argmin_complementary_on_distinct_values() {
+        // For any array with distinct max and min, argmax and argmin
+        // must return different indices.
+        for arr in [floats(&[1.0, 5.0, 3.0, 2.0]), floats(&[10.0, 0.0, 5.0])] {
+            let max_idx = as_int(builtin_array_argmax_float(std::slice::from_ref(&arr)).unwrap());
+            let min_idx = as_int(builtin_array_argmin_float(std::slice::from_ref(&arr)).unwrap());
+            assert_ne!(max_idx, min_idx);
+        }
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -12,6 +12,9 @@ use std::rc::Rc;
 // Pure leaf builtins; module-isolated so adding new bytes/int helpers
 // doesn't have to dodge each other inside lib.rs.
 mod alignment_helpers;
+// RES-1160: argmax / argmin for float and string arrays.
+// Pure leaf builtins; module-isolated.
+mod array_argminmax;
 // RES-1148: binary search on sorted int / float / string arrays.
 // Pure leaf builtins; module-isolated.
 mod array_binary_search;
@@ -11280,6 +11283,25 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("hash_string", crate::hash_builtins::builtin_hash_string),
     ("hash_bytes", crate::hash_builtins::builtin_hash_bytes),
     ("hash_combine", crate::hash_builtins::builtin_hash_combine),
+    // RES-1160: argmax / argmin for float and string arrays.
+    // Pure leaf builtins; module-isolated in `array_argminmax.rs`.
+    // Appended at the end of BUILTINS per the perf rule from PR #1125.
+    (
+        "array_argmax_float",
+        crate::array_argminmax::builtin_array_argmax_float,
+    ),
+    (
+        "array_argmin_float",
+        crate::array_argminmax::builtin_array_argmin_float,
+    ),
+    (
+        "array_argmax_string",
+        crate::array_argminmax::builtin_array_argmax_string,
+    ),
+    (
+        "array_argmin_string",
+        crate::array_argminmax::builtin_array_argmin_string,
+    ),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2996,6 +2996,15 @@ impl TypeChecker {
                 return_type: Box::new(Type::Any),
             },
         );
+        // RES-1160: argmax / argmin for float and string arrays.
+        let fn_array_to_int = || Type::Function {
+            params: vec![Type::Array],
+            return_type: Box::new(Type::Int),
+        };
+        env.set("array_argmax_float".to_string(), fn_array_to_int());
+        env.set("array_argmin_float".to_string(), fn_array_to_int());
+        env.set("array_argmax_string".to_string(), fn_array_to_int());
+        env.set("array_argmin_string".to_string(), fn_array_to_int());
 
         // RES-149: Set builtins. Same permissive-Any convention as
         // Map — no dedicated `Type::Set<T>` until inference lands.
@@ -6771,6 +6780,11 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "set_from_array",
         "result_and",
         "option_and",
+        // RES-1160: argmax / argmin for float and string arrays.
+        "array_argmax_float",
+        "array_argmin_float",
+        "array_argmax_string",
+        "array_argmin_string",
         "set_new",
         "set_insert",
         "set_remove",


### PR DESCRIPTION
Closes #1160.

Argmin / argmax for float and string arrays — completes the family
alongside the existing `array_argmax_int` / `array_argmin_int`.

### Surface added

| Builtin | Signature | Notes |
|---|---|---|
| `array_argmax_float(arr)`   | `(Array) -> Int` | NaN-safe via IEEE 754 total order |
| `array_argmin_float(arr)`   | `(Array) -> Int` | Same |
| `array_argmax_string(arr)`  | `(Array) -> Int` | Lex byte-wise |
| `array_argmin_string(arr)`  | `(Array) -> Int` | Same |

### Design notes

- Float variants use `f64::total_cmp` (RES-1138) so NaN / ±0 sort
  deterministically.
- String variants use byte-wise UTF-8 comparison.
- Empty array → typed error (matches `array_argmax_int`).
- First match wins on ties.
- Module-isolated in `array_argminmax.rs` per CLAUDE.md.

### Tests

- 18 unit tests + 1 golden example.
- Complementarity property verified: `argmax != argmin` on
  distinct-value arrays.

### Local gates

All four clean: build, test, clippy, fmt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>