### PR TITLE
RES-1274: fast-reject 3 dispatch-shape passes (try_catch, epoch_ordering, loop_invariants)

### DIFF
--- a/resilient/src/epoch_ordering.rs
+++ b/resilient/src/epoch_ordering.rs
@@ -18,9 +18,27 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{for_each_function, visit};
+use crate::uniqueness_walk::{any_node, for_each_function, visit};
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1274: fast-reject. The per-function `visit` collects every
+    // call to a function whose identifier matches `_epoch<N>`, then
+    // pairs consecutive calls to detect out-of-order epochs. Programs
+    // with zero `_epoch<N>`-named calls produce an empty `sequence`
+    // and no windows-of-2 pairs, so every per-function walk is dead
+    // work. Pre-scan with the early-terminating `any_node` (RES-1238)
+    // for any `CallExpression` whose identifier matches `epoch_of`,
+    // and skip the per-function loop entirely when none exist.
+    let has_epoch_call = any_node(program, |n| match n {
+        Node::CallExpression { function, .. } => match function.as_ref() {
+            Node::Identifier { name, .. } => epoch_of(name).is_some(),
+            _ => false,
+        },
+        _ => false,
+    });
+    if !has_epoch_call {
+        return Ok(());
+    }
     for_each_function(program, |fname, _params, body| {
         let mut sequence: Vec<(String, u32)> = Vec::new();
         visit(body, &mut |n| {

--- a/resilient/src/loop_invariants.rs
+++ b/resilient/src/loop_invariants.rs
@@ -61,6 +61,18 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let Node::Program(statements) = program else {
         return Ok(());
     };
+    // RES-1274: fast-reject. `walk` only produces a diagnostic when
+    // it encounters `Node::InvariantStatement` outside a `while`/`for`
+    // body. Programs with no `InvariantStatement` anywhere — the
+    // overwhelming majority, since `invariant` is a verifier-only
+    // construct — have nothing to validate. Pre-scan the program once
+    // with the early-terminating `any_node` (RES-1238) and skip the
+    // per-stmt recursion entirely when no `InvariantStatement` exists.
+    let has_invariant =
+        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::InvariantStatement { .. }));
+    if !has_invariant {
+        return Ok(());
+    }
     for spanned in statements {
         walk(&spanned.node, /*in_loop=*/ false, source_path)?;
     }

--- a/resilient/src/try_catch.rs
+++ b/resilient/src/try_catch.rs
@@ -173,6 +173,18 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let Node::Program(statements) = program else {
         return Ok(());
     };
+    // RES-1274: fast-reject. The fn_fails table is only consulted by
+    // `walk` when it encounters a `Node::TryCatch`. For programs with
+    // no `TryCatch` anywhere — the overwhelming majority, including
+    // every fixture in `examples/` — both the table-building pass and
+    // the per-function descent produce nothing. Pre-scan the program
+    // once with the early-terminating `any_node` (RES-1238) and skip
+    // both passes when no `TryCatch` exists.
+    let has_try_catch =
+        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::TryCatch { .. }));
+    if !has_try_catch {
+        return Ok(());
+    }
     // Collect the table of each fn's declared `fails` set so we can
     // resolve call sites inside try bodies without round-tripping
     // through the main typechecker.


### PR DESCRIPTION
Closes #1274.

## Summary

Three more compiler passes each walk the whole program looking for a single, specific AST shape that the overwhelming majority of programs never contain. Same dead-pass pattern that the RES-1211/1217/1218/1228/1252/1254/1266/1270 line already fast-rejected for ~25 other checks.

(The fourth check in the original ticket scope — \`lock_ordering\` — was shipped in parallel as RES-1275 / #1276 and is already on \`main\`; the rebase dropped that file from this PR's diff. The remaining three are still wins.)

Each gets a single \`any_node\`-based pre-scan prepended to its \`check\`:

- **\`try_catch\`** — bail unless some \`Node::TryCatch\` exists. Without one, both the \`fn_fails\` table build and the per-function descent produce nothing.
- **\`epoch_ordering\`** — bail unless some \`CallExpression\` invokes an identifier matching \`epoch_of\` (\`*_epoch<N>\`).
- **\`loop_invariants\`** — bail unless some \`Node::InvariantStatement\` exists. \`invariant\` is a verifier-only construct missing from every fixture and every test that doesn't exercise the feature.

All three reuse the early-terminating \`uniqueness_walk::any_node\` from RES-1238.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green (3342 tests)