### PR TITLE
RES-1357: gate self.certificates push on opt-in capture_certificates flag

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -25953,7 +25953,12 @@ fn execute_file(
             // fixpoint only when its result is consumed. `--audit`
             // and `--explain-effects` both read `stats.fn_effects`;
             // every other invocation skips the fixpoint.
-            .with_audit_stats(audit || explain_effects);
+            .with_audit_stats(audit || explain_effects)
+            // RES-1357: opt into populating `tc.certificates` only
+            // when `--emit-certificate <DIR>` will consume it.
+            // Every other invocation drops the captured certs on
+            // TypeChecker drop; skip the per-discharge allocations.
+            .with_capture_certificates(emit_cert_dir.is_some());
         // RES-354: apply the --z3-theory flag when z3 feature is on.
         #[cfg(feature = "z3")]
         let mut tc = tc_base.with_z3_theory(z3_theory);

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1036,6 +1036,13 @@ pub struct TypeChecker {
     /// `let` only to drop the Vec on TypeChecker drop. Default
     /// `false`; the LSP path flips it via `with_capture_inlay_hints(true)`.
     capture_inlay_hints: bool,
+    /// RES-1357: opt-in flag for populating `certificates`. The vec
+    /// is consumed only by `emit_certificates` under the
+    /// `--emit-certificate <DIR>` driver path. Every default-mode
+    /// compile pushes one `CapturedCertificate` per Z3-proven
+    /// obligation only to drop the vec on TypeChecker drop. Default
+    /// `false`; the cert-emit driver flips it on.
+    capture_certificates: bool,
 }
 
 impl TypeChecker {
@@ -3501,6 +3508,9 @@ impl TypeChecker {
             // populating `let_type_hints` (it's only consumed by the
             // inlay-hint provider).
             capture_inlay_hints: false,
+            // RES-1357: opt-in. `--emit-certificate` driver sets this;
+            // default-mode runs skip populating `certificates`.
+            capture_certificates: false,
         }
     }
 
@@ -3567,6 +3577,17 @@ impl TypeChecker {
         self
     }
 
+    /// RES-1357: opt into pushing `CapturedCertificate` entries into
+    /// `self.certificates`. The vector is consumed only by
+    /// `emit_certificates` under the `--emit-certificate <DIR>`
+    /// driver path; every other invocation discards it on
+    /// TypeChecker drop. Default `false`; the cert-emit driver
+    /// flips it on.
+    pub fn with_capture_certificates(mut self, on: bool) -> Self {
+        self.capture_certificates = on;
+        self
+    }
+
     /// RES-318: read accessor for the verifier pass.
     #[allow(dead_code)]
     pub(crate) fn verifier_timeout_ms(&self) -> u32 {
@@ -3583,12 +3604,14 @@ impl TypeChecker {
     /// participates in the regular `--emit-certificate <DIR>` dump.
     #[allow(dead_code)]
     pub(crate) fn push_loop_invariant_certificate(&mut self, idx: usize, smt2: String) {
-        self.certificates.push(CapturedCertificate {
-            fn_name: "<loop>".to_string(),
-            kind: "loop_invariant",
-            idx,
-            smt2,
-        });
+        if self.capture_certificates {
+            self.certificates.push(CapturedCertificate {
+                fn_name: "<loop>".to_string(),
+                kind: "loop_invariant",
+                idx,
+                smt2,
+            });
+        }
         self.stats.loop_invariants_proven += 1;
     }
 
@@ -4273,7 +4296,12 @@ impl TypeChecker {
                         verdict = v;
                         if matches!(verdict, Some(true)) {
                             self.stats.requires_discharged_by_z3 += 1;
-                            if let Some(smt2) = cert {
+                            // RES-1357: only store the cert when the
+                            // emit-certificate driver is going to
+                            // consume it.
+                            if self.capture_certificates
+                                && let Some(smt2) = cert
+                            {
                                 self.certificates.push(CapturedCertificate {
                                     fn_name: name.clone(),
                                     kind: "decl",
@@ -4417,7 +4445,12 @@ impl TypeChecker {
                     // can dump it alongside requires/ensures certs.
                     if matches!(verdict, Some(true)) {
                         self.stats.requires_discharged_by_z3 += 1;
-                        if let Some(smt2) = cert_smt2 {
+                        // RES-1357: only store the cert when the
+                        // emit-certificate driver is going to consume
+                        // it.
+                        if self.capture_certificates
+                            && let Some(smt2) = cert_smt2
+                        {
                             self.certificates.push(CapturedCertificate {
                                 fn_name: name.clone(),
                                 kind: "recovers_to",
@@ -5881,7 +5914,10 @@ impl TypeChecker {
                             if verdict.is_none() && self.warn_unverified {
                                 emit_partial_proof_warning(&self.source_path, clause);
                             }
+                            // RES-1357: only store the cert when the
+                            // emit-certificate driver will consume it.
                             if matches!(verdict, Some(true))
+                                && self.capture_certificates
                                 && let Some(smt2) = cert
                             {
                                 self.certificates.push(CapturedCertificate {

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -482,7 +482,14 @@ mod tests {
         // program doesn't reach the verifier with an out-of-loop
         // `invariant` statement.
         crate::loop_invariants::check(&p, "<test>").expect("loop_invariants check failed");
-        let mut tc = TypeChecker::new().with_warn_unverified(false);
+        // RES-1357: opt into cert capture so
+        // `push_loop_invariant_certificate` actually writes into
+        // `tc.certificates` — the test counts pushes via
+        // `loop_invariant_certificate_count`, and the helper now
+        // no-ops when the flag is off (default).
+        let mut tc = TypeChecker::new()
+            .with_warn_unverified(false)
+            .with_capture_certificates(true);
         let before = tc.loop_invariant_certificate_count();
         super::verify_and_capture(&mut tc, &p);
         tc.loop_invariant_certificate_count() - before


### PR DESCRIPTION
Closes #1357.

## Summary

\`TypeChecker.certificates\` was populated at four sites — every Z3-proven \`requires\` / \`ensures\` clause, every \`recovers_to\` clause, every loop-invariant cert helper call. Consumed only by \`emit_certificates\` under \`--emit-certificate <DIR>\`. Every default-mode compile pushed one \`CapturedCertificate\` per discharged obligation only to drop the vec on TypeChecker drop.

Per-push cost: \`name.clone()\` + \`CapturedCertificate\` struct alloc + the moved \`smt2\` String held until drop.

Mirror RES-1322 / RES-1353: add \`capture_certificates: bool\` (default \`false\`) + \`.with_capture_certificates(bool)\` builder. Compile driver sets the flag to \`emit_cert_dir.is_some()\`.

\`verifier_loop_invariants::tests::run\` updated to call \`.with_capture_certificates(true)\` because the test counts pushes via \`loop_invariant_certificate_count\`.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo build --locked --features z3\` clean
- [x] \`cargo clippy --locked --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --locked --features z3 --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --locked\` — full suite green
- [x] \`cargo test --locked --features z3\` — z3 suite green (loop-invariant cert counter tests still pass under the opt-in flag)