### PR TITLE
RES-1285: fast-reject cluster_verifier::verify_program when no ClusterDecl exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -139,6 +139,10 @@
     "resilient/src/unsafe_check.rs": {
       "branch": "res-1281-unsafe-check-fast-reject",
       "claimed_at": "2026-05-12T04:21:23Z"
+    },
+    "resilient/src/cluster_verifier.rs": {
+      "branch": "res-1285-cluster-fast-reject",
+      "claimed_at": "2026-05-12T04:31:08Z"
     }
   }
 }

--- a/resilient/src/cluster_verifier.rs
+++ b/resilient/src/cluster_verifier.rs
@@ -126,6 +126,21 @@ pub(crate) fn verify_program(program: &Node, timeout_ms: u32) -> Vec<ClusterDiag
         return Vec::new();
     };
 
+    // RES-1285: fast-reject. The cluster invariant verifier only
+    // produces output when there's at least one `ClusterDecl` to
+    // verify. For programs that declare zero clusters — the
+    // overwhelming majority of `cargo test` inputs and the entire
+    // `examples/` tree — the second loop is a no-op, but the
+    // `ActorTable` build below would still clone every actor's
+    // state-fields list and handler set into a HashMap that's
+    // immediately dropped. Skip both loops when no cluster exists.
+    let has_cluster = stmts
+        .iter()
+        .any(|s| matches!(&s.node, Node::ClusterDecl { .. }));
+    if !has_cluster {
+        return Vec::new();
+    }
+
     // Build an `actor name → &ActorDecl-fields` lookup so the
     // cluster verifier can resolve member types.
     let mut actors: ActorTable = HashMap::new();


### PR DESCRIPTION
## Summary

`cluster_verifier::verify_program` is the Z3-gated cluster-invariant verifier. It walks every `ActorDecl` to build an `ActorTable` HashMap, then walks every `ClusterDecl` to verify its invariants.

For programs that declare zero `ClusterDecl`s (the overwhelming majority of test inputs and the entire `examples/` tree — clusters are a niche feature for distributed actor invariants), the cluster-verify loop is a no-op, but the `ActorTable` build still clones every actor's state-fields list and handler set into a HashMap that's immediately dropped.

This PR pre-scans `stmts.iter().any(matches!(_, Node::ClusterDecl))` before building the ActorTable. If no cluster exists, return an empty `Vec` immediately.

## Scope

- `resilient/src/cluster_verifier.rs` only. Gated on `#[cfg(feature = "z3")]`, so default builds are unaffected.

Closes #1285