### PR TITLE
RES-1236: fast-reject crash_only_cert::check when no #[crash_only_cert] attribute exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -87,6 +87,10 @@
     "resilient/src/priority_inheritance.rs": {
       "branch": "res-1232-priority-fast-reject",
       "claimed_at": "2026-05-12T02:35:05Z"
+    },
+    "resilient/src/crash_only_cert.rs": {
+      "branch": "res-1236-crash-only-cert-fast-reject",
+      "claimed_at": "2026-05-12T02:42:33Z"
     }
   }
 }

--- a/resilient/src/crash_only_cert.rs
+++ b/resilient/src/crash_only_cert.rs
@@ -54,6 +54,16 @@ fn is_safe_return(node: &Node) -> bool {
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let attrs = crate::feature_attrs::find_kind("crash_only_cert");
+    // RES-1236: fast-reject. The diagnostic only fires for functions
+    // annotated `#[crash_only_cert]`. When no such attribute exists
+    // in the program (the overwhelming common case — `examples/` and
+    // most tests don't use it), the inner `attrs.iter().any(...)`
+    // returns false for every function and the loop produces no
+    // output. Skip the loop entirely when the attribute set is
+    // empty. Same shape as the dead-walk fast-reject series.
+    if attrs.is_empty() {
+        return Ok(());
+    }
     let Node::Program(stmts) = program else {
         return Ok(());
     };


### PR DESCRIPTION
Single-line fast-reject: `if attrs.is_empty() { return Ok(()); }` before the per-statement loop. Skips the AST destructure + N `iter().any(...)` calls when the attribute is unused, which is the typical case. Closes #1236.