### PR TITLE
RES-1313: skip collect_actor_obligations when no ActorDecl exists in the program

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -3672,7 +3672,22 @@ impl TypeChecker {
                 // Unsupported verdicts emit a stderr warning but do
                 // not fail the check (matching how partial proofs
                 // of `requires` / `ensures` are handled — RES-217).
-                let obligations = collect_actor_obligations(statements, self.verifier_timeout_ms);
+                //
+                // RES-1313: short-circuit when no `ActorDecl` exists.
+                // `collect_actor_obligations` would iterate `statements`
+                // filtering ActorDecls and call `verifier_actors::verify_actor`
+                // for each — for programs with zero actors the inner
+                // loop never enters, but the dispatch + Z3 setup call
+                // still happens. Pre-check once with a single
+                // `iter().any` on the top-level statement slice.
+                let has_actor = statements
+                    .iter()
+                    .any(|s| matches!(&s.node, Node::ActorDecl { .. }));
+                let obligations = if has_actor {
+                    collect_actor_obligations(statements, self.verifier_timeout_ms)
+                } else {
+                    Vec::new()
+                };
                 let mut refuted: Vec<String> = Vec::new();
                 for o in obligations {
                     match o.result {


### PR DESCRIPTION
Closes #1313.

## Summary

\`check_program_with_source\` unconditionally calls \`collect_actor_obligations\` before the EXTENSION_PASSES block on every program. The helper iterates every top-level statement filtering \`Node::ActorDecl\`, then for each calls \`verifier_actors::verify_actor\` which kicks off Z3 work per \`always\` clause × handler combination.

For programs with zero \`ActorDecl\` — the overwhelming majority of \`cargo test\` inputs and every fixture in \`examples/\` outside the actor feature tests — the inner loop never enters and the dispatch + Z3 setup work is dead.

Pre-check once with \`statements.iter().any(|s| matches!(&s.node, Node::ActorDecl { .. }))\`. If false, skip the call entirely and use an empty \`Vec\` for the downstream verdict loop.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green
- [x] Byte-identical output on programs that *do* declare an actor