### PR TITLE
RES-1288: fast-reject generics::check when no function declares type parameters

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -143,6 +143,10 @@
     "resilient/src/cluster_verifier.rs": {
       "branch": "res-1285-cluster-fast-reject",
       "claimed_at": "2026-05-12T04:31:08Z"
+    },
+    "resilient/src/generics.rs": {
+      "branch": "res-1288-generics-fast-reject",
+      "claimed_at": "2026-05-12T04:38:37Z"
     }
   }
 }

--- a/resilient/src/generics.rs
+++ b/resilient/src/generics.rs
@@ -192,6 +192,22 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         Node::Program(stmts) => stmts,
         _ => return Ok(()),
     };
+    // RES-1288: fast-reject. The per-function work in `check_node`
+    // — the duplicate-type-parameter scan and the body-consistency
+    // walk — only fires for functions that declare type parameters.
+    // For programs that declare zero generic functions (the
+    // overwhelming majority of `cargo test` inputs and the entire
+    // `examples/` tree), the outer iteration destructures every
+    // `Node::Function` and allocates a per-function `HashSet`
+    // before discovering `type_params` is empty. Pre-scan once for
+    // any `Function` with non-empty `type_params` and skip the
+    // entire pass when none exists.
+    let has_generic_fn = stmts
+        .iter()
+        .any(|s| matches!(&s.node, Node::Function { type_params, .. } if !type_params.is_empty()));
+    if !has_generic_fn {
+        return Ok(());
+    }
     for stmt in stmts {
         check_node(&stmt.node)?;
     }


### PR DESCRIPTION
## Summary

`generics::check` iterates every top-level statement and destructures `Node::Function`. For programs that declare zero generic functions (the overwhelming majority of test inputs and the entire `examples/` tree), the outer iteration runs for every function, allocating a per-function `HashSet` before discovering `type_params` is empty.

This PR pre-scans once for any `Function` with non-empty `type_params`. If none, the pass returns `Ok(())` immediately.

## Scope

- `resilient/src/generics.rs` only.

Closes #1288