### PR TITLE
RES-1275: fast-reject lock_ordering::check when no lock-style call exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -131,6 +131,10 @@
     "resilient/src/age_bounded_data.rs": {
       "branch": "res-1271-age-bounded-fast-reject",
       "claimed_at": "2026-05-12T04:06:34Z"
+    },
+    "resilient/src/lock_ordering.rs": {
+      "branch": "res-1275-lock-ordering-fast-reject",
+      "claimed_at": "2026-05-12T04:11:27Z"
     }
   }
 }

--- a/resilient/src/lock_ordering.rs
+++ b/resilient/src/lock_ordering.rs
@@ -27,7 +27,7 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::visit;
+use crate::uniqueness_walk::{any_node, visit};
 use std::collections::{HashMap, HashSet};
 
 const LOCK_FNS: &[&str] = &["lock", "acquire", "mutex_lock"];
@@ -37,6 +37,29 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
+    // RES-1275: fast-reject. `collect_pairs` walks every function
+    // body looking for `lock`/`acquire`/`mutex_lock` calls (or names
+    // prefixed `lock_`/`unlock_`). If the program has no such call
+    // anywhere, the per-function `pair_sites` map is always empty
+    // and the inversion-check loop does nothing — but we still
+    // walked every body. Pre-scan once via `any_node` (RES-1238
+    // early-terminating) and skip the entire pass when no
+    // lock-style call exists.
+    let has_lock_call = any_node(program, |n| match n {
+        Node::CallExpression { function, .. } => match function.as_ref() {
+            Node::Identifier { name, .. } => {
+                LOCK_FNS.contains(&name.as_str())
+                    || UNLOCK_FNS.contains(&name.as_str())
+                    || name.starts_with("lock_")
+                    || name.starts_with("unlock_")
+            }
+            _ => false,
+        },
+        _ => false,
+    });
+    if !has_lock_call {
+        return Ok(());
+    }
     let mut pair_sites: HashMap<(String, String), Vec<String>> = HashMap::new();
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {


### PR DESCRIPTION
## Summary

`lock_ordering::check` walks every function body via `collect_pairs` looking for `lock` / `acquire` / `mutex_lock` calls (or names prefixed `lock_` / `unlock_`). For programs without any such call, the work is wasted.

This PR pre-scans the program once via `any_node` (RES-1238 made this early-terminating). If no lock-style call exists, the pass returns `Ok(())` immediately.

## Scope

- `resilient/src/lock_ordering.rs` only.

Closes #1275