### PR TITLE
RES-1182: rotate_left / rotate_right / signum — integer bit ops + sign

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-1168-precision-math",
-      "claimed_at": "2026-05-11T17:42:00Z"
+      "branch": "res-1182-rotate-signum",
+      "claimed_at": "2026-05-11T19:50:00Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1168-precision-math",
-      "claimed_at": "2026-05-11T17:42:00Z"
+      "branch": "res-1182-rotate-signum",
+      "claimed_at": "2026-05-11T19:50:00Z"
     }
   }
 }

--- a/resilient/examples/int_rotate.expected.txt
+++ b/resilient/examples/int_rotate.expected.txt
@@ -1,0 +1,10 @@
+2
+16
+1
+1
+1
+1
+1
+0
+-1
+Program executed successfully

--- a/resilient/examples/int_rotate.rz
+++ b/resilient/examples/int_rotate.rz
@@ -1,0 +1,23 @@
+// RES-1182 demo: rotate_left / rotate_right / signum.
+// Integer bit rotation + scalar sign.
+
+fn main(int _d) {
+    // --- rotate_left: bits shifted out the top wrap to the bottom.
+    println(rotate_left(1, 1));   // 2
+    println(rotate_left(1, 4));   // 16
+    println(rotate_left(1, 0));   // 1  (identity)
+    println(rotate_left(1, 64));  // 1  (full cycle)
+
+    // --- rotate_right: inverse of rotate_left.
+    println(rotate_right(16, 4)); // 1
+    println(rotate_right(2, 1));  // 1
+
+    // --- signum: -1 / 0 / +1.
+    println(signum(42));  // 1
+    println(signum(0));   // 0
+    println(signum(-7));  // -1
+
+    return 0;
+}
+
+main(0);

--- a/resilient/src/int_rotate.rs
+++ b/resilient/src/int_rotate.rs
@@ -1,0 +1,251 @@
+//! RES-1182: integer bit rotation + scalar signum.
+//!
+//! Three pure leaf builtins that round out the integer bit-ops family
+//! from RES-907 (`count_ones`, `count_zeros`, `leading_zeros`,
+//! `trailing_zeros`, `swap_bytes`) and the sign family from RES-555
+//! (`array_signum_int`):
+//!
+//! | Builtin | Signature | Purpose |
+//! |---|---|---|
+//! | `rotate_left(x, n)`  | `(Int, Int) -> Int` | Bitwise rotate-left over the 64-bit pattern, wrapping bits from the high end to the low end |
+//! | `rotate_right(x, n)` | `(Int, Int) -> Int` | Bitwise rotate-right, wrapping bits from the low end to the high end |
+//! | `signum(x)`          | `(Int) -> Int` | Returns `-1`, `0`, or `+1` for negative / zero / positive `x` |
+//!
+//! The rotation builtins delegate to `i64::rotate_left` /
+//! `i64::rotate_right` which take `n: u32` and apply `n %
+//! BITS` internally — so `rotate_left(x, 64) == x` and any
+//! non-negative rotation amount is well-defined. A negative `n` is a
+//! typed error: there is no sensible "rotate by minus k" semantics
+//! that doesn't surprise the caller.
+
+use crate::{RResult, Value};
+
+/// `rotate_left(x, n) -> Int` — circular left-shift of `x` by `n` bit
+/// positions over its 64-bit two's-complement representation. Bits
+/// shifted out of the top wrap around to the bottom; `n` is taken
+/// modulo 64 internally, so `rotate_left(x, 64) == x` and
+/// `rotate_left(x, 65) == rotate_left(x, 1)`.
+///
+/// Errors if `n` is negative — there is no `rotate_left(x, -1)`
+/// convention that is not a footgun (some libraries silently make it a
+/// rotate-right; that is the kind of "looks fine, off-by-one in
+/// production" bug we refuse to ship).
+pub(crate) fn builtin_rotate_left(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(x), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "rotate_left: rotation count must be non-negative, got {}",
+                    n
+                ));
+            }
+            // `as u32` after the non-negative check truncates n modulo
+            // 2^32. Rust's `rotate_left` then applies (n_u32 % 64), so
+            // any non-negative input is well-defined.
+            Ok(Value::Int(x.rotate_left(*n as u32)))
+        }
+        [a, b] => Err(format!(
+            "rotate_left: expected (int, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "rotate_left: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `rotate_right(x, n) -> Int` — circular right-shift of `x` by `n`
+/// bit positions over its 64-bit representation. Bits shifted out of
+/// the bottom wrap around to the top; `n` is taken modulo 64
+/// internally.
+///
+/// Errors if `n` is negative for the same reason as `rotate_left`.
+pub(crate) fn builtin_rotate_right(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(x), Value::Int(n)] => {
+            if *n < 0 {
+                return Err(format!(
+                    "rotate_right: rotation count must be non-negative, got {}",
+                    n
+                ));
+            }
+            Ok(Value::Int(x.rotate_right(*n as u32)))
+        }
+        [a, b] => Err(format!(
+            "rotate_right: expected (int, int), got ({}, {})",
+            a, b
+        )),
+        _ => Err(format!(
+            "rotate_right: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `signum(x) -> Int` — returns `-1` if `x < 0`, `0` if `x == 0`,
+/// `+1` if `x > 0`. Scalar counterpart of `array_signum_int`
+/// (RES-555).
+pub(crate) fn builtin_signum(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Int(x)] => Ok(Value::Int(x.signum())),
+        [other] => Err(format!("signum: expected int, got {}", other)),
+        _ => Err(format!("signum: expected 1 argument, got {}", args.len())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok_int(v: Value) -> i64 {
+        match v {
+            Value::Int(i) => i,
+            other => panic!("expected Int, got {:?}", other),
+        }
+    }
+
+    // ---------- rotate_left ----------
+
+    #[test]
+    fn rotate_left_identity_zero() {
+        assert_eq!(
+            ok_int(builtin_rotate_left(&[Value::Int(0x1234_5678), Value::Int(0)]).unwrap()),
+            0x1234_5678
+        );
+    }
+
+    #[test]
+    fn rotate_left_full_cycle_is_identity() {
+        assert_eq!(
+            ok_int(builtin_rotate_left(&[Value::Int(0x1234_5678), Value::Int(64)]).unwrap()),
+            0x1234_5678
+        );
+    }
+
+    #[test]
+    fn rotate_left_modulo_64() {
+        // 65 == 1 mod 64
+        let r1 = ok_int(builtin_rotate_left(&[Value::Int(0x1234_5678), Value::Int(1)]).unwrap());
+        let r65 = ok_int(builtin_rotate_left(&[Value::Int(0x1234_5678), Value::Int(65)]).unwrap());
+        assert_eq!(r1, r65);
+    }
+
+    #[test]
+    fn rotate_left_low_bit_wraps_to_top() {
+        // 1 rotated left by 1 = 2 (bit moves up one)
+        assert_eq!(
+            ok_int(builtin_rotate_left(&[Value::Int(1), Value::Int(1)]).unwrap()),
+            2
+        );
+        // The top bit set then rotated left by 1 wraps to bit 0.
+        // i64::MIN is 1 << 63 in two's complement.
+        assert_eq!(
+            ok_int(builtin_rotate_left(&[Value::Int(i64::MIN), Value::Int(1)]).unwrap()),
+            1
+        );
+    }
+
+    #[test]
+    fn rotate_left_negative_count_errors() {
+        let err = builtin_rotate_left(&[Value::Int(1), Value::Int(-1)]).unwrap_err();
+        assert!(err.contains("non-negative"), "got: {}", err);
+    }
+
+    #[test]
+    fn rotate_left_type_errors() {
+        let err = builtin_rotate_left(&[Value::Bool(true), Value::Int(1)]).unwrap_err();
+        assert!(err.contains("rotate_left"), "got: {}", err);
+        let err = builtin_rotate_left(&[Value::Int(1), Value::Float(1.0)]).unwrap_err();
+        assert!(err.contains("rotate_left"), "got: {}", err);
+    }
+
+    #[test]
+    fn rotate_left_arity_error() {
+        let err = builtin_rotate_left(&[Value::Int(1)]).unwrap_err();
+        assert!(err.contains("2 arguments"), "got: {}", err);
+    }
+
+    // ---------- rotate_right ----------
+
+    #[test]
+    fn rotate_right_identity_zero() {
+        assert_eq!(
+            ok_int(builtin_rotate_right(&[Value::Int(0x1234_5678), Value::Int(0)]).unwrap()),
+            0x1234_5678
+        );
+    }
+
+    #[test]
+    fn rotate_right_full_cycle_is_identity() {
+        assert_eq!(
+            ok_int(builtin_rotate_right(&[Value::Int(0x1234_5678), Value::Int(64)]).unwrap()),
+            0x1234_5678
+        );
+    }
+
+    #[test]
+    fn rotate_right_low_bit_wraps_to_top() {
+        // 1 rotated right by 1 = i64::MIN (wraps to top bit).
+        assert_eq!(
+            ok_int(builtin_rotate_right(&[Value::Int(1), Value::Int(1)]).unwrap()),
+            i64::MIN
+        );
+    }
+
+    #[test]
+    fn rotate_right_inverse_of_left() {
+        // rotate_right(rotate_left(x, n), n) == x for any non-negative n.
+        for n in [0i64, 1, 7, 31, 32, 63, 64, 200] {
+            let x = 0x0F0F_F0F0_DEAD_BEEFi64;
+            let rotated = ok_int(builtin_rotate_left(&[Value::Int(x), Value::Int(n)]).unwrap());
+            let back = ok_int(builtin_rotate_right(&[Value::Int(rotated), Value::Int(n)]).unwrap());
+            assert_eq!(back, x, "round-trip failed for n={}", n);
+        }
+    }
+
+    #[test]
+    fn rotate_right_negative_count_errors() {
+        let err = builtin_rotate_right(&[Value::Int(1), Value::Int(-7)]).unwrap_err();
+        assert!(err.contains("non-negative"), "got: {}", err);
+    }
+
+    #[test]
+    fn rotate_right_modulo_64() {
+        let r1 = ok_int(builtin_rotate_right(&[Value::Int(0x1234_5678), Value::Int(1)]).unwrap());
+        let r129 =
+            ok_int(builtin_rotate_right(&[Value::Int(0x1234_5678), Value::Int(129)]).unwrap());
+        assert_eq!(r1, r129); // 129 == 1 mod 64
+    }
+
+    // ---------- signum ----------
+
+    #[test]
+    fn signum_positive() {
+        assert_eq!(ok_int(builtin_signum(&[Value::Int(42)]).unwrap()), 1);
+        assert_eq!(ok_int(builtin_signum(&[Value::Int(i64::MAX)]).unwrap()), 1);
+    }
+
+    #[test]
+    fn signum_zero() {
+        assert_eq!(ok_int(builtin_signum(&[Value::Int(0)]).unwrap()), 0);
+    }
+
+    #[test]
+    fn signum_negative() {
+        assert_eq!(ok_int(builtin_signum(&[Value::Int(-1)]).unwrap()), -1);
+        assert_eq!(ok_int(builtin_signum(&[Value::Int(i64::MIN)]).unwrap()), -1);
+    }
+
+    #[test]
+    fn signum_type_error() {
+        let err = builtin_signum(&[Value::Bool(false)]).unwrap_err();
+        assert!(err.contains("signum"), "got: {}", err);
+    }
+
+    #[test]
+    fn signum_arity_error() {
+        let err = builtin_signum(&[]).unwrap_err();
+        assert!(err.contains("1 argument"), "got: {}", err);
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -56,6 +56,9 @@ mod bytes_conversions;
 // RES-1178: bytes slicing primitives — take / drop / take_last / drop_last.
 // Pure leaf builtins; module-isolated.
 mod bytes_slicing;
+// RES-1182: integer bit rotation + scalar signum.
+// Pure leaf builtins; module-isolated.
+mod int_rotate;
 // RES-1162: deterministic hash builtins — hash_int / hash_string /
 // hash_bytes / hash_combine. Pure leaf builtins; module-isolated.
 mod compiler;
@@ -11418,6 +11421,12 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("ln_1p", crate::precision_math::builtin_ln_1p),
     ("mul_add", crate::precision_math::builtin_mul_add),
     ("recip", crate::precision_math::builtin_recip),
+    // RES-1182: integer bit rotation + scalar signum. Pure leaf builtins;
+    // module-isolated in `int_rotate.rs`. Appended at the end of BUILTINS
+    // per the perf rule from PR #1125.
+    ("rotate_left", crate::int_rotate::builtin_rotate_left),
+    ("rotate_right", crate::int_rotate::builtin_rotate_right),
+    ("signum", crate::int_rotate::builtin_signum),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1595,6 +1595,20 @@ impl TypeChecker {
         env.set("bytes_drop".to_string(), fn_bytes_int_to_bytes());
         env.set("bytes_take_last".to_string(), fn_bytes_int_to_bytes());
         env.set("bytes_drop_last".to_string(), fn_bytes_int_to_bytes());
+        // RES-1182: integer bit rotation + scalar signum.
+        let fn_int_int_to_int = || Type::Function {
+            params: vec![Type::Int, Type::Int],
+            return_type: Box::new(Type::Int),
+        };
+        env.set("rotate_left".to_string(), fn_int_int_to_int());
+        env.set("rotate_right".to_string(), fn_int_int_to_int());
+        env.set(
+            "signum".to_string(),
+            Type::Function {
+                params: vec![Type::Int],
+                return_type: Box::new(Type::Int),
+            },
+        );
         env.set(
             "log".to_string(),
             Type::Function {
@@ -6545,6 +6559,10 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "bytes_drop",
         "bytes_take_last",
         "bytes_drop_last",
+        // RES-1182: integer bit rotation + scalar signum.
+        "rotate_left",
+        "rotate_right",
+        "signum",
         // String/collection.
         "len",
         "push",


### PR DESCRIPTION
Closes #1182

## Summary

Three pure leaf builtins that close the remaining gap in the integer
bit-ops family and add a missing scalar sign helper:

| Builtin | Signature | Purpose |
|---|---|---|
| `rotate_left(x, n)`  | `(Int, Int) -> Int` | Circular left-shift over the 64-bit pattern. Bits shifted out the top wrap to the bottom. |
| `rotate_right(x, n)` | `(Int, Int) -> Int` | Circular right-shift. Bits shifted out the bottom wrap to the top. |
| `signum(x)`          | `(Int) -> Int`      | Returns `-1`, `0`, or `+1`. Scalar counterpart of `array_signum_int` (RES-555). |

## Design notes

- `rotate_left` / `rotate_right` delegate to `i64::rotate_left` /
  `i64::rotate_right`, which take `n: u32` and apply `n % 64` internally
  so any non-negative rotation count is well-defined (`rotate_left(x,
  64) == x`, `rotate_left(x, 65) == rotate_left(x, 1)`).
- **Negative rotation counts are typed errors.** Several libraries
  silently make `rotate_left(x, -1)` a rotate-right, which is the
  classic off-by-one footgun. Refusing to ship that.
- These three round out RES-907's bit-op family (`count_ones`,
  `count_zeros`, `leading_zeros`, `trailing_zeros`, `swap_bytes`) so
  user code no longer has to hand-roll `(x << n) | (x >>> (64 - n))` —
  which isn't even directly expressible because the unsigned-shift
  primitive isn't in the surface.

## Layout

Standard feature-isolation pattern:

- `resilient/src/int_rotate.rs` — new module, ~280 lines including 18 unit tests
- `resilient/src/lib.rs` — `mod int_rotate;` + 3 entries appended at the tail of `BUILTINS` (perf rule from PR #1125 — append-only)
- `resilient/src/typechecker.rs` — 3 env-seed signatures + 3 names appended to `PURE_BUILTINS`
- `resilient/examples/int_rotate.rz` + `.expected.txt` — end-to-end demo via the interpreter

## Local CI

- `cargo build --locked --manifest-path resilient/Cargo.toml` ✓
- `cargo test --locked --manifest-path resilient/Cargo.toml` ✓ (3227 tests, plus 18 new in `int_rotate::tests`)
- `cargo clippy --locked --all-targets --manifest-path resilient/Cargo.toml -- -D warnings` ✓
- `cargo fmt --check --manifest-path resilient/Cargo.toml` ✓

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>