### PR TITLE
RES-1343: parse() — drop redundant .to_string() clone on every parser error string

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -24852,7 +24852,13 @@ fn parse(src: &str) -> (Node, Vec<String>) {
     let lexer = Lexer::new(src);
     let mut parser = Parser::new(lexer);
     let mut program = parser.parse_program();
-    let mut errs: Vec<String> = parser.errors.into_iter().map(|e| e.to_string()).collect();
+    // RES-1343: `parser.errors` is already `Vec<String>`; move it
+    // directly instead of the round-trip
+    // `.into_iter().map(|e| e.to_string()).collect()` shape — every
+    // `String::to_string` allocated a fresh `String` identical to
+    // its source. Saves one heap alloc per recorded parser error
+    // (zero on the clean-parse fast path, since the Vec is empty).
+    let mut errs: Vec<String> = parser.errors;
     // RES-325: lower named call arguments to positional ones for
     // every call whose callee is a known top-level fn or impl
     // method. Failures here (unknown name, duplicate target, etc.)


### PR DESCRIPTION
Closes #1343.

## Summary

\`fn parse(src: &str)\` collected the parser's diagnostics with \`parser.errors.into_iter().map(|e| e.to_string()).collect()\`. But \`parser.errors\` is already \`Vec<String>\` (\`Parser\` struct at \`lib.rs:2920\`) — each \`e: String\`'s \`.to_string()\` is \`Clone::clone\` in disguise, allocating a fresh \`String\` identical to its source. The \`into_iter().map().collect()\` round-trip rebuilt the Vec slot by slot, paying one redundant heap allocation per recorded parser error.

Replace with the direct move: \`let mut errs: Vec<String> = parser.errors;\`.

For successful parses (the overwhelming majority of inputs) this is a no-op — \`parser.errors\` is empty either way. For failing parses, the \`N\` redundant String clones are gone.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green (the parser-error tests continue to surface the same diagnostic strings)