### PR TITLE
RES-1320: with_quantifier_binding — eliminate redundant TypeEnvironment clone

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4062,10 +4062,18 @@ impl TypeChecker {
         ty: Type,
         body: &Node,
     ) -> Result<Type, String> {
-        let saved = self.env.clone();
-        let mut inner = TypeEnvironment::new_enclosed(saved.clone());
+        // RES-1320: build the enclosed inner env from a single clone of
+        // the current env, then use `mem::replace` to swap it into
+        // `self.env` while capturing the original outer for restore.
+        // The previous shape did one clone for `saved` and another for
+        // `inner.outer`, paying two full `TypeEnvironment::clone`s on
+        // every quantifier the typechecker descends into. The body
+        // walk only ever reads `self.env` (via lookups that fall
+        // through to `inner.outer` on miss), so the moved original is
+        // safe to hand back unchanged after the recursive check.
+        let mut inner = TypeEnvironment::new_enclosed(self.env.clone());
         inner.set(var.to_string(), ty);
-        self.env = inner;
+        let saved = std::mem::replace(&mut self.env, inner);
         let result = self.check_node(body);
         self.env = saved;
         result


### PR DESCRIPTION
Closes #1320.

## Summary

\`TypeChecker::with_quantifier_binding\` is invoked once per quantifier in every \`requires\` / \`ensures\` / \`invariant\` / \`always\` clause the typechecker processes. The previous shape cloned \`self.env\` twice per call:

\`\`\`rust
let saved = self.env.clone();                                  // clone #1
let mut inner = TypeEnvironment::new_enclosed(saved.clone());  // clone #2
\`\`\`

The second clone is dead weight. Use \`std::mem::replace\` to swap a fresh enclosed inner into \`self.env\` while capturing the original outer for restore in one step:

\`\`\`rust
let mut inner = TypeEnvironment::new_enclosed(self.env.clone());
inner.set(var.to_string(), ty);
let saved = std::mem::replace(&mut self.env, inner);
let result = self.check_node(body);
self.env = saved;
\`\`\`

One clone instead of two. \`check_node(body)\` only reads \`self.env\` (via \`TypeEnvironment::get\`, which falls through to the enclosed outer on miss), so the moved-out original is safe to hand back unchanged after the recursive check.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green
- [x] \`cargo test --locked --features z3\` — verifier suite green (which exercises this path heavily through forall/exists in invariant clauses)