### PR TITLE
RES-1372: TypeEnvironment.outer — Box → Arc to drop deep-clone-on-clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -189,8 +189,8 @@
       "claimed_at": "2026-05-12T06:52:39Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1365-struct-fields-rc",
-      "claimed_at": "2026-05-12T08:19:30Z"
+      "branch": "res-1372-typeenv-outer-rc",
+      "claimed_at": "2026-05-12T08:45:01Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -596,10 +596,27 @@ fn fold_const_i64(n: &Node, bindings: &HashMap<String, i64>) -> Option<i64> {
 }
 
 // Environment for storing type information
+//
+// RES-1372: `outer` is `Arc<TypeEnvironment>` (not `Box`) so cloning a
+// `TypeEnvironment` is O(current store) instead of O(sum of stores
+// along the outer chain). The typechecker enters a new scope (via
+// `self.env.clone()` + `new_enclosed`) at every function body, block,
+// fn-literal, actor body, handler, while/for loop, and quantifier
+// binding — hundreds of times per non-trivial program. With the old
+// `Box`, each clone walked the entire outer chain and deep-cloned
+// every frame's `store` HashMap. With `Arc`, the chain-clone is a
+// refcount bump; only the current scope's own `store` clones for real.
+// `Arc` (not `Rc`) so the type stays `Send + Sync` — required because
+// the RES-1349 builtin-env `LazyLock<TypeEnvironment>` is a `Sync`
+// static. Atomic refcount ops are still trivially cheaper than the
+// deep HashMap clone they replace.
+// Mutation safety: `set` / `remove` only touch `self.store`; `get` /
+// `all_names` only read through `&self.outer`. Nothing ever mutates
+// through the indirection, so the Arc share is sound.
 #[derive(Debug, Clone)]
 pub struct TypeEnvironment {
     store: HashMap<String, Type>,
-    outer: Option<Box<TypeEnvironment>>,
+    outer: Option<std::sync::Arc<TypeEnvironment>>,
 }
 
 impl TypeEnvironment {
@@ -613,7 +630,7 @@ impl TypeEnvironment {
     pub fn new_enclosed(outer: TypeEnvironment) -> Self {
         TypeEnvironment {
             store: HashMap::new(),
-            outer: Some(Box::new(outer)),
+            outer: Some(std::sync::Arc::new(outer)),
         }
     }
 


### PR DESCRIPTION
Closes #1372

`TypeEnvironment` derives `Clone`, and `Box<T>: Clone` is a deep clone,
so every `self.env.clone()` walks the outer chain and clones each
frame's `store` HashMap along the way. The typechecker enters a new
scope (via `self.env.clone()` + `new_enclosed`) at every function body,
block, fn-literal, actor body, handler, while/for loop, and quantifier
binding — hundreds of times per non-trivial program.

Wrapping `outer` in `Arc` makes the chain-clone an O(1) refcount bump
per frame; only the current scope's own `store` clones for real. The
mutation surface is unchanged: `set` / `remove` only touch
`self.store`; `get` / `all_names` only read through `&self.outer`,
which auto-derefs identically for `Box` and `Arc`. Nothing ever
mutates through the indirection, so the share is sound.

`Arc`, not `Rc`, because the RES-1349 builtin-env
`LazyLock<TypeEnvironment>` is a `Sync` static — `Rc` fails the `Sync`
bound. Atomic refcount ops are still trivially cheaper than the deep
HashMap clone they replace.

## Test changes
None. All 3206 lib tests + integration tests pass unchanged (the eight
`new_enclosed(self.env.clone())` call sites stay byte-identical because
the `new_enclosed` signature still takes an owned `TypeEnvironment`).

## Pattern
Mirror of RES-1363 (contract_table) / RES-1365 (struct_fields) /
RES-1368 (enum_decls) `Rc`-wrap pattern, but on the env-chain clone
hot path instead of contract / struct / enum lookups.