### PR TITLE
RES-1270: fast-reject 3 early-pass dead walks (recovery_checker, assume_false_checker, ranges)

### DIFF
--- a/resilient/src/assume_false_checker.rs
+++ b/resilient/src/assume_false_checker.rs
@@ -5,8 +5,26 @@
 // predicates and warns at the next statement boundary.
 
 use crate::Node;
+use crate::uniqueness_walk::any_node;
 
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    // RES-1270: fast-reject. The walker only emits the
+    // "dead-code following assume(false)" warning when it sees a
+    // `Node::Assume { condition: BooleanLiteral { value: false } }`.
+    // The overwhelming majority of programs contain zero `Assume`
+    // nodes (it's a verifier-only construct, ignored by the runtime
+    // and absent from every fixture in `examples/`), so the per-stmt
+    // descent produces nothing. Pre-scan once with the early-
+    // terminating `any_node` (RES-1238) for *any* `Assume`, and skip
+    // the walk entirely when none exist. (We don't pre-filter on
+    // `condition` being `BooleanLiteral { false }` because matching
+    // the exact shape costs a hash-table dispatch per node — the
+    // single bit "has Assume" predicate is enough to short-circuit
+    // the common case, and the inner walk re-checks the shape.)
+    let has_assume = any_node(program, |n| matches!(n, Node::Assume { .. }));
+    if !has_assume {
+        return Ok(());
+    }
     let mut checker = AssumeChecker::new(source_path);
     checker.walk(program);
     Ok(())

--- a/resilient/src/ranges.rs
+++ b/resilient/src/ranges.rs
@@ -73,6 +73,19 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         Node::Program(stmts) => stmts,
         _ => return Ok(()),
     };
+    // RES-1270: fast-reject. `check_stmt` is a recursive walk over every
+    // top-level statement (and through every block / for / while / fn
+    // body) looking for `Node::Range` to either accept (in `for…in` /
+    // `let` position) or reject (anywhere else). Without a `Node::Range`
+    // anywhere in the program — the case for every fixture in
+    // `examples/` and every unit test that doesn't use range literals
+    // — every recursion produces nothing. Pre-scan once with the
+    // early-terminating `any_node` (RES-1238) and skip the per-stmt
+    // walk entirely when no `Range` exists.
+    let has_range = crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::Range { .. }));
+    if !has_range {
+        return Ok(());
+    }
     for stmt in stmts {
         check_stmt(&stmt.node, source_path)?;
     }

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -9,9 +9,23 @@
 // V1 emits warnings; V2 will escalate to errors under --v2-strict.
 
 use crate::Node;
+use crate::uniqueness_walk::any_node;
 use std::collections::HashSet;
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1270: fast-reject. Both `collect_declarations` and
+    // `check_live_blocks` only produce diagnostics when a `live{}` block
+    // exists somewhere in the program — the recovery-body warnings
+    // (opaque FFI, recursion, capturing closures) fire on nodes
+    // *inside* `Node::LiveBlock`. The overwhelming majority of programs
+    // (every fixture in `examples/`, every test) contain zero
+    // `LiveBlock`s, so the full two-pass descent is dead work. Pre-scan
+    // once with the early-terminating `any_node` (RES-1238) and skip
+    // the walks entirely when none exist.
+    let has_live = any_node(program, |n| matches!(n, Node::LiveBlock { .. }));
+    if !has_live {
+        return Ok(());
+    }
     let mut ctx = Context::new();
     ctx.collect_declarations(program);
     ctx.check_live_blocks(program);


### PR DESCRIPTION
Closes #1270.

## Summary

Three early-dispatched compiler passes each walk the whole program looking for one specific AST node variant. Programs without that variant pay the per-stmt descent cost for zero results — same dead-pass shape that the RES-1211/1217/1218/1228/1252/1254/1266 line of tickets already fast-rejected for the Ralph-Loop uniqueness checks.

Each gets a single \`any_node\`-based pre-scan prepended to its \`check\`:

- **\`recovery_checker\`** — bail unless some \`Node::LiveBlock\` exists. Without one, both \`collect_declarations\` and \`check_live_blocks\` produce nothing.
- **\`assume_false_checker\`** — bail unless some \`Node::Assume\` exists. The dead-code warning fires only on \`Assume { condition: BooleanLiteral { false } }\`; without \`Assume\` at all the walker has nothing to say.
- **\`ranges\`** — bail unless some \`Node::Range\` exists. The pass's whole job is to either accept or reject range expressions; without any it's pure waste.

All three reuse the early-terminating \`uniqueness_walk::any_node\` from RES-1238, so the pre-scan costs O(first match) on programs that *do* exercise the feature. Byte-identical output on both paths.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green (3342 tests across 38 integration crates)