### PR TITLE
RES-1206: kill 5 more dead-work analysis passes

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -27,6 +27,26 @@
     "resilient/.cargo/config.toml": {
       "branch": "res-1192-cargo-config-linker",
       "claimed_at": "2026-05-12T01:09:57Z"
+    },
+    "resilient/src/vibe_debt.rs": {
+      "branch": "res-1206-kill-dead-work-checks",
+      "claimed_at": "2026-05-12T01:43:21Z"
+    },
+    "resilient/src/behavioral_fingerprint.rs": {
+      "branch": "res-1206-kill-dead-work-checks",
+      "claimed_at": "2026-05-12T01:43:21Z"
+    },
+    "resilient/src/contract_inference.rs": {
+      "branch": "res-1206-kill-dead-work-checks",
+      "claimed_at": "2026-05-12T01:43:21Z"
+    },
+    "resilient/src/resilience_score.rs": {
+      "branch": "res-1206-kill-dead-work-checks",
+      "claimed_at": "2026-05-12T01:43:21Z"
+    },
+    "resilient/src/property_tests.rs": {
+      "branch": "res-1206-kill-dead-work-checks",
+      "claimed_at": "2026-05-12T01:43:21Z"
     }
   }
 }

--- a/resilient/src/behavioral_fingerprint.rs
+++ b/resilient/src/behavioral_fingerprint.rs
@@ -147,8 +147,15 @@ pub fn diff_fingerprints(
     changed
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    let _ = fingerprint_program(program);
+pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1206: this pass historically called `fingerprint_program`
+    // and discarded the returned `HashMap<String, Fingerprint>`. The
+    // CLI's `--check-fingerprints` mode (and any external integrator)
+    // builds its own map from `fingerprint_program(program)` when it
+    // needs one, so the work here was unobservable. The entry point
+    // is kept so the `EXTENSION_PASSES` block in `typechecker.rs`
+    // stays undisturbed and a future use can flow data through this
+    // slot.
     Ok(())
 }
 

--- a/resilient/src/contract_inference.rs
+++ b/resilient/src/contract_inference.rs
@@ -169,8 +169,15 @@ fn format_simple_expr(node: &Node) -> String {
     }
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    let _ = infer_program(program);
+pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1206: this pass historically called `infer_program` and
+    // discarded the returned `Vec<InferredContracts>`. The real
+    // consumers (the `--suggest-contracts` CLI flag and any external
+    // integrator) call `infer_program` directly when they need the
+    // suggestions, so the work here was unobservable. The entry point
+    // is kept so the `EXTENSION_PASSES` block in `typechecker.rs`
+    // stays undisturbed and a future use can flow data through this
+    // slot.
     Ok(())
 }
 

--- a/resilient/src/property_tests.rs
+++ b/resilient/src/property_tests.rs
@@ -82,7 +82,14 @@ pub fn run_property(spec: &PropertySpec) -> PropertyResult {
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    let _ = collect();
+    // RES-1206: this pass historically called `collect()` and
+    // discarded the returned `Vec<PropertySpec>`. `collect` reads
+    // the static `feature_attrs` registry (no AST walk needed) and
+    // returns the property-test specs; the real consumer (the
+    // `--run-property-tests` driver) calls `collect` directly. The
+    // work here was unobservable. The entry point is kept so the
+    // `EXTENSION_PASSES` block in `typechecker.rs` stays undisturbed
+    // and a future use can flow data through this slot.
     Ok(())
 }
 

--- a/resilient/src/resilience_score.rs
+++ b/resilient/src/resilience_score.rs
@@ -216,8 +216,16 @@ fn count_body_statements(node: &Node) -> usize {
     }
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    let _ = score_program(program);
+pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1206: this pass historically called `score_program` and
+    // discarded the returned `Vec<ResilienceScore>`. The real
+    // consumers (the `--score` CLI flag and any external integrator)
+    // call `score_program` directly when they need the scores, so the
+    // work here was unobservable: a call-reference HashMap build, an
+    // AST walk, and a Vec population, all dropped on function exit.
+    // The entry point is kept so the `EXTENSION_PASSES` block in
+    // `typechecker.rs` stays undisturbed and a future use can flow
+    // data through this slot.
     Ok(())
 }
 

--- a/resilient/src/vibe_debt.rs
+++ b/resilient/src/vibe_debt.rs
@@ -175,8 +175,15 @@ fn collect_refs(node: &Node, out: &mut HashMap<String, u32>) {
     }
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    let _ = analyze(program);
+pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1206: this pass historically called `analyze(program)` and
+    // immediately discarded the returned `VibeDebtReport`. The real
+    // consumer (`autopilot::run` at autopilot.rs:42) calls `analyze`
+    // directly when it needs the report, so the work here was
+    // unobservable: a HashMap allocation, an AST walk, and a Vec
+    // population, all dropped on function exit. The entry point is
+    // kept so the `EXTENSION_PASSES` block in `typechecker.rs` stays
+    // undisturbed and a future use can flow data through this slot.
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

RES-1202 found one dead `check` pass (`region_inference::infer`) whose body called an analysis function and immediately discarded the result. Grepping for the exact pattern (`pub(crate) fn check(...) -> Result<(), String>` whose body is `let _ = ANALYZE(program); Ok(())`) turns up **five more** analysis modules wired into `typechecker.rs`'s `EXTENSION_PASSES` block that do the same thing:

| Module                  | Discarded call            | Real consumer                              |
|-------------------------|---------------------------|--------------------------------------------|
| `vibe_debt`             | `analyze(program)`        | `autopilot::run` calls `analyze` directly  |
| `behavioral_fingerprint`| `fingerprint_program`     | `--check-fingerprints` CLI                 |
| `contract_inference`    | `infer_program(program)`  | `--suggest-contracts` CLI                  |
| `resilience_score`      | `score_program(program)`  | `--score` CLI                              |
| `property_tests`        | `collect()`               | `--run-property-tests` driver              |

All five analysis functions are pure: they build a HashMap or Vec, populate it from the program AST (`collect` reads the `feature_attrs` static), and return it. No thread-local mutations, no global writes, no I/O. The typechecker pass walked the AST through them, allocated the result, and dropped it on function exit — five wasted passes per type-check.

## Change

Each `check` body becomes a no-op, mirroring RES-1202's pattern:

```rust
pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
    // RES-1206: see commit log — analysis fn was called directly
    // by its real consumers; result was dropped here.
    Ok(())
}
```

The `EXTENSION_PASSES` lines in `typechecker.rs` are intentionally **untouched**: the slot stays present so a future use can flow data through it, and the feature-isolation append-only block remains clean.

## Scope

Five single-function edits, all in dedicated module files. **No `typechecker.rs` change**, no public API change, no test changes.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — **3227 passing**, no change vs main.

The consumer call sites (autopilot, `--check-fingerprints`, `--suggest-contracts`, `--score`, `--run-property-tests`) continue to build their own copies via the analysis functions when needed.

Closes #1206