### PR TITLE
RES-1263: upload cargo build --timings HTML report as a CI artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,28 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: cargo fmt --check
 
+      # RES-1263: emit a `cargo build --timings` HTML report from a clean
+      # build and upload it as an artifact. The next round of speedup PRs
+      # needs profiling data (per-crate compile time, frontend vs codegen
+      # split, critical-path graph) rather than static reads of `Cargo.toml`
+      # to know where to spend effort. Cargo writes
+      # `target/cargo-timings/cargo-timing-<timestamp>.html` per invocation;
+      # we upload the whole directory glob so re-runs accumulate inside the
+      # same artifact. `if-no-files-found: ignore` keeps the step silent on
+      # docs-only fast paths where cargo never ran. 14-day retention matches
+      # GitHub's default for CI artifacts.
+      - name: cargo build --timings
+        if: needs.changes.outputs.docs_only != 'true'
+        run: cargo build --locked --timings
+      - name: Upload cargo --timings report
+        if: needs.changes.outputs.docs_only != 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-timings-${{ github.run_id }}
+          path: resilient/target/cargo-timings/cargo-timing-*.html
+          retention-days: 14
+          if-no-files-found: ignore
+
   z3_ci:
     name: build / test with --features z3
     needs: [changes]


### PR DESCRIPTION
Closes #1263.

## Summary

The next round of compiler-speedup PRs needs profiling data — per-crate compile times, frontend vs codegen split, the critical-path graph — to target hot units instead of being driven by static reads of `Cargo.toml`. `cargo build --timings` emits exactly this as an HTML report; this PR runs it in CI and uploads the result as an artifact.

## Changes

Two new steps appended to the `default_ci` job in `.github/workflows/ci.yml`, after `cargo fmt`:

1. **\`cargo build --locked --timings\`** — clean-build invocation that produces `target/cargo-timings/cargo-timing-<timestamp>.html`. Gated on the docs-only fast path so docs PRs stay quiet.
2. **\`actions/upload-artifact@v4\`** — ships the HTML under `cargo-timings-<run_id>`. `if-no-files-found: ignore` keeps the step silent when cargo never ran; 14-day retention matches GitHub's default.

The artifact is purely advisory — no check gates on timing data. Pulling it from a CI run is a one-click download from the run summary page.

## Test plan

- [x] `actions/upload-artifact@v4` is the current major
- [x] Path glob (`cargo-timing-*.html`) matches cargo's actual output (`cargo-timing-<UTC-timestamp>.html`)
- [x] `if-no-files-found: ignore` keeps the step quiet on the docs-only fast path
- [x] `always()` on the upload step ensures the report is uploaded even if a downstream step fails — that's the useful case
- [x] No behavioral change for non-CI consumers