### PR TITLE
RES-1202: drop dead AST walk in region_inference::infer

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -19,6 +19,10 @@
     "resilient/Cargo.toml": {
       "branch": "res-1195-criterion-features",
       "claimed_at": "2026-05-12T01:14:37Z"
+    },
+    "resilient/src/region_inference.rs": {
+      "branch": "res-1202-region-inference-dead-work",
+      "claimed_at": "2026-05-12T01:33:01Z"
     }
   }
 }

--- a/resilient/src/region_inference.rs
+++ b/resilient/src/region_inference.rs
@@ -302,10 +302,23 @@ pub fn build_region_map(program: &crate::Node) -> RegionMap {
 
 /// EXTENSION_PASSES entry point — runs after type-checking.
 ///
-/// Builds the region map for the program. D8 wires call-site substitution
-/// into `check_region_aliasing` via `check_call_site_region_aliasing`.
-pub fn infer(program: &crate::Node, _source_path: &str) -> Result<(), String> {
-    let _map = build_region_map(program);
+/// RES-1202: this pass was originally a placeholder slot for the D2/D5
+/// inference work that landed in `build_region_map`. The function body
+/// historically called `build_region_map(program)` and immediately
+/// *discarded* the returned `RegionMap`, then returned `Ok(())`.
+///
+/// The actual consumer of the region map (the alias-aliasing check at
+/// `lib.rs:check_region_aliasing`) builds its own copy via
+/// `build_region_map(program)` when it needs one, so the work here was
+/// unobservable: no thread-local, no global, no I/O — just an
+/// allocation and a tree walk whose result was dropped on function
+/// exit. For a single type-check that meant walking the AST twice for
+/// region inference (once here, once at the consumer) instead of once.
+///
+/// The entry point is kept (so the `EXTENSION_PASSES` block in
+/// `typechecker.rs` is undisturbed and a future use can flow data
+/// here) but the body is now empty.
+pub fn infer(_program: &crate::Node, _source_path: &str) -> Result<(), String> {
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`region_inference::infer` is wired into typechecker.rs's `EXTENSION_PASSES` block with a body that called `build_region_map(program)` and immediately *discarded* the returned `RegionMap`:

```rust
pub fn infer(program: &crate::Node, _source_path: &str) -> Result<(), String> {
    let _map = build_region_map(program);
    Ok(())
}
```

`build_region_map` walks every top-level function in the program, collects parameter and local-binding region labels, and resolves them through a fresh `RegionTable` — all into a `RegionMap` owned by the function-local `_map`. **No side effects**: no thread-local, no global state, no I/O. The map is dropped on function exit.

Meanwhile, the actual consumer (the alias-aliasing check at `lib.rs:24927`) builds its own copy via `build_region_map(program)` when it needs one — completely independent of this `infer` call. So `build_region_map` ran **twice** per type-check: once with the result thrown away, once where it was actually used. The first call was pure waste — an extra AST walk plus a `HashMap` allocation that nothing observes.

This PR replaces the body with a no-op that just returns `Ok(())`. The function signature is preserved (so the `EXTENSION_PASSES` block in `typechecker.rs` stays untouched and a future use can flow data through this slot) and the doc comment now records the history.

## Scope

- `resilient/src/region_inference.rs` only — single function body change.
- No public API or test changes.
- `typechecker.rs` is **not** modified; the call site stays exactly as it was.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — **3227 passing**, no change vs main.
- [x] `cargo test --locked --lib region` — 21 of 21 pass.
- [x] `cargo test --locked --lib alias` — 18 of 18 pass.

The two test groups above are the only ones that exercise the region-inference machinery; their continued passing confirms the dropped work is genuinely unobserved.

Closes #1202