### PR TITLE
RES-1206: thread-local verdict cache for Z3 prove_with_axioms_and_timeout

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,17 +1,5 @@
 {
   "claims": {
-    "resilient/src/verifier_z3.rs": {
-      "branch": "res-1194-z3-tautology-only",
-      "claimed_at": "2026-05-12T01:13:16Z"
-    },
-    "resilient/src/bounds_check.rs": {
-      "branch": "res-1194-z3-tautology-only",
-      "claimed_at": "2026-05-12T01:13:16Z"
-    },
-    "resilient/src/verifier_loop_invariants.rs": {
-      "branch": "res-1194-z3-tautology-only",
-      "claimed_at": "2026-05-12T01:13:16Z"
-    },
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
       "claimed_at": "2026-05-12T01:23:24Z"
@@ -47,6 +35,10 @@
     "resilient/src/property_tests.rs": {
       "branch": "res-1206-kill-dead-work-checks",
       "claimed_at": "2026-05-12T01:43:21Z"
+    },
+    "resilient/src/verifier_z3.rs": {
+      "branch": "res-1206-z3-verdict-cache",
+      "claimed_at": "2026-05-12T01:45:28Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -215,7 +215,56 @@ pub fn prove_with_axioms_and_timeout(
     axioms: &[Node],
     timeout_ms: u32,
 ) -> (Option<bool>, Option<ProofCertificate>, Option<String>, bool) {
-    Z3_CTX.with(|ctx| prove_with_axioms_and_timeout_in(ctx, expr, bindings, axioms, timeout_ms))
+    // RES-1206: thread-local verdict cache. Builds frequently re-ask
+    // the verifier the same `(expr, bindings, axioms, timeout)` —
+    // identical bounds checks on different call sites that share an
+    // axiom set, the same `requires` clause re-checked at every
+    // function callsite, etc. Each cache hit short-circuits the full
+    // Z3 round trip (solver construction + formula assertion +
+    // solve), which is by far the dominant cost even after RES-1188
+    // (thread-local libz3 context) and RES-1194 (tautology fast
+    // path) already paid down the setup cost.
+    //
+    // Key shape: AST debug-print of every input, separated by `|`
+    // sentinels. `Node` doesn't derive `Hash`, so we lean on its
+    // `Debug` impl — slower than a structural hash but still O(AST
+    // size) per key, comfortably cheaper than the dispatch + solve
+    // it replaces on a hit, and on a miss the format cost is
+    // amortised against the Z3 work that follows. Lives in a
+    // `RefCell` inside a `thread_local!` to match the
+    // existing `Z3_CTX` ownership model — each test thread (and the
+    // CLI's main thread) keeps its own cache without cross-thread
+    // synchronisation.
+    //
+    // `bindings` is sorted into a `BTreeMap` before formatting so
+    // identical input maps produce identical keys regardless of
+    // `HashMap`'s nondeterministic iteration order — otherwise the
+    // cache would miss on semantically equal queries.
+    let bindings_sorted: std::collections::BTreeMap<&String, &i64> = bindings.iter().collect();
+    let key = format!("{expr:?}|{bindings_sorted:?}|{axioms:?}|{timeout_ms}");
+    if let Some(cached) = Z3_VERDICT_CACHE.with(|c| c.borrow().get(&key).cloned()) {
+        return cached;
+    }
+    let result = Z3_CTX
+        .with(|ctx| prove_with_axioms_and_timeout_in(ctx, expr, bindings, axioms, timeout_ms));
+    Z3_VERDICT_CACHE.with(|c| {
+        c.borrow_mut().insert(key, result.clone());
+    });
+    result
+}
+
+thread_local! {
+    /// RES-1206: see `prove_with_axioms_and_timeout`. Stays the lifetime
+    /// of the thread; reset between top-level compiles isn't needed
+    /// because the key includes the full input, so stale entries can
+    /// only be re-hit by an identical query (which would be correct
+    /// either way).
+    static Z3_VERDICT_CACHE: std::cell::RefCell<
+        std::collections::HashMap<
+            String,
+            (Option<bool>, Option<ProofCertificate>, Option<String>, bool),
+        >,
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
 fn prove_with_axioms_and_timeout_in(


### PR DESCRIPTION
## Summary

Builds frequently re-ask the verifier the same `(expr, bindings, axioms, timeout)`: identical bounds checks at different call sites that share an axiom set, the same `requires` clause re-checked at every function callsite, the same induction step re-attempted from different loop bodies in one fixpoint pass. RES-1188 (thread-local libz3 context) and RES-1194 (tautology fast path) reduced the per-query setup cost, but neither short-circuits a repeat query.

This PR adds a thread-local `HashMap<String, (Option<bool>, Option<ProofCertificate>, Option<String>, bool)>` queried at the top of `prove_with_axioms_and_timeout`. On a cache hit, we return the stored verdict + cert + counterexample + timed-out flag (all four slots cloned from the cached tuple) without touching libz3. On a cache miss, the inner-solver path runs as before and the result is stored.

Key shape: `{expr:?}|{bindings_sorted:?}|{axioms:?}|{timeout_ms}`. `bindings` is funnelled through a `BTreeMap` first so two semantically-equal `HashMap`s with different iteration orders produce identical keys — otherwise the cache would miss on reordered-but-equal inputs. `Node` doesn't derive `Hash`, so we lean on `Debug`; the format cost is O(AST size) per key, comfortably cheaper than the solver work on a hit and fully amortised by the Z3 round-trip on a miss.

The cache is per-thread to match the `Z3_CTX` ownership model from RES-1188 — no cross-thread sync, each parallel `cargo test` thread (and parallel typechecker passes) gets its own.

## Scope

- `resilient/src/verifier_z3.rs` only (z3-feature-gated module).
- `agent-scripts/file-claims.json` claim entry plus a sweep of stale RES-1194 claims that the release workflow hadn't cleared.

## Test plan

- [x] `cargo build --locked` clean locally (the cache code is z3-feature-gated; default build doesn't compile it).
- [ ] Linux CI `build / test with --features z3` exercises the new path through every existing verifier-z3 test.

Closes #1208