### PR TITLE
RES-1284: fast-reject coverage_warnings + fmt_validation when their trigger calls don't exist

### DIFF
--- a/resilient/src/coverage_warnings.rs
+++ b/resilient/src/coverage_warnings.rs
@@ -90,6 +90,24 @@ fn is_err_call(node: &Node) -> bool {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1284: fast-reject. `analyze` walks every function body
+    // looking for `if`/`else` branches whose terminator is
+    // `return Err(...)`. Without any `CallExpression` whose callee is
+    // the `Err` constructor anywhere in the program — every fixture
+    // in `examples/` that doesn't use the `Result` happy path —
+    // `analyze` returns an empty Vec and no warnings fire. Pre-scan
+    // once with the early-terminating `any_node` (RES-1238) and skip
+    // the analysis entirely when no `Err` call exists.
+    let has_err_call = crate::uniqueness_walk::any_node(program, |n| match n {
+        Node::CallExpression { function, .. } => match function.as_ref() {
+            Node::Identifier { name, .. } => name == "Err",
+            _ => false,
+        },
+        _ => false,
+    });
+    if !has_err_call {
+        return Ok(());
+    }
     let warnings = analyze(program);
     for w in &warnings {
         eprintln!("warning: coverage in `{}`: {}", w.function, w.message);

--- a/resilient/src/fmt_validation.rs
+++ b/resilient/src/fmt_validation.rs
@@ -98,6 +98,24 @@ fn walk(node: &Node, fn_name: &str, errs: &mut Vec<String>) {
 }
 
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    // RES-1284: fast-reject. `analyze` walks every function body
+    // looking for `CallExpression` to the `format` builtin with a
+    // `StringLiteral` first arg. Without any `format` call anywhere
+    // in the program — the overwhelming majority of `cargo test`
+    // inputs and every fixture in `examples/` that doesn't use
+    // `format(...)` — the analyser returns an empty Vec. Pre-scan
+    // once with the early-terminating `any_node` (RES-1238) and skip
+    // the analysis entirely when no `format` call exists.
+    let has_format_call = crate::uniqueness_walk::any_node(program, |n| match n {
+        Node::CallExpression { function, .. } => match function.as_ref() {
+            Node::Identifier { name, .. } => name == "format",
+            _ => false,
+        },
+        _ => false,
+    });
+    if !has_format_call {
+        return Ok(());
+    }
     let errs = analyze(program);
     if !errs.is_empty() {
         return Err(format!("{}:0:0: error: {}", source_path, errs[0]));


### PR DESCRIPTION
Closes #1284.

## Summary

Two more EXTENSION_PASSES dispatchers walk every top-level function body looking for one specific \`CallExpression\` shape the overwhelming majority of programs never contain. Same dead-pass pattern that RES-1211..RES-1281 already fast-rejected for ~25 other checks.

- **\`coverage_warnings::check\`** — bail unless some \`CallExpression\` invokes the \`Err\` identifier. The pass only emits a warning when an \`if\`/\`else\` branch returns \`Err(...)\`; without an \`Err\` call there's nothing to flag.
- **\`fmt_validation::check\`** — bail unless some \`CallExpression\` invokes the \`format\` identifier. The pass only validates \`format(template, …)\` placeholder counts; without a \`format\` call there's nothing to validate.

Both reuse the early-terminating \`uniqueness_walk::any_node\` from RES-1238.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green
- [x] Byte-identical output on both positive and negative paths (programs that *do* contain \`Err\` / \`format\` calls get the same diagnostics as before)