### PR TITLE
RES-1278: fast-reject bounds_check::check_array_bounds when no IndexExpression exists

### DIFF
--- a/resilient/src/bounds_check.rs
+++ b/resilient/src/bounds_check.rs
@@ -141,6 +141,24 @@ pub fn check_array_bounds(program: &Node, source_path: &str) -> Result<(), Strin
     let Node::Program(statements) = program else {
         return Ok(());
     };
+    // RES-1278: fast-reject. `walk_toplevel` only does meaningful work
+    // when it descends into a `Node::IndexExpression` (every other AST
+    // shape is plain recursion). For programs that never index an
+    // array — the overwhelming majority of `cargo test` inputs and
+    // every fixture in `examples/` that isn't array-shaped — the full
+    // descent classifies nothing. Pre-scan once with the early-
+    // terminating `any_node` (RES-1238) and skip the per-stmt walk
+    // entirely when no `IndexExpression` exists. The `reset_stats()`
+    // call above stays — it must run on every invocation so a stale
+    // PROVEN_SITES set from a prior call doesn't cause `is_proven_site`
+    // to report false positives for the current program's bytecode
+    // compilation (safe default: indices not proven → bounds checks
+    // emitted at runtime).
+    let has_index =
+        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::IndexExpression { .. }));
+    if !has_index {
+        return Ok(());
+    }
     let mut strict_errors: Vec<String> = Vec::new();
     for stmt in statements {
         walk_toplevel(&stmt.node, source_path, &mut strict_errors);


### PR DESCRIPTION
Closes #1278.

## Summary

\`bounds_check::check_array_bounds\` is one of the heaviest passes in the EXTENSION_PASSES dispatch list: it walks every top-level function body and classifies every \`Node::IndexExpression\` for static bounds-proof under an accumulating axiom set. Programs that never index an array (every fixture in \`examples/\` that isn't array-shaped, the bulk of \`cargo test\` inputs) pay the full descent for zero classifications.

Adds an \`any_node\`-based fast-reject after \`reset_stats()\` and before the per-stmt walk:

\`\`\`rust
reset_stats();
let has_index = uniqueness_walk::any_node(program, |n| matches!(n, Node::IndexExpression { .. }));
if !has_index { return Ok(()); }
\`\`\`

\`reset_stats()\` stays before the fast-reject — it must run on every invocation so a stale \`PROVEN_SITES\` from a prior call doesn't cause \`is_proven_site\` to report false positives for the current program's bytecode compilation. The safe default after skip is "indices not proven → runtime bounds check fires."

Reuses the early-terminating \`uniqueness_walk::any_node\` from RES-1238.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green (3342 tests)
- [x] Byte-identical output and bytecode on both positive (programs *with* IndexExpression) and negative (no IndexExpression) paths