### PR TITLE
RES-1291: fast-reject 3 graph-shape passes (blame_attribution, deadlock_freedom, iterator_protocol)

### DIFF
--- a/resilient/src/blame_attribution.rs
+++ b/resilient/src/blame_attribution.rs
@@ -116,6 +116,21 @@ pub fn callers_of(callee: &str) -> Vec<(String, usize)> {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1291: fast-reject. `build` walks every function body
+    // recursively, emitting one (caller, arg_index) edge per
+    // `CallExpression`. For programs with zero `CallExpression`
+    // anywhere, the walk visits every Node but emits nothing. Pre-
+    // scan with the early-terminating `any_node` (RES-1238) and skip
+    // the walk when no `CallExpression` exists. We still call
+    // `install` with an empty `BlameMap` so the process-global
+    // `BLAME_MAP` is reset between compilations and `callers_of(...)`
+    // doesn't return stale entries from a prior program.
+    let has_call =
+        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::CallExpression { .. }));
+    if !has_call {
+        install(BlameMap::default());
+        return Ok(());
+    }
     install(build(program));
     Ok(())
 }

--- a/resilient/src/deadlock_freedom.rs
+++ b/resilient/src/deadlock_freedom.rs
@@ -124,6 +124,21 @@ pub fn detect_cycles(graph: &ActorGraph) -> Vec<Vec<String>> {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1291: fast-reject. `build` collects an actor→actors graph
+    // by scanning every top-level statement, filtering ActorDecls,
+    // then walking each ActorDecl's handler bodies for `send` calls.
+    // Programs with zero `Node::ActorDecl` produce an empty graph
+    // (no nodes, no edges) and `detect_cycles` finds nothing. The
+    // overwhelming majority of programs — every fixture in
+    // `examples/` that doesn't model an actor network, every
+    // standalone-function unit test — pay this scan for zero output.
+    // Pre-scan with the early-terminating `any_node` (RES-1238) and
+    // skip both passes when no ActorDecl exists.
+    let has_actor =
+        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::ActorDecl { .. }));
+    if !has_actor {
+        return Ok(());
+    }
     let g = build(program);
     let cycles = detect_cycles(&g);
     for c in &cycles {

--- a/resilient/src/iterator_protocol.rs
+++ b/resilient/src/iterator_protocol.rs
@@ -37,6 +37,23 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
+    // RES-1291: fast-reject. The for-loop below filters every top-
+    // level statement looking for an `ImplBlock` whose trait_name is
+    // `"Iterator"`. Programs without any Iterator impl produce an
+    // empty set; the loop is dead work for them. Pre-scan with the
+    // early-terminating `any_node` (RES-1238) and short-circuit to
+    // an empty install when no matching ImplBlock exists. We still
+    // install an empty set so a prior program's iterator-impl
+    // registration doesn't leak into this compilation (the
+    // process-global ITERATORS otherwise retains stale entries).
+    let has_iterator_impl = crate::uniqueness_walk::any_node(program, |n| match n {
+        Node::ImplBlock { trait_name, .. } => trait_name.as_deref() == Some("Iterator"),
+        _ => false,
+    });
+    if !has_iterator_impl {
+        install_iterator_impls(HashSet::new());
+        return Ok(());
+    }
     let mut iters = HashSet::new();
     for s in stmts {
         if let Node::ImplBlock {


### PR DESCRIPTION
Closes #1291.

## Summary

Three more EXTENSION_PASSES dispatchers walk the program to populate process-global maps consulted only when a specific AST shape exists. Same dead-pass pattern that RES-1211..RES-1288 already fast-rejected for the rest of EXTENSION_PASSES.

Each \`check\` gets a single \`any_node\`-based pre-scan:

- **\`blame_attribution\`** — bail (and install an empty \`BlameMap\` so \`callers_of(...)\` doesn't return stale entries from a prior program) when no \`Node::CallExpression\` exists.
- **\`deadlock_freedom\`** — bail when no \`Node::ActorDecl\` exists. Without an actor, the actor graph has no nodes; no cycles to detect.
- **\`iterator_protocol\`** — bail (and install an empty set so a prior Iterator-impl registration doesn't leak) when no \`Node::ImplBlock\` has \`trait_name == Some("Iterator")\`.

All three reuse the early-terminating \`uniqueness_walk::any_node\` from RES-1238.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green (3342 tests)
- [x] Byte-identical output on positive paths; on negative paths the process-global maps reset to default — the same state the existing code reaches when its walk completes with nothing collected