### PR TITLE
RES-1214: fast-reject reentrancy_guard::check when no NR function exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -47,6 +47,10 @@
     "resilient/src/incremental_verify.rs": {
       "branch": "res-1210-incremental-verify-dead-work",
       "claimed_at": "2026-05-12T01:53:15Z"
+    },
+    "resilient/src/reentrancy_guard.rs": {
+      "branch": "res-1214-reentrancy-fast-reject",
+      "claimed_at": "2026-05-12T02:00:42Z"
     }
   }
 }

--- a/resilient/src/reentrancy_guard.rs
+++ b/resilient/src/reentrancy_guard.rs
@@ -29,6 +29,21 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
+    // RES-1214: fast-reject. The warning loop only fires for
+    // functions in `roots` — i.e. those whose names match
+    // `is_nonreentrant` (NR-flavoured prefix/suffix). Programs that
+    // declare no such function get an empty roots Vec and the BFS
+    // never runs, but the callee-map population still walks every
+    // function body. Skip the whole pass when there's no possible
+    // root; `is_nonreentrant` itself is just a pair of
+    // `&[&str]::iter().any(...)` string-prefix/suffix checks, far
+    // cheaper than the per-body `visit` recursion it replaces here.
+    let has_nonreentrant = stmts
+        .iter()
+        .any(|s| matches!(&s.node, Node::Function { name, .. } if is_nonreentrant(name)));
+    if !has_nonreentrant {
+        return Ok(());
+    }
     let mut callees: HashMap<String, HashSet<String>> = HashMap::new();
     let mut roots: Vec<String> = Vec::new();
     for stmt in stmts {


### PR DESCRIPTION
Same shape as RES-1211 for `isr_call_graph`: pre-build of per-function callee map is dead work for any program without a function whose name matches `is_nonreentrant` (NR-flavoured prefix/suffix). Added O(N)-over-toplevel-names fast-reject; programs that do declare such a function are unchanged. Closes #1214.