### PR TITLE
RES-1290: fast-reject verifier_liveness::check when no eventually clause exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -147,6 +147,10 @@
     "resilient/src/generics.rs": {
       "branch": "res-1288-generics-fast-reject",
       "claimed_at": "2026-05-12T04:38:37Z"
+    },
+    "resilient/src/verifier_liveness.rs": {
+      "branch": "res-1290-liveness-fast-reject",
+      "claimed_at": "2026-05-12T04:46:14Z"
     }
   }
 }

--- a/resilient/src/verifier_liveness.rs
+++ b/resilient/src/verifier_liveness.rs
@@ -492,6 +492,20 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         Node::Program(s) => s,
         _ => return Ok(()),
     };
+    // RES-1290: fast-reject. The bounded liveness verifier only runs
+    // per `Node::ActorDecl` with non-empty `eventually_clauses`. For
+    // programs with no such clause anywhere — the overwhelming
+    // majority of `cargo test` inputs and the entire `examples/`
+    // tree — the inner `if eventually_clauses.is_empty() continue`
+    // fires for every iteration, but we still destructure every
+    // top-level statement. Pre-scan once over the statement list
+    // and skip the whole loop when no eventually clause exists.
+    let has_eventually = statements.iter().any(|s| {
+        matches!(&s.node, Node::ActorDecl { eventually_clauses, .. } if !eventually_clauses.is_empty())
+    });
+    if !has_eventually {
+        return Ok(());
+    }
     let mut refuted: Vec<String> = Vec::new();
     for stmt in statements {
         if let Node::ActorDecl {


### PR DESCRIPTION
## Summary

`verifier_liveness::check` walks every top-level statement and pattern-matches `Node::ActorDecl`. The per-actor early-out (`if eventually_clauses.is_empty() continue`) fires inside the loop, but the outer iteration destructures every statement.

For programs that declare zero `eventually(after: H): Q;` clauses (the overwhelming majority of test inputs and the entire `examples/` tree), the inner `continue` fires for every iteration without producing output.

This PR pre-scans once: if no `Node::ActorDecl` has any `eventually_clauses`, return `Ok(())` immediately.

## Scope

- `resilient/src/verifier_liveness.rs` only.

Closes #1290