### PR TITLE
RES-1174: unix_time_s / unix_time_ms / unix_time_ns — wall-clock builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -6,6 +6,7 @@
     },
     "resilient/src/lib.rs": {
 <<<<<<< HEAD
+<<<<<<< HEAD
       "branch": "res-1170-cumulative-ops",
       "claimed_at": "2026-05-11T17:52:00Z"
     },
@@ -53,6 +54,14 @@
       "branch": "res-1172-string-array-misc",
       "claimed_at": "2026-05-11T18:02:00Z"
 >>>>>>> f4d5d5e (RES-1172: string_split_once / rsplit_once / from_chars / array_is_empty)
+=======
+      "branch": "res-1174-unix-time",
+      "claimed_at": "2026-05-11T18:12:00Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1174-unix-time",
+      "claimed_at": "2026-05-11T18:12:00Z"
+>>>>>>> 3cff255 (RES-1174: unix_time_s / unix_time_ms / unix_time_ns — wall clock builtins)
     }
   }
 }

--- a/resilient/examples/unix_time.expected.txt
+++ b/resilient/examples/unix_time.expected.txt
@@ -1,0 +1,6 @@
+true
+true
+true
+true
+true
+Program executed successfully

--- a/resilient/examples/unix_time.rz
+++ b/resilient/examples/unix_time.rz
@@ -1,0 +1,21 @@
+// RES-1174 demo: unix_time_s / unix_time_ms / unix_time_ns.
+// Non-deterministic values — we only verify invariants, not exact output.
+
+fn main(int _d) {
+    let t_s = unix_time_s();
+    let t_ms = unix_time_ms();
+    let t_ns = unix_time_ns();
+
+    // All three are positive (we're after 1970).
+    println(t_s > 0);                 // true
+    println(t_ms > 0);                // true
+    println(t_ns > 0);                // true
+
+    // Scale invariants.
+    println(t_ms > t_s);              // true (ms has 1000x more units)
+    println(t_ns > t_ms);             // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -59,6 +59,8 @@ mod hash_builtins;
 // RES-1172: small string + array gaps — split_once / rsplit_once /
 // string_from_chars / array_is_empty. Pure leaf builtins; module-isolated.
 mod string_array_misc;
+// RES-1174: wall-clock unix time builtins. @io / impure.
+mod unix_time;
 // RES-1164: iteration helpers — enumerate, array_zip3, string_truncate.
 // Pure leaf builtins; module-isolated.
 mod iter_helpers;
@@ -11365,6 +11367,12 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
         "array_is_empty",
         crate::string_array_misc::builtin_array_is_empty,
     ),
+    // RES-1174: wall-clock unix time. @io / impure.
+    // Pure leaf builtins; module-isolated in `unix_time.rs`. Appended
+    // at the end of BUILTINS per the perf rule from PR #1125.
+    ("unix_time_s", crate::unix_time::builtin_unix_time_s),
+    ("unix_time_ms", crate::unix_time::builtin_unix_time_ms),
+    ("unix_time_ns", crate::unix_time::builtin_unix_time_ns),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1558,6 +1558,14 @@ impl TypeChecker {
                 return_type: Box::new(Type::Bool),
             },
         );
+        // RES-1174: wall-clock unix time. @io / impure.
+        let fn_zero_to_int = || Type::Function {
+            params: vec![],
+            return_type: Box::new(Type::Int),
+        };
+        env.set("unix_time_s".to_string(), fn_zero_to_int());
+        env.set("unix_time_ms".to_string(), fn_zero_to_int());
+        env.set("unix_time_ns".to_string(), fn_zero_to_int());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -5974,6 +5982,10 @@ const IMPURE_BUILTINS: &[&str] = &[
     "input",
     // RES-147: monotonic clock.
     "clock_ms",
+    // RES-1174: wall-clock unix time.
+    "unix_time_s",
+    "unix_time_ms",
+    "unix_time_ns",
     // RES-150: seedable PRNG — nondeterministic from the caller's
     // point of view even though the seed pins it globally.
     "random_int",

--- a/resilient/src/unix_time.rs
+++ b/resilient/src/unix_time.rs
@@ -1,0 +1,154 @@
+//! RES-1174: wall-clock unix time builtins.
+//!
+//! Three @io / impure builtins that return seconds / milliseconds /
+//! nanoseconds since the Unix epoch (1970-01-01 UTC).
+//!
+//! Companion to RES-147's `clock_ms` (monotonic since process start).
+//! These three read the system wall clock — required for log
+//! timestamps, file mtime comparisons, TLS expiry checks, distributed
+//! Lamport-clock fallbacks, etc.
+//!
+//! | Builtin | Returns | Wraps at |
+//! |---|---|---|
+//! | `unix_time_s()`  | seconds since epoch  | year 292 277 026 596 (never) |
+//! | `unix_time_ms()` | milliseconds since epoch | year 292 278 994 (never) |
+//! | `unix_time_ns()` | nanoseconds since epoch  | year 2262 |
+//!
+//! All three clamp to `i64::MAX` on overflow rather than panicking,
+//! consistent with `clock_ms`. Behavior on systems with a clock set
+//! before the Unix epoch is well-defined (returns 0 — same as
+//! `SystemTime::duration_since(UNIX_EPOCH)` saturating).
+
+use crate::{RResult, Value};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn now_unix() -> std::time::Duration {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::ZERO)
+}
+
+fn clamp_to_i64(n: u128) -> i64 {
+    if n > i64::MAX as u128 {
+        i64::MAX
+    } else {
+        n as i64
+    }
+}
+
+/// `unix_time_s() -> Int` — seconds since 1970-01-01 UTC. Impure.
+pub(crate) fn builtin_unix_time_s(args: &[Value]) -> RResult<Value> {
+    if !args.is_empty() {
+        return Err(format!(
+            "unix_time_s: expected 0 arguments, got {}",
+            args.len()
+        ));
+    }
+    let secs = now_unix().as_secs();
+    Ok(Value::Int(clamp_to_i64(secs as u128)))
+}
+
+/// `unix_time_ms() -> Int` — milliseconds since 1970-01-01 UTC. Impure.
+pub(crate) fn builtin_unix_time_ms(args: &[Value]) -> RResult<Value> {
+    if !args.is_empty() {
+        return Err(format!(
+            "unix_time_ms: expected 0 arguments, got {}",
+            args.len()
+        ));
+    }
+    let ms = now_unix().as_millis();
+    Ok(Value::Int(clamp_to_i64(ms)))
+}
+
+/// `unix_time_ns() -> Int` — nanoseconds since 1970-01-01 UTC. Impure.
+/// Will saturate at `i64::MAX` after the year 2262.
+pub(crate) fn builtin_unix_time_ns(args: &[Value]) -> RResult<Value> {
+    if !args.is_empty() {
+        return Err(format!(
+            "unix_time_ns: expected 0 arguments, got {}",
+            args.len()
+        ));
+    }
+    let ns = now_unix().as_nanos();
+    Ok(Value::Int(clamp_to_i64(ns)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn as_int(v: Value) -> i64 {
+        match v {
+            Value::Int(n) => n,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unix_time_s_positive() {
+        let t = as_int(builtin_unix_time_s(&[]).unwrap());
+        // Test runs after 2020 → should be > 1.6 billion seconds.
+        assert!(t > 1_500_000_000, "unix_time_s = {}", t);
+        // Test runs before some far-future date → should be < 4 billion.
+        assert!(t < 4_000_000_000, "unix_time_s = {}", t);
+    }
+
+    #[test]
+    fn unix_time_ms_consistent_with_s() {
+        // ms must be roughly 1000× larger than s (allowing for timing slack).
+        let s = as_int(builtin_unix_time_s(&[]).unwrap());
+        let ms = as_int(builtin_unix_time_ms(&[]).unwrap());
+        let delta_ms = ms - s * 1000;
+        assert!(
+            (0..1500).contains(&delta_ms),
+            "ms ({}) and s ({}) should be ~1000:1, diff was {}",
+            ms,
+            s,
+            delta_ms
+        );
+    }
+
+    #[test]
+    fn unix_time_ns_consistent_with_ms() {
+        // ns / 1_000_000 ≈ ms.
+        let ms = as_int(builtin_unix_time_ms(&[]).unwrap());
+        let ns = as_int(builtin_unix_time_ns(&[]).unwrap());
+        let derived_ms = ns / 1_000_000;
+        let delta = derived_ms - ms;
+        // Allow up to 1.5 seconds of slack for measurement gap.
+        assert!(
+            delta.abs() < 1500,
+            "ns/1M ({}) and ms ({}) should match closely, delta {}",
+            derived_ms,
+            ms,
+            delta
+        );
+    }
+
+    #[test]
+    fn unix_time_s_monotonic_or_equal() {
+        // Two consecutive calls — second is >= first.
+        let a = as_int(builtin_unix_time_s(&[]).unwrap());
+        let b = as_int(builtin_unix_time_s(&[]).unwrap());
+        assert!(b >= a);
+    }
+
+    #[test]
+    fn unix_time_rejects_arguments() {
+        let err = builtin_unix_time_s(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected 0"));
+        let err = builtin_unix_time_ms(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected 0"));
+        let err = builtin_unix_time_ns(&[Value::Int(0)]).unwrap_err();
+        assert!(err.contains("expected 0"));
+    }
+
+    #[test]
+    fn clamp_helper_handles_overflow() {
+        assert_eq!(clamp_to_i64(0), 0);
+        assert_eq!(clamp_to_i64(100), 100);
+        assert_eq!(clamp_to_i64(i64::MAX as u128), i64::MAX);
+        assert_eq!(clamp_to_i64((i64::MAX as u128) + 1), i64::MAX);
+        assert_eq!(clamp_to_i64(u128::MAX), i64::MAX);
+    }
+}


### PR DESCRIPTION
Closes #1174.

`clock_ms` returns monotonic time since process start; the language
had no **wall-clock** primitive. Every log timestamp, file mtime,
TLS expiry check, distributed Lamport-clock fallback needed unix
epoch time and had to fall through to FFI or external scripts.

### Surface added

| Builtin | Returns | Saturates at |
|---|---|---|
| `unix_time_s()`  | seconds since 1970-01-01 UTC | never (year 292 B) |
| `unix_time_ms()` | milliseconds since epoch     | never (year 292 M) |
| `unix_time_ns()` | nanoseconds since epoch      | year 2262 (i64::MAX) |

### Design notes

- All three are **@io / impure** — added to IMPURE_BUILTINS in the
  typechecker alongside `clock_ms` and `random_int`. Pure functions
  marked `@pure` cannot call these.
- Use `std::time::SystemTime::now()` against `UNIX_EPOCH`. Clocks set
  before the epoch are clamped to 0 (saturating `duration_since`).
- Overflow saturates to `i64::MAX` (relevant only for ns past 2262).
- std-only — same `no_std` constraint as `clock_ms`.
- Module-isolated in `unix_time.rs` per CLAUDE.md.

### Tests

- 6 unit tests covering positive return, scale invariants
  (ms ≈ 1000 × s, ns ≈ 1M × ms), monotonic-or-equal across calls,
  argument rejection, and overflow clamp.
- 1 golden example verifying only invariants (since wall-clock output
  is non-deterministic).

### Local gates

All four clean: build, test, clippy, fmt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>