### PR TITLE
RES-1198: skip test/bench builds for the rz bin (it is a 12-line shim)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -11,6 +11,10 @@
     "resilient/src/verifier_loop_invariants.rs": {
       "branch": "res-1194-z3-tautology-only",
       "claimed_at": "2026-05-12T01:13:16Z"
+    },
+    "resilient/Cargo.toml": {
+      "branch": "res-1198-bin-skip-test-bench",
+      "claimed_at": "2026-05-12T01:22:45Z"
     }
   }
 }

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -32,6 +32,13 @@ doctest = false
 [[bin]]
 name = "rz"
 path = "src/main.rs"
+# RES-1198: `main.rs` is a 12-line shim (`fn main() { resilient::run_cli(); }`)
+# with zero `#[test]` and zero `#[bench]` items, so re-linking it under the
+# test / bench profiles is pure waste — cargo otherwise rebuilds it under
+# every profile (dev, test, bench) plus when `cargo clippy --all-targets`
+# checks them. Saves a link per non-dev profile; nothing else changes.
+test = false
+bench = false
 
 [features]
 # RES-067: opt-in Z3 SMT verification. Default off so the build only


### PR DESCRIPTION
## Summary

`resilient/src/main.rs` is the binary shim introduced in RES-510:

```rust
fn main() {
    resilient::run_cli();
}
```

12 lines, zero `#[test]`s, zero `#[bench]`es — all real code lives in `lib.rs`. Cargo's default `[[bin]]` settings nevertheless rebuild + re-link it under every profile: dev (for `cargo build`), test (for any unit tests — there are none), bench (for any benches — there are none), plus once more per `cargo clippy --all-targets` pass. All builds after the dev profile are pure waste — the shim has no profile-conditional code paths.

This PR adds `test = false` and `bench = false` to the `[[bin]]` block. Integration tests in `resilient/tests/*` continue to receive `CARGO_BIN_EXE_rz` (it's wired from the dev-profile build, which is unchanged).

## Scope

- `resilient/Cargo.toml` — two lines added to the existing `[[bin]]` block (plus a doc comment).
- `agent-scripts/file-claims.json` — claim entry.
- No code, profile, or feature changes.

## Test plan

- [x] `cargo test --no-run` clean (integration tests still see `CARGO_BIN_EXE_rz`).
- [ ] Linux CI confirms `build / test / clippy` is unaffected functionally, just slightly faster.

Closes #1199