### PR TITLE
RES-1218: fast-reject bounded_blocking::check when no _bound{N} function exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -51,6 +51,10 @@
     "resilient/src/reentrancy_guard.rs": {
       "branch": "res-1214-reentrancy-fast-reject",
       "claimed_at": "2026-05-12T02:00:42Z"
+    },
+    "resilient/src/bounded_blocking.rs": {
+      "branch": "res-1218-fast-reject-extras",
+      "claimed_at": "2026-05-12T02:10:00Z"
     }
   }
 }

--- a/resilient/src/bounded_blocking.rs
+++ b/resilient/src/bounded_blocking.rs
@@ -38,6 +38,26 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
+    // RES-1218: fast-reject. The transitive-blocking analysis below
+    // only fires for functions whose name ends in one of the
+    // `_bound{N}` suffixes — the per-function `visit(body, ...)`
+    // walk that builds `callees` + `blocking_calls` is dead work for
+    // every other program. The overwhelming majority of `cargo test`
+    // inputs declare zero `_bound{N}` functions, so a cheap O(N)
+    // suffix scan over the top-level statement list short-circuits
+    // the entire AST walk in that case. Mirrors RES-1211's
+    // `isr_call_graph::check` fast-reject (which used the same shape
+    // for `is_isr_name`).
+    let has_bound_suffix = stmts.iter().any(|s| {
+        if let Node::Function { name, .. } = &s.node {
+            SUFFIXES.iter().any(|(suffix, _)| name.ends_with(*suffix))
+        } else {
+            false
+        }
+    });
+    if !has_bound_suffix {
+        return Ok(());
+    }
     let mut callees: HashMap<String, Vec<String>> = HashMap::new();
     let mut blocking_calls: HashMap<String, usize> = HashMap::new();
     let mut decls: Vec<String> = Vec::new();


### PR DESCRIPTION
## Summary

RES-1211 added a fast-reject to `isr_call_graph::check` so the per-function callee-collection walk is skipped when no ISR-named function is declared. `bounded_blocking::check` follows the **exact same shape**:

- Unconditionally walks every top-level function body via `visit(body, ...)` to build `callees` + `blocking_calls` HashMaps.
- Then iterates `decls`, filtering on `SUFFIXES.iter().find(|(s,_)| d.ends_with(*s))` — only functions whose names end in `_bound1`/`_bound2`/`_bound4`/`_bound8` get transitive-blocking analysis.

For programs that declare zero `_bound{N}` functions (the overwhelming majority of `cargo test` inputs and the entire `examples/` tree), the per-body AST walk is dead work — the maps it populates are consumed only by the second loop, which immediately short-circuits when no name matches.

This PR adds an O(N)-over-toplevel-statements suffix scan at the top of `check`. If no function name matches any of `SUFFIXES`, the pass returns `Ok(())` immediately. Programs that *do* declare a budgeted function fall through to the existing analysis with no behaviour change.

The name scan is a tight `name.ends_with(*suffix)` loop over at most four entries — orders of magnitude cheaper than the recursive `visit(body, ...)` walk it short-circuits.

## Scope

- `resilient/src/bounded_blocking.rs` only.
- No `typechecker.rs` change. No public API change. No test changes.

A sibling PR ([#1215](https://github.com/EricSpencer00/Resilient/pull/1215), RES-1214) applies the identical fast-reject to `reentrancy_guard::check`; this PR was originally scoped to cover both but narrowed once that work landed in flight.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — **3227 passing**, no change vs main.

Closes #1218