### PR TITLE
RES-1164: enumerate / array_zip3 / string_truncate — 3 new builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -14,6 +14,7 @@
       "branch": "res-1162-hash-builtins",
       "claimed_at": "2026-05-11T17:12:00Z"
 =======
+<<<<<<< HEAD
       "branch": "res-1160-array-argmin-argmax",
       "claimed_at": "2026-05-11T17:02:00Z"
     },
@@ -22,6 +23,7 @@
       "claimed_at": "2026-05-11T17:02:00Z"
 >>>>>>> fe1909d (RES-1160: array_argmax_float / argmin_float / argmax_string / argmin_string)
 =======
+<<<<<<< HEAD
       "branch": "res-1166-rounding",
       "claimed_at": "2026-05-11T17:32:00Z"
     },
@@ -29,6 +31,16 @@
       "branch": "res-1166-rounding",
       "claimed_at": "2026-05-11T17:32:00Z"
 >>>>>>> b2b2d07 (RES-1166: round / trunc / round_to_int / trunc_to_int)
+=======
+      "branch": "res-1164-iter-helpers",
+      "claimed_at": "2026-05-11T17:22:00Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1164-iter-helpers",
+      "claimed_at": "2026-05-11T17:22:00Z"
+>>>>>>> cfbc288 (RES-1164: enumerate / array_zip3 / string_truncate — 3 iteration helpers)
+>>>>>>> 475108d (RES-1164: enumerate / array_zip3 / string_truncate — 3 iteration helpers)
+>>>>>>> f037c48 (RES-1164: enumerate / array_zip3 / string_truncate — 3 iteration helpers)
     }
   }
 }

--- a/resilient/examples/iter_helpers.expected.txt
+++ b/resilient/examples/iter_helpers.expected.txt
@@ -1,0 +1,11 @@
+3
+[0, "a"]
+[2, "c"]
+3
+[1, 10, 100]
+2
+hel
+hello
+
+caf
+Program executed successfully

--- a/resilient/examples/iter_helpers.rz
+++ b/resilient/examples/iter_helpers.rz
@@ -1,0 +1,27 @@
+// RES-1164 demo: enumerate / array_zip3 / string_truncate.
+
+fn main(int _d) {
+    // enumerate produces [[0, v0], [1, v1], ...].
+    let pairs = enumerate(["a", "b", "c"]);
+    println(len(pairs));            // 3
+    println(pairs[0]);              // [0, "a"]
+    println(pairs[2]);              // [2, "c"]
+
+    // array_zip3 — 3-way zip.
+    let triples = array_zip3([1, 2, 3], [10, 20, 30], [100, 200, 300]);
+    println(len(triples));          // 3
+    println(triples[0]);            // [1, 10, 100]
+
+    // zip3 truncates to the shortest input.
+    println(len(array_zip3([1, 2, 3, 4], [10, 20], [100, 200, 300])));  // 2
+
+    // string_truncate — first N Unicode scalars.
+    println(string_truncate("hello", 3));        // hel
+    println(string_truncate("hello", 100));      // hello
+    println(string_truncate("hello", 0));        // (empty)
+    println(string_truncate("café", 3));         // caf
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/iter_helpers.rs
+++ b/resilient/src/iter_helpers.rs
@@ -1,0 +1,292 @@
+//! RES-1164: small iteration helpers.
+//!
+//! Three pure leaf builtins:
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `enumerate(arr)`         | `(Array) -> Array`                | `[[i, v], ...]` index-value pairs |
+//! | `array_zip3(a, b, c)`    | `(Array, Array, Array) -> Array`  | 3-way zip; length = min |
+//! | `string_truncate(s, n)`  | `(String, Int) -> String`         | First `n` Unicode scalars |
+
+use crate::{RResult, Value};
+
+/// `enumerate(arr) -> Array` — `[[0, arr[0]], [1, arr[1]], ...]`.
+/// Indices start at 0. Empty input returns empty.
+pub(crate) fn builtin_enumerate(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(items)] => {
+            let out: Vec<Value> = items
+                .iter()
+                .enumerate()
+                .map(|(i, v)| Value::Array(vec![Value::Int(i as i64), v.clone()]))
+                .collect();
+            Ok(Value::Array(out))
+        }
+        [other] => Err(format!("enumerate: expected array, got {}", other)),
+        _ => Err(format!(
+            "enumerate: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `array_zip3(a, b, c) -> Array[[A, B, C]]` — three-way zip. Length is
+/// `min(|a|, |b|, |c|)`; trailing elements of longer inputs are dropped.
+pub(crate) fn builtin_array_zip3(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(a), Value::Array(b), Value::Array(c)] => {
+            let n = a.len().min(b.len()).min(c.len());
+            let mut out: Vec<Value> = Vec::with_capacity(n);
+            for i in 0..n {
+                out.push(Value::Array(vec![a[i].clone(), b[i].clone(), c[i].clone()]));
+            }
+            Ok(Value::Array(out))
+        }
+        [a, b, c] => Err(format!(
+            "array_zip3: expected (array, array, array), got ({}, {}, {})",
+            a, b, c
+        )),
+        _ => Err(format!(
+            "array_zip3: expected 3 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_truncate(s, n) -> String` — keep the first `n` Unicode scalars.
+/// `n` must be non-negative. `n` larger than the char count returns `s`
+/// unchanged.
+pub(crate) fn builtin_string_truncate(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(s), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "string_truncate: n must be non-negative, got {}",
+                    n
+                ));
+            }
+            let max = *n as usize;
+            // Iterate chars and rebuild — Unicode-scalar aware so we
+            // don't slice mid-codepoint.
+            let out: String = s.chars().take(max).collect();
+            Ok(Value::String(out))
+        }
+        [a, b] => Err(format!(
+            "string_truncate: expected (string, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "string_truncate: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ints(xs: &[i64]) -> Value {
+        Value::Array(xs.iter().map(|&n| Value::Int(n)).collect())
+    }
+
+    fn as_array(v: Value) -> Vec<Value> {
+        match v {
+            Value::Array(items) => items,
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    fn as_int(v: Value) -> i64 {
+        match v {
+            Value::Int(n) => n,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    fn as_string(v: Value) -> String {
+        match v {
+            Value::String(s) => s,
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    // --- enumerate ---
+
+    #[test]
+    fn enumerate_basic() {
+        let r = builtin_enumerate(&[ints(&[10, 20, 30])]).unwrap();
+        let outer = as_array(r);
+        assert_eq!(outer.len(), 3);
+        for (expected_idx, pair) in outer.into_iter().enumerate() {
+            let p = as_array(pair);
+            assert_eq!(p.len(), 2);
+            assert_eq!(as_int(p[0].clone()), expected_idx as i64);
+            assert_eq!(as_int(p[1].clone()), (expected_idx as i64 + 1) * 10);
+        }
+    }
+
+    #[test]
+    fn enumerate_empty() {
+        let r = builtin_enumerate(&[ints(&[])]).unwrap();
+        assert_eq!(as_array(r).len(), 0);
+    }
+
+    #[test]
+    fn enumerate_singleton() {
+        let r = builtin_enumerate(&[ints(&[42])]).unwrap();
+        let outer = as_array(r);
+        assert_eq!(outer.len(), 1);
+        let p = as_array(outer.into_iter().next().unwrap());
+        assert_eq!(as_int(p[0].clone()), 0);
+        assert_eq!(as_int(p[1].clone()), 42);
+    }
+
+    #[test]
+    fn enumerate_mixed_types() {
+        let arr = Value::Array(vec![
+            Value::Int(1),
+            Value::String("hello".to_string()),
+            Value::Bool(true),
+        ]);
+        let r = as_array(builtin_enumerate(&[arr]).unwrap());
+        assert_eq!(r.len(), 3);
+    }
+
+    #[test]
+    fn enumerate_rejects_non_array() {
+        let err = builtin_enumerate(&[Value::Int(7)]).unwrap_err();
+        assert!(err.contains("expected array"));
+    }
+
+    // --- array_zip3 ---
+
+    #[test]
+    fn zip3_basic() {
+        let r = builtin_array_zip3(&[
+            ints(&[1, 2, 3]),
+            ints(&[10, 20, 30]),
+            ints(&[100, 200, 300]),
+        ])
+        .unwrap();
+        let outer = as_array(r);
+        assert_eq!(outer.len(), 3);
+        let first = as_array(outer.into_iter().next().unwrap());
+        assert_eq!(first.len(), 3);
+        assert_eq!(as_int(first[0].clone()), 1);
+        assert_eq!(as_int(first[1].clone()), 10);
+        assert_eq!(as_int(first[2].clone()), 100);
+    }
+
+    #[test]
+    fn zip3_truncates_to_shortest() {
+        let r = builtin_array_zip3(&[ints(&[1, 2, 3, 4]), ints(&[10, 20]), ints(&[100, 200, 300])])
+            .unwrap();
+        let outer = as_array(r);
+        assert_eq!(outer.len(), 2); // min(4, 2, 3) = 2
+    }
+
+    #[test]
+    fn zip3_one_empty_input_is_empty() {
+        let r = builtin_array_zip3(&[ints(&[1, 2]), ints(&[]), ints(&[10, 20])]).unwrap();
+        assert_eq!(as_array(r).len(), 0);
+    }
+
+    #[test]
+    fn zip3_all_empty_is_empty() {
+        let r = builtin_array_zip3(&[ints(&[]), ints(&[]), ints(&[])]).unwrap();
+        assert_eq!(as_array(r).len(), 0);
+    }
+
+    #[test]
+    fn zip3_rejects_non_array() {
+        let err = builtin_array_zip3(&[ints(&[1]), Value::Int(5), ints(&[2])]).unwrap_err();
+        assert!(err.contains("expected (array, array, array)"));
+    }
+
+    #[test]
+    fn zip3_rejects_wrong_arity() {
+        let err = builtin_array_zip3(&[ints(&[1])]).unwrap_err();
+        assert!(err.contains("expected 3"));
+        let err = builtin_array_zip3(&[ints(&[1]), ints(&[2])]).unwrap_err();
+        assert!(err.contains("expected 3"));
+    }
+
+    // --- string_truncate ---
+
+    #[test]
+    fn truncate_basic() {
+        let s = Value::String("hello".to_string());
+        let r = builtin_string_truncate(&[s, Value::Int(3)]).unwrap();
+        assert_eq!(as_string(r), "hel");
+    }
+
+    #[test]
+    fn truncate_exact_length() {
+        let s = Value::String("hello".to_string());
+        let r = builtin_string_truncate(&[s, Value::Int(5)]).unwrap();
+        assert_eq!(as_string(r), "hello");
+    }
+
+    #[test]
+    fn truncate_larger_than_length() {
+        let s = Value::String("hello".to_string());
+        let r = builtin_string_truncate(&[s, Value::Int(100)]).unwrap();
+        assert_eq!(as_string(r), "hello");
+    }
+
+    #[test]
+    fn truncate_to_zero_is_empty() {
+        let s = Value::String("hello".to_string());
+        let r = builtin_string_truncate(&[s, Value::Int(0)]).unwrap();
+        assert_eq!(as_string(r), "");
+    }
+
+    #[test]
+    fn truncate_empty_string() {
+        let s = Value::String("".to_string());
+        let r = builtin_string_truncate(&[s, Value::Int(5)]).unwrap();
+        assert_eq!(as_string(r), "");
+    }
+
+    #[test]
+    fn truncate_unicode_aware() {
+        // "café" is 4 chars but 5 bytes — truncate should be char-aware
+        // and not split the é codepoint.
+        let s = Value::String("café".to_string());
+        let r = builtin_string_truncate(&[s, Value::Int(3)]).unwrap();
+        assert_eq!(as_string(r), "caf");
+    }
+
+    #[test]
+    fn truncate_multi_byte_at_boundary() {
+        // 🌟 is a 4-byte multi-byte codepoint. Truncating to 1 char
+        // should keep it intact (not slice into the middle).
+        let s = Value::String("🌟hello".to_string());
+        let r = builtin_string_truncate(&[s, Value::Int(1)]).unwrap();
+        assert_eq!(as_string(r), "🌟");
+    }
+
+    #[test]
+    fn truncate_rejects_negative() {
+        let s = Value::String("hello".to_string());
+        let err = builtin_string_truncate(&[s, Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"));
+    }
+
+    #[test]
+    fn truncate_rejects_wrong_types() {
+        let err = builtin_string_truncate(&[Value::Int(0), Value::Int(1)]).unwrap_err();
+        assert!(err.contains("expected (string, int)"));
+    }
+
+    // --- general ---
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        let err = builtin_enumerate(&[]).unwrap_err();
+        assert!(err.contains("expected 1"));
+        let err = builtin_string_truncate(&[]).unwrap_err();
+        assert!(err.contains("expected 2"));
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -53,6 +53,9 @@ mod compiler;
 mod const_fold;
 mod disasm;
 mod hash_builtins;
+// RES-1164: iteration helpers — enumerate, array_zip3, string_truncate.
+// Pure leaf builtins; module-isolated.
+mod iter_helpers;
 // RES-1166: rounding builtins — round / trunc / round_to_int / trunc_to_int.
 // Pure leaf builtins; module-isolated.
 mod rounding;
@@ -11304,6 +11307,15 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     (
         "array_argmin_string",
         crate::array_argminmax::builtin_array_argmin_string,
+    ),
+    // RES-1164: iteration helpers — enumerate, array_zip3, string_truncate.
+    // Pure leaf builtins; module-isolated in `iter_helpers.rs`. Appended
+    // at the end of BUILTINS per the perf rule from PR #1125.
+    ("enumerate", crate::iter_helpers::builtin_enumerate),
+    ("array_zip3", crate::iter_helpers::builtin_array_zip3),
+    (
+        "string_truncate",
+        crate::iter_helpers::builtin_string_truncate,
     ),
     // RES-1166: rounding builtins — round / trunc + int variants.
     // Pure leaf builtins; module-isolated in `rounding.rs`. Appended

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1490,6 +1490,28 @@ impl TypeChecker {
             },
         );
         env.set("hash_combine".to_string(), fn_int_int_to_int());
+        // RES-1164: iteration helpers.
+        env.set(
+            "enumerate".to_string(),
+            Type::Function {
+                params: vec![Type::Array],
+                return_type: Box::new(Type::Array),
+            },
+        );
+        env.set(
+            "array_zip3".to_string(),
+            Type::Function {
+                params: vec![Type::Array, Type::Array, Type::Array],
+                return_type: Box::new(Type::Array),
+            },
+        );
+        env.set(
+            "string_truncate".to_string(),
+            Type::Function {
+                params: vec![Type::String, Type::Int],
+                return_type: Box::new(Type::String),
+            },
+        );
         // RES-1166: rounding builtins.
         let fn_float_to_float = || Type::Function {
             params: vec![Type::Float],
@@ -6406,6 +6428,10 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "hash_string",
         "hash_bytes",
         "hash_combine",
+        // RES-1164: iteration helpers.
+        "enumerate",
+        "array_zip3",
+        "string_truncate",
         // RES-1166: rounding builtins.
         "round",
         "trunc",


### PR DESCRIPTION
Closes #1164.

Three small frequently-needed iteration helpers:

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| `enumerate(arr)`         | `(Array) -> Array`                | `[[i, v], ...]` pairs for index-and-value iteration |
| `array_zip3(a, b, c)`    | `(Array, Array, Array) -> Array`  | 3-way zip; length = min of inputs |
| `string_truncate(s, n)`  | `(String, Int) -> String`         | First `n` Unicode scalars |

### Design notes

- `enumerate` saves the user from walking `array_range(0, len)` in
  parallel with `arr[i]`.
- `array_zip3` is parallel to the existing `array_zip`; length is
  the min of all three so callers don't have to pre-truncate.
- `string_truncate` is Unicode-scalar aware (uses `chars().take()`)
  so multi-byte codepoints are never split — covers the easy
  `café` / `🌟` foot-gun cases.
- All three pure leaf builtins, module-isolated in `iter_helpers.rs`
  per CLAUDE.md.

### Tests

- 21 unit tests + 1 golden example.
- Unicode test cases: `café` (3 → `caf`) and `🌟hello` (1 → `🌟`).

### Local gates

All four clean: build, test, clippy, fmt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>