### PR TITLE
RES-1316: named_args::lower_program — fast-reject when program contains no NamedArg

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -191,6 +191,10 @@
     "resilient/src/default_params.rs": {
       "branch": "res-1312-default-params-fast-reject",
       "claimed_at": "2026-05-12T05:26:51Z"
+    },
+    "resilient/src/named_args.rs": {
+      "branch": "res-1317-named-args-fast-reject",
+      "claimed_at": "2026-05-12T05:37:55Z"
     }
   }
 }

--- a/resilient/src/named_args.rs
+++ b/resilient/src/named_args.rs
@@ -129,7 +129,21 @@ pub fn has_named(arguments: &[Node]) -> bool {
 /// replaces named-arg lists with the resolved positional vector.
 /// Returns the first resolution error (with `line:col`) if any
 /// call's named args fail validation.
+///
+/// RES-1316: fast-reject. `rewrite_calls` only mutates a
+/// `CallExpression` when `has_named(arguments)` is true. For every
+/// program where no call site uses named arguments — the
+/// overwhelming majority of `examples/` and the test suite — the
+/// walk is pure overhead. Pre-scan the AST once via
+/// `uniqueness_walk::any_node` (early-terminating since RES-1238):
+/// if no `Node::NamedArg` exists anywhere, return immediately and
+/// skip the rewrite. Mirrors the shape of
+/// `crate::newtypes::lower_program` and
+/// `crate::default_params::lower_program` (RES-1311).
 pub fn lower_program(program: &mut Node) -> Result<(), String> {
+    if !crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::NamedArg { .. })) {
+        return Ok(());
+    }
     let mut sigs: HashMap<String, Vec<String>> = HashMap::new();
     collect_signatures(program, &mut sigs);
     rewrite_calls(program, &sigs)


### PR DESCRIPTION
Closes #1317

## Summary

`named_args::lower_program` runs after every parse and walks the entire AST in `rewrite_calls`, only mutating `CallExpression`s where `has_named(arguments)` is true. For programs where no call site uses named arguments — the overwhelming majority of `examples/` and the test suite — the walk is pure overhead.

Pre-scan the AST once with `uniqueness_walk::any_node` (early-terminating since RES-1238). If no `Node::NamedArg` exists anywhere, return immediately and skip the rewrite walk. Mirrors the shape of `crate::newtypes::lower_program` and `crate::default_params::lower_program` (RES-1311).

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml` (3205 lib tests + integration tests green, including all 12 `named_args` tests exercising the actual rewrite path)
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)