### PR TITLE
RES-1294: fast-reject linear::check_linear_usage when no linear-typed binding exists

### DIFF
--- a/resilient/src/linear.rs
+++ b/resilient/src/linear.rs
@@ -70,6 +70,28 @@ pub fn check_linear_usage(program: &Node, source_path: &str) -> Result<(), Strin
     let Node::Program(statements) = program else {
         return Ok(());
     };
+    // RES-1294: fast-reject. The single-use walker inserts a
+    // `LinearBinding` only when it sees a `Function` parameter whose
+    // type starts with `LINEAR_PREFIX` or a `LetStatement` whose
+    // `type_annot` does. Without either anywhere in the program — the
+    // overwhelming majority of `cargo test` inputs and every fixture
+    // in `examples/` outside the linear-types feature tests — the
+    // per-function `bindings` HashMap is always empty, no diagnostic
+    // can fire, and the `Assignment` arm (which only errors when
+    // `bindings.get(name)` returns `Some`) is unreachable. Pre-scan
+    // once with the early-terminating `any_node` (RES-1238) and skip
+    // the per-fn walk when no linear-typed binding exists.
+    let has_linear = crate::uniqueness_walk::any_node(program, |n| match n {
+        Node::Function { parameters, .. } => parameters.iter().any(|(ty, _)| is_linear(ty)),
+        Node::LetStatement {
+            type_annot: Some(ty),
+            ..
+        } => is_linear(ty),
+        _ => false,
+    });
+    if !has_linear {
+        return Ok(());
+    }
     for stmt in statements {
         match &stmt.node {
             Node::Function {


### PR DESCRIPTION
Closes #1294.

## Summary

\`linear::check_linear_usage\` is invoked from \`typechecker.rs\` right before EXTENSION_PASSES on every program. It walks every top-level function (and every \`impl\` method) body to enforce the single-use rule on linear-typed parameters and \`let\` bindings.

The single-use walker only inserts a \`LinearBinding\` when it sees a \`Function\` parameter or \`LetStatement.type_annot\` whose string starts with \`LINEAR_PREFIX\` (the marker \`\"linear \"\`). For programs without either anywhere — the overwhelming majority of \`cargo test\` inputs and every fixture in \`examples/\` outside the linear-types feature tests — the per-function \`bindings\` HashMap stays empty for the entire walk and every diagnostic arm is unreachable by construction.

Pre-scan once with the early-terminating \`uniqueness_walk::any_node\` (RES-1238) for any \`Function\` parameter or \`LetStatement\` annot starting with \`LINEAR_PREFIX\`. If none, return \`Ok(())\` immediately.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green (3342 tests)
- [x] Byte-identical diagnostics on programs that *do* use linear types — the existing walk runs unchanged