### PR TITLE
RES-1341: cache RESILIENT_CONST_FOLD env-var lookup via LazyLock<bool>

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -188,9 +188,9 @@
       "branch": "res-1317-named-args-fast-reject",
       "claimed_at": "2026-05-12T05:37:55Z"
     },
-    "resilient/src/lib.rs": {
-      "branch": "res-1338-skip-canonicalize-when-no-use",
-      "claimed_at": "2026-05-12T06:39:38Z"
+    "resilient/src/const_fold.rs": {
+      "branch": "res-1341-cache-opt-env-vars",
+      "claimed_at": "2026-05-12T06:52:39Z"
     }
   }
 }

--- a/resilient/src/const_fold.rs
+++ b/resilient/src/const_fold.rs
@@ -134,8 +134,16 @@ pub fn optimize(chunk: &mut Chunk) -> Result<(), FoldError> {
 /// shipped as a fully-tested but opt-in optimization. To enable in
 /// any compile pipeline (CLI, REPL, JIT codegen frontend), run
 /// with `RESILIENT_CONST_FOLD=1`.
+///
+/// RES-1341: cache the env-var lookup. `compiler.rs` calls this
+/// once per function chunk plus once for `main`, so a VM compile
+/// with N user fns paid N+1 `std::env::var` syscalls. `LazyLock`
+/// reads the env once per process; every subsequent call is a
+/// relaxed atomic load of the cached `bool`.
 pub fn optimize_if_enabled(chunk: &mut Chunk) -> Result<(), FoldError> {
-    if std::env::var("RESILIENT_CONST_FOLD").as_deref() == Ok("1") {
+    static CONST_FOLD_ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var("RESILIENT_CONST_FOLD").as_deref() == Ok("1"));
+    if *CONST_FOLD_ENABLED {
         optimize(chunk)?;
     }
     Ok(())


### PR DESCRIPTION
Closes #1341

## Summary

`compiler.rs` calls `const_fold::optimize_if_enabled` per function chunk (line 158) plus once for `main` (line 214). Each call did `std::env::var("RESILIENT_CONST_FOLD").as_deref() == Ok("1")` — `std::env::var` is a syscall, typically 100ns to 1µs hot, can spike higher.

For a VM compile with N user functions that's N+1 syscalls per compile, all returning the same value.

Wrap the lookup in a `LazyLock<bool>` defined inside `optimize_if_enabled`. The env var is read once per process; every subsequent call is a relaxed atomic load of the cached `bool`.

Out of scope: the matching `inline::optimize_if_enabled` gate (compiler.rs:235) is called only once per compile (so the syscall savings is at most 1 per compile), and its tests at `inline.rs:962-1037` flip the env var mid-process and expect runtime visibility — caching there would require a parallel test-only uncached path. Left alone in this PR.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml` (full suite green — no tests in const_fold.rs reference the env var, so caching is invisible to callers)
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)