### PR TITLE
RES-1357: gate certificates Vec push on opt-in emit_certificates flag

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -140,10 +140,6 @@
       "branch": "res-1290-liveness-fast-reject",
       "claimed_at": "2026-05-12T04:46:14Z"
     },
-    "resilient/src/verifier_loop_invariants.rs": {
-      "branch": "res-1297-verifier-loop-inv-fast-reject",
-      "claimed_at": "2026-05-12T04:57:49Z"
-    },
     "resilient/src/feature_attrs.rs": {
       "branch": "res-1303-feature-attrs-kind-index",
       "claimed_at": "2026-05-12T05:08:27Z"
@@ -193,8 +189,16 @@
       "claimed_at": "2026-05-12T06:52:39Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1354-fold-const-bool-short-circuit",
-      "claimed_at": "2026-05-12T07:30:00Z"
+      "branch": "res-1358-emit-certificates-opt-in",
+      "claimed_at": "2026-05-12T07:42:21Z"
+    },
+    "resilient/src/verifier_loop_invariants.rs": {
+      "branch": "res-1358-emit-certificates-opt-in",
+      "claimed_at": "2026-05-12T07:42:21Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "res-1358-emit-certificates-opt-in",
+      "claimed_at": "2026-05-12T07:42:21Z"
     }
   }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -25953,7 +25953,13 @@ fn execute_file(
             // fixpoint only when its result is consumed. `--audit`
             // and `--explain-effects` both read `stats.fn_effects`;
             // every other invocation skips the fixpoint.
-            .with_audit_stats(audit || explain_effects);
+            .with_audit_stats(audit || explain_effects)
+            // RES-1357: opt into stashing SMT-LIB2 certs only when
+            // `--emit-certificate <DIR>` will consume them. Every
+            // other invocation skips the per-push `fn_name.clone()`
+            // and the growing `Vec<CapturedCertificate>` it'd drop
+            // on TypeChecker drop.
+            .with_emit_certificates(emit_cert_dir.is_some());
         // RES-354: apply the --z3-theory flag when z3 feature is on.
         #[cfg(feature = "z3")]
         let mut tc = tc_base.with_z3_theory(z3_theory);

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -1056,6 +1056,14 @@ pub struct TypeChecker {
     /// `let` only to drop the Vec on TypeChecker drop. Default
     /// `false`; the LSP path flips it via `with_capture_inlay_hints(true)`.
     capture_inlay_hints: bool,
+    /// RES-1357: opt-in flag for pushing `CapturedCertificate`
+    /// entries onto `self.certificates`. The only consumer is the
+    /// `--emit-certificate <DIR>` CLI driver (lib.rs:26008) — every
+    /// other invocation (default `rz prog.rz`, LSP/REPL, every
+    /// `cargo test` typecheck) pushed certs onto a Vec it dropped
+    /// on TypeChecker drop. Default `false`; the cert-emit driver
+    /// flips it via `with_emit_certificates(true)`.
+    emit_certificates: bool,
 }
 
 impl TypeChecker {
@@ -3521,6 +3529,11 @@ impl TypeChecker {
             // populating `let_type_hints` (it's only consumed by the
             // inlay-hint provider).
             capture_inlay_hints: false,
+            // RES-1357: opt-in. The `--emit-certificate` driver flips
+            // this; every other invocation skips pushing
+            // `CapturedCertificate` onto the Vec it'd drop on
+            // TypeChecker drop.
+            emit_certificates: false,
         }
     }
 
@@ -3587,6 +3600,17 @@ impl TypeChecker {
         self
     }
 
+    /// RES-1357: opt into pushing `CapturedCertificate` entries onto
+    /// `self.certificates`. The only consumer is the
+    /// `--emit-certificate <DIR>` driver in lib.rs; every other
+    /// path leaves the flag off so the per-push `fn_name.clone()` +
+    /// Vec growth doesn't fire on hot paths that never read the
+    /// certs.
+    pub fn with_emit_certificates(mut self, on: bool) -> Self {
+        self.emit_certificates = on;
+        self
+    }
+
     /// RES-318: read accessor for the verifier pass.
     #[allow(dead_code)]
     pub(crate) fn verifier_timeout_ms(&self) -> u32 {
@@ -3601,14 +3625,21 @@ impl TypeChecker {
 
     /// RES-318: push a loop-invariant proof certificate so it
     /// participates in the regular `--emit-certificate <DIR>` dump.
+    ///
+    /// RES-1357: only stores the cert when `emit_certificates` is
+    /// on. The `loop_invariants_proven` stat counter increments
+    /// unconditionally so the audit summary still reports the
+    /// total — only the SMT-LIB2 body Vec push is gated.
     #[allow(dead_code)]
     pub(crate) fn push_loop_invariant_certificate(&mut self, idx: usize, smt2: String) {
-        self.certificates.push(CapturedCertificate {
-            fn_name: "<loop>".to_string(),
-            kind: "loop_invariant",
-            idx,
-            smt2,
-        });
+        if self.emit_certificates {
+            self.certificates.push(CapturedCertificate {
+                fn_name: "<loop>".to_string(),
+                kind: "loop_invariant",
+                idx,
+                smt2,
+            });
+        }
         self.stats.loop_invariants_proven += 1;
     }
 
@@ -4293,7 +4324,11 @@ impl TypeChecker {
                         verdict = v;
                         if matches!(verdict, Some(true)) {
                             self.stats.requires_discharged_by_z3 += 1;
-                            if let Some(smt2) = cert {
+                            // RES-1357: only stash the SMT-LIB2 cert
+                            // when a consumer asked for it.
+                            if self.emit_certificates
+                                && let Some(smt2) = cert
+                            {
                                 self.certificates.push(CapturedCertificate {
                                     fn_name: name.clone(),
                                     kind: "decl",
@@ -4437,7 +4472,11 @@ impl TypeChecker {
                     // can dump it alongside requires/ensures certs.
                     if matches!(verdict, Some(true)) {
                         self.stats.requires_discharged_by_z3 += 1;
-                        if let Some(smt2) = cert_smt2 {
+                        // RES-1357: only stash the cert when the
+                        // `--emit-certificate` driver asked for it.
+                        if self.emit_certificates
+                            && let Some(smt2) = cert_smt2
+                        {
                             self.certificates.push(CapturedCertificate {
                                 fn_name: name.clone(),
                                 kind: "recovers_to",
@@ -5901,7 +5940,10 @@ impl TypeChecker {
                             if verdict.is_none() && self.warn_unverified {
                                 emit_partial_proof_warning(&self.source_path, clause);
                             }
+                            // RES-1357: only stash the cert when the
+                            // `--emit-certificate` driver asked for it.
                             if matches!(verdict, Some(true))
+                                && self.emit_certificates
                                 && let Some(smt2) = cert
                             {
                                 self.certificates.push(CapturedCertificate {

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -482,7 +482,13 @@ mod tests {
         // program doesn't reach the verifier with an out-of-loop
         // `invariant` statement.
         crate::loop_invariants::check(&p, "<test>").expect("loop_invariants check failed");
-        let mut tc = TypeChecker::new().with_warn_unverified(false);
+        // RES-1357: opt into cert capture so
+        // `loop_invariant_certificate_count` reflects the proven
+        // count (the production path leaves it off so the Vec push
+        // doesn't fire on hot paths that don't read it).
+        let mut tc = TypeChecker::new()
+            .with_warn_unverified(false)
+            .with_emit_certificates(true);
         let before = tc.loop_invariant_certificate_count();
         super::verify_and_capture(&mut tc, &p);
         tc.loop_invariant_certificate_count() - before


### PR DESCRIPTION
Closes #1358

## Summary

`TypeChecker::check_program_with_source` pushed a `CapturedCertificate` (with `fn_name.clone()` per push) onto `self.certificates` for every Z3-discharged contract obligation (requires/ensures/recovers_to/loop_invariant). The only consumer is the `--emit-certificate <DIR>` CLI driver (lib.rs:26008) — every other path (default `rz prog.rz`, every `cargo test` typecheck, the LSP/REPL) let the Vec grow and dropped it on TypeChecker drop.

Add `emit_certificates: bool` on `TypeChecker` (default `false`), expose via `with_emit_certificates(self, on: bool) -> Self`. The 4 push sites in `check_program_with_source` and the `push_loop_invariant_certificate` helper now gate on the flag. The CLI driver sets it to `emit_cert_dir.is_some()`.

Stats counters (`requires_discharged_by_z3`, `loop_invariants_proven`) increment unconditionally so the `--audit` summary still reports totals — only the Vec push + `fn_name.clone()` is gated. The `verifier_loop_invariants` test that counts loop-invariant certs now calls `.with_emit_certificates(true)` to preserve coverage.

Same shape as RES-1322 (audit_stats) and RES-1353 (capture_inlay_hints) — populate only when a consumer asked for it.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 3206 tests pass
- [x] `cargo test --manifest-path resilient/Cargo.toml` — full suite green, including the `verifier_loop_invariants` tests that count proven invariants
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)