### PR TITLE
RES-1232: fast-reject priority_inheritance::check when no low_pri/bg/idle function exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -83,6 +83,10 @@
     "resilient/src/feature_attrs.rs": {
       "branch": "res-1224-feature-attrs-no-snapshot",
       "claimed_at": "2026-05-12T02:18:56Z"
+    },
+    "resilient/src/priority_inheritance.rs": {
+      "branch": "res-1232-priority-fast-reject",
+      "claimed_at": "2026-05-12T02:35:05Z"
     }
   }
 }

--- a/resilient/src/priority_inheritance.rs
+++ b/resilient/src/priority_inheritance.rs
@@ -27,6 +27,33 @@ const PI_VARIANTS: &[&str] = &["pi_lock", "pi_acquire", "with_priority_inherit"]
 const RAW_LOCKS: &[&str] = &["lock", "acquire", "mutex_lock"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1232: fast-reject. The per-function early-return inside
+    // `for_each_function` already short-circuits the body walk for
+    // any function whose name doesn't match `LOW_PRI_PREFIXES`, but
+    // `for_each_function` itself is still entered for every program
+    // and iterates every top-level statement. Programs with zero
+    // `low_pri_*`/`bg_*`/`idle_*` functions (the overwhelming
+    // majority of `cargo test` inputs and the entire `examples/`
+    // tree) pay the iteration + closure-call cost for no work.
+    // Hoist the suffix check above `for_each_function` so the whole
+    // pass returns `Ok(())` immediately when no candidate exists.
+    // Mirrors RES-1211 (isr_call_graph), RES-1214 (reentrancy_guard),
+    // RES-1218 (bounded_blocking + watchdog_feed + sensor_freshness +
+    // transaction_commit), RES-1217 (handler-suffix), and RES-1228
+    // (rate_limit_static).
+    let Node::Program(stmts) = program else {
+        return Ok(());
+    };
+    let has_low_pri_fn = stmts.iter().any(|s| {
+        if let Node::Function { name, .. } = &s.node {
+            LOW_PRI_PREFIXES.iter().any(|p| name.starts_with(*p))
+        } else {
+            false
+        }
+    });
+    if !has_low_pri_fn {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         if !LOW_PRI_PREFIXES.iter().any(|p| fname.starts_with(*p)) {
             return;


### PR DESCRIPTION
## Summary

`priority_inheritance::check` follows the same shape as the merged fast-rejects RES-1211 / RES-1214 / RES-1218 / RES-1217 / RES-1228. `for_each_function` is called unconditionally and a per-function inner-`return` filters on `LOW_PRI_PREFIXES.iter().any(|p| fname.starts_with(*p))` — but the outer iteration still runs for every program, paying the per-statement match + closure call cost on programs that declare zero `low_pri_*` / `bg_*` / `idle_*` functions (the overwhelming majority of test inputs and the entire `examples/` tree).

This PR hoists the suffix check above `for_each_function`: if no top-level statement is a function whose name starts with any `LOW_PRI_PREFIXES`, return `Ok(())` immediately. The behaviour is unchanged — by construction no analysis ever ran in that case.

## Scope

- `resilient/src/priority_inheritance.rs` only.
- No `typechecker.rs` change. No public API change. No test changes.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — **3227 passing**, no change vs main.

Closes #1232