### PR TITLE
RES-1248: build.rs rerun-if-* hints so Cargo skips re-runs on unrelated changes

### DIFF
--- a/resilient/build.rs
+++ b/resilient/build.rs
@@ -10,6 +10,24 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
+    // RES-1248: declare the build script's actual dependencies so Cargo
+    // doesn't re-run it unnecessarily. Without these directives Cargo
+    // falls back to its default heuristic of re-running build.rs on
+    // every package change, which on a 55k-line `lib.rs` happens on
+    // every incremental rebuild.
+    //
+    // We list:
+    //   - the build script itself (so edits here invalidate the cache),
+    //   - the C source we sometimes compile (only matters under `ffi`),
+    //   - the `CARGO_FEATURE_FFI` env var (so toggling the feature
+    //     re-runs the script but nothing else does).
+    //
+    // The early-return below for non-ffi builds now lets Cargo cache
+    // "build.rs produced nothing" against the relevant inputs.
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=tests/ffi/lib_testhelper.c");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_FFI");
+
     // Only compile the FFI test helper when the `ffi` feature is active.
     if std::env::var("CARGO_FEATURE_FFI").is_err() {
         return;
@@ -17,9 +35,6 @@ fn main() {
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let c_src = PathBuf::from("tests/ffi/lib_testhelper.c");
-
-    // Tell Cargo to re-run build.rs if the C source changes.
-    println!("cargo:rerun-if-changed=tests/ffi/lib_testhelper.c");
 
     let (lib_name, extra_flags): (&str, &[&str]) = if cfg!(target_os = "macos") {
         ("libtesthelper.dylib", &["-dynamiclib"])


### PR DESCRIPTION
Declares actual build-script deps so Cargo can cache the "build.rs produced nothing" result instead of re-running it on every incremental rebuild. Different shape from the EXTENSION_PASSES fast-rejects — targets Cargo build-script invalidation logic. No file-claims edit. Closes #1250.