### PR TITLE
RES-1345: Parser::next_token — replace peek_token clone with mem::replace move

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -3025,12 +3025,21 @@ impl Parser {
     }
 
     fn next_token(&mut self) {
-        self.current_token = self.peek_token.clone();
+        // RES-1345: swap with `mem::replace` instead of
+        // `peek_token.clone()`. Most token variants are unit-like
+        // and clone trivially, but `Token::Identifier(String)` and
+        // `Token::StringLiteral(String)` clone an owned heap String
+        // each — and this function fires once per token consumed
+        // (~50K calls for a 10K-line program). The new tokens
+        // produced by `lexer.next_token()` replace `peek_token` in
+        // place; the previous `peek_token` moves into
+        // `current_token`. No clone, identical state transitions.
         self.current_line = self.peek_line;
         self.current_column = self.peek_column;
-        self.peek_token = self.lexer.next_token();
+        let new_token = self.lexer.next_token();
         self.peek_line = self.lexer.last_token_line;
         self.peek_column = self.lexer.last_token_column;
+        self.current_token = std::mem::replace(&mut self.peek_token, new_token);
     }
 
     fn parse_program(&mut self) -> Node {


### PR DESCRIPTION
Closes #1345.

## Summary

\`Parser::next_token\` runs once per token consumed — for a 10K-line program (~50K tokens) it's called 50K times. The body cloned \`self.peek_token\`. Most token variants are unit-like (\`Token::Plus\`, \`Token::LeftBrace\`, etc.) — clone is cheap. But \`Token::Identifier(String)\` and \`Token::StringLiteral(String)\` clone their owned \`String\`, allocating a fresh heap buffer each time. ~30–50% of typical tokens are identifiers or string literals.

Swap to \`std::mem::replace\` so the existing \`peek_token\` moves into \`current_token\` and the freshly-pulled lexer token slots into \`peek_token\`:

\`\`\`rust
let new_token = self.lexer.next_token();
...
self.current_token = std::mem::replace(&mut self.peek_token, new_token);
\`\`\`

Identical state transitions, one Token clone eliminated per call. For identifier-heavy programs that's tens of thousands of String allocations eliminated per compile.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green