### PR TITLE
RES-1224: feature_attrs::find_kind — read under RwLock without snapshotting

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -79,6 +79,10 @@
     "resilient/src/rate_limit_static.rs": {
       "branch": "res-1228-rate-limit-fast-reject",
       "claimed_at": "2026-05-12T02:24:23Z"
+    },
+    "resilient/src/feature_attrs.rs": {
+      "branch": "res-1224-feature-attrs-no-snapshot",
+      "claimed_at": "2026-05-12T02:18:56Z"
     }
   }
 }

--- a/resilient/src/feature_attrs.rs
+++ b/resilient/src/feature_attrs.rs
@@ -114,6 +114,12 @@ pub fn record(item_name: &str, record: AttrRecord) {
 
 /// Snapshot the registry for read-only inspection by an analysis pass.
 /// Returns an empty map if nothing has been registered yet.
+///
+/// RES-1224: `find_kind` no longer goes through this — it reads the
+/// registry directly under the `RwLock` to avoid the full-registry
+/// clone — but the function is kept public for callers that want the
+/// whole map (e.g. the `--audit` reporter and any external integrator).
+#[allow(dead_code)]
 pub fn snapshot() -> AttrMap {
     ATTR_REGISTRY
         .read()
@@ -124,13 +130,30 @@ pub fn snapshot() -> AttrMap {
 
 /// Lookup all attributes of a given kind across all items. Returns
 /// `(item_name, AttrRecord)` pairs.
+///
+/// RES-1224: read the registry under its `RwLock` without snapshotting.
+/// The previous implementation called `snapshot()`, which deep-cloned
+/// the whole `HashMap<String, Vec<AttrRecord>>` (and every `AttrRecord`
+/// inside, each carrying two owned `String`s), then filtered. With
+/// ~25 analysis passes calling `find_kind` per typecheck, every call
+/// allocated a full-registry clone on the way to discarding most of
+/// it. Walking the map directly and cloning only matching entries
+/// keeps the same return shape while allocating only the bytes the
+/// caller actually consumes. The lock is held read-only and the walk
+/// is bounded by `map.len()`, so concurrent readers (parallel tests)
+/// don't serialise.
 pub fn find_kind(kind: &str) -> Vec<(String, AttrRecord)> {
-    let snap = snapshot();
+    let Ok(g) = ATTR_REGISTRY.read() else {
+        return Vec::new();
+    };
+    let Some(map) = g.as_ref() else {
+        return Vec::new();
+    };
     let mut out = Vec::new();
-    for (item, attrs) in snap {
+    for (item, attrs) in map {
         for a in attrs {
             if a.name == kind {
-                out.push((item.clone(), a));
+                out.push((item.clone(), a.clone()));
             }
         }
     }


### PR DESCRIPTION
## Summary

`feature_attrs::find_kind` is called by ~25 analysis passes per typecheck. The previous implementation called `snapshot()` first, which deep-clones the entire `HashMap<String, Vec<AttrRecord>>` — every map entry, every `Vec<AttrRecord>`, and every `AttrRecord` (two owned `String`s each) — *before* the filter discards most of it. With 25 passes, that's 25 full-registry clones per compile.

This PR reads the registry directly under its `RwLock` and clones only the entries whose `name == kind`:

```rust
pub fn find_kind(kind: &str) -> Vec<(String, AttrRecord)> {
    let Ok(g) = ATTR_REGISTRY.read() else { return Vec::new(); };
    let Some(map) = g.as_ref() else { return Vec::new(); };
    let mut out = Vec::new();
    for (item, attrs) in map {
        for a in attrs {
            if a.name == kind { out.push((item.clone(), a.clone())); }
        }
    }
    out
}
```

The lock is held read-only and the walk is bounded by `map.len()`, so concurrent readers (parallel tests) don't serialise. The return shape (`Vec<(String, AttrRecord)>`) is unchanged.

## Scope

- `resilient/src/feature_attrs.rs` only.
- `snapshot()` is kept `pub` (now `#[allow(dead_code)]` after the migration) so the `--audit` reporter and external integrators that want the whole map still have a public entry point.
- No public API change. No test changes.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — **3227 passing**, no change vs main.
- [x] `cargo test --locked --lib feature_attrs` — 3 of 3 pass.

Closes #1224