### PR TITLE
RES-1353: gate let_type_hints push on opt-in capture_inlay_hints flag

### DIFF
--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -2257,7 +2257,14 @@ impl LanguageServer for Backend {
         // Run the typechecker purely for its hint side-channel.
         // Ignore the return value — errors don't invalidate hints
         // collected up to the error point.
-        let mut tc = typechecker::TypeChecker::new();
+        //
+        // RES-1353: opt into populating `let_type_hints`. Other
+        // typechecker call sites (diagnostics in `did_open` /
+        // `did_change`, every CLI `rz prog.rz` run, every
+        // `cargo test`) leave the flag off so the per-`let`
+        // allocations don't fire on hot paths that never read the
+        // hints.
+        let mut tc = typechecker::TypeChecker::new().with_capture_inlay_hints(true);
         let _ = tc.check_program_with_source(&program, uri.as_str());
         let let_hints: Vec<InlayHint> = tc.let_type_hints.iter().map(inlay_hint_from_let).collect();
 
@@ -2663,7 +2670,7 @@ mod tests {
             }\n";
         let (program, errs) = parse(src);
         assert!(errs.is_empty(), "parse errors: {errs:?}");
-        let mut tc = typechecker::TypeChecker::new();
+        let mut tc = typechecker::TypeChecker::new().with_capture_inlay_hints(true);
         let _ = tc.check_program_with_source(&program, "file:///tmp/test.rs");
         let hints = &tc.let_type_hints;
         assert_eq!(
@@ -2685,7 +2692,7 @@ mod tests {
         // information and clutters the editor.
         let src = "fn main(int _d) { let x = println(\"hi\"); return 0; }\n";
         let (program, _) = parse(src);
-        let mut tc = typechecker::TypeChecker::new();
+        let mut tc = typechecker::TypeChecker::new().with_capture_inlay_hints(true);
         let _ = tc.check_program_with_source(&program, "<t>");
         // `println` returns Void, so `x` is Void → skipped.
         assert_eq!(tc.let_type_hints.len(), 0);

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1030,6 +1030,12 @@ pub struct TypeChecker {
     /// consulted. Default `false`; the audit/explain-effects drivers
     /// set it via `with_audit_stats(true)`.
     audit_stats: bool,
+    /// RES-1353: opt-in flag for populating `let_type_hints`. The
+    /// hints are only consumed by `lsp_server`'s inlay-hint provider,
+    /// so every non-LSP compile pushed a `LetTypeHint` per inferred
+    /// `let` only to drop the Vec on TypeChecker drop. Default
+    /// `false`; the LSP path flips it via `with_capture_inlay_hints(true)`.
+    capture_inlay_hints: bool,
 }
 
 impl TypeChecker {
@@ -3491,6 +3497,10 @@ impl TypeChecker {
             // the LSP/REPL, every `cargo test` typecheck) skip the
             // `infer_fn_effects` fixpoint.
             audit_stats: false,
+            // RES-1353: opt-in. LSP sets this; default-mode runs skip
+            // populating `let_type_hints` (it's only consumed by the
+            // inlay-hint provider).
+            capture_inlay_hints: false,
         }
     }
 
@@ -3542,6 +3552,18 @@ impl TypeChecker {
     /// flips this on for the audit/explain-effects paths.
     pub fn with_audit_stats(mut self, on: bool) -> Self {
         self.audit_stats = on;
+        self
+    }
+
+    /// RES-1353: opt into populating `self.let_type_hints` with an
+    /// entry per inferred `let` binding. The LSP backend reads
+    /// these to produce inlay hints; every other entry point
+    /// (default `rz prog.rz` path, REPL, every `cargo test`
+    /// typecheck call) discards them on TypeChecker drop. Default
+    /// `false`; LSP flips this on before running typecheck.
+    #[allow(dead_code)] // only called behind the `lsp` feature
+    pub fn with_capture_inlay_hints(mut self, on: bool) -> Self {
+        self.capture_inlay_hints = on;
         self
     }
 
@@ -4681,7 +4703,15 @@ impl TypeChecker {
                     // (shouldn't happen for a let, but guard
                     // against it) or `Var` (inference artifact
                     // that shouldn't leak to users).
-                    if !matches!(value_type, Type::Any | Type::Void | Type::Var(..)) {
+                    //
+                    // RES-1353: opt-in. Only the LSP consumes
+                    // `let_type_hints`; every other entry point
+                    // dropped the Vec on TypeChecker drop. Gate
+                    // the push (plus its `name.chars().count()` walk
+                    // and `value_type.clone()`) on the flag.
+                    if self.capture_inlay_hints
+                        && !matches!(value_type, Type::Any | Type::Void | Type::Var(..))
+                    {
                         self.let_type_hints.push(LetTypeHint {
                             span: *span,
                             name_len_chars: name.chars().count(),


### PR DESCRIPTION
Closes #1353.

## Summary

\`TypeChecker\` recorded every unannotated \`let\` binding's inferred type into \`self.let_type_hints: Vec<LetTypeHint>\`. The hints are consumed only by \`lsp_server\`'s inlay-hint provider — every non-LSP compile pushed one \`LetTypeHint\` per inferred \`let\` and dropped the vector on TypeChecker drop.

Per-let cost on the wasted path:
- one \`LetTypeHint\` struct allocation
- one \`name.chars().count()\` walk over the binding name
- one \`value_type.clone()\` (Type::Function clones recursively through \`Box<Type>\` and \`Vec<Type>\`)

Mirror the RES-1322 pattern: add \`capture_inlay_hints: bool\` (default \`false\`) plus \`.with_capture_inlay_hints(bool)\` builder. Gate the push + cost on the flag. LSP's inlay-hint provider flips it; every other entry point leaves it off.

For a 5K-line program with ~500 inferred lets, that's 500 \`LetTypeHint\` allocations + 500 Type clones eliminated per compile.

LSP tests reading \`tc.let_type_hints\` updated to call \`.with_capture_inlay_hints(true)\`. The LSP diagnostics path (which doesn't read hints) leaves the flag off.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo build --locked --features lsp\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --locked --features lsp --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green
- [x] \`cargo test --locked --features lsp\` — LSP suite green (the inlay-hint tests still see the populated vector under the new flag)