### PR TITLE
RES-1337: Lexer::new(input: String) → Lexer::new(input: &str) — drop the per-compile String clone

### DIFF
--- a/resilient/src/bounds_check.rs
+++ b/resilient/src/bounds_check.rs
@@ -473,7 +473,7 @@ mod tests {
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     fn parse(src: &str) -> Node {
-        let lexer = crate::Lexer::new(src.to_string());
+        let lexer = crate::Lexer::new(src);
         let mut parser = crate::Parser::new(lexer);
         parser.parse_program()
     }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -661,7 +661,7 @@ mod tests {
     }
 
     fn parse_program(src: &str) -> Node {
-        let lexer = crate::Lexer::new(src.to_string());
+        let lexer = crate::Lexer::new(src);
         let mut parser = crate::Parser::new(lexer);
         parser.parse_program()
     }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -978,7 +978,15 @@ struct Lexer {
 }
 
 impl Lexer {
-    fn new(input: String) -> Self {
+    // RES-1337: take `&str` rather than `String`. The lexer's internal
+    // storage is a `Vec<char>` produced by `chars().collect()`, so
+    // owning the original `String` was never necessary. Every call
+    // site previously had to materialise a `String` (often via
+    // `.to_string()` or `.clone()`) just to satisfy the signature;
+    // the main compile path's `Lexer::new(contents.clone())` cloned
+    // the entire source file (~hundreds of KB for large inputs) on
+    // every compile. Borrowing eliminates that clone.
+    fn new(input: &str) -> Self {
         #[cfg(feature = "logos-lexer")]
         {
             // RES-108: under the `logos-lexer` feature, pre-tokenize
@@ -987,7 +995,7 @@ impl Lexer {
             // the legacy scan state (`input`, `position`, etc.) stays
             // initialized so diagnostics that reach into fields like
             // `last_token_line` still work.
-            let tokens = lexer_logos::tokenize(&input);
+            let tokens = lexer_logos::tokenize(input);
             Lexer {
                 input: input.chars().collect(),
                 position: 0,
@@ -24465,7 +24473,7 @@ fn start_repl() -> RustylineResult<()> {
                 }
 
                 // Parse the input
-                let lexer = Lexer::new(input.to_string());
+                let lexer = Lexer::new(input);
                 let mut parser = Parser::new(lexer);
                 let mut program = parser.parse_program();
 
@@ -24672,7 +24680,7 @@ fn dump_tokens_to_stdout(src: &str) {
     // char-offset `Span::{start.offset, end.offset}` regardless of
     // UTF-8 boundaries.
     let chars: Vec<char> = src.chars().collect();
-    let mut lex = Lexer::new(src.to_string());
+    let mut lex = Lexer::new(src);
     loop {
         let (tok, span) = lex.next_token_with_span();
         let is_eof = matches!(tok, Token::Eof);
@@ -24841,7 +24849,7 @@ fn dump_ast_json_to_stdout(src: &str) -> Result<(), Vec<String>> {
 /// parser error strings collected along the way. Used by both the
 /// driver and `imports::expand_uses`.
 fn parse(src: &str) -> (Node, Vec<String>) {
-    let lexer = Lexer::new(src.to_string());
+    let lexer = Lexer::new(src);
     let mut parser = Parser::new(lexer);
     let mut program = parser.parse_program();
     let mut errs: Vec<String> = parser.errors.into_iter().map(|e| e.to_string()).collect();
@@ -25152,7 +25160,7 @@ pub(crate) fn collect_semantic_tokens(src: &str) -> Vec<AbsSemToken> {
     let mut out: Vec<AbsSemToken> = Vec::new();
     // Lexer-driven pass for keywords / literals / operators /
     // identifiers.
-    let mut lex = Lexer::new(src.to_string());
+    let mut lex = Lexer::new(src);
     let mut prev_kw: Option<Token> = None;
     loop {
         let (tok, span) = lex.next_token_with_span();
@@ -25758,7 +25766,7 @@ fn execute_file(
         (source_hash, cache_dir, hit)
     };
 
-    let lexer = Lexer::new(contents.clone());
+    let lexer = Lexer::new(&contents);
     let mut parser = Parser::new(lexer);
     let mut program = parser.parse_program();
 
@@ -28380,7 +28388,7 @@ mod tests {
 
     /// Lex the entire input into a Vec<Token>, stopping at (and including) Eof.
     fn tokenize(input: &str) -> Vec<Token> {
-        let mut lexer = Lexer::new(input.to_string());
+        let mut lexer = Lexer::new(input);
         let mut out = Vec::new();
         loop {
             let tok = lexer.next_token();
@@ -28775,7 +28783,7 @@ mod tests {
     // ---------- Parser ----------
 
     fn parse(input: &str) -> (Node, Vec<String>) {
-        let lexer = Lexer::new(input.to_string());
+        let lexer = Lexer::new(input);
         let mut parser = Parser::new(lexer);
         let mut program = parser.parse_program();
         let mut errs = parser.errors;
@@ -39686,7 +39694,7 @@ mod tests {
 
     #[test]
     fn lexer_tracks_line_across_newlines() {
-        let mut lex = Lexer::new("let x = 1;\nlet y = 2;".to_string());
+        let mut lex = Lexer::new("let x = 1;\nlet y = 2;");
         let _ = lex.next_token(); // let (line 1)
         let _ = lex.next_token(); // x
         let _ = lex.next_token(); // =
@@ -51847,7 +51855,7 @@ mod tests {
         // A leading shebang line is silently consumed; the first
         // real token (`println`) lands on line 2, col 1.
         let src = "#!/usr/bin/env resilient\nprintln(\"ok\");";
-        let mut lex = Lexer::new(src.to_string());
+        let mut lex = Lexer::new(src);
         let (tok, span) = lex.next_token_with_span();
         match tok {
             Token::Identifier(ref n) => assert_eq!(n, "println"),
@@ -51862,7 +51870,7 @@ mod tests {
         // `#!` anywhere other than byte 0 must lex as an Unknown
         // `#` token — no free comment syntax from this change.
         let src = "println(\"hi\");\n#!/bin/sh";
-        let mut lex = Lexer::new(src.to_string());
+        let mut lex = Lexer::new(src);
         // Drain the legitimate prefix.
         let mut saw_unknown_hash = false;
         loop {
@@ -51885,7 +51893,7 @@ mod tests {
         // `#!\n` (no path) followed by code: still consumed. Real
         // token lands on line 2.
         let src = "#!\nprintln(\"ok\");";
-        let mut lex = Lexer::new(src.to_string());
+        let mut lex = Lexer::new(src);
         let (tok, span) = lex.next_token_with_span();
         match tok {
             Token::Identifier(ref n) => assert_eq!(n, "println"),
@@ -51900,7 +51908,7 @@ mod tests {
         // File is just `#!/usr/bin/env resilient` (no trailing
         // newline, no code). Shebang consumed, next token is Eof.
         let src = "#!/usr/bin/env resilient";
-        let mut lex = Lexer::new(src.to_string());
+        let mut lex = Lexer::new(src);
         let tok = lex.next_token();
         assert!(matches!(tok, Token::Eof), "got {:?}", tok);
     }
@@ -51913,7 +51921,7 @@ mod tests {
         // in most fonts — the ASCII-only policy is the defense
         // against that class of homoglyph attack.
         let src = "let кафа = 1;";
-        let mut lex = Lexer::new(src.to_string());
+        let mut lex = Lexer::new(src);
         let mut saw_non_ascii = false;
         loop {
             let tok = lex.next_token();

--- a/resilient/src/loop_invariants.rs
+++ b/resilient/src/loop_invariants.rs
@@ -221,7 +221,7 @@ mod tests {
     use crate::{Interpreter, Lexer, Parser};
 
     fn parse(src: &str) -> Node {
-        let lexer = Lexer::new(src.to_string());
+        let lexer = Lexer::new(src);
         let mut parser = Parser::new(lexer);
         parser.parse_program()
     }

--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -284,7 +284,7 @@ fn span_to_range(span: crate::span::Span) -> Range {
 /// than the HashMap operation that reads it.
 pub(crate) fn hover_literal_at(src: &str, pos: Position) -> Option<(&'static str, Range)> {
     use crate::{Lexer, Token};
-    let mut lex = Lexer::new(src.to_string());
+    let mut lex = Lexer::new(src);
     loop {
         let (tok, span) = lex.next_token_with_span();
         if matches!(tok, Token::Eof) {
@@ -344,7 +344,7 @@ fn lex_span_contains_lsp_position(span: crate::span::Span, pos: Position) -> boo
 /// the definition in a `TopLevelDefMap`.
 pub(crate) fn identifier_at(src: &str, pos: Position) -> Option<(String, Range)> {
     use crate::{Lexer, Token};
-    let mut lex = Lexer::new(src.to_string());
+    let mut lex = Lexer::new(src);
     loop {
         let (tok, span) = lex.next_token_with_span();
         if matches!(tok, Token::Eof) {
@@ -526,7 +526,7 @@ fn infer_literal_type(value: &Node) -> &'static str {
 /// (which stores the whole-statement span, not the name span).
 pub(crate) fn find_decl_name_range(src: &str, target: &str) -> Option<Range> {
     use crate::{Lexer, Token};
-    let mut lex = Lexer::new(src.to_string());
+    let mut lex = Lexer::new(src);
     let mut prev_was_fn = false;
     loop {
         let (tok, span) = lex.next_token_with_span();

--- a/resilient/src/quantifiers.rs
+++ b/resilient/src/quantifiers.rs
@@ -374,7 +374,7 @@ mod tests {
     use super::*;
 
     fn parse_program(src: &str) -> Node {
-        let lexer = crate::Lexer::new(src.to_string());
+        let lexer = crate::Lexer::new(src);
         let mut p = crate::Parser::new(lexer);
         p.parse_program()
     }

--- a/resilient/src/ranges.rs
+++ b/resilient/src/ranges.rs
@@ -200,7 +200,7 @@ mod tests {
     use super::*;
 
     fn parse_program(src: &str) -> Node {
-        let lexer = crate::Lexer::new(src.to_string());
+        let lexer = crate::Lexer::new(src);
         let mut p = crate::Parser::new(lexer);
         p.parse_program()
     }

--- a/resilient/src/repl.rs
+++ b/resilient/src/repl.rs
@@ -370,7 +370,7 @@ impl EnhancedREPL {
         }
 
         // Regular code evaluation
-        let lexer = Lexer::new(input.to_string());
+        let lexer = Lexer::new(input);
         let mut parser = Parser::new(lexer);
 
         // Parse the program

--- a/resilient/src/string_interp.rs
+++ b/resilient/src/string_interp.rs
@@ -84,7 +84,7 @@ pub(crate) fn parse_parts(raw: &str) -> Result<Option<Vec<StringPart>>, String> 
                 }
 
                 // Parse the sub-expression using the main parser.
-                let lexer = Lexer::new(expr_src.clone());
+                let lexer = Lexer::new(&expr_src);
                 let mut sub_parser = Parser::new(lexer);
                 let expr_node = match sub_parser.parse_expression(0) {
                     Some(n) if sub_parser.errors.is_empty() => n,
@@ -176,7 +176,7 @@ mod tests {
     use super::*;
 
     fn interp_eval(src: &str) -> String {
-        let lexer = crate::Lexer::new(src.to_string());
+        let lexer = crate::Lexer::new(src);
         let mut parser = crate::Parser::new(lexer);
         let program = parser.parse_program();
         assert!(

--- a/resilient/src/traits.rs
+++ b/resilient/src/traits.rs
@@ -856,7 +856,7 @@ mod tests {
     use crate::span::Span;
 
     fn parse_program(src: &str) -> Node {
-        let lexer = Lexer::new(src.to_string());
+        let lexer = Lexer::new(src);
         let mut parser = Parser::new(lexer);
         parser.parse_program()
     }

--- a/resilient/src/tuples.rs
+++ b/resilient/src/tuples.rs
@@ -262,7 +262,7 @@ mod tests {
     /// programs that print via `println`. Tests assert against
     /// captured side effects via the runtime's known semantics.
     fn run(src: &str) -> Value {
-        let lexer = Lexer::new(src.to_string());
+        let lexer = Lexer::new(src);
         let mut parser = Parser::new(lexer);
         let program = parser.parse_program();
         assert!(
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn element_access_out_of_range_errors() {
-        let lexer = Lexer::new("(1, 2).5".to_string());
+        let lexer = Lexer::new("(1, 2).5");
         let mut parser = Parser::new(lexer);
         let program = parser.parse_program();
         assert!(parser.errors.is_empty());
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn destructure_arity_mismatch_errors() {
-        let lexer = Lexer::new("let (a, b, c) = (1, 2);".to_string());
+        let lexer = Lexer::new("let (a, b, c) = (1, 2);");
         let mut parser = Parser::new(lexer);
         let program = parser.parse_program();
         assert!(parser.errors.is_empty());
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn destructure_non_tuple_errors() {
-        let lexer = Lexer::new("let (a, b) = 42;".to_string());
+        let lexer = Lexer::new("let (a, b) = 42;");
         let mut parser = Parser::new(lexer);
         let program = parser.parse_program();
         assert!(parser.errors.is_empty());
@@ -409,7 +409,7 @@ mod tests {
 
     #[test]
     fn tuple_index_on_non_tuple_errors() {
-        let lexer = Lexer::new("let x = 42; x.0".to_string());
+        let lexer = Lexer::new("let x = 42; x.0");
         let mut parser = Parser::new(lexer);
         let program = parser.parse_program();
         assert!(parser.errors.is_empty());

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -471,7 +471,7 @@ mod tests {
     use crate::{Lexer, Parser};
 
     fn parse(src: &str) -> Node {
-        let lexer = Lexer::new(src.to_string());
+        let lexer = Lexer::new(src);
         let mut parser = Parser::new(lexer);
         parser.parse_program()
     }


### PR DESCRIPTION
Closes #1337.

## Summary

\`Lexer::new\` took \`input: String\` and immediately called \`input.chars().collect()\` to build a \`Vec<char>\`. The original \`String\` was dropped after construction — nothing about the lexer's internals required owning it.

Every call site had to materialise an owned \`String\` to feed in:

- \`lib.rs:25769\` (main compile path): \`Lexer::new(contents.clone())\` — a full clone of the source file (~hundreds of KB for large inputs) just to hand it over.
- The shared \`parse(src: &str)\` helper and ~15 driver / test sites: \`Lexer::new(src.to_string())\` — owned-String materialisation of an \`&str\` literal or borrowed slice.

Change the signature to \`fn new(input: &str) -> Self\`. The internal \`input.chars().collect()\` works identically on \`&str\`; no behavioural change. Updated every caller to drop the \`.to_string()\` / \`.clone()\`:

- main-path \`Lexer::new(contents.clone())\` → \`Lexer::new(&contents)\`
- \`Lexer::new(src.to_string())\` → \`Lexer::new(src)\` everywhere src was \`&str\`
- \`Lexer::new(\"…\".to_string())\` → \`Lexer::new(\"…\")\` for literal test inputs

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo build --locked --tests\` clean (~15 call sites updated)
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green