### PR TITLE
RES-1306: skip empty install() in 6 EXTENSION_PASSES (async_await, session_types, mmio_regmap, hw_state_machine, typestate_types, default_trait_methods)

### DIFF
--- a/resilient/src/async_await.rs
+++ b/resilient/src/async_await.rs
@@ -45,11 +45,18 @@ pub fn is_async(name: &str) -> bool {
 }
 
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    // RES-1306: gate `install` on the non-empty case. The previous
+    // wiring did the RwLock write before the `is_empty` early-out,
+    // burning a write-lock acquisition + replace on every program
+    // that declares no `#[async_fn]` attribute (the overwhelming
+    // majority). It also created the same wipe-on-empty test race
+    // documented in RES-1302 against any test that installs into
+    // `ASYNC_FNS` directly. Bail when the collected set is empty.
     let async_fns = collect();
-    install(async_fns.clone());
     if async_fns.is_empty() {
         return Ok(());
     }
+    install(async_fns.clone());
     let Node::Program(stmts) = program else {
         return Ok(());
     };

--- a/resilient/src/default_trait_methods.rs
+++ b/resilient/src/default_trait_methods.rs
@@ -54,13 +54,23 @@ pub fn has_default(trait_name: &str, method: &str) -> bool {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1306: gate `install` on the non-empty case. `find_kind`
+    // returning empty (no `#[default_impl]` attribute anywhere) is
+    // the common case; skipping the `install` write avoids the
+    // wasted RwLock acquisition and the wipe-on-empty test race
+    // shape documented in RES-1302.
+    let _ = program;
+    let attrs = crate::feature_attrs::find_kind("default_impl");
+    if attrs.is_empty() {
+        return Ok(());
+    }
     // The Node::TraitDecl variant in lib.rs holds method signatures
     // without bodies in the current ABI. As a first slice we discover
     // default bodies via the `#[derive]`-style attribute companion:
     // any trait method named in `#[default_impl(trait="T", method="m")]`
     // is registered here.
     let mut items = Vec::new();
-    for (item, rec) in crate::feature_attrs::find_kind("default_impl") {
+    for (item, rec) in attrs {
         let mut trait_name = String::new();
         let mut method_name = item;
         for chunk in rec.args.split(',') {
@@ -82,8 +92,10 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
             });
         }
     }
+    if items.is_empty() {
+        return Ok(());
+    }
     install(items);
-    let _ = program;
     Ok(())
 }
 

--- a/resilient/src/hw_state_machine.rs
+++ b/resilient/src/hw_state_machine.rs
@@ -97,7 +97,14 @@ pub fn transition(peripheral: &str, current: &str, method: &str) -> Result<Strin
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    install(collect());
+    // RES-1306: gate `install` on the non-empty case — avoids a
+    // wasted RwLock write per compilation and removes the
+    // wipe-on-empty test race shape documented in RES-1302.
+    let specs = collect();
+    if specs.is_empty() {
+        return Ok(());
+    }
+    install(specs);
     Ok(())
 }
 

--- a/resilient/src/mmio_regmap.rs
+++ b/resilient/src/mmio_regmap.rs
@@ -84,7 +84,14 @@ pub fn lookup(struct_name: &str) -> Option<MmioRegmap> {
 }
 
 pub(crate) fn check(_program: &Node, source_path: &str) -> Result<(), String> {
+    // RES-1306: gate `install` (and the overlap loop, which is
+    // already a no-op for empty maps) on the non-empty case —
+    // avoids a wasted RwLock write per compilation and removes the
+    // wipe-on-empty test race shape documented in RES-1302.
     let maps = collect();
+    if maps.is_empty() {
+        return Ok(());
+    }
     install(maps.clone());
     // Detect overlapping address ranges — a real bug.
     for (i, a) in maps.iter().enumerate() {

--- a/resilient/src/session_types.rs
+++ b/resilient/src/session_types.rs
@@ -104,7 +104,14 @@ pub fn validate_step(channel: &str, step: usize, op: &SessionOp) -> Result<(), S
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    install(collect());
+    // RES-1306: gate `install` on the non-empty case — avoids a
+    // wasted RwLock write per compilation and removes the
+    // wipe-on-empty test race shape documented in RES-1302.
+    let specs = collect();
+    if specs.is_empty() {
+        return Ok(());
+    }
+    install(specs);
     Ok(())
 }
 

--- a/resilient/src/typestate_types.rs
+++ b/resilient/src/typestate_types.rs
@@ -101,7 +101,14 @@ pub fn validate_call(
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    install(collect());
+    // RES-1306: gate `install` on the non-empty case — avoids a
+    // wasted RwLock write per compilation and removes the
+    // wipe-on-empty test race shape documented in RES-1302.
+    let specs = collect();
+    if specs.is_empty() {
+        return Ok(());
+    }
+    install(specs);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1306.

## Summary

Six EXTENSION_PASSES helpers called \`install(collect())\` unconditionally on every compilation. \`install\` acquires an \`RwLock\` write and replaces its global. For programs that declare zero relevant attributes (the overwhelming majority of \`cargo test\` inputs and every fixture in \`examples/\` outside the corresponding feature tests), the install is a full write-lock just to clobber the global with an empty Vec / HashSet.

Two wins from gating each \`install\` on the non-empty case:

1. **Wall-clock**: skip 6 RwLock write acquisitions per compilation in the no-attr case.
2. **Test-race hygiene** (matches RES-1302): tests that install state directly into these globals can race against parallel-test typechecks landing here; skipping the empty install removes the wipe-on-empty side of the race.

Changes:
- \`async_await::check\` — move \`install\` AFTER the existing \`is_empty\` guard.
- \`session_types\`, \`mmio_regmap\`, \`hw_state_machine\`, \`typestate_types\`, \`default_trait_methods\` — add an \`if collect().is_empty() { return Ok(()); }\` guard before \`install\`.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green