### PR TITLE
RES-1349: ActorDecl typecheck — drop resolved_fields.clone() at last-use insert

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -5205,8 +5205,11 @@ impl TypeChecker {
                     self.env.set(field.clone(), resolved.clone());
                     resolved_fields.push((field.clone(), resolved));
                 }
-                self.struct_fields
-                    .insert(name.clone(), resolved_fields.clone());
+                // RES-1349: move `resolved_fields` directly — it has
+                // no further reader in this arm, so `.clone()` was
+                // pure dead allocation (one extra `Vec` + one extra
+                // `String` per state field).
+                self.struct_fields.insert(name.clone(), resolved_fields);
                 for clause in always_clauses {
                     let ty = self.check_node(clause)?;
                     if ty != Type::Bool && ty != Type::Any {


### PR DESCRIPTION
Closes #1349.

## Summary

\`self.struct_fields.insert(name.clone(), resolved_fields.clone());\` in the \`Node::ActorDecl\` arm of \`TypeChecker::check_node\`. After this insert, \`resolved_fields\` is never read again — the rest of the arm operates on \`always_clauses\`, \`eventually_clauses\`, and \`receive_handlers\` from the original Node, not on \`resolved_fields\`. The \`.clone()\` built a fresh \`Vec\` plus a fresh \`String\` per entry only to drop the original on function exit.

Move \`resolved_fields\` directly. For an actor with K state fields, this saves K String clones + one Vec allocation per ActorDecl. Marginal in absolute terms but the move is the idiomatic Rust shape — the previous \`.clone()\` was pure dead allocation.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green