### PR TITLE
RES-1327: imports::expand_uses — fast-reject when program contains no Node::Use

### DIFF
--- a/resilient/src/imports.rs
+++ b/resilient/src/imports.rs
@@ -55,6 +55,20 @@ pub fn expand_uses(
         _ => return Ok(()),
     };
 
+    // RES-1327: fast-reject. Every full-compile entry point in
+    // `lib.rs` invokes `expand_uses` unconditionally before the
+    // typechecker runs. The loop below drains every top-level
+    // statement and rebuilds the `expanded` Vec — for programs that
+    // contain no `Node::Use`, the rebuild is a pure copy: every
+    // statement is moved out and moved back. The overwhelming
+    // majority of `cargo test` inputs and every fixture in
+    // `examples/` outside the import feature tests fall into that
+    // case. A single `iter().any` pre-scan returns `Ok(())` before
+    // we touch the Vec.
+    if !stmts.iter().any(|s| matches!(&s.node, Node::Use { .. })) {
+        return Ok(());
+    }
+
     let mut expanded: Vec<Spanned<Node>> = Vec::with_capacity(stmts.len());
     for stmt in stmts.drain(..) {
         if let Node::Use { path, alias, .. } = &stmt.node {


### PR DESCRIPTION
Closes #1327.

## Summary

\`imports::expand_uses\` runs from every full-compile entry point in \`lib.rs\` before the typechecker. Its body \`drain(..)\`s every top-level statement, walks each, and pushes the survivors into a fresh \`expanded\` Vec, then replaces the original. For programs with no \`Node::Use\` — the overwhelming majority of \`cargo test\` inputs and every fixture in \`examples/\` outside the import feature tests — that's a pure drain-then-refill.

Add a single \`iter().any\` pre-scan. If no \`Use\` exists, return \`Ok(())\` before touching the Vec. Same shape as RES-1311 / RES-1316 (\`default_params::lower_program\`, \`named_args::lower_program\`).

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green (the imports tests in this file exercise the positive path)