### PR TITLE
RES-1332: skip fail_on_error_lints when safety_critical_mode is off

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -188,13 +188,9 @@
       "branch": "res-1317-named-args-fast-reject",
       "claimed_at": "2026-05-12T05:37:55Z"
     },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1326-audit-stats-opt-in",
-      "claimed_at": "2026-05-12T06:05:30Z"
-    },
     "resilient/src/lib.rs": {
-      "branch": "res-1326-audit-stats-opt-in",
-      "claimed_at": "2026-05-12T06:05:30Z"
+      "branch": "res-1332-skip-lints-when-not-safety-critical",
+      "claimed_at": "2026-05-12T06:22:22Z"
     }
   }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -25767,8 +25767,18 @@ fn execute_file(
         ));
     }
 
-    if let Err(count) =
-        fail_on_error_lints(&program, &contents, filename, false, "safety-critical lint")
+    // RES-1332: gate `fail_on_error_lints` on safety-critical mode.
+    // `lint::check` only escalates a lint to `Severity::Error` when
+    // `safety_critical_mode()` is on (L0006 / assume(false)) — every
+    // other lint stays a Warning. Without `--safety-critical` set,
+    // the 13-pass lint walk produces only Warnings, the
+    // `Error`-severity filter drains them all, and the helper
+    // returns Ok(()). For the overwhelming majority of CLI
+    // invocations (and every test in the suite that hits this code
+    // path), gating skips ~13 AST walks per compile.
+    if lint::safety_critical_mode()
+        && let Err(count) =
+            fail_on_error_lints(&program, &contents, filename, false, "safety-critical lint")
     {
         return Err(format!("Safety-critical lint failed: {} error(s)", count));
     }
@@ -27174,13 +27184,20 @@ fn dispatch_check_subcommand(args: &[String]) -> Option<i32> {
     }
 
     lint::set_safety_critical_mode(safety_critical);
-    if let Err(_count) = fail_on_error_lints(
-        &program,
-        &src,
-        path.to_string_lossy().as_ref(),
-        quiet,
-        "safety-critical lint",
-    ) {
+    // RES-1332: skip the 13-pass lint walk when safety-critical
+    // mode is off — see the gate at lib.rs:25770 for the rationale.
+    // `safety_critical` is the local CLI flag value the atomic was
+    // just set from; using it directly avoids an unnecessary
+    // atomic load.
+    if safety_critical
+        && let Err(_count) = fail_on_error_lints(
+            &program,
+            &src,
+            path.to_string_lossy().as_ref(),
+            quiet,
+            "safety-critical lint",
+        )
+    {
         return Some(1);
     }
 


### PR DESCRIPTION
Closes #1332

## Summary

`fail_on_error_lints` runs `lint::check` (13 lint passes, each walking the program AST) and filters the output for `Severity::Error`. Looking at `lint::check` (lint.rs:99-149), the only call site that escalates a lint to `Error` is the `safety_critical_mode()` branch that bumps L0006 (assume(false)) to Error — every other lint is unconditionally `Severity::Warning`.

Without `--safety-critical` set (the overwhelming majority of CLI invocations and every test that hits this code path), the helper runs all 13 passes only to filter every warning away and return `Ok(())`. Gate the call on `lint::safety_critical_mode()` (main path) and on the local CLI flag (subcommand path) — the only path that can produce an Error-severity lint is dormant when the gate is off, so behavior is unchanged.

Same shape as RES-1281 / RES-1290 / RES-1294 / RES-1297 / RES-1311 / RES-1316 / RES-1320 / RES-1322 / RES-1327.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml` (full suite green)
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)