### PR TITLE
RES-1297: fast-reject verifier_loop_invariants when no invariants exist

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -151,6 +151,10 @@
     "resilient/src/verifier_liveness.rs": {
       "branch": "res-1290-liveness-fast-reject",
       "claimed_at": "2026-05-12T04:46:14Z"
+    },
+    "resilient/src/verifier_loop_invariants.rs": {
+      "branch": "res-1297-verifier-loop-inv-fast-reject",
+      "claimed_at": "2026-05-12T04:57:49Z"
     }
   }
 }

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -47,6 +47,27 @@ use std::collections::{BTreeSet, HashMap};
 /// only line of defense.
 #[cfg(feature = "z3")]
 pub(crate) fn verify_and_capture(tc: &mut crate::typechecker::TypeChecker, program: &Node) {
+    // RES-1297: fast-reject. The recursive `walk` only does Z3 work
+    // when it finds a `WhileStatement` whose `invariants` field is
+    // non-empty OR whose body contains a `Node::InvariantStatement`.
+    // For programs with no `invariant(P);` clauses anywhere — the
+    // overwhelming majority of `cargo test --features z3` inputs —
+    // the walk descends into every block / fn / for / while only to
+    // find empty invariant lists everywhere.
+    //
+    // Pre-scan via `any_node` (RES-1238 early-terminating) for any
+    // node that signals an invariant: either a `WhileStatement`
+    // with non-empty `invariants`, or a body-statement
+    // `InvariantStatement`. If neither is present, no per-while
+    // work would have anything to do.
+    let has_invariant = crate::uniqueness_walk::any_node(program, |n| match n {
+        Node::WhileStatement { invariants, .. } => !invariants.is_empty(),
+        Node::InvariantStatement { .. } => true,
+        _ => false,
+    });
+    if !has_invariant {
+        return;
+    }
     let timeout_ms = tc.verifier_timeout_ms();
     let verbose = tc.verbose_loop_invariants();
     let mut bindings: HashMap<String, i64> = HashMap::new();


### PR DESCRIPTION
## Summary

`verifier_loop_invariants::verify_and_capture` (Z3-gated) walks the whole program recursively looking for `WhileStatement`s and collecting pre-body / body invariants. For programs with no `invariant(P);` clauses anywhere (the overwhelming majority of `cargo test --features z3` inputs), the walk descends through every block, function, for-loop, and while-loop only to find empty invariant lists.

This PR pre-scans the program once via `any_node` (RES-1238 made this early-terminating) for any node signalling an invariant: either a `WhileStatement` with non-empty `invariants`, or a `Node::InvariantStatement` (body-statement form). If neither is present, return immediately.

## Scope

- `resilient/src/verifier_loop_invariants.rs` only. Gated on `#[cfg(feature = "z3")]`, so default builds are unaffected.

Closes #1297