### PR TITLE
RES-1222: fast-reject budget-suffix passes (stack_budget + heap_budget + bandwidth_budget)

### DIFF
--- a/resilient/src/bandwidth_budget.rs
+++ b/resilient/src/bandwidth_budget.rs
@@ -41,6 +41,19 @@ const BUDGETS: &[(usize, &str)] = &[
 ];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1222: fast-reject — see stack_budget for the same pattern.
+    // Skip the closure dispatch for programs that declare no
+    // `_iobytes{N}` suffix.
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let has_budget = stmts.iter().any(|s| {
+        matches!(&s.node, Node::Function { name, .. }
+            if BUDGETS.iter().any(|(_, suf)| name.ends_with(*suf)))
+    });
+    if !has_budget {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         let Some(budget) = BUDGETS
             .iter()

--- a/resilient/src/heap_budget.rs
+++ b/resilient/src/heap_budget.rs
@@ -34,6 +34,18 @@ const ALLOC_FNS: &[&str] = &[
 ];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1222: fast-reject — see stack_budget for the same pattern.
+    // Skip the closure dispatch for programs that declare no
+    // `_alloc{N}` suffix.
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let has_budget = stmts
+        .iter()
+        .any(|s| matches!(&s.node, Node::Function { name, .. } if parse_budget(name).is_some()));
+    if !has_budget {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         let Some(budget) = parse_budget(fname) else {
             return;

--- a/resilient/src/stack_budget.rs
+++ b/resilient/src/stack_budget.rs
@@ -29,6 +29,22 @@ const SUFFIXES: &[(&str, usize)] = &[
 ];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1222: fast-reject. The pass only emits diagnostics for
+    // functions whose name ends in a `_stack{N}` suffix. Programs
+    // that declare no such function get nothing back from the
+    // SUFFIX lookup inside the closure, yet still pay the
+    // `for_each_function` dispatch per function. Scan top-level
+    // names once up front.
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let has_budget = stmts.iter().any(|s| {
+        matches!(&s.node, Node::Function { name, .. }
+            if SUFFIXES.iter().any(|(suf, _)| name.ends_with(*suf)))
+    });
+    if !has_budget {
+        return Ok(());
+    }
     for_each_function(program, |fname, params, body| {
         let budget = SUFFIXES
             .iter()


### PR DESCRIPTION
Same name-suffix shape as RES-1211/RES-1214/RES-1217/RES-1218. Pre-scan top-level function names for `_stack{N}` / `_alloc{N}` / `_iobytes{N}`; if none, return immediately. The parallel RES-1218 (#1219) already applied this to `bounded_blocking::check`. Closes #1222.