### PR TITLE
RES-1252: fast-reject degraded_mode::check when no critical/abort call exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -103,6 +103,10 @@
     ".github/workflows/playground.yml": {
       "branch": "res-1248-playground-rust-cache",
       "claimed_at": "2026-05-12T03:10:39Z"
+    },
+    "resilient/src/degraded_mode.rs": {
+      "branch": "res-1252-degraded-mode-fast-reject",
+      "claimed_at": "2026-05-12T03:27:30Z"
     }
   }
 }

--- a/resilient/src/degraded_mode.rs
+++ b/resilient/src/degraded_mode.rs
@@ -23,12 +23,36 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::for_each_function;
+use crate::uniqueness_walk::{any_node, for_each_function};
 
 const CRITICAL_PREFIXES: &[&str] = &["assert_critical_", "abort_", "halt_"];
 const RECOVERY_PREFIXES: &[&str] = &["degraded_", "safe_mode_", "recover_"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1252: fast-reject. `scan_blocks` recursively visits every
+    // block in every function and runs `any_node` per statement just
+    // to find a `CRITICAL_PREFIXES`-named call. For programs that
+    // declare no `assert_critical_*` / `abort_*` / `halt_*` call (the
+    // overwhelming majority of `cargo test` inputs and the entire
+    // `examples/` tree), the entire triple loop produces nothing.
+    //
+    // Pre-scan the whole program once via `any_node` (RES-1238
+    // already made this early-terminating). If no critical call
+    // exists anywhere in the AST, the pass returns `Ok(())`
+    // immediately — strictly cheaper than the existing
+    // `for_each_function → scan_blocks(recursive) → per-stmt
+    // any_node` triple loop on the same input. If any critical call
+    // exists, the existing `scan_blocks` path runs unchanged.
+    let has_critical = any_node(program, |n| match n {
+        Node::CallExpression { function, .. } => match function.as_ref() {
+            Node::Identifier { name, .. } => CRITICAL_PREFIXES.iter().any(|p| name.starts_with(*p)),
+            _ => false,
+        },
+        _ => false,
+    });
+    if !has_critical {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         scan_blocks(fname, body);
     });


### PR DESCRIPTION
## Summary

`degraded_mode::check` walks every top-level function via `for_each_function`, then `scan_blocks` recursively descends every block. For each block, it iterates statements and calls `any_node` to look for a "critical" call (`assert_critical_*`, `abort_*`, `halt_*`).

For programs that never call any such function — the overwhelming majority of `cargo test` inputs and the entire `examples/` tree — this triple-nested structure (per-function → per-block → per-statement → per-sub-node) is dead work.

This PR pre-scans the program once via `any_node` (RES-1238 already made this early-terminating). If no critical call exists anywhere, the pass returns `Ok(())` immediately — strictly cheaper than the existing triple loop. If any critical call *does* exist, the existing `scan_blocks` path runs unchanged with identical semantics.

## Scope

- `resilient/src/degraded_mode.rs` only.
- No `typechecker.rs` change. No public API change. No test changes.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — **3227 passing**, no change vs main.

Closes #1252