### PR TITLE
RES-1218: fast-reject param-type-keyed passes (watchdog_feed + sensor_freshness + transaction_commit)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -55,6 +55,18 @@
     "resilient/src/bounded_blocking.rs": {
       "branch": "res-1218-fast-reject-extras",
       "claimed_at": "2026-05-12T02:10:00Z"
+    },
+    "resilient/src/watchdog_feed.rs": {
+      "branch": "res-1218-param-type-fast-reject",
+      "claimed_at": "2026-05-12T02:11:38Z"
+    },
+    "resilient/src/sensor_freshness.rs": {
+      "branch": "res-1218-param-type-fast-reject",
+      "claimed_at": "2026-05-12T02:11:38Z"
+    },
+    "resilient/src/transaction_commit.rs": {
+      "branch": "res-1218-param-type-fast-reject",
+      "claimed_at": "2026-05-12T02:11:38Z"
     }
   }
 }

--- a/resilient/src/sensor_freshness.rs
+++ b/resilient/src/sensor_freshness.rs
@@ -28,6 +28,19 @@ const FRESH_METHODS: &[&str] = &["is_fresh", "fresh", "is_recent", "stamp"];
 const FRESH_FREE_FNS: &[&str] = &["is_fresh", "assert_fresh"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1218: fast-reject — see watchdog_feed for the same pattern.
+    // Skip the closure dispatch + per-fn allocation for programs
+    // that declare no `Sensor*`-typed parameter.
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let has_sensor = stmts.iter().any(|s| {
+        matches!(&s.node, Node::Function { parameters, .. }
+            if parameters.iter().any(|(ty, _)| SENSOR_TYPE_PREFIXES.iter().any(|p| ty.starts_with(*p))))
+    });
+    if !has_sensor {
+        return Ok(());
+    }
     for_each_function(program, |name, params, body| {
         let sensors: Vec<&str> = params
             .iter()

--- a/resilient/src/transaction_commit.rs
+++ b/resilient/src/transaction_commit.rs
@@ -38,6 +38,19 @@ const CLOSE_METHODS: &[&str] = &["commit", "rollback", "abort", "finish", "close
 const CLOSE_FREE_FNS: &[&str] = &["commit", "rollback", "abort_tx", "commit_tx"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1218: fast-reject — see watchdog_feed for the same pattern.
+    // Skip the closure dispatch + per-fn allocation for programs
+    // that declare no `Transaction`/`Tx`-typed parameter.
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let has_tx = stmts.iter().any(|s| {
+        matches!(&s.node, Node::Function { parameters, .. }
+            if parameters.iter().any(|(ty, _)| TX_TYPES.contains(&ty.as_str())))
+    });
+    if !has_tx {
+        return Ok(());
+    }
     for_each_function(program, |fname, params, body| {
         let txs: Vec<&str> = params
             .iter()

--- a/resilient/src/watchdog_feed.rs
+++ b/resilient/src/watchdog_feed.rs
@@ -33,6 +33,25 @@ const FEED_METHODS: &[&str] = &["feed", "kick", "pet", "reset"];
 const FEED_FREE_FNS: &[&str] = &["feed_watchdog", "kick_watchdog", "pet_watchdog"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1218: fast-reject. The pass only emits diagnostics for
+    // functions whose parameter list contains a `Watchdog`-typed
+    // entry. Programs that declare no such parameter pay the
+    // `for_each_function` closure dispatch plus the per-function
+    // `.collect::<Vec>()` allocation for every function — pure
+    // waste in the overwhelming majority of `examples/` and the
+    // test suite. Scan the top-level parameter lists once up front
+    // and bail; programs that do take a Watchdog hit the same
+    // code path they did before.
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let has_watchdog = stmts.iter().any(|s| {
+        matches!(&s.node, Node::Function { parameters, .. }
+            if parameters.iter().any(|(ty, _)| WATCHDOG_TYPES.contains(&ty.as_str())))
+    });
+    if !has_watchdog {
+        return Ok(());
+    }
     for_each_function(program, |name, params, body| {
         let watchdogs: Vec<&str> = params
             .iter()


### PR DESCRIPTION
Same shape as RES-1211/RES-1214/RES-1217, but matching on `parameters` field of `Node::Function` rather than `name`. Each pass currently allocates a `Vec<&str>` of matching param names per function via `.collect()` and only does real work when non-empty. Pre-scan checks all toplevel function param lists once and bails if none has a matching type — drops the closure dispatch + per-fn allocation for programs without `Watchdog`/`Sensor*`/`Tx` params (essentially every test). Closes #1220.