### PR TITLE
RES-1330: drop dead Z3 call in recovers_to verification (result discarded into _v / _cert / _c / _timed_out)

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4307,22 +4307,17 @@ impl TypeChecker {
                     let mut cert_smt2: Option<String> = None;
                     let mut timed_out_flag = false;
                     if verdict.is_none() {
-                        // RES-354: use theory-aware prover.
-                        let (_v, _cert, _c, _timed_out) = {
-                            #[cfg(feature = "z3")]
-                            {
-                                z3_prove_with_cert_theory(
-                                    clause,
-                                    &no_bindings,
-                                    self.verifier_timeout_ms,
-                                    self.z3_theory,
-                                )
-                            }
-                            #[cfg(not(feature = "z3"))]
-                            {
-                                z3_prove_with_cert(clause, &no_bindings, self.verifier_timeout_ms)
-                            }
-                        };
+                        // RES-1330: drop the dead `z3_prove_with_cert_theory`
+                        // call that previously sat here. Its result was
+                        // bound to `(_v, _cert, _c, _timed_out)` and
+                        // never read — `z3_prove_with_axioms_and_cert`
+                        // below was already the load-bearing call (it
+                        // admits `requires` preconditions + leading
+                        // `assume(P)` as axioms, the only correct shape
+                        // for the recovery point per RES-222). The
+                        // theory-aware call without axioms would only
+                        // ever be strictly weaker than the axioms-aware
+                        // one, so dropping it doesn't change the verdict.
                         let (v, cert, c, t) = z3_prove_with_axioms_and_cert(
                             clause,
                             &no_bindings,


### PR DESCRIPTION
Closes #1330.

## Summary

\`typechecker.rs:4310\` invoked \`z3_prove_with_cert_theory(clause, &no_bindings, …)\` and bound the result to \`(_v, _cert, _c, _timed_out)\` — never read. Immediately after, \`z3_prove_with_axioms_and_cert(clause, &no_bindings, &axioms, …)\` ran the actual recovery proof (admitting \`requires\` preconditions and leading \`assume(P)\` axioms — the only shape that matches RES-222's recovery-point semantics).

Git archaeology:

- 9bb994b2 (RES-222): added the axioms-and-cert call.
- 492d85b7 (RES-354): added the theory-aware call alongside.
- 34fcac4e: tagged the unused result vars with leading underscores.

The theory-aware call was added with the expectation that BV32 / LIA selection should run on the recovery clause, but the result was never wired into \`verdict\` / \`cert_smt2\` / \`cx\` / \`timed_out_flag\`. The theory-aware variant — called without axioms — would also be strictly weaker than the axioms-aware one.

For every function with a \`recovers_to\` clause whose contract isn't constant-folded, this was one wasted Z3 setup + check per typecheck. RES-1206 / RES-1316 verdict caches catch re-asks, but the first call on every distinct clause shape paid the full Z3 round-trip.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo build --locked --features z3\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --locked --features z3 --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green
- [x] \`cargo test --locked --features z3\` — verifier suite green (the recovers_to fixtures still discharge under the kept axioms-aware call)