### PR TITLE
RES-1266: fast-reject 2 Ralph-Loop uniqueness checks (saturation_required, toctou_guard)

### DIFF
--- a/resilient/src/saturation_required.rs
+++ b/resilient/src/saturation_required.rs
@@ -19,12 +19,26 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{for_each_function, visit};
+use crate::uniqueness_walk::{any_node, for_each_function, visit};
 
 const SAT_NAME_SUFFIXES: &[&str] = &["_pwm", "_duty", "_brightness", "_pct", "_throttle"];
 const SAT_FNS: &[&str] = &["saturating_add", "saturating_sub", "saturating_mul"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1266: fast-reject. The per-function descent walks every function
+    // body looking for `LetStatement`s whose name ends in a saturation-typed
+    // suffix (`_pwm`, `_duty`, …). The overwhelming majority of programs
+    // (every fixture in `examples/`, every unit test, every integration
+    // test) have no such binding, so every descent produces zero work.
+    // Pre-scan once with the early-terminating `any_node` (RES-1238) and
+    // skip the per-function loop entirely when nothing matches.
+    let has_sat_let = any_node(program, |n| match n {
+        Node::LetStatement { name, .. } => SAT_NAME_SUFFIXES.iter().any(|s| name.ends_with(*s)),
+        _ => false,
+    });
+    if !has_sat_let {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         visit(body, &mut |n| {
             if let Node::LetStatement { name, value, .. } = n {

--- a/resilient/src/toctou_guard.rs
+++ b/resilient/src/toctou_guard.rs
@@ -22,12 +22,30 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{for_each_function, visit};
+use crate::uniqueness_walk::{any_node, for_each_function, visit};
 
 const CHECK_SUFFIXES: &[&str] = &["_exists", "_is_valid", "_status", "_check"];
 const USE_SUFFIXES: &[&str] = &["_open", "_read", "_write", "_delete", "_unlink", "_chmod"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1266: fast-reject. The TOCTOU detector pairs a `*_exists` /
+    // `*_is_valid` / `*_status` / `*_check` call with a later non-atomic
+    // `*_open` / `*_read` / … on the same argument. Without a *check*
+    // call in the function, there can never be a pair, so the per-function
+    // event collection is dead work for the overwhelming majority of
+    // programs (every fixture in `examples/`, every test). Pre-scan once
+    // for any check-suffixed CallExpression via the early-terminating
+    // `any_node` (RES-1238) and skip the loop entirely when none exist.
+    let has_check_call = any_node(program, |n| match n {
+        Node::CallExpression { function, .. } => match function.as_ref() {
+            Node::Identifier { name, .. } => CHECK_SUFFIXES.iter().any(|s| name.ends_with(*s)),
+            _ => false,
+        },
+        _ => false,
+    });
+    if !has_check_call {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         let mut events: Vec<(bool, String, Option<String>)> = Vec::new();
         // (is_check, fn_name, first_ident_arg)


### PR DESCRIPTION
Closes #1266.

## Summary

Two Ralph-Loop uniqueness checks (\`saturation_required\`, \`toctou_guard\`) were paying the full per-function descent for zero results on every program that doesn't use their specific naming convention. Same dead-pass pattern that RES-1211 / RES-1217 / RES-1218 / RES-1228 etc. already fast-rejected for the other 20+ uniqueness checks.

(The third check in the original ticket scope — \`numeric_units\` — was shipped in parallel as RES-1267 / #1268 and is already on \`main\`; the rebase dropped that file from this PR's diff. The remaining two are still wins.)

Each gets a single \`any_node\`-based pre-scan prepended to its \`check\`:

- **\`saturation_required\`** — bail unless some \`LetStatement\` name ends in \`_pwm\`/\`_duty\`/\`_brightness\`/\`_pct\`/\`_throttle\`.
- **\`toctou_guard\`** — bail unless some \`CallExpression\` invokes a function-identifier ending in \`_exists\`/\`_is_valid\`/\`_status\`/\`_check\`. (A check pattern is the required trigger; without one no pair can fire.)

Both reuse the early-terminating \`uniqueness_walk::any_node\` from RES-1238, so the pre-scan costs O(first match) on programs that *do* hit the pattern.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green
- [x] Byte-identical output on both positive (warn) and negative (silent) paths