### PR TITLE
RES-1345: parser next_token — replace peek_token.clone() with mem::replace move

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -191,6 +191,10 @@
     "resilient/src/const_fold.rs": {
       "branch": "res-1341-cache-opt-env-vars",
       "claimed_at": "2026-05-12T06:52:39Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "res-1347-parser-next-token-no-clone",
+      "claimed_at": "2026-05-12T07:12:38Z"
     }
   }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -3025,12 +3025,24 @@ impl Parser {
     }
 
     fn next_token(&mut self) {
-        self.current_token = self.peek_token.clone();
+        // RES-1345: shift the lookahead with a single `mem::replace`
+        // instead of `peek_token.clone()`. The clone was a per-token
+        // heap allocation for every `Token::Identifier(String)` /
+        // `Token::StringLiteral(String)` payload — for a 1k-line
+        // program (~5k tokens) that meant ~5k `String` allocations
+        // on the parse hot path. `mem::replace` swaps the freshly-
+        // lexed peek into `self.peek_token` and returns the old peek
+        // by value, with no allocation; the old `current_token` is
+        // dropped exactly as it would have been under the previous
+        // assignment.
+        let new_peek = self.lexer.next_token();
+        let new_peek_line = self.lexer.last_token_line;
+        let new_peek_column = self.lexer.last_token_column;
+        self.current_token = std::mem::replace(&mut self.peek_token, new_peek);
         self.current_line = self.peek_line;
         self.current_column = self.peek_column;
-        self.peek_token = self.lexer.next_token();
-        self.peek_line = self.lexer.last_token_line;
-        self.peek_column = self.lexer.last_token_column;
+        self.peek_line = new_peek_line;
+        self.peek_column = new_peek_column;
     }
 
     fn parse_program(&mut self) -> Node {


### PR DESCRIPTION
Closes #1347

## Summary

`Parser::next_token` (lib.rs:3027) shifts the lookahead via `self.current_token = self.peek_token.clone()`. `Token::Identifier(String)` / `Token::StringLiteral(String)` (and several other payload-bearing variants) clone their inner `String` on every shift — for a 1k-line program (~5k tokens) that's ~5k heap allocations on the parse hot path, all of them immediately replaced by the next shift.

Use `std::mem::replace` to swap the freshly-lexed peek into `self.peek_token` and return the old peek by value. The old `current_token` is dropped exactly as it would have been under the previous assignment; no behavioural change.

Out of scope: the ~30 other `self.current_token.clone()` sites take the token by value mid-parse to release the immutable borrow before recursing — they're load-bearing for borrow-check correctness and not on the per-token shift hot path.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 3206 tests pass
- [x] `cargo test --manifest-path resilient/Cargo.toml` — full suite green
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)