### PR TITLE
RES-1316: verdict cache for prove_bv (mirror RES-1206 / RES-1309 for the BV32 Z3 entry point)

### DIFF
--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -276,6 +276,17 @@ thread_local! {
     static Z3_TAUTOLOGY_CACHE: std::cell::RefCell<
         std::collections::HashMap<String, (bool, Option<ProofCertificate>, bool)>,
     > = std::cell::RefCell::new(std::collections::HashMap::new());
+
+    /// RES-1316: thread-local cache for the BV32 entry point.
+    /// Disjoint key namespace (`|BV` suffix) from the LIA verdict
+    /// cache and the tautology cache. Same persistence rules.
+    #[allow(clippy::type_complexity)]
+    static Z3_BV_CACHE: std::cell::RefCell<
+        std::collections::HashMap<
+            String,
+            (Option<bool>, Option<ProofCertificate>, Option<String>, bool),
+        >,
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
 fn prove_with_axioms_and_timeout_in(
@@ -599,7 +610,23 @@ pub fn prove_bv(
     bindings: &HashMap<String, i64>,
     timeout_ms: u32,
 ) -> (Option<bool>, Option<ProofCertificate>, Option<String>, bool) {
-    Z3_CTX.with(|ctx| prove_bv_in(ctx, expr, bindings, timeout_ms))
+    // RES-1316: thread-local verdict cache for the BV32 entry point.
+    // RES-1206 caches the LIA path; RES-1309 the tautology fast path.
+    // This is the third uncached Z3 entry — routed to from
+    // `prove_auto` (and thus `z3_prove_with_cert_theory`) whenever
+    // the contract clause has bitwise operations. Same key shape as
+    // the other caches; suffix `|BV` keeps the namespace disjoint
+    // from `|TAUT` and the unsuffixed LIA cache.
+    let bindings_sorted: std::collections::BTreeMap<&String, &i64> = bindings.iter().collect();
+    let key = format!("{expr:?}|{bindings_sorted:?}|{timeout_ms}|BV");
+    if let Some(cached) = Z3_BV_CACHE.with(|c| c.borrow().get(&key).cloned()) {
+        return cached;
+    }
+    let result = Z3_CTX.with(|ctx| prove_bv_in(ctx, expr, bindings, timeout_ms));
+    Z3_BV_CACHE.with(|c| {
+        c.borrow_mut().insert(key, result.clone());
+    });
+    result
 }
 
 fn prove_bv_in(


### PR DESCRIPTION
Closes #1316.

## Summary

RES-1206 cached \`prove_with_axioms_and_timeout\`; RES-1309 extended that to \`prove_tautology_with_axioms_and_timeout\`. The third uncached Z3 entry point is \`prove_bv\` — the BV32 variant routed to from \`prove_auto\` (and thus the typechecker's \`z3_prove_with_cert_theory\`) whenever the contract clause has bitwise operations.

Every BV proof rebuilds the formula, asserts on both tautology/contradiction solvers, and calls \`solver.check()\` twice. Cache hits skip all of that — same wall-clock improvement RES-1206 delivered on the LIA path.

Add a parallel \`Z3_BV_CACHE\` thread-local with the same shape as \`Z3_VERDICT_CACHE\`. Key shape mirrors RES-1206 (AST \`Debug\` of inputs separated by \`|\`, bindings sorted into a \`BTreeMap\`) plus a \`|BV\` suffix to keep the namespace disjoint from \`|TAUT\` (RES-1309) and the unsuffixed LIA cache.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo build --locked --features z3\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --locked --features z3 --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked --features z3\` — z3 suite green