### PR TITLE
RES-1189: Cargo build-override — opt-level=1 for proc-macros + build scripts

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -9,12 +9,8 @@
       "claimed_at": "2026-05-11T19:50:00Z"
     },
     "resilient/Cargo.toml": {
-      "branch": "res-1184-cargo-profile-speedups",
-      "claimed_at": "2026-05-12T00:43:22Z"
-    },
-    "resilient/tests/examples_golden.rs": {
-      "branch": "res-1186-cross-platform-goldens",
-      "claimed_at": "2026-05-12T00:52:47Z"
+      "branch": "res-1189-cargo-build-override",
+      "claimed_at": "2026-05-12T01:03:52Z"
     }
   }
 }

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -212,3 +212,21 @@ debug = "line-tables-only"
 
 [profile.test.package."*"]
 opt-level = 1
+
+# RES-1189: build-override is the *only* knob that touches build scripts,
+# proc-macros, and their transitive deps — `package."*"` deliberately
+# skips them. With proc-macros (serde_derive, thiserror, criterion's
+# benchmark codegen, etc.) compiled at the stock `opt-level = 0`, every
+# `cargo build`/`test`/`clippy` re-runs the slow unoptimized macro
+# expanders against `lib.rs` (~55k lines, derives sprinkled throughout).
+# Bumping the override to `opt-level = 1` pays a one-time compile cost
+# per macro crate (cached by `Swatinem/rust-cache@v2` in CI and by
+# Cargo's incremental cache locally) in exchange for an optimized
+# expander that runs measurably faster on every subsequent rebuild.
+# Disjoint from the `package."*"` tunings above — the two combine
+# cleanly.
+[profile.dev.build-override]
+opt-level = 1
+
+[profile.test.build-override]
+opt-level = 1


### PR DESCRIPTION
## Summary

RES-1184 (merged) added `[profile.{dev,test}.package."*"] opt-level = 1`, optimizing **runtime** deps (criterion, notify, sha2, ed25519-dalek, …) but deliberately **does not** apply to build scripts, proc-macro crates, or their transitive deps — those are governed by the separate `[profile.<name>.build-override]` block. Today they all compile at the stock `opt-level = 0`, so `serde_derive`, `thiserror`, `clap_derive`, and friends run unoptimized expansion code against `lib.rs` (~55k lines, derives sprinkled throughout) on every build.

This PR adds:

```toml
[profile.dev.build-override]
opt-level = 1

[profile.test.build-override]
opt-level = 1
```

One-time cost: proc-macro crates themselves compile slightly slower (still cheap — they're small). Steady-state win: every subsequent `cargo build`/`test`/`clippy` runs the optimized macro expanders, which is where most macro time goes. `Swatinem/rust-cache@v2` in CI caches build-script + proc-macro artifacts the same way it caches package artifacts, so the one-time rebuild cost is amortized after the first sync.

Strictly complementary to RES-1184 — `package."*"` and `build-override` apply to disjoint sets of targets, so the two knobs combine cleanly.

## Scope

- `resilient/Cargo.toml` only — append two profile blocks (~20 LoC counting the doc comment).
- `agent-scripts/file-claims.json` — claim entry for this branch (and release of the now-merged RES-1184 + RES-1186 claims that the release workflow hadn't cleared yet).
- No code, API, or test changes. Release profile unchanged.

## Test plan

- [x] `cargo build --locked` clean (19.5s, no errors).
- [ ] Full guardrail (fmt + clippy + test + diff-shape) running locally.
- [ ] Linux CI gates: `build / test / clippy`, `build / test with --features z3`, embedded cross-compiles, `.text` budget check.

Closes #1189