### PR TITLE
RES-1254: fast-reject audit_log_required::check when no audited field exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -107,6 +107,10 @@
     "resilient/src/degraded_mode.rs": {
       "branch": "res-1252-degraded-mode-fast-reject",
       "claimed_at": "2026-05-12T03:27:30Z"
+    },
+    "resilient/src/audit_log_required.rs": {
+      "branch": "res-1254-audit-log-fast-reject",
+      "claimed_at": "2026-05-12T03:32:45Z"
     }
   }
 }

--- a/resilient/src/audit_log_required.rs
+++ b/resilient/src/audit_log_required.rs
@@ -23,6 +23,23 @@ use crate::uniqueness_walk::{any_node, for_each_function, visit};
 const AUDIT_FNS: &[&str] = &["audit_log", "journal", "record_event", "emit_audit"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1254: fast-reject. The per-function `visit(body)` walk only
+    // does anything when it finds a `FieldAssignment` whose field name
+    // starts with `audited_` or ends with `_audited`. For programs
+    // that have no such fields (the overwhelming majority of test
+    // inputs and the entire `examples/` tree), every per-function
+    // visit produces nothing. Pre-scan the whole program once via
+    // `any_node` (RES-1238 made this early-terminating) and skip the
+    // pass entirely when no audited field exists.
+    let has_audited_field = any_node(program, |n| match n {
+        Node::FieldAssignment { field, .. } => {
+            field.starts_with("audited_") || field.ends_with("_audited")
+        }
+        _ => false,
+    });
+    if !has_audited_field {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         let mut has_audited_write = false;
         visit(body, &mut |n| {


### PR DESCRIPTION
## Summary

`audit_log_required::check` walks every top-level function via `for_each_function`, and for each body runs `visit` to look for a `FieldAssignment` whose field name starts with `audited_` or ends with `_audited`. For programs with no audited fields anywhere (the overwhelming majority of test inputs and the entire `examples/` tree), every per-function visit produces nothing but still touches every node.

This PR pre-scans the program once via `any_node` (RES-1238 already made this early-terminating). If no audited `FieldAssignment` exists, the pass returns `Ok(())` immediately and the `for_each_function` loop is skipped entirely. If any does exist, the existing per-function path runs unchanged.

## Scope

- `resilient/src/audit_log_required.rs` only.
- No `typechecker.rs` change. No public API change. No test changes.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — **3227 passing**, no change vs main.

Closes #1254