### PR TITLE
RES-1363: contract_table — wrap ContractInfo in Rc to make per-CallExpression lookup cheap

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -189,8 +189,8 @@
       "claimed_at": "2026-05-12T06:52:39Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1361-rich-diag-env-cache",
-      "claimed_at": "2026-05-12T07:54:53Z"
+      "branch": "res-1363-contract-table-rc",
+      "claimed_at": "2026-05-12T08:04:15Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -966,7 +966,10 @@ pub struct TypeChecker {
     env: TypeEnvironment,
     /// RES-061: top-level function name → its parameters + contract clauses.
     /// Populated by check_program's first pass; consulted by CallExpression.
-    contract_table: HashMap<String, ContractInfo>,
+    /// RES-1363: stored behind `Rc` so the per-CallExpression lookup
+    /// at typechecker.rs:5877 ticks a single refcount instead of
+    /// deep-cloning four `Vec`s on every call to a user-defined fn.
+    contract_table: HashMap<String, std::rc::Rc<ContractInfo>>,
     /// RES-340: top-level function name → span of its `fn` keyword.
     /// Populated by the same pre-pass that fills `contract_table`. Read
     /// by the rich-diagnostic path in `CallExpression` to attach a
@@ -3708,14 +3711,18 @@ impl TypeChecker {
                             span,
                             ..
                         } => {
+                            // RES-1363: wrap in `Rc` so the call-site
+                            // reader at typechecker.rs:5877 clones a
+                            // single refcount instead of deep-cloning
+                            // four `Vec`s.
                             self.contract_table.insert(
                                 name.clone(),
-                                ContractInfo {
+                                std::rc::Rc::new(ContractInfo {
                                     parameters: parameters.clone(),
                                     requires: requires.clone(),
                                     ensures: ensures.clone(),
                                     fails: fails.clone(),
-                                },
+                                }),
                             );
                             // RES-340: remember the fn keyword's span so
                             // the rich type-mismatch path can point at


### PR DESCRIPTION
Closes #1363

## Summary

`TypeChecker::contract_table` is keyed by fn name with values of `ContractInfo { parameters: Vec<(String, String)>, requires: Vec<Node>, ensures: Vec<Node>, fails: Vec<String> }`. The CallExpression arm at typechecker.rs:5877 looks up the callee and `.cloned()`s the whole struct to break the borrow before mutating self — four `Vec` clones plus their embedded `Node` / `String` clones, on every call to a user-defined fn.

Wrap the value in `std::rc::Rc<ContractInfo>`. The pre-pass insert costs one extra `Rc::new` allocation; the reader's `.cloned()` becomes a single non-atomic refcount bump instead of the deep clone. Auto-deref keeps the `info.fails` / `info.requires` / `info.parameters` field accesses unchanged.

Net per CallExpression to a contracted callee: 1 refcount bump instead of 4 `Vec` clones + nested heap allocations.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml` — full suite green (3206 lib tests + every integration test)
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)