### PR TITLE
RES-1184: dev/test profile speedups — line-tables debug + dep opt-level=1

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -7,6 +7,10 @@
     "resilient/src/typechecker.rs": {
       "branch": "res-1182-rotate-signum",
       "claimed_at": "2026-05-11T19:50:00Z"
+    },
+    "resilient/Cargo.toml": {
+      "branch": "res-1184-cargo-profile-speedups",
+      "claimed_at": "2026-05-12T00:43:22Z"
     }
   }
 }

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -175,3 +175,40 @@ criterion = { version = "0.5", features = ["html_reports"] }
 # inline Resilient source.
 name = "interpreter"
 harness = false
+
+# RES-1184: dev-iteration speedups for the compiler crate.
+#
+# `lib.rs` is ~55k lines of compiler code, so any constant-factor
+# reduction in codegen / link cost is a real wall-clock win for every
+# `cargo build`, `cargo test`, and `cargo clippy` run. Two tunings:
+#
+# 1. `debug = "line-tables-only"` — drops the bulk of DWARF entries
+#    (variables, type info) and keeps just the call-frame mapping.
+#    `panic = "unwind"` still produces useful backtraces (function +
+#    line), which is all the compiler's diagnostic infrastructure
+#    relies on; the typed `Error` path carries its own `line:col`.
+#    Cuts the codegen and linker work proportional to debuginfo size.
+#
+# 2. `[profile.{dev,test}.package."*"] opt-level = 1` — heavy
+#    third-party crates in the dep tree (criterion, notify,
+#    ed25519-dalek, sha2, rustyline, clap) are inlining-shaped: their
+#    generic instantiations explode at `opt-level = 0`. Building deps
+#    at `opt-level = 1` is slower one-time but produces tighter object
+#    files, smaller link inputs, and faster downstream rebuilds when
+#    only local code changes. `Swatinem/rust-cache@v2` in CI caches
+#    these dep artifacts, so the one-time cost is amortized across
+#    every PR. The main `resilient` crate stays at the default
+#    `opt-level = 0` so its own iteration stays fast.
+#
+# Release profile is unchanged — these are dev/test-only knobs.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+opt-level = 1
+
+[profile.test]
+debug = "line-tables-only"
+
+[profile.test.package."*"]
+opt-level = 1


### PR DESCRIPTION
## Summary

The `resilient` crate has no explicit `[profile.dev]` / `[profile.test]` sections, so every `cargo build` / `cargo test` / `cargo clippy` inherits Cargo's stock defaults: full DWARF debug info on a 55k-line `lib.rs` and `opt-level=0` for every dep.

This PR adds two cheap, well-trodden dev-iteration tunings to `resilient/Cargo.toml`:

1. **`debug = "line-tables-only"`** — drops the bulk of DWARF entries while keeping call-frame mappings. Backtraces still resolve to function + line; the compiler's diagnostic infrastructure already prints its own `line:col` from the typed `Error` path. Reduces codegen and linker work proportional to debuginfo size.

2. **`[profile.{dev,test}.package."*"] opt-level = 1`** — builds third-party deps (criterion, notify, ed25519-dalek, sha2, rustyline, clap …) with mild optimization. Inlining-heavy generics no longer explode at every call site, link inputs are smaller, and `Swatinem/rust-cache@v2` keeps the one-time dep rebuild cached across CI runs. The main `resilient` crate stays at `opt-level=0` for fast local iteration.

## Scope

- `resilient/Cargo.toml` only — appended a new comment block plus four profile sections at the end of the file.
- No code changes, no API changes, no test changes.
- Release profile is unchanged.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — 3227 passed; 0 failed
- [x] Full `cargo test --locked` exposed one pre-existing platform-difference failure in `examples_golden/golden_outputs_match` on macOS (libm's `f64::exp_m1(1.0)` returns `1.7182818284590453` on Apple Silicon vs `1.718281828459045` baked into the Linux-authored golden from RES-1168). The same failure reproduces on `main` with this PR's changes reverted, so this is an out-of-tree golden portability bug unrelated to the profile tuning. CI on Linux is the merge gate and matches the golden.

Closes #1184