### PR TITLE
RES-1280: feature_attrs tests use the binary-wide TEST_LOCK (RES-1132 follow-up)

### DIFF
--- a/resilient/src/feature_attrs.rs
+++ b/resilient/src/feature_attrs.rs
@@ -205,27 +205,26 @@ pub fn is_known_attribute(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    /// RES-1132: `record_and_lookup` and `reset_clears_state` both
-    /// drive the global `ATTR_REGISTRY`. cargo runs tests in parallel
-    /// by default, so without serialization the two races: A's
-    /// `record` can be wiped by B's `reset` between A's `record` and
-    /// `find_kind` calls, intermittently failing `record_and_lookup`
-    /// with `len = 0`. A per-module mutex held for the entire test
-    /// makes the global-state writes serial without affecting any
-    /// other test in the binary.
-    fn serial_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: Mutex<()> = Mutex::new(());
-        // Poison-tolerant: if a prior test panicked while holding the
-        // lock, the registry isn't corrupted (reset() rebuilds it),
-        // so we recover the guard and proceed.
-        LOCK.lock().unwrap_or_else(|p| p.into_inner())
-    }
+    // RES-1280: serialise registry-touching tests against the
+    // *binary-wide* `TEST_LOCK` (via `lock_for_test()`), not a
+    // module-local mutex.
+    //
+    // RES-1132 added a private `serial_lock()` here that used its own
+    // fresh `Mutex`. That serialised the two in-module tests against
+    // each other, but not against the dozens of tests in other
+    // modules (`refinement_types`, `session_types`, `lock_priority`,
+    // `info_flow`, `wcet_contracts`, etc.) that drive the same
+    // `ATTR_REGISTRY` through `lock_for_test()`. Result: another
+    // module's `reset()` could still wipe this test's `record` between
+    // the `record` and the `find_kind`, intermittently failing the
+    // `assert_eq!(found.len(), 1)` below with `0`. Reusing the public
+    // `TEST_LOCK` makes every registry-touching test in the binary
+    // serial.
 
     #[test]
     fn record_and_lookup() {
-        let _g = serial_lock();
+        let _g = lock_for_test();
         reset();
         record(
             "my_fn",
@@ -250,7 +249,7 @@ mod tests {
 
     #[test]
     fn reset_clears_state() {
-        let _g = serial_lock();
+        let _g = lock_for_test();
         reset();
         record(
             "f",


### PR DESCRIPTION
Closes #1280.

## Summary

RES-1132 added a module-local \`serial_lock()\` in \`feature_attrs.rs\`'s test module. The lock used a *fresh* \`Mutex\`, not the existing public \`TEST_LOCK\` that \`lock_for_test()\` returns. Result: those two in-module tests serialised against each other, but NOT against the dozens of tests in other modules that drive the same \`ATTR_REGISTRY\` through \`lock_for_test()\` (\`refinement_types\`, \`session_types\`, \`lock_priority\`, \`info_flow\`, \`wcet_contracts\`, etc.) — those held a different lock and could still race.

Observed failure on a parallel agent's z3 build (PR #1277):

\`\`\`
thread 'feature_attrs::tests::record_and_lookup' panicked at src/feature_attrs.rs:239:9:
assertion \`left == right\` failed
  left: 0
  right: 1
\`\`\`

That's \`find_kind("wcet").len() == 0\` immediately after a \`record\` for \`"wcet"\` — another module's test called \`reset()\` between the record and the find, while both tests held their respective (but disjoint) locks.

## Changes

Replace the module-local \`serial_lock()\` with a call to the public \`lock_for_test()\`. The same \`TEST_LOCK\` now guards every registry-touching test in the binary.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green (3342 tests)
- [x] \`cargo test feature_attrs::tests\` — all three pass under the new lock
- [x] No production-code change; the two test bodies use the same lock the rest of the binary already uses