### PR TITLE
RES-1311: default_params::lower_program — fast-reject when no fn declares a default

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -187,6 +187,10 @@
     "resilient/src/ghost_types.rs": {
       "branch": "res-1308-skip-empty-install-8-passes",
       "claimed_at": "2026-05-12T05:18:02Z"
+    },
+    "resilient/src/default_params.rs": {
+      "branch": "res-1312-default-params-fast-reject",
+      "claimed_at": "2026-05-12T05:26:51Z"
     }
   }
 }

--- a/resilient/src/default_params.rs
+++ b/resilient/src/default_params.rs
@@ -40,9 +40,24 @@ struct FnDefaults {
 ///
 /// Runs after `named_args::lower_program` so the argument list is
 /// already in positional order when we get here.
+///
+/// RES-1311: fast-reject. The `rewrite_calls` walk only does work
+/// when a CallExpression's callee is a known fn AND one of its
+/// trailing parameters has a declared default. For every program
+/// where no function declares any default — the overwhelming
+/// majority of `examples/` and the test suite — the rewrite walk
+/// is pure overhead. Pre-scan the collected sigs: if no
+/// `FnDefaults` entry has a `Some(_)` slot, skip the walk entirely.
+/// `crate::newtypes::lower_program` follows the same shape.
 pub fn lower_program(program: &mut Node) {
     let mut sigs: HashMap<String, FnDefaults> = HashMap::new();
     collect_defaults(program, &mut sigs);
+    let any_default = sigs
+        .values()
+        .any(|s| s.defaults.iter().any(|d| d.is_some()));
+    if !any_default {
+        return;
+    }
     rewrite_calls(program, &sigs);
 }
 


### PR DESCRIPTION
Closes #1312

## Summary

`default_params::lower_program` runs after every parse and walks the entire AST in `rewrite_calls` looking for `CallExpression`s that need their trailing slots topped-up with declared defaults. The rewrite only does anything when at least one function's `defaults` vec contains a `Some(_)` slot — for every program where no function declares any default value (the overwhelming majority of `examples/` and the test suite, since the feature is relatively new), the walk is pure overhead.

After `collect_defaults`, scan the collected `FnDefaults` map: if no entry has any non-`None` default slot, return immediately and skip the rewrite walk. Same fast-reject shape as `crate::newtypes::lower_program`.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml` (3205 lib tests + integration tests green, including all 4 `default_params` tests that exercise the actual rewrite path)
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)