### PR TITLE
RES-1271: fast-reject age_bounded_data::check when no *_at field exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -127,6 +127,10 @@
     "resilient/src/numeric_units.rs": {
       "branch": "res-1267-numeric-units-fast-reject",
       "claimed_at": "2026-05-12T03:58:58Z"
+    },
+    "resilient/src/age_bounded_data.rs": {
+      "branch": "res-1271-age-bounded-fast-reject",
+      "claimed_at": "2026-05-12T04:06:34Z"
     }
   }
 }

--- a/resilient/src/age_bounded_data.rs
+++ b/resilient/src/age_bounded_data.rs
@@ -19,9 +19,23 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{for_each_function, visit};
+use crate::uniqueness_walk::{any_node, for_each_function, visit};
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1271: fast-reject. The whole point of this pass is to find
+    // `target.field` reads that aren't gated by a `target.*_at`
+    // comparison. If the program has no `*_at` field anywhere, the
+    // pattern doesn't apply — every read would warn indiscriminately
+    // and the warnings are meaningless for programs that don't use
+    // the age-bounded convention. Pre-scan for any `FieldAccess`
+    // whose field name ends in `_at`; if none, skip the entire pass.
+    let has_age_field = any_node(program, |n| match n {
+        Node::FieldAccess { field, .. } => field.ends_with("_at"),
+        _ => false,
+    });
+    if !has_age_field {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         let mut reads_value: Vec<(String, String)> = Vec::new(); // (target, field)
         let mut compares_age: std::collections::HashSet<(String, String)> =


### PR DESCRIPTION
## Summary

`age_bounded_data::check` walks every function body looking for `FieldAccess` reads and `*_at`-based comparisons. For programs without any `*_at` field anywhere, the analysis can't produce meaningful output — the pattern doesn't apply.

This PR pre-scans the program once via `any_node` (RES-1238 made this early-terminating). If no `FieldAccess` field name ends with `_at`, the pass returns `Ok(())` immediately.

## Scope

- `resilient/src/age_bounded_data.rs` only.

Closes #1271