### PR TITLE
RES-1228: fast-reject rate_limit_static when no rate-limited function exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -75,6 +75,10 @@
     "resilient/src/idempotent_handler.rs": {
       "branch": "res-1217-handler-suffix-fast-reject",
       "claimed_at": "2026-05-12T02:07:46Z"
+    },
+    "resilient/src/rate_limit_static.rs": {
+      "branch": "res-1228-rate-limit-fast-reject",
+      "claimed_at": "2026-05-12T02:24:23Z"
     }
   }
 }

--- a/resilient/src/rate_limit_static.rs
+++ b/resilient/src/rate_limit_static.rs
@@ -28,6 +28,23 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
+    // RES-1228: fast-reject. The diagnostic only fires for functions
+    // whose name ends in `_oncepertick` / `_singleshot` / `_few`.
+    // Programs without any such suffix don't need the program-wide
+    // call-site count — yet the existing code walks every function
+    // body and populates a `HashMap<String, usize>` of every callee
+    // first, then loops `decls` looking for the suffix. Pre-scan
+    // top-level names for the suffix once up front; if none match,
+    // return immediately and skip both the AST traversals and the
+    // HashMap allocation. Same shape as RES-1211 / RES-1214 /
+    // RES-1217 / RES-1218 / RES-1222 / RES-1224.
+    let has_rate_limited = stmts.iter().any(|s| {
+        matches!(&s.node, Node::Function { name, .. }
+            if ONCE_SUFFIXES.iter().any(|suf| name.ends_with(*suf)) || name.ends_with(FEW_SUFFIX))
+    });
+    if !has_rate_limited {
+        return Ok(());
+    }
     let mut decls: Vec<String> = Vec::new();
     let mut counts: HashMap<String, usize> = HashMap::new();
     for stmt in stmts {


### PR DESCRIPTION
Same name-suffix shape: rate_limit_static walks every function body counting callees into a HashMap *before* checking if any function has `_oncepertick`/`_singleshot`/`_few` suffix. Pre-scan top-level names; skip if none. Closes #1228.