### PR TITLE
RES-1178: bytes_take / bytes_drop / bytes_take_last / bytes_drop_last — 4 bytes slicing primitives

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-1176-bytes-conversions",
-      "claimed_at": "2026-05-11T18:22:00Z"
+      "branch": "res-1178-bytes-slicing",
+      "claimed_at": "2026-05-11T19:14:39Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1176-bytes-conversions",
-      "claimed_at": "2026-05-11T18:22:00Z"
+      "branch": "res-1178-bytes-slicing",
+      "claimed_at": "2026-05-11T19:14:39Z"
     }
   }
 }

--- a/resilient/examples/bytes_slicing.expected.txt
+++ b/resilient/examples/bytes_slicing.expected.txt
@@ -1,0 +1,14 @@
+5
+0
+13
+6
+13
+0
+6
+0
+13
+6
+13
+0
+true
+Program executed successfully

--- a/resilient/examples/bytes_slicing.rz
+++ b/resilient/examples/bytes_slicing.rz
@@ -1,0 +1,36 @@
+// RES-1178 demo: bytes_take / bytes_drop / bytes_take_last / bytes_drop_last.
+// Four bytes slicing primitives, parallel to RES-421/RES-537 for arrays.
+
+fn main(int _d) {
+    let payload = b"Hello, World!";
+
+    // --- bytes_take: first n bytes ("Hello" -> 5 bytes).
+    println(bytes_len(bytes_take(payload, 5)));   // 5
+    println(bytes_len(bytes_take(payload, 0)));   // 0
+    println(bytes_len(bytes_take(payload, 99)));  // 13 (clamps to len)
+
+    // --- bytes_drop: drop first n bytes (skip past "Hello, " — 7 bytes).
+    println(bytes_len(bytes_drop(payload, 7)));   // 6
+    println(bytes_len(bytes_drop(payload, 0)));   // 13
+    println(bytes_len(bytes_drop(payload, 99)));  // 0 (clamps)
+
+    // --- bytes_take_last: last n bytes.
+    println(bytes_len(bytes_take_last(payload, 6)));  // 6 ("World!")
+    println(bytes_len(bytes_take_last(payload, 0)));  // 0
+    println(bytes_len(bytes_take_last(payload, 99))); // 13
+
+    // --- bytes_drop_last: drop last n bytes.
+    println(bytes_len(bytes_drop_last(payload, 7)));  // 6 ("Hello,")
+    println(bytes_len(bytes_drop_last(payload, 0)));  // 13
+    println(bytes_len(bytes_drop_last(payload, 99))); // 0
+
+    // --- composite: take + drop is a complete bisect.
+    // bytes_take(b, 5) ++ bytes_drop(b, 5) == b
+    let head = bytes_take(payload, 5);
+    let tail = bytes_drop(payload, 5);
+    println(bytes_eq(bytes_concat(head, tail), payload));  // true
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/bytes_slicing.rs
+++ b/resilient/src/bytes_slicing.rs
@@ -1,0 +1,375 @@
+//! RES-1178: `bytes_take` / `bytes_drop` / `bytes_take_last` / `bytes_drop_last`.
+//!
+//! Four pure leaf builtins that fill the slicing surface for `Value::Bytes`,
+//! parallel to RES-421 (`array_take` / `array_drop`) and RES-537
+//! (`array_take_last` / `array_drop_last`) for arrays.
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `bytes_take(b, n)`      | `(Bytes, Int) -> Bytes` | First `n` bytes |
+//! | `bytes_drop(b, n)`      | `(Bytes, Int) -> Bytes` | `b` minus the first `n` |
+//! | `bytes_take_last(b, n)` | `(Bytes, Int) -> Bytes` | Last `n` bytes |
+//! | `bytes_drop_last(b, n)` | `(Bytes, Int) -> Bytes` | `b` minus the last `n` |
+//!
+//! Semantics:
+//! - All four require `n >= 0`. Negative `n` is a typed error.
+//! - `n > len(b)` clamps to `len(b)` — no error, matches the array
+//!   counterparts.
+//! - `n == 0` returns the appropriate identity.
+//! - All four produce a fresh `Bytes` — the input is never mutated.
+
+use crate::{RResult, Value};
+
+/// `bytes_take(b, n) -> Bytes` — first `n` bytes of `b`.
+/// `n` must be non-negative; `n > len(b)` clamps to `len(b)`.
+pub(crate) fn builtin_bytes_take(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!("bytes_take: count must be non-negative, got {}", n));
+            }
+            let take = (*n as usize).min(b.len());
+            Ok(Value::Bytes(b[..take].to_vec()))
+        }
+        [Value::Bytes(_), other] => Err(format!("bytes_take: count must be Int, got {}", other)),
+        [other, _] => Err(format!(
+            "bytes_take: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_take: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_drop(b, n) -> Bytes` — `b` with the first `n` bytes removed.
+/// `n` must be non-negative; `n >= len(b)` returns empty Bytes.
+pub(crate) fn builtin_bytes_drop(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!("bytes_drop: count must be non-negative, got {}", n));
+            }
+            let drop = (*n as usize).min(b.len());
+            Ok(Value::Bytes(b[drop..].to_vec()))
+        }
+        [Value::Bytes(_), other] => Err(format!("bytes_drop: count must be Int, got {}", other)),
+        [other, _] => Err(format!(
+            "bytes_drop: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_drop: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_take_last(b, n) -> Bytes` — last `n` bytes of `b`.
+/// `n` must be non-negative; `n > len(b)` clamps to `len(b)`.
+pub(crate) fn builtin_bytes_take_last(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "bytes_take_last: count must be non-negative, got {}",
+                    n
+                ));
+            }
+            let take = (*n as usize).min(b.len());
+            let start = b.len() - take;
+            Ok(Value::Bytes(b[start..].to_vec()))
+        }
+        [Value::Bytes(_), other] => {
+            Err(format!("bytes_take_last: count must be Int, got {}", other))
+        }
+        [other, _] => Err(format!(
+            "bytes_take_last: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_take_last: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `bytes_drop_last(b, n) -> Bytes` — `b` with the last `n` bytes removed.
+/// `n` must be non-negative; `n >= len(b)` returns empty Bytes.
+/// Round-trip: `bytes_concat(bytes_drop_last(b, n), bytes_take_last(b, n)) == b`.
+pub(crate) fn builtin_bytes_drop_last(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Bytes(b), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "bytes_drop_last: count must be non-negative, got {}",
+                    n
+                ));
+            }
+            let drop = (*n as usize).min(b.len());
+            let end = b.len() - drop;
+            Ok(Value::Bytes(b[..end].to_vec()))
+        }
+        [Value::Bytes(_), other] => {
+            Err(format!("bytes_drop_last: count must be Int, got {}", other))
+        }
+        [other, _] => Err(format!(
+            "bytes_drop_last: first argument must be Bytes, got {}",
+            other
+        )),
+        _ => Err(format!(
+            "bytes_drop_last: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bytes(xs: &[u8]) -> Value {
+        Value::Bytes(xs.to_vec())
+    }
+
+    fn as_bytes(v: Value) -> Vec<u8> {
+        match v {
+            Value::Bytes(b) => b,
+            other => panic!("expected Bytes, got {:?}", other),
+        }
+    }
+
+    // --- bytes_take ---
+
+    #[test]
+    fn take_basic() {
+        let r = builtin_bytes_take(&[bytes(&[1, 2, 3, 4, 5]), Value::Int(3)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn take_zero_returns_empty() {
+        let r = builtin_bytes_take(&[bytes(&[1, 2, 3]), Value::Int(0)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn take_more_than_len_clamps() {
+        let r = builtin_bytes_take(&[bytes(&[1, 2, 3]), Value::Int(99)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn take_exact_len_returns_full() {
+        let r = builtin_bytes_take(&[bytes(&[1, 2, 3]), Value::Int(3)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn take_from_empty_is_empty() {
+        let r = builtin_bytes_take(&[bytes(&[]), Value::Int(5)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn take_rejects_negative() {
+        let err = builtin_bytes_take(&[bytes(&[1, 2]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"));
+    }
+
+    #[test]
+    fn take_rejects_wrong_types() {
+        let err = builtin_bytes_take(&[bytes(&[1]), Value::Bool(true)]).unwrap_err();
+        assert!(err.contains("count must be Int"));
+        let err = builtin_bytes_take(&[Value::Int(5), Value::Int(2)]).unwrap_err();
+        assert!(err.contains("first argument must be Bytes"));
+    }
+
+    // --- bytes_drop ---
+
+    #[test]
+    fn drop_basic() {
+        let r = builtin_bytes_drop(&[bytes(&[1, 2, 3, 4, 5]), Value::Int(2)]).unwrap();
+        assert_eq!(as_bytes(r), vec![3, 4, 5]);
+    }
+
+    #[test]
+    fn drop_zero_returns_full() {
+        let r = builtin_bytes_drop(&[bytes(&[1, 2, 3]), Value::Int(0)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn drop_more_than_len_returns_empty() {
+        let r = builtin_bytes_drop(&[bytes(&[1, 2, 3]), Value::Int(99)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn drop_exact_len_returns_empty() {
+        let r = builtin_bytes_drop(&[bytes(&[1, 2, 3]), Value::Int(3)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn drop_from_empty_is_empty() {
+        let r = builtin_bytes_drop(&[bytes(&[]), Value::Int(5)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn drop_rejects_negative() {
+        let err = builtin_bytes_drop(&[bytes(&[1, 2]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"));
+    }
+
+    // --- bytes_take_last ---
+
+    #[test]
+    fn take_last_basic() {
+        let r = builtin_bytes_take_last(&[bytes(&[1, 2, 3, 4, 5]), Value::Int(2)]).unwrap();
+        assert_eq!(as_bytes(r), vec![4, 5]);
+    }
+
+    #[test]
+    fn take_last_zero_returns_empty() {
+        let r = builtin_bytes_take_last(&[bytes(&[1, 2, 3]), Value::Int(0)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn take_last_more_than_len_returns_full() {
+        let r = builtin_bytes_take_last(&[bytes(&[1, 2, 3]), Value::Int(99)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn take_last_exact_len_returns_full() {
+        let r = builtin_bytes_take_last(&[bytes(&[1, 2, 3]), Value::Int(3)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn take_last_from_empty_is_empty() {
+        let r = builtin_bytes_take_last(&[bytes(&[]), Value::Int(5)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn take_last_rejects_negative() {
+        let err = builtin_bytes_take_last(&[bytes(&[1]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"));
+    }
+
+    // --- bytes_drop_last ---
+
+    #[test]
+    fn drop_last_basic() {
+        let r = builtin_bytes_drop_last(&[bytes(&[1, 2, 3, 4, 5]), Value::Int(2)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn drop_last_zero_returns_full() {
+        let r = builtin_bytes_drop_last(&[bytes(&[1, 2, 3]), Value::Int(0)]).unwrap();
+        assert_eq!(as_bytes(r), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn drop_last_more_than_len_returns_empty() {
+        let r = builtin_bytes_drop_last(&[bytes(&[1, 2, 3]), Value::Int(99)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn drop_last_exact_len_returns_empty() {
+        let r = builtin_bytes_drop_last(&[bytes(&[1, 2, 3]), Value::Int(3)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn drop_last_from_empty_is_empty() {
+        let r = builtin_bytes_drop_last(&[bytes(&[]), Value::Int(5)]).unwrap();
+        assert_eq!(as_bytes(r), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn drop_last_rejects_negative() {
+        let err = builtin_bytes_drop_last(&[bytes(&[1]), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"));
+    }
+
+    // --- arity / type diagnostics ---
+
+    #[test]
+    fn arity_diagnostics_consistent() {
+        for &(label, f) in &[
+            ("take", builtin_bytes_take as fn(&[Value]) -> RResult<Value>),
+            ("drop", builtin_bytes_drop),
+            ("take_last", builtin_bytes_take_last),
+            ("drop_last", builtin_bytes_drop_last),
+        ] {
+            let err = f(&[]).unwrap_err();
+            assert!(err.contains("expected 2"), "{}: {}", label, err);
+        }
+    }
+
+    // --- composite properties ---
+
+    #[test]
+    fn take_drop_round_trip() {
+        // bytes_take(b, n) ++ bytes_drop(b, n) == b, for any 0 <= n <= len(b).
+        let b = vec![10u8, 20, 30, 40, 50];
+        for n in 0..=b.len() {
+            let head = as_bytes(builtin_bytes_take(&[bytes(&b), Value::Int(n as i64)]).unwrap());
+            let tail = as_bytes(builtin_bytes_drop(&[bytes(&b), Value::Int(n as i64)]).unwrap());
+            let mut joined = head;
+            joined.extend(tail);
+            assert_eq!(joined, b, "round-trip failed at n={}", n);
+        }
+    }
+
+    #[test]
+    fn take_last_drop_last_round_trip() {
+        // bytes_drop_last(b, n) ++ bytes_take_last(b, n) == b.
+        let b = vec![1u8, 2, 3, 4, 5, 6];
+        for n in 0..=b.len() {
+            let head =
+                as_bytes(builtin_bytes_drop_last(&[bytes(&b), Value::Int(n as i64)]).unwrap());
+            let tail =
+                as_bytes(builtin_bytes_take_last(&[bytes(&b), Value::Int(n as i64)]).unwrap());
+            let mut joined = head;
+            joined.extend(tail);
+            assert_eq!(joined, b, "round-trip failed at n={}", n);
+        }
+    }
+
+    #[test]
+    fn take_then_drop_equals_input() {
+        // bytes_drop(b, len(b)) == empty; bytes_take(b, len(b)) == b.
+        let b = vec![7u8, 8, 9];
+        let len = b.len() as i64;
+        assert_eq!(
+            as_bytes(builtin_bytes_take(&[bytes(&b), Value::Int(len)]).unwrap()),
+            b
+        );
+        assert_eq!(
+            as_bytes(builtin_bytes_drop(&[bytes(&b), Value::Int(len)]).unwrap()),
+            Vec::<u8>::new()
+        );
+    }
+
+    #[test]
+    fn does_not_mutate_input() {
+        let original = bytes(&[1, 2, 3, 4, 5]);
+        let _ = builtin_bytes_take(&[original.clone(), Value::Int(2)]).unwrap();
+        let _ = builtin_bytes_drop(&[original.clone(), Value::Int(2)]).unwrap();
+        let _ = builtin_bytes_take_last(&[original.clone(), Value::Int(2)]).unwrap();
+        let _ = builtin_bytes_drop_last(&[original.clone(), Value::Int(2)]).unwrap();
+        match original {
+            Value::Bytes(b) => assert_eq!(b, vec![1, 2, 3, 4, 5]),
+            _ => panic!("expected Bytes"),
+        }
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -53,6 +53,9 @@ mod bytes_helpers;
 // RES-1176: bytes ↔ string conversions — strip_prefix / strip_suffix /
 // bytes_to_string. Pure leaf builtins; module-isolated.
 mod bytes_conversions;
+// RES-1178: bytes slicing primitives — take / drop / take_last / drop_last.
+// Pure leaf builtins; module-isolated.
+mod bytes_slicing;
 // RES-1162: deterministic hash builtins — hash_int / hash_string /
 // hash_bytes / hash_combine. Pure leaf builtins; module-isolated.
 mod compiler;
@@ -11391,6 +11394,19 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     (
         "bytes_to_string",
         crate::bytes_conversions::builtin_bytes_to_string,
+    ),
+    // RES-1178: bytes slicing primitives — take / drop / take_last /
+    // drop_last. Pure leaf builtins; module-isolated in `bytes_slicing.rs`.
+    // Appended at the end of BUILTINS per the perf rule from PR #1125.
+    ("bytes_take", crate::bytes_slicing::builtin_bytes_take),
+    ("bytes_drop", crate::bytes_slicing::builtin_bytes_drop),
+    (
+        "bytes_take_last",
+        crate::bytes_slicing::builtin_bytes_take_last,
+    ),
+    (
+        "bytes_drop_last",
+        crate::bytes_slicing::builtin_bytes_drop_last,
     ),
 ];
 

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1586,6 +1586,15 @@ impl TypeChecker {
                 return_type: Box::new(Type::Any),
             },
         );
+        // RES-1178: bytes slicing primitives — (Bytes, Int) -> Bytes.
+        let fn_bytes_int_to_bytes = || Type::Function {
+            params: vec![Type::Bytes, Type::Int],
+            return_type: Box::new(Type::Bytes),
+        };
+        env.set("bytes_take".to_string(), fn_bytes_int_to_bytes());
+        env.set("bytes_drop".to_string(), fn_bytes_int_to_bytes());
+        env.set("bytes_take_last".to_string(), fn_bytes_int_to_bytes());
+        env.set("bytes_drop_last".to_string(), fn_bytes_int_to_bytes());
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6516,6 +6525,11 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "bytes_strip_prefix",
         "bytes_strip_suffix",
         "bytes_to_string",
+        // RES-1178: bytes slicing primitives.
+        "bytes_take",
+        "bytes_drop",
+        "bytes_take_last",
+        "bytes_drop_last",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1178.

Fills the bytes slicing surface — parallel to RES-421 (`array_take` /
`array_drop`) and RES-537 (`array_take_last` / `array_drop_last`).

### Surface added

| Builtin | Signature | Purpose |
|---|---|---|
| `bytes_take(b, n)`      | `(Bytes, Int) -> Bytes` | First `n` bytes |
| `bytes_drop(b, n)`      | `(Bytes, Int) -> Bytes` | `b` minus the first `n` |
| `bytes_take_last(b, n)` | `(Bytes, Int) -> Bytes` | Last `n` bytes |
| `bytes_drop_last(b, n)` | `(Bytes, Int) -> Bytes` | `b` minus the last `n` |

### Semantics

- All four require `n >= 0`. Negative `n` is a typed error.
- `n > len(b)` clamps to `len(b)` — no error, matches the array counterparts.
- Round-trip property tested:
  - `bytes_take(b, n) ++ bytes_drop(b, n) == b`
  - `bytes_drop_last(b, n) ++ bytes_take_last(b, n) == b`
- All four produce a fresh `Bytes` — the input is never mutated.

### Why now

- Closes the obvious symmetry gap: `bytes_strip_prefix` / `bytes_strip_suffix` (RES-1176) just shipped, but the more general "take first N / drop first N" slicing surface was missing.
- Every TLS-record-prefix decode, protocol-framing header strip, or fixed-width binary tail extract reaches for these four primitives.
- Adjacent to RES-1152 (`bytes_repeat` / `bytes_count_byte` / `bytes_replace_byte`) and RES-1176 — same module-isolation pattern.

### Design notes

- Module-isolated in `bytes_slicing.rs` per CLAUDE.md.
- Appended at the tail of `BUILTINS` per the perf rule established in PR #1125.
- Added to `PURE_BUILTINS` in the `RES-117x` cluster alongside the sibling additions.

### Tests

- 30 unit tests in `bytes_slicing.rs`, including round-trip properties.
- Golden example at `resilient/examples/bytes_slicing.rz` + `.expected.txt`.

### Local gates

All four clean: `cargo build --locked`, `cargo test --locked`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo fmt --check`.

Co-Authored-By: Claude Opus 4.7 (1M context)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKgooz9Lvq44ySMCQV3wDs)_