### PR TITLE
RES-1217: fast-reject handler-suffix passes (backpressure_safe + idempotent_handler)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -67,6 +67,14 @@
     "resilient/src/transaction_commit.rs": {
       "branch": "res-1218-param-type-fast-reject",
       "claimed_at": "2026-05-12T02:11:38Z"
+    },
+    "resilient/src/backpressure_safe.rs": {
+      "branch": "res-1217-handler-suffix-fast-reject",
+      "claimed_at": "2026-05-12T02:07:46Z"
+    },
+    "resilient/src/idempotent_handler.rs": {
+      "branch": "res-1217-handler-suffix-fast-reject",
+      "claimed_at": "2026-05-12T02:07:46Z"
     }
   }
 }

--- a/resilient/src/backpressure_safe.rs
+++ b/resilient/src/backpressure_safe.rs
@@ -34,6 +34,21 @@ const FULLNESS_FNS: &[&str] = &["mailbox_full", "is_full", "queue_full", "at_cap
 const QUEUE_TYPES: &[&str] = &["Mailbox", "BoundedQueue", "&Mailbox", "&mut Mailbox"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1217: fast-reject. The pass only emits diagnostics for
+    // functions whose name ends in `_handler`. For every program
+    // that declares no such function — overwhelmingly the case in
+    // `examples/` and the test suite — `for_each_function`'s
+    // closure dispatch + per-fn suffix check is wasted work. Scan
+    // the top-level names once up front and bail.
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let has_handler = stmts
+        .iter()
+        .any(|s| matches!(&s.node, Node::Function { name, .. } if name.ends_with("_handler")));
+    if !has_handler {
+        return Ok(());
+    }
     for_each_function(program, |fname, params, body| {
         if !fname.ends_with("_handler") {
             return;

--- a/resilient/src/idempotent_handler.rs
+++ b/resilient/src/idempotent_handler.rs
@@ -25,6 +25,19 @@ use crate::uniqueness_walk::{any_node, for_each_function};
 const DEDUPE_FNS: &[&str] = &["is_duplicate", "was_seen", "dedupe", "is_processed"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1217: fast-reject — same shape as `backpressure_safe`.
+    // The pass only emits diagnostics for functions whose name
+    // ends in `_idempotent`; for every other program the entire
+    // walk is wasted work.
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let has_idempotent = stmts
+        .iter()
+        .any(|s| matches!(&s.node, Node::Function { name, .. } if name.ends_with("_idempotent")));
+    if !has_idempotent {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         if !fname.ends_with("_idempotent") {
             return;


### PR DESCRIPTION
Bundled fast-reject: same name-suffix shape as RES-1211 (`isr_call_graph`) and RES-1214 (`reentrancy_guard`). `backpressure_safe::check` only emits for `*_handler` functions; `idempotent_handler::check` only emits for `*_idempotent` functions. Added O(N)-over-toplevel-names pre-scans; non-matching programs skip the `for_each_function` walk entirely. Closes #1216.