### PR TITLE
RES-1248: playground.yml — switch cache from actions/cache to Swatinem/rust-cache

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -41,16 +41,20 @@ jobs:
             curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
           fi
 
+      # RES-1248: rust-aware cache strips incremental compilation
+      # artifacts before saving (smaller cache, faster restore) and
+      # keys off rustc version + Cargo.lock + Cargo.toml + the active
+      # feature set automatically. Matches the caching strategy
+      # ci.yml's `default_ci` / `z3_ci` / `feature_matrix` jobs and
+      # embedded.yml (post-RES-1198) already use. The `wasm32-unknown-
+      # unknown` target is keyed by rust-cache automatically; the
+      # explicit `key:` disambiguator keeps the cache scope readable
+      # in the Actions UI.
       - name: cache cargo
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            playground/target
-          key: ${{ runner.os }}-playground-${{ hashFiles('playground/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-playground-
+          workspaces: playground
+          key: playground-wasm
 
       - name: build playground (release, size-checked)
         run: |

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -99,6 +99,10 @@
     "resilient/src/uniqueness_walk.rs": {
       "branch": "res-1238-any-node-early-terminate",
       "claimed_at": "2026-05-12T02:48:11Z"
+    },
+    ".github/workflows/playground.yml": {
+      "branch": "res-1248-playground-rust-cache",
+      "claimed_at": "2026-05-12T03:10:39Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

`playground.yml` was the last workflow in the repo still using `actions/cache@v4` with a manual cache key. Same migration as RES-1198 (`embedded.yml`'s three jobs), for the same reasons:

- **Cache size** — `actions/cache@v4` saves the whole `target/` directory, including `target/wasm32-unknown-unknown/{debug,release}/incremental/*` fingerprint dirs. `rust-cache` strips these.
- **Cache key** — `hashFiles('playground/Cargo.toml')` misses `Cargo.lock` changes (dep version bumps) and rustc version flips. `rust-cache` keys off rustc version + Cargo.lock + Cargo.toml + active feature set.
- **Consistency** — `ci.yml` (all jobs) and `embedded.yml` (post RES-1198) already use `Swatinem/rust-cache@v2`.

The new config:

```yaml
- name: cache cargo
  uses: Swatinem/rust-cache@v2
  with:
    workspaces: playground
    key: playground-wasm
```

`workspaces: playground` points at the per-job crate root; rust-cache auto-keys off the rustc target triple, so `wasm32-unknown-unknown` builds get their own cache slot. The explicit `key:` keeps the cache scope readable in the Actions UI.

## Scope

- `.github/workflows/playground.yml` only — no script or build-step changes. `playground/build.sh --check-size` is unchanged.
- No public API change. No Rust source change. No test changes.

## Test plan

- Workflow is invoked on PRs touching `playground/**`, `resilient/examples/**`, or itself. The build step (`bash playground/build.sh --check-size`) is unchanged, so a clean run on the new cache layer demonstrates parity. First run after merge populates the new cache slot; subsequent runs hit it.

Closes #1248