### PR TITLE
RES-1302: don't wipe REFINEMENTS from refinement_types::check when the program declares none

### DIFF
--- a/resilient/src/refinement_types.rs
+++ b/resilient/src/refinement_types.rs
@@ -116,7 +116,32 @@ pub fn refine_int(value: i64, refinement_name: &str) -> Result<i64, String> {
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    install(collect_specs());
+    // RES-1302: skip the `install` call when the current program
+    // declares no `#[refinement]` attributes. The `install` helper
+    // *replaces* the process-global `REFINEMENTS` vector — calling
+    // it with an empty list wipes whatever the previous compilation
+    // (or, in `cargo test`, a parallel test that called `install`
+    // directly under `feature_attrs::lock_for_test()`) set.
+    //
+    // The race: `refine_int_enforces_predicate` holds
+    // `feature_attrs::lock_for_test()` and calls `install([Positive])`
+    // directly. That lock guards `ATTR_REGISTRY`, not `REFINEMENTS`.
+    // A parallel test that parses + typechecks a program with no
+    // refinement attribute lands here, where `collect_specs()`
+    // returns `[]`, and the unconditional `install(vec![])` clears
+    // `REFINEMENTS` between the test's install and its
+    // `refine_int(value, "Positive")` lookup. The lookup then
+    // returns `None`, `refine_int` passes the value through, and
+    // the `assert!(refine_int(-1, "Positive").is_err())` assertion
+    // fails. Skipping the call when the input is empty avoids the
+    // wipe; production compilation only mutates the global when the
+    // *current* program declares refinements, which is the only
+    // case the global is needed for that program anyway.
+    let specs = collect_specs();
+    if specs.is_empty() {
+        return Ok(());
+    }
+    install(specs);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1302.

## Summary

\`refinement_types::check\` did \`install(collect_specs())\` on every compilation. \`install\` *replaces* the process-global \`REFINEMENTS\` — calling it with an empty list wipes whatever the previous compilation, or a parallel test, had set. The race surfaced on PR #1301's CI:

\`\`\`
test refinement_types::tests::refine_int_enforces_predicate ... FAILED
assertion failed: refine_int(-1, \"Positive\").is_err()
\`\`\`

The holding test acquires \`feature_attrs::lock_for_test()\` (which guards \`ATTR_REGISTRY\`, not \`REFINEMENTS\`), calls \`install([Positive])\` directly, then \`refine_int(-1, \"Positive\")\`. A parallel test's typechecker call landed \`install(vec![])\` between the two, wiped \`REFINEMENTS\`, and \`refine_int\` passed the value through.

Skip the \`install\` call when \`collect_specs()\` returns empty. The global only needs mutation when the current program declares refinements; skipping the empty case avoids the wipe and removes the test-race source. Production behaviour for programs that *do* declare refinements is unchanged.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green
- [x] \`refinement_types::tests::refine_int_enforces_predicate\` still passes (the holding test wasn't the problem; the wiping side was)