### PR TITLE
RES-1300: merge cargo build --timings into the first build instead of doing a redundant clean build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,16 @@ jobs:
         with:
           workspaces: resilient
 
-      - name: cargo build
+      # RES-1263 + RES-1300: build with `--timings` so Cargo writes
+      # `target/cargo-timings/cargo-timing-<timestamp>.html` during
+      # the first (and only) compile of the workspace. The earlier
+      # wiring did a *second* `cargo build` after `clippy` / `test`
+      # / `fmt` solely to drop the report — wasted re-link of the
+      # 55k-line `resilient` lib on every PR. The merged invocation
+      # produces an identical timing artifact.
+      - name: cargo build --timings
         if: needs.changes.outputs.docs_only != 'true'
-        run: cargo build --locked --verbose
+        run: cargo build --locked --verbose --timings
 
       - name: cargo clippy
         if: needs.changes.outputs.docs_only != 'true'
@@ -85,19 +92,6 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: cargo fmt --check
 
-      # RES-1263: emit a `cargo build --timings` HTML report from a clean
-      # build and upload it as an artifact. The next round of speedup PRs
-      # needs profiling data (per-crate compile time, frontend vs codegen
-      # split, critical-path graph) rather than static reads of `Cargo.toml`
-      # to know where to spend effort. Cargo writes
-      # `target/cargo-timings/cargo-timing-<timestamp>.html` per invocation;
-      # we upload the whole directory glob so re-runs accumulate inside the
-      # same artifact. `if-no-files-found: ignore` keeps the step silent on
-      # docs-only fast paths where cargo never ran. 14-day retention matches
-      # GitHub's default for CI artifacts.
-      - name: cargo build --timings
-        if: needs.changes.outputs.docs_only != 'true'
-        run: cargo build --locked --timings
       - name: Upload cargo --timings report
         if: needs.changes.outputs.docs_only != 'true' && always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #1300.

## Summary

RES-1263 added a \`cargo build --locked --timings\` step at the end of the \`default_ci\` job to upload Cargo's per-crate timing HTML as an artifact. That ran a *second* \`cargo build\` after the existing \`cargo build / clippy / test / fmt\` chain had already populated \`target/\` — re-linking the 55k-line \`resilient\` lib just to drop a timing report.

Fold the \`--timings\` flag into the *first* \`cargo build\` step. Same artifact (\`target/cargo-timings/cargo-timing-*.html\`), one less invocation, less wall time per CI run.

## Test plan

- [x] YAML diff is minimal — two steps merged, one step removed, upload step's path/glob unchanged
- [x] The first build still gates clippy / test / fmt — order preserved
- [x] Artifact upload still runs with \`if-no-files-found: ignore\` and the same retention
- [x] No behavioural change for downstream consumers of the timing report