### PR TITLE
RES-1198: embedded.yml — switch cache from actions/cache to Swatinem/rust-cache

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -70,15 +70,17 @@ jobs:
           components: clippy
           targets: thumbv7em-none-eabihf
 
+      # RES-1198: rust-aware cache strips incremental compilation artifacts
+      # before saving (smaller cache, faster restore) and keys off
+      # Cargo.lock + Cargo.toml + rustc version + feature set
+      # automatically. Matches the caching strategy ci.yml's
+      # `default_ci` / `z3_ci` / `feature_matrix` jobs already use.
       - name: Cache cargo
         if: needs.changes.outputs.docs_only != 'true'
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            resilient-runtime-cortex-m-demo/target
-          key: cortex-m-${{ hashFiles('resilient-runtime-cortex-m-demo/Cargo.lock', 'resilient-runtime/Cargo.lock') }}
+          workspaces: resilient-runtime-cortex-m-demo
+          key: cortex-m
 
       - name: build_cortex_m_demo.sh
         if: needs.changes.outputs.docs_only != 'true'
@@ -103,15 +105,15 @@ jobs:
           components: clippy
           targets: riscv32imac-unknown-none-elf
 
+      # RES-1198: see notes on cortex_m above — rust-cache strips
+      # incremental compilation artifacts and uses a richer key than
+      # raw `hashFiles('Cargo.lock')`.
       - name: Cache cargo
         if: needs.changes.outputs.docs_only != 'true'
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            resilient-runtime/target
-          key: riscv32-${{ hashFiles('resilient-runtime/Cargo.lock') }}
+          workspaces: resilient-runtime
+          key: riscv32
 
       - name: build_riscv32.sh
         if: needs.changes.outputs.docs_only != 'true'
@@ -136,15 +138,15 @@ jobs:
           components: clippy
           targets: thumbv6m-none-eabi
 
+      # RES-1198: see notes on cortex_m above — rust-cache strips
+      # incremental compilation artifacts and uses a richer key than
+      # raw `hashFiles('Cargo.lock')`.
       - name: Cache cargo
         if: needs.changes.outputs.docs_only != 'true'
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            resilient-runtime/target
-          key: cortex-m0-${{ hashFiles('resilient-runtime/Cargo.lock') }}
+          workspaces: resilient-runtime
+          key: cortex-m0
 
       - name: build_cortex_m0.sh
         if: needs.changes.outputs.docs_only != 'true'

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -12,9 +12,9 @@
       "branch": "res-1194-z3-tautology-only",
       "claimed_at": "2026-05-12T01:13:16Z"
     },
-    "resilient/Cargo.toml": {
-      "branch": "res-1198-bin-skip-test-bench",
-      "claimed_at": "2026-05-12T01:22:45Z"
+    ".github/workflows/embedded.yml": {
+      "branch": "res-1198-embedded-rust-cache",
+      "claimed_at": "2026-05-12T01:23:24Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

`embedded.yml`'s three cross-compile jobs (`cortex_m`, `riscv32`, `cortex_m0`) used `actions/cache@v4` with a raw `hashFiles('Cargo.lock')` key. Three downsides versus the `Swatinem/rust-cache@v2` action `ci.yml` already uses for `default_ci` / `z3_ci` / `feature_matrix`:

1. **Cache size** — `actions/cache@v4` saves the whole `target/` directory, including `target/<triple>/{debug,release}/incremental/*` fingerprint dirs that re-hydrate on the next compile anyway. `rust-cache` strips these before saving; restore and save both drop in wall time.
2. **Cache key** — `hashFiles('Cargo.lock')` doesn't differentiate Cargo.toml feature-flag flips. `rust-cache` keys off rustc version + Cargo.lock + Cargo.toml + the active feature set, which matches what Cargo actually decides on for the artifact set.
3. **Consistency** — splitting cache implementations across workflows means the cache configurations drift independently. Aligning embedded with ci.yml's strategy keeps the surface area small.

Each of the three jobs converts to:

```yaml
- name: Cache cargo
  uses: Swatinem/rust-cache@v2
  with:
    workspaces: <workspace-path>
    key: <triple-tag>
```

`workspaces` points to the per-job crate root (different across jobs: `resilient-runtime-cortex-m-demo`, `resilient-runtime`, `resilient-runtime`). The `key` disambiguator keeps the three jobs' caches separate; rust-cache also keys off the rustc target triple automatically, but an explicit per-job tag keeps the cache scope readable in the Actions UI.

## Scope

- `.github/workflows/embedded.yml` only — no script or build-step changes; the existing `scripts/build_*.sh` invocations stay as-is.
- `perf_gate.yml` and `playground.yml` also use `actions/cache` but are intentionally left untouched — perf-gate's cache state is sensitive to bench numbers, and the playground workflow has WASM-specific concerns. Those can follow up independently if useful.

## Test plan

- [x] `yaml syntax-checked` — diff parses as valid YAML; structure preserved (each job retains its `Cache cargo` step in the same position, only the `uses:` and `with:` differ).
- [ ] First push to this branch will trigger `embedded.yml`; we expect each of the three jobs to still pass. Cache may miss on first run after the keying change, then hit on subsequent PRs.

Closes #1198