### PR TITLE
RES-1176: bytes_strip_prefix / bytes_strip_suffix / bytes_to_string

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,67 +1,12 @@
 {
   "claims": {
-    "resilient/src/feature_attrs.rs": {
-      "branch": "res-1132-feature-attrs-test-race",
-      "claimed_at": "2026-05-11T14:34:56Z"
-    },
     "resilient/src/lib.rs": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "branch": "res-1170-cumulative-ops",
-      "claimed_at": "2026-05-11T17:52:00Z"
+      "branch": "res-1176-bytes-conversions",
+      "claimed_at": "2026-05-11T18:22:00Z"
     },
     "resilient/src/typechecker.rs": {
-<<<<<<< HEAD
-      "branch": "res-1162-hash-builtins",
-      "claimed_at": "2026-05-11T17:12:00Z"
-=======
-<<<<<<< HEAD
-      "branch": "res-1160-array-argmin-argmax",
-      "claimed_at": "2026-05-11T17:02:00Z"
-    },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1160-array-argmin-argmax",
-      "claimed_at": "2026-05-11T17:02:00Z"
->>>>>>> fe1909d (RES-1160: array_argmax_float / argmin_float / argmax_string / argmin_string)
-=======
-<<<<<<< HEAD
-      "branch": "res-1166-rounding",
-      "claimed_at": "2026-05-11T17:32:00Z"
-    },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1166-rounding",
-      "claimed_at": "2026-05-11T17:32:00Z"
->>>>>>> b2b2d07 (RES-1166: round / trunc / round_to_int / trunc_to_int)
-=======
-      "branch": "res-1164-iter-helpers",
-      "claimed_at": "2026-05-11T17:22:00Z"
-    },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1164-iter-helpers",
-      "claimed_at": "2026-05-11T17:22:00Z"
->>>>>>> cfbc288 (RES-1164: enumerate / array_zip3 / string_truncate — 3 iteration helpers)
->>>>>>> 475108d (RES-1164: enumerate / array_zip3 / string_truncate — 3 iteration helpers)
->>>>>>> f037c48 (RES-1164: enumerate / array_zip3 / string_truncate — 3 iteration helpers)
-=======
-      "branch": "res-1170-cumulative-ops",
-      "claimed_at": "2026-05-11T17:52:00Z"
->>>>>>> 189bc81 (RES-1170: array_cumsum / array_cumprod / array_diffs / array_min_max)
-=======
-      "branch": "res-1172-string-array-misc",
-      "claimed_at": "2026-05-11T18:02:00Z"
-    },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1172-string-array-misc",
-      "claimed_at": "2026-05-11T18:02:00Z"
->>>>>>> f4d5d5e (RES-1172: string_split_once / rsplit_once / from_chars / array_is_empty)
-=======
-      "branch": "res-1174-unix-time",
-      "claimed_at": "2026-05-11T18:12:00Z"
-    },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1174-unix-time",
-      "claimed_at": "2026-05-11T18:12:00Z"
->>>>>>> 3cff255 (RES-1174: unix_time_s / unix_time_ms / unix_time_ns — wall clock builtins)
+      "branch": "res-1176-bytes-conversions",
+      "claimed_at": "2026-05-11T18:22:00Z"
     }
   }
 }

--- a/resilient/examples/bytes_conversions.expected.txt
+++ b/resilient/examples/bytes_conversions.expected.txt
@@ -1,0 +1,9 @@
+11
+19
+19
+5
+9
+Ok("hello")
+Ok("")
+Err("invalid UTF-8 at byte 0")
+Program executed successfully

--- a/resilient/examples/bytes_conversions.rz
+++ b/resilient/examples/bytes_conversions.rz
@@ -1,0 +1,25 @@
+// RES-1176 demo: bytes_strip_prefix / bytes_strip_suffix / bytes_to_string.
+// Three small Bytes <-> String conversion helpers.
+
+fn main(int _d) {
+    // --- bytes_strip_prefix: strip matching prefix; else unchanged.
+    let url = b"https://example.com";
+    let scheme = b"https://";
+    println(bytes_len(bytes_strip_prefix(url, scheme)));    // 11
+    println(bytes_len(bytes_strip_prefix(url, b"ftp://"))); // 19 (unchanged)
+    println(bytes_len(bytes_strip_prefix(url, b"")));        // 19 (empty = identity)
+
+    // --- bytes_strip_suffix: same, from the right.
+    let file = b"image.png";
+    println(bytes_len(bytes_strip_suffix(file, b".png")));   // 5
+    println(bytes_len(bytes_strip_suffix(file, b".jpg")));   // 9 (unchanged)
+
+    // --- bytes_to_string: UTF-8 decode, returns Result<String, String>.
+    println(bytes_to_string(b"hello"));               // Ok("hello")
+    println(bytes_to_string(b""));                    // Ok("")
+    println(bytes_to_string(b"\xFF\xFE"));            // Err("invalid UTF-8 at byte 0")
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/bytes_conversions.rs
+++ b/resilient/src/bytes_conversions.rs
@@ -1,0 +1,268 @@
+//! RES-1176: bytes_strip_prefix / bytes_strip_suffix / bytes_to_string.
+//!
+//! Three pure leaf builtins that close gaps in the Bytes ↔ String
+//! conversion surface:
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `bytes_strip_prefix(b, prefix)` | `(Bytes, Bytes) -> Bytes`         | Strip prefix if matches; else return b unchanged |
+//! | `bytes_strip_suffix(b, suffix)` | `(Bytes, Bytes) -> Bytes`         | Strip suffix if matches; else return b unchanged |
+//! | `bytes_to_string(b)`            | `(Bytes) -> Result<String, String>` | UTF-8 decode |
+
+use crate::{RResult, Value};
+
+/// `bytes_strip_prefix(b, prefix) -> Bytes` — return `b` with `prefix`
+/// removed from the front if it matches. Returns `b` unchanged
+/// otherwise (matches `string_strip_prefix` ergonomics — no Option
+/// wrap).
+pub(crate) fn builtin_bytes_strip_prefix(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b), Value::Bytes(prefix)] => {
+            let stripped = match b.strip_prefix(prefix.as_slice()) {
+                Some(rest) => rest.to_vec(),
+                None => b.clone(),
+            };
+            Ok(Value::Bytes(stripped))
+        }
+        [Value::Bytes(_), other] => Err(format!(
+            "bytes_strip_prefix: second argument must be Bytes, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "bytes_strip_prefix: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_strip_prefix: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_strip_suffix(b, suffix) -> Bytes` — return `b` with `suffix`
+/// removed from the end if it matches. Returns `b` unchanged otherwise.
+pub(crate) fn builtin_bytes_strip_suffix(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b), Value::Bytes(suffix)] => {
+            let stripped = match b.strip_suffix(suffix.as_slice()) {
+                Some(rest) => rest.to_vec(),
+                None => b.clone(),
+            };
+            Ok(Value::Bytes(stripped))
+        }
+        [Value::Bytes(_), other] => Err(format!(
+            "bytes_strip_suffix: second argument must be Bytes, got {}",
+            other
+        )),
+        [other, _] => Err(format!(
+            "bytes_strip_suffix: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_strip_suffix: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_to_string(b) -> Result<String, String>` — UTF-8 decode.
+/// `Ok(s)` if the bytes are valid UTF-8, `Err(msg)` otherwise.
+/// Mirrors `string_from_bytes` (RES-566) which takes `Array<Int>` —
+/// this is the direct `Bytes` overload.
+pub(crate) fn builtin_bytes_to_string(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b)] => match std::str::from_utf8(b) {
+            Ok(s) => Ok(Value::Result {
+                ok: true,
+                payload: Box::new(Value::String(s.to_string())),
+            }),
+            Err(e) => Ok(Value::Result {
+                ok: false,
+                payload: Box::new(Value::String(format!(
+                    "invalid UTF-8 at byte {}",
+                    e.valid_up_to()
+                ))),
+            }),
+        },
+        [other] => Err(format!("bytes_to_string: expected Bytes, got {}", other)),
+        _ => Err(format!(
+            "bytes_to_string: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bytes(xs: &[u8]) -> Value {
+        Value::Bytes(xs.to_vec())
+    }
+
+    fn as_bytes(v: Value) -> Vec<u8> {
+        match v {
+            Value::Bytes(b) => b,
+            other => panic!("expected Bytes, got {:?}", other),
+        }
+    }
+
+    fn as_result(v: Value) -> (bool, Value) {
+        match v {
+            Value::Result { ok, payload } => (ok, *payload),
+            other => panic!("expected Result, got {:?}", other),
+        }
+    }
+
+    fn as_string(v: Value) -> String {
+        match v {
+            Value::String(s) => s,
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    // --- strip_prefix ---
+
+    #[test]
+    fn strip_prefix_match_returns_suffix() {
+        let r = builtin_bytes_strip_prefix(&[bytes(&[1, 2, 3, 4, 5]), bytes(&[1, 2])]).unwrap();
+        assert_eq!(as_bytes(r), vec![3, 4, 5]);
+    }
+
+    #[test]
+    fn strip_prefix_no_match_returns_unchanged() {
+        let r = builtin_bytes_strip_prefix(&[bytes(&[1, 2, 3]), bytes(&[9, 9])]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn strip_prefix_empty_prefix_is_identity() {
+        let r = builtin_bytes_strip_prefix(&[bytes(&[1, 2, 3]), bytes(&[])]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn strip_prefix_full_match_returns_empty() {
+        let r = builtin_bytes_strip_prefix(&[bytes(&[1, 2, 3]), bytes(&[1, 2, 3])]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn strip_prefix_longer_than_input_no_match() {
+        let r = builtin_bytes_strip_prefix(&[bytes(&[1]), bytes(&[1, 2, 3])]).unwrap();
+        assert_eq!(as_bytes(r), vec![1]);
+    }
+
+    #[test]
+    fn strip_prefix_rejects_wrong_type() {
+        let err = builtin_bytes_strip_prefix(&[bytes(&[1]), Value::Int(2)]).unwrap_err();
+        assert!(err.contains("second argument"));
+        let err = builtin_bytes_strip_prefix(&[Value::Int(1), bytes(&[1])]).unwrap_err();
+        assert!(err.contains("first argument"));
+    }
+
+    // --- strip_suffix ---
+
+    #[test]
+    fn strip_suffix_match_returns_prefix() {
+        let r = builtin_bytes_strip_suffix(&[bytes(&[1, 2, 3, 4, 5]), bytes(&[4, 5])]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn strip_suffix_no_match_returns_unchanged() {
+        let r = builtin_bytes_strip_suffix(&[bytes(&[1, 2, 3]), bytes(&[9, 9])]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn strip_suffix_empty_suffix_is_identity() {
+        let r = builtin_bytes_strip_suffix(&[bytes(&[1, 2, 3]), bytes(&[])]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn strip_suffix_full_match_returns_empty() {
+        let r = builtin_bytes_strip_suffix(&[bytes(&[1, 2, 3]), bytes(&[1, 2, 3])]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    // --- bytes_to_string ---
+
+    #[test]
+    fn to_string_ascii_round_trip() {
+        let r = builtin_bytes_to_string(&[bytes(b"hello")]).unwrap();
+        let (ok, payload) = as_result(r);
+        assert!(ok);
+        assert_eq!(as_string(payload), "hello");
+    }
+
+    #[test]
+    fn to_string_empty_is_ok_empty() {
+        let r = builtin_bytes_to_string(&[bytes(&[])]).unwrap();
+        let (ok, payload) = as_result(r);
+        assert!(ok);
+        assert_eq!(as_string(payload), "");
+    }
+
+    #[test]
+    fn to_string_valid_utf8_multibyte() {
+        // "🌟" is 4 bytes in UTF-8: F0 9F 8C 9F
+        let r = builtin_bytes_to_string(&[bytes(&[0xF0, 0x9F, 0x8C, 0x9F])]).unwrap();
+        let (ok, payload) = as_result(r);
+        assert!(ok);
+        assert_eq!(as_string(payload), "🌟");
+    }
+
+    #[test]
+    fn to_string_invalid_utf8_is_err() {
+        // 0xFF is never a valid start byte in UTF-8.
+        let r = builtin_bytes_to_string(&[bytes(&[0xFF, 0xFE, 0xFD])]).unwrap();
+        let (ok, payload) = as_result(r);
+        assert!(!ok);
+        let msg = as_string(payload);
+        assert!(msg.contains("invalid UTF-8"));
+    }
+
+    #[test]
+    fn to_string_invalid_utf8_in_middle_reports_position() {
+        // "ab" + 0xFF + "cd" — UTF-8 valid up to byte 2.
+        let r = builtin_bytes_to_string(&[bytes(&[b'a', b'b', 0xFF, b'c', b'd'])]).unwrap();
+        let (ok, payload) = as_result(r);
+        assert!(!ok);
+        let msg = as_string(payload);
+        assert!(msg.contains("byte 2"), "got {}", msg);
+    }
+
+    #[test]
+    fn to_string_rejects_non_bytes() {
+        let err = builtin_bytes_to_string(&[Value::String("hello".to_string())]).unwrap_err();
+        assert!(err.contains("expected Bytes"));
+    }
+
+    // --- general ---
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        let err = builtin_bytes_strip_prefix(&[]).unwrap_err();
+        assert!(err.contains("expected 2"));
+        let err = builtin_bytes_strip_suffix(&[]).unwrap_err();
+        assert!(err.contains("expected 2"));
+        let err = builtin_bytes_to_string(&[]).unwrap_err();
+        assert!(err.contains("expected 1"));
+    }
+
+    #[test]
+    fn strip_round_trips_with_concat() {
+        // For any (prefix, suffix, middle): strip_prefix(concat(prefix, middle), prefix) == middle
+        let prefix = vec![0xDE, 0xADu8];
+        let middle = vec![0x01, 0x02, 0x03u8];
+        let combined: Vec<u8> = prefix
+            .iter()
+            .copied()
+            .chain(middle.iter().copied())
+            .collect();
+        let r = builtin_bytes_strip_prefix(&[bytes(&combined), bytes(&prefix)]).unwrap();
+        assert_eq!(as_bytes(r), middle);
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -50,6 +50,9 @@ mod bytes_bitwise;
 // RES-1152: per-byte helpers — repeat / count_byte / replace_byte.
 // Pure leaf builtins; module-isolated.
 mod bytes_helpers;
+// RES-1176: bytes ↔ string conversions — strip_prefix / strip_suffix /
+// bytes_to_string. Pure leaf builtins; module-isolated.
+mod bytes_conversions;
 // RES-1162: deterministic hash builtins — hash_int / hash_string /
 // hash_bytes / hash_combine. Pure leaf builtins; module-isolated.
 mod compiler;
@@ -11373,6 +11376,22 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("unix_time_s", crate::unix_time::builtin_unix_time_s),
     ("unix_time_ms", crate::unix_time::builtin_unix_time_ms),
     ("unix_time_ns", crate::unix_time::builtin_unix_time_ns),
+    // RES-1176: bytes ↔ string conversions — strip_prefix / strip_suffix /
+    // bytes_to_string. Pure leaf builtins; module-isolated in
+    // `bytes_conversions.rs`. Appended at the end of BUILTINS per the
+    // perf rule from PR #1125.
+    (
+        "bytes_strip_prefix",
+        crate::bytes_conversions::builtin_bytes_strip_prefix,
+    ),
+    (
+        "bytes_strip_suffix",
+        crate::bytes_conversions::builtin_bytes_strip_suffix,
+    ),
+    (
+        "bytes_to_string",
+        crate::bytes_conversions::builtin_bytes_to_string,
+    ),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1566,6 +1566,26 @@ impl TypeChecker {
         env.set("unix_time_s".to_string(), fn_zero_to_int());
         env.set("unix_time_ms".to_string(), fn_zero_to_int());
         env.set("unix_time_ns".to_string(), fn_zero_to_int());
+        // RES-1176: bytes ↔ string conversions.
+        let fn_bytes_bytes_to_bytes_strip = || Type::Function {
+            params: vec![Type::Bytes, Type::Bytes],
+            return_type: Box::new(Type::Bytes),
+        };
+        env.set(
+            "bytes_strip_prefix".to_string(),
+            fn_bytes_bytes_to_bytes_strip(),
+        );
+        env.set(
+            "bytes_strip_suffix".to_string(),
+            fn_bytes_bytes_to_bytes_strip(),
+        );
+        env.set(
+            "bytes_to_string".to_string(),
+            Type::Function {
+                params: vec![Type::Bytes],
+                return_type: Box::new(Type::Any),
+            },
+        );
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6492,6 +6512,10 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "string_rsplit_once",
         "string_from_chars",
         "array_is_empty",
+        // RES-1176: bytes ↔ string conversions.
+        "bytes_strip_prefix",
+        "bytes_strip_suffix",
+        "bytes_to_string",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1176

## Summary

Three pure leaf builtins that close gaps in the `Bytes` ↔ `String` conversion surface.

| Builtin | Signature | Behavior |
|---|---|---|
| `bytes_strip_prefix(b, prefix)` | `(Bytes, Bytes) -> Bytes` | Strip prefix if matches; else return `b` unchanged. |
| `bytes_strip_suffix(b, suffix)` | `(Bytes, Bytes) -> Bytes` | Strip suffix if matches; else return `b` unchanged. |
| `bytes_to_string(b)` | `(Bytes) -> Result<String, String>` | UTF-8 decode. Err payload reports the byte position of the first invalid sequence. |

## Design notes

- `strip_prefix` / `strip_suffix` mirror `string_strip_prefix` (RES-1031) ergonomics — no `Option` wrap, return the original on no-match. Empty prefix/suffix is the identity. This matches Rust's `[T]::strip_prefix` semantics in spirit.
- `bytes_to_string` is the direct `Bytes` overload of `string_from_bytes` (RES-566), which takes `Array<Int>`. The Err message includes the first invalid byte position via `Utf8Error::valid_up_to`.

## Layout

Standard feature-isolation pattern:

- `resilient/src/bytes_conversions.rs` — new module, ~280 lines including 18 unit tests
- `resilient/src/lib.rs` — `mod bytes_conversions;` + 3 entries appended at the tail of `BUILTINS` (perf rule from PR #1125 — append-only)
- `resilient/src/typechecker.rs` — 3 env-seed signatures + 3 names appended to `PURE_BUILTINS`
- `resilient/examples/bytes_conversions.rz` + `.expected.txt` — end-to-end demo

## Test coverage

- 18 unit tests in `bytes_conversions::tests`: match/no-match/empty/full-match/longer-than-input for both strip ops, ASCII/empty/multibyte-emoji/invalid-UTF-8/mid-string-invalid for `bytes_to_string`, type & arity diagnostics, and a round-trip property test (`concat + strip == identity`).
- Golden example covers the happy path end-to-end via the interpreter.

## Local CI

- `cargo build --locked` ✓
- `cargo test --locked` ✓ (full suite green)
- `cargo clippy --locked --all-targets -- -D warnings` ✓
- `cargo fmt --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)