### PR TITLE
RES-1192: Linux split-debuginfo=unpacked — smaller link inputs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -23,6 +23,10 @@
     "resilient/src/region_inference.rs": {
       "branch": "res-1202-region-inference-dead-work",
       "claimed_at": "2026-05-12T01:33:01Z"
+    },
+    "resilient/.cargo/config.toml": {
+      "branch": "res-1192-cargo-config-linker",
+      "claimed_at": "2026-05-12T01:09:57Z"
     }
   }
 }

--- a/resilient/.cargo/config.toml
+++ b/resilient/.cargo/config.toml
@@ -14,3 +14,23 @@ LIBRARY_PATH = "/opt/homebrew/lib:/usr/local/lib:/usr/lib"
 # headroom on Linux test runners. macOS already defaults to 8 MiB; this lines
 # Linux up. The runtime itself ships unchanged.
 RUST_MIN_STACK = "8388608"
+
+# RES-1192: Linux-only debuginfo splitting.
+#
+# On macOS, Rust already emits split debuginfo by default (.dSYM
+# bundles next to the binary). On Linux the stock behaviour is
+# `split-debuginfo = "off"`, which forces the linker to relocate
+# every DWARF block into the final executable — work proportional
+# to debuginfo size.
+#
+# Combined with RES-1184's `debug = "line-tables-only"` the win is
+# modest (less debuginfo to split), but it's still strictly fewer
+# bytes for the linker to touch on every `cargo build` and every
+# integration-test binary. The .dwo files land in `target/` alongside
+# the existing `.o`s and are cached the same way.
+#
+# Scoped to `x86_64-unknown-linux-gnu` (the only Linux runner used by
+# CI) so other targets — embedded cross-compiles, WASM, macOS — are
+# left untouched.
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-Csplit-debuginfo=unpacked"]


### PR DESCRIPTION
## Summary

Default Linux Rust targets emit `split-debuginfo = "off"`, inlining every DWARF block into the binary. The linker has to relocate that debuginfo on every link — paid on every test binary and every CI run. macOS already handles this correctly via `.dSYM` bundles.

This PR adds a single per-target rustflag in `resilient/.cargo/config.toml`:

```toml
[target.x86_64-unknown-linux-gnu]
rustflags = ["-Csplit-debuginfo=unpacked"]
```

DWARF goes into adjacent `.dwo` files instead of the binary. Linker only has to relocate `.text`/`.data`/`.rodata`. `.dwo` files land in `target/` and are cached the same way `.o`s are.

Strictly complementary to RES-1184 (`line-tables-only` reduces what's left to split) and RES-1189 (proc-macro build-override, totally disjoint). Scoped narrowly to `x86_64-unknown-linux-gnu` so embedded cross-compiles, wasm32, and macOS / Windows hosts are untouched.

## Scope

- `resilient/.cargo/config.toml` — one new `[target.x86_64-unknown-linux-gnu]` block.
- `agent-scripts/file-claims.json` — claim entry.
- No code, profile, or test changes.

## Test plan

- [x] `cargo build --locked` on macOS — 18.5s, clean (target-specific rustflag is a no-op off Linux, as designed).
- [ ] Linux CI `build / test / clippy` confirms the `.dwo` artifacts work; embedded cross-compiles still pass.

Closes #1192