### PR TITLE
RES-1195: prune criterion default-features (drop html_reports + plotters + rayon)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -15,6 +15,10 @@
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
       "claimed_at": "2026-05-12T01:23:24Z"
+    },
+    "resilient/Cargo.toml": {
+      "branch": "res-1195-criterion-features",
+      "claimed_at": "2026-05-12T01:14:37Z"
     }
   }
 }

--- a/resilient/Cargo.lock
+++ b/resilient/Cargo.lock
@@ -488,8 +488,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -507,31 +505,6 @@ dependencies = [
  "cast",
  "itertools",
 ]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1435,34 +1408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,26 +1529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -2283,16 +2208,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -172,7 +172,18 @@ insta = { version = "1", features = ["filters"] }
 # bubble-sort, string-processing). Test-only dep; see
 # `resilient/benches/interpreter.rs` and the Performance section
 # of the repo README for how to run.
-criterion = { version = "0.5", features = ["html_reports"] }
+#
+# RES-1195: opt out of criterion's default-features. The bench code in
+# `benches/interpreter.rs` only touches the `Criterion`, `criterion_group`,
+# `criterion_main` surface — it doesn't render HTML reports, doesn't
+# generate plots, and the harness uses ten samples per workload so
+# rayon-parallelised sample collection isn't a needle-mover. Dropping
+# `html_reports` (tinytemplate), `plotters` (plotters-backend +
+# plotters-svg), and `rayon` removes a sizeable transitive dep
+# subtree from every `cargo test` build — none of those crates are
+# touched outside the bench, and as a `dev-dependencies` entry the
+# release binary's transitive tree is unaffected either way.
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 
 [[bench]]
 # RES-218: Criterion-driven baselines for the tree-walker. `harness


### PR DESCRIPTION
## Summary

`criterion = { version = "0.5", features = ["html_reports"] }` pulled in criterion's full default-feature set (`rayon`, `plotters`, `cargo_bench_support`, `html_reports`) plus the explicit `html_reports`, which transitively builds tinytemplate, walkdir, plotters, plotters-backend, plotters-svg, rayon, rayon-core, and their cascades on every `cargo test` / `cargo clippy --all-targets` — even though `benches/interpreter.rs` never touches any of that surface.

The bench's entire criterion usage is just `use criterion::{Criterion, criterion_group, criterion_main};` — no HTML reports, no SVG plots, ten samples per workload (rayon wouldn't move the needle).

This PR switches to:

```toml
criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
```

…the minimum criterion needs for `harness = false` integration. Release tree is untouched — criterion stays in `[dev-dependencies]`, so the shipped binary never carried any of this either way.

## Scope

- `resilient/Cargo.toml` — one dep line changed (plus a doc comment).
- `agent-scripts/file-claims.json` — claim entry.
- No code, profile, or test changes.

## Test plan

- [x] `cargo bench --no-run` clean locally (51.8s cold).
- [ ] Linux CI `build / test / clippy` confirms the smaller dep tree builds.

Closes #1195