### PR TITLE
RES-1211: fast-reject isr_call_graph::check when no ISR is declared

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -39,6 +39,10 @@
     "resilient/src/verifier_z3.rs": {
       "branch": "res-1206-z3-verdict-cache",
       "claimed_at": "2026-05-12T01:45:28Z"
+    },
+    "resilient/src/isr_call_graph.rs": {
+      "branch": "res-1211-isr-fast-reject",
+      "claimed_at": "2026-05-12T01:57:48Z"
     }
   }
 }

--- a/resilient/src/isr_call_graph.rs
+++ b/resilient/src/isr_call_graph.rs
@@ -48,6 +48,21 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
+    // RES-1211: fast-reject. The pass only emits diagnostics for ISR
+    // functions and their transitive callees; if the program declares
+    // no ISR, every later step is a no-op (`isr_roots` stays empty
+    // and the BFS never enters its loop). Scan the top-level function
+    // names first — that's O(N) over toplevel statements with a cheap
+    // suffix/prefix string check — and skip the per-body
+    // `collect_callees` walks, which would otherwise dominate this
+    // pass on non-embedded programs (the overwhelming majority of
+    // `examples/` and the test suite).
+    let has_isr = stmts
+        .iter()
+        .any(|s| matches!(&s.node, Node::Function { name, .. } if is_isr_name(name)));
+    if !has_isr {
+        return Ok(());
+    }
     let mut callees: HashMap<String, HashSet<String>> = HashMap::new();
     let mut isr_roots: Vec<String> = Vec::new();
     for stmt in stmts {


### PR DESCRIPTION
## Summary

`isr_call_graph::check` walks every top-level function in the program and runs `collect_callees(body)` on each — building the callee map up front — before deciding whether any function is actually an ISR. The BFS that consumes that callee map only ever fires from `isr_roots` (functions whose names match `is_isr_name`: suffix `_isr`/`_irq`/`_handler`, prefix `ISR_`). For every program with zero ISR-named functions — basically the entire `examples/` directory and most of the test suite — the per-body recursion is dead work.

This PR adds an O(N)-over-toplevel-statements name scan up front:

```rust
let has_isr = stmts.iter().any(|s| {
    matches!(&s.node, Node::Function { name, .. } if is_isr_name(name))
});
if !has_isr {
    return Ok(());
}
```

`is_isr_name` is two `&[&str]::iter().any(...)` string-prefix/suffix checks — cheap. If no function matches, the rest of the pass body (per-body callee collection + BFS) is skipped entirely. Programs that do declare an ISR fall through to the existing path with no change.

Same shape as the parallel agents' RES-1202 / RES-1206 dead-work eliminations: target a pass that walks the AST and produces no output for the common case.

## Scope

- `resilient/src/isr_call_graph.rs` — 8-line addition inside `check`, plus a doc comment.
- `agent-scripts/file-claims.json` — claim entry.
- No public API change, no test changes; programs that *do* have ISR functions hit the same code path they did before.

## Test plan

- [x] `cargo build --locked` clean (20.5s)
- [x] `cargo clippy --locked --all-targets -- -D warnings` clean (20.2s)
- [x] `cargo fmt --check` clean
- [ ] Linux CI exercises the full pass via `build / test / clippy`

Closes #1212