### PR TITLE
RES-1308: skip empty install() in 8 EXTENSION_PASSES

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -155,6 +155,38 @@
     "resilient/src/feature_attrs.rs": {
       "branch": "res-1303-feature-attrs-kind-index",
       "claimed_at": "2026-05-12T05:08:27Z"
+    },
+    "resilient/src/associated_constants.rs": {
+      "branch": "res-1308-skip-empty-install-8-passes",
+      "claimed_at": "2026-05-12T05:18:02Z"
+    },
+    "resilient/src/macros.rs": {
+      "branch": "res-1308-skip-empty-install-8-passes",
+      "claimed_at": "2026-05-12T05:18:02Z"
+    },
+    "resilient/src/phantom_types.rs": {
+      "branch": "res-1308-skip-empty-install-8-passes",
+      "claimed_at": "2026-05-12T05:18:02Z"
+    },
+    "resilient/src/recursive_types.rs": {
+      "branch": "res-1308-skip-empty-install-8-passes",
+      "claimed_at": "2026-05-12T05:18:02Z"
+    },
+    "resilient/src/probabilistic_contracts.rs": {
+      "branch": "res-1308-skip-empty-install-8-passes",
+      "claimed_at": "2026-05-12T05:18:02Z"
+    },
+    "resilient/src/row_polymorphism.rs": {
+      "branch": "res-1308-skip-empty-install-8-passes",
+      "claimed_at": "2026-05-12T05:18:02Z"
+    },
+    "resilient/src/distributed_invariants.rs": {
+      "branch": "res-1308-skip-empty-install-8-passes",
+      "claimed_at": "2026-05-12T05:18:02Z"
+    },
+    "resilient/src/ghost_types.rs": {
+      "branch": "res-1308-skip-empty-install-8-passes",
+      "claimed_at": "2026-05-12T05:18:02Z"
     }
   }
 }

--- a/resilient/src/associated_constants.rs
+++ b/resilient/src/associated_constants.rs
@@ -80,7 +80,18 @@ pub fn lookup(type_name: &str, const_name: &str) -> Option<String> {
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    install(collect());
+    // RES-1308: gate `install` on the non-empty case. The previous
+    // wiring wrote to `ASSOC` on every typecheck, burning a
+    // RwLock write acquisition + replace on every program that
+    // declares no `#[assoc_const]` attribute. It also created the
+    // wipe-on-empty test race documented in RES-1302 against any
+    // test that calls `install` directly under
+    // `feature_attrs::lock_for_test()`.
+    let items = collect();
+    if items.is_empty() {
+        return Ok(());
+    }
+    install(items);
     Ok(())
 }
 

--- a/resilient/src/distributed_invariants.rs
+++ b/resilient/src/distributed_invariants.rs
@@ -71,11 +71,15 @@ pub fn for_actor(actor: &str) -> Vec<DistributedInvariant> {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-1308: gate `install` on the non-empty case. The historical
+    // wiring called `install(invs.clone())` before the early-out,
+    // burning a RwLock write per compile and creating the
+    // wipe-on-empty test race documented in RES-1302.
     let invs = collect();
-    install(invs.clone());
     if invs.is_empty() {
         return Ok(());
     }
+    install(invs.clone());
     let Node::Program(stmts) = program else {
         return Ok(());
     };

--- a/resilient/src/ghost_types.rs
+++ b/resilient/src/ghost_types.rs
@@ -41,11 +41,15 @@ pub fn is_ghost(name: &str) -> bool {
 }
 
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    // RES-1308: gate `install` on the non-empty case. The historical
+    // wiring called `install(ghosts.clone())` before the early-out,
+    // burning a RwLock write per compile and creating the
+    // wipe-on-empty test race documented in RES-1302.
     let ghosts = collect();
-    install(ghosts.clone());
     if ghosts.is_empty() {
         return Ok(());
     }
+    install(ghosts.clone());
     let Node::Program(stmts) = program else {
         return Ok(());
     };

--- a/resilient/src/macros.rs
+++ b/resilient/src/macros.rs
@@ -72,7 +72,14 @@ pub fn expand(name: &str, args: &[String]) -> Option<String> {
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    install(collect());
+    // RES-1308: gate `install` on the non-empty case — see RES-1302
+    // for the wipe-on-empty race rationale; same pattern saves a
+    // wasted RwLock write per compile in the common case.
+    let macros = collect();
+    if macros.is_empty() {
+        return Ok(());
+    }
+    install(macros);
     Ok(())
 }
 

--- a/resilient/src/phantom_types.rs
+++ b/resilient/src/phantom_types.rs
@@ -71,7 +71,14 @@ pub fn compatible(lhs: &str, rhs: &str) -> bool {
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    install(collect());
+    // RES-1308: gate `install` on the non-empty case — see RES-1302
+    // for the wipe-on-empty race rationale; same pattern saves a
+    // wasted RwLock write per compile in the common case.
+    let specs = collect();
+    if specs.is_empty() {
+        return Ok(());
+    }
+    install(specs);
     Ok(())
 }
 

--- a/resilient/src/probabilistic_contracts.rs
+++ b/resilient/src/probabilistic_contracts.rs
@@ -87,7 +87,14 @@ pub fn empirical_rate(fn_name: &str) -> Option<f64> {
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    install(collect());
+    // RES-1308: gate `install` on the non-empty case — see RES-1302
+    // for the wipe-on-empty race rationale; same pattern saves a
+    // wasted RwLock write per compile in the common case.
+    let contracts = collect();
+    if contracts.is_empty() {
+        return Ok(());
+    }
+    install(contracts);
     Ok(())
 }
 

--- a/resilient/src/recursive_types.rs
+++ b/resilient/src/recursive_types.rs
@@ -40,17 +40,20 @@ pub fn is_recursive(type_name: &str) -> bool {
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let set = collect();
-    install(set.clone());
     // RES-1244: fast-reject. The "does it reference itself?"
     // diagnostic only fires for struct names in `set`, i.e. those
-    // annotated `#[recursive]`. When no such attribute exists in the
-    // program (the overwhelming common case), `set` is empty, every
-    // `set.contains(name)` returns false, and the per-statement loop
-    // produces no output. `install` still runs first so any stale
-    // global state from a prior compile gets cleared to empty.
+    // annotated `#[recursive]`. When no such attribute exists in
+    // the program (the overwhelming common case), `set` is empty
+    // and the per-statement loop produces no output.
+    //
+    // RES-1308: also gate `install` on the non-empty case. The
+    // historical wiring called `install(set.clone())` before the
+    // early-out, burning a RwLock write per compile and creating
+    // the wipe-on-empty test race documented in RES-1302.
     if set.is_empty() {
         return Ok(());
     }
+    install(set.clone());
     // Validation: a recursive type must syntactically reference itself.
     let Node::Program(stmts) = program else {
         return Ok(());

--- a/resilient/src/row_polymorphism.rs
+++ b/resilient/src/row_polymorphism.rs
@@ -74,7 +74,14 @@ pub fn validate(fn_name: &str, fields: &[(String, String)]) -> Result<(), String
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    install(collect());
+    // RES-1308: gate `install` on the non-empty case — see RES-1302
+    // for the wipe-on-empty race rationale; same pattern saves a
+    // wasted RwLock write per compile in the common case.
+    let specs = collect();
+    if specs.is_empty() {
+        return Ok(());
+    }
+    install(specs);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1308

Built on #1304 (RES-1302 refinement_types) and #1307 (RES-1306 — 6 modules: async_await, session_types, mmio_regmap, hw_state_machine, typestate_types, default_trait_methods).

## Summary

Applies the same wipe-on-empty fix to the remaining 8 install-unconditionally `EXTENSION_PASSES` modules:

* associated_constants
* macros
* phantom_types
* recursive_types
* probabilistic_contracts
* row_polymorphism
* distributed_invariants
* ghost_types

Each `check()` now collects first, returns `Ok(())` when the collected set is empty, only then `install()`s. Saves one write-lock acquisition per pass per compile in the common case and closes the wipe-on-empty test race shape documented in RES-1302.

Combined with RES-1302/RES-1306 this brings every `install(collect())` pass under the same gate — programs that declare no attribute of a given kind pay nothing for the per-module global.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml` (3205 lib tests + every integration test green)
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Each module's existing tests (which install + lookup directly under `lock_for_test`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)