### PR TITLE
RES-1256: fast-reject secret_erasure::check when no secret binding exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -115,6 +115,10 @@
     "resilient/src/audit_log_required.rs": {
       "branch": "res-1254-audit-log-fast-reject",
       "claimed_at": "2026-05-12T03:32:45Z"
+    },
+    "resilient/src/secret_erasure.rs": {
+      "branch": "res-1256-secret-erasure-fast-reject",
+      "claimed_at": "2026-05-12T03:39:06Z"
     }
   }
 }

--- a/resilient/src/secret_erasure.rs
+++ b/resilient/src/secret_erasure.rs
@@ -31,6 +31,29 @@ const SECRET_TYPE_PREFIXES: &[&str] = &["Secret", "&Secret", "&mut Secret"];
 const WIPE_FNS: &[&str] = &["zeroize", "zero_out", "wipe", "scrub"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1256: fast-reject. `collect_local_secrets` walks each
+    // function body looking for `LetStatement` / `StaticLet` whose
+    // name or type annotation matches the secret prefix list. For
+    // programs with no such binding (the overwhelming majority of
+    // `cargo test` inputs and the entire `examples/` tree), every
+    // per-function visit walks the body in full and finds nothing —
+    // and the per-function `leaks` Vec is then empty so the rest of
+    // the closure is a no-op. Pre-scan the program once via
+    // `any_node` (RES-1238 made this early-terminating) and skip the
+    // pass entirely when no secret-prefixed binding exists.
+    let has_secret = any_node(program, |n| match n {
+        Node::LetStatement {
+            name, type_annot, ..
+        } => {
+            SECRET_NAME_PREFIXES.iter().any(|p| name.starts_with(*p))
+                || type_annot.as_deref().map(is_secret_type).unwrap_or(false)
+        }
+        Node::StaticLet { name, .. } => SECRET_NAME_PREFIXES.iter().any(|p| name.starts_with(*p)),
+        _ => false,
+    });
+    if !has_secret {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         let mut leaks = Vec::new();
         collect_local_secrets(body, &mut leaks);


### PR DESCRIPTION
## Summary

`secret_erasure::check` walks every top-level function via `for_each_function`, then `collect_local_secrets` walks each body via `visit` looking for `LetStatement` / `StaticLet` whose name starts with `secret_` / `key_` / `priv_` / `password` / `nonce_` (or whose type annotation starts with `Secret`).

For programs with no such binding (the overwhelming majority of test inputs and the entire `examples/` tree), every per-function visit walks the body in full and finds nothing.

This PR pre-scans the program once via `any_node` (RES-1238 already made this early-terminating). If no secret-prefixed binding exists anywhere, the pass returns `Ok(())` immediately. If any does exist, the existing per-function path runs unchanged.

## Scope

- `resilient/src/secret_erasure.rs` only.
- No `typechecker.rs` change. No public API change. No test changes.

## Test plan

- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --locked --lib` — **3227 passing**, no change vs main.

Closes #1256