### PR TITLE
RES-1296: avoid redundant statements walk in check_program_purity / check_program_effects when no pure fn exists

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -6131,6 +6131,14 @@ fn check_program_purity(
         }
     }
 
+    // RES-1296: short-circuit. The second pass walks every top-level
+    // statement and only descends into `Node::Function { pure: true,
+    // ... }`. If no `@pure` fn was found above, no descent ever
+    // fires — every iteration is wasted match-dispatch overhead.
+    if pure_fns.is_empty() {
+        return Ok(());
+    }
+
     // Second pass: check each pure fn's body.
     for stmt in statements {
         if let Node::Function {
@@ -7280,6 +7288,19 @@ fn check_program_effects(
     statements: &[crate::span::Spanned<Node>],
     source_path: &str,
 ) -> Result<(), String> {
+    // RES-1296: short-circuit. `collect_fn_effects` builds a
+    // name→effects HashMap by iterating every top-level statement,
+    // and the per-stmt loop below only enters its body for `Function`
+    // nodes with `effects.pure == true`. Programs that don't declare
+    // any pure fn — the overwhelming majority — pay for both passes
+    // and produce nothing useful. Pre-scan once before doing either
+    // and bail when no pure fn exists.
+    let has_pure_fn = statements
+        .iter()
+        .any(|s| matches!(&s.node, Node::Function { effects, .. } if effects.pure));
+    if !has_pure_fn {
+        return Ok(());
+    }
     let fn_effects = collect_fn_effects(statements);
     for stmt in statements {
         if let Node::Function {


### PR DESCRIPTION
Closes #1296.

## Summary

Two pre-EXTENSION_PASSES helpers in \`typechecker.rs\` each iterate the top-level statement slice twice on every program:

- \`check_program_purity\` collects \`@pure\` fn names into a HashSet, then walks each \`@pure\` fn body.
- \`check_program_effects\` builds a \`fn_effects\` HashMap (via \`collect_fn_effects\`), then walks each \`effects.pure\` fn body.

For programs without a \`@pure\` annotation or a pure-effect fn, both produce empty input to the per-fn walker; the second iteration is dead work.

## Changes

- \`check_program_purity\`: after the collection pass, return \`Ok\` if \`pure_fns.is_empty()\`.
- \`check_program_effects\`: do a single up-front \`statements.iter().any\` for \`Function { effects.pure }\`. If none, skip both the HashMap build and the per-stmt loop.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green (3342 tests)
- [x] Byte-identical diagnostics on programs that *do* declare a \`@pure\` or pure-effect fn