### PR TITLE
RES-1210: incremental_verify::check — stop pre-populating the unconsulted cache

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -43,6 +43,10 @@
     "resilient/src/isr_call_graph.rs": {
       "branch": "res-1211-isr-fast-reject",
       "claimed_at": "2026-05-12T01:57:48Z"
+    },
+    "resilient/src/incremental_verify.rs": {
+      "branch": "res-1210-incremental-verify-dead-work",
+      "claimed_at": "2026-05-12T01:53:15Z"
     }
   }
 }

--- a/resilient/src/incremental_verify.rs
+++ b/resilient/src/incremental_verify.rs
@@ -70,14 +70,24 @@ pub fn stats() -> (u64, u64) {
         .unwrap_or((0, 0))
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // Pre-populate the cache with the current contract digests.
-    let fps = crate::behavioral_fingerprint::fingerprint_program(program);
-    for (name, fp) in fps {
-        if lookup(&name, fp.digest).is_none() {
-            store(&name, fp.digest, ProofResult::Discharged);
-        }
-    }
+pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1210: the historical body called `fingerprint_program` and
+    // pre-populated the cache with `ProofResult::Discharged` for every
+    // function on every type-check. Two problems with that:
+    //
+    //   1. No consumer in the crate calls `lookup` (a
+    //      `grep -rn 'incremental_verify::' resilient/src/` shows
+    //      only this pass — the Z3 verifier doesn't consult the
+    //      cache yet), so the work was unobservable.
+    //   2. If a future PR wires the Z3 verifier to call `lookup`,
+    //      the pre-population would already cache every function as
+    //      `Discharged`, *skipping the actual proof*. The cache
+    //      should only record verdicts the verifier has produced.
+    //
+    // The `lookup` / `store` / `stats` / `reset` API stays as-is so
+    // the cache infrastructure is ready for the consumer side when
+    // someone lands it. The `EXTENSION_PASSES` slot in
+    // `typechecker.rs` stays present for the same reason.
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`incremental_verify::check` walked the program through `fingerprint_program(program)` and inserted every fingerprint with `ProofResult::Discharged` into a process-wide cache. Two problems:

1. **Wasted work.** No callsite in the crate invokes `incremental_verify::lookup` — a `grep -rn 'incremental_verify::'` turns up only the call from `typechecker.rs` to this `check`. The Z3 verifier doesn't consult the cache yet, so the per-typecheck fingerprint walk + insert loop produced state that nothing read. Same shape as RES-1202 / RES-1206.

2. **Latent unsoundness.** The module's docs describe the cache as a memoisation layer where "calls to the Z3 verifier first consult the cache; if the digest matches, the cached result is returned without re-running SMT." If a future PR wires that consumer side, the pre-population would already cache every function as `Discharged`, *skipping the actual proof*. The cache should only record verdicts the verifier has produced.

This PR makes the `check` body a no-op. The `lookup` / `store` / `stats` / `reset` API stays exactly as-is so the cache infrastructure is ready for the consumer side when someone lands it. The `EXTENSION_PASSES` slot in `typechecker.rs` stays present for the same reason.

## Scope

- `resilient/src/incremental_verify.rs` only.
- No `typechecker.rs` change. No public API change.
- The two existing unit tests pass unchanged — they call `store` / `lookup` directly without going through `check`.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — **3227 passing**, no change vs main.
- [x] `cargo test --locked --lib incremental_verify` — 2 of 2 pass.

Closes #1210