### PR TITLE
RES-1323: ActorDecl typecheck — replace 2x env.clone() with mem::swap (mirror block/fn/loop pattern)

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -5144,7 +5144,15 @@ impl TypeChecker {
                 receive_handlers,
                 ..
             } => {
-                let saved_env = self.env.clone();
+                // RES-1323: mirror the block / function / loop env-scope
+                // pattern (one `.clone()` + `mem::swap` for restore) instead
+                // of the previous `let saved_env = self.env.clone()` shape
+                // that paid two full env clones per actor (one outer, one
+                // per handler). Lookups during state-field / always /
+                // eventually checking fall through the enclosed `outer` on
+                // miss, so the saved chain stays observable for free.
+                let mut actor_env = TypeEnvironment::new_enclosed(self.env.clone());
+                std::mem::swap(&mut self.env, &mut actor_env);
                 let mut resolved_fields: Vec<(String, Type)> = Vec::new();
                 for (ty, field, init) in state_fields {
                     // RES-777: reject reference types in actor state
@@ -5195,7 +5203,12 @@ impl TypeChecker {
                     }
                 }
                 for handler in receive_handlers {
-                    let handler_saved = self.env.clone();
+                    // RES-1323: per-handler scope via mem::swap (see the
+                    // outer comment above) — one clone of the actor env
+                    // for the enclosed handler env's outer, then swap in
+                    // and out instead of cloning + restoring.
+                    let mut handler_env = TypeEnvironment::new_enclosed(self.env.clone());
+                    std::mem::swap(&mut self.env, &mut handler_env);
                     self.env.set("self".to_string(), Type::Struct(name.clone()));
                     for (pty, pname) in &handler.parameters {
                         // RES-777: reject reference types in handler payloads
@@ -5215,9 +5228,9 @@ impl TypeChecker {
                         let _ = self.check_node(e)?;
                     }
                     let _ = self.check_node(&handler.body)?;
-                    self.env = handler_saved;
+                    std::mem::swap(&mut self.env, &mut handler_env);
                 }
-                self.env = saved_env;
+                std::mem::swap(&mut self.env, &mut actor_env);
                 Ok(Type::Void)
             }
 


### PR DESCRIPTION
Closes #1323.

## Summary

The \`Node::ActorDecl\` arm in \`TypeChecker::check_node\` saved \`self.env\` with \`clone()\` once at the outer actor scope and once per receive handler. For an actor with K handlers that's K + 1 full \`TypeEnvironment\` clones per actor — every other env-scope site in \`check_node\` (block, function, closure, loop bodies) had already moved to the cheaper \`mem::swap\` pattern.

Switch the actor outer scope and per-handler scope to the same shape: one \`.clone()\` for the enclosed env's outer, then \`mem::swap\` in and out.

\`TypeEnvironment::get\` falls through to the enclosed \`outer\` on miss, so lookups during state-field / always / eventually clause checking still see the surrounding scope; handler bodies still see state fields (set on the actor's enclosed env, which is the handler env's outer).

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green
- [x] \`cargo test --locked --features z3\` — verifier suite green (exercises ActorDecl typecheck heavily via the always/eventually clauses)