### PR TITLE
RES-1267: fast-reject numeric_units::check when no unit-suffixed binding exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -123,6 +123,10 @@
     "resilient/src/monotonic_field.rs": {
       "branch": "res-1262-monotonic-fast-reject",
       "claimed_at": "2026-05-12T03:53:13Z"
+    },
+    "resilient/src/numeric_units.rs": {
+      "branch": "res-1267-numeric-units-fast-reject",
+      "claimed_at": "2026-05-12T03:58:58Z"
     }
   }
 }

--- a/resilient/src/numeric_units.rs
+++ b/resilient/src/numeric_units.rs
@@ -18,7 +18,7 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{for_each_function, visit};
+use crate::uniqueness_walk::{any_node, for_each_function, visit};
 
 const UNIT_SUFFIXES: &[&str] = &[
     "_ms", "_s", "_us", "_ns", // time
@@ -31,6 +31,28 @@ const UNIT_SUFFIXES: &[&str] = &[
 ];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1267: fast-reject. The per-function body walk only does
+    // anything when it finds a `LetStatement` whose name matches a
+    // unit suffix (`_ms` / `_s` / `_m` / `_kg` / …). Function params
+    // can also seed the units map. For programs without any
+    // unit-suffixed binding (the overwhelming majority of `cargo
+    // test` inputs and the entire `examples/` tree), every
+    // per-function visit produces nothing.
+    //
+    // Pre-scan the program once via `any_node` (RES-1238 made this
+    // early-terminating) for any `LetStatement` or `Function` param
+    // whose name matches a unit suffix. If none, return `Ok(())`
+    // immediately. The pre-scan also examines `Node::Function`
+    // params because the original closure seeds the units map from
+    // both sources.
+    let has_unit_binding = any_node(program, |n| match n {
+        Node::LetStatement { name, .. } => unit_of(name).is_some(),
+        Node::Function { parameters, .. } => parameters.iter().any(|(_ty, p)| unit_of(p).is_some()),
+        _ => false,
+    });
+    if !has_unit_binding {
+        return Ok(());
+    }
     for_each_function(program, |fname, params, body| {
         let mut units: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         for (_ty, name) in params {


### PR DESCRIPTION
## Summary

`numeric_units::check` walks every top-level function via `for_each_function`. For each function, it builds a units `HashMap` from param names that match a unit suffix, then `visit`s the body for `LetStatement` whose name matches a unit suffix.

For programs without any unit-suffixed binding (the overwhelming majority of test inputs and the entire `examples/` tree), every per-function visit produces nothing.

This PR pre-scans the program once via `any_node` (RES-1238 made this early-terminating). The pre-scan examines both `LetStatement` names and `Function` param names — both sources seed the units map in the original closure. If neither finds a match, the pass returns `Ok(())` immediately.

## Scope

- `resilient/src/numeric_units.rs` only.

Closes #1267