### PR TITLE
RES-1376: quantifiers::eval_quantifier — drop redundant Environment clone (RES-1320 pattern, interpreter side)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -191,6 +191,10 @@
     "resilient/src/typechecker.rs": {
       "branch": "res-1372-typeenv-outer-rc",
       "claimed_at": "2026-05-12T08:45:01Z"
+    },
+    "resilient/src/quantifiers.rs": {
+      "branch": "res-1376-quantifier-eval-clone",
+      "claimed_at": "2026-05-12T08:58:44Z"
     }
   }
 }

--- a/resilient/src/quantifiers.rs
+++ b/resilient/src/quantifiers.rs
@@ -162,9 +162,18 @@ pub(crate) fn eval_quantifier(
     body: &Node,
 ) -> RResult<Value> {
     let witnesses = collect_witnesses(interp, range)?;
-    let saved_env = interp.env.clone();
-    let inner_env = crate::Environment::new_enclosed(saved_env.clone());
-    interp.env = inner_env;
+    // RES-1376: build the enclosed inner from a single clone of the
+    // current env, then `mem::replace` the inner into `interp.env`
+    // while capturing the original outer for restore. Mirrors the
+    // RES-1320 shape from `TypeChecker::with_quantifier_binding`:
+    // the previous code did one clone for `saved` and another for
+    // `inner.outer`, paying two `Environment::clone`s (Rc bumps) per
+    // quantifier evaluation. The body walk only reads through the
+    // enclosed env (lookups fall through to the outer on miss), so
+    // the moved original is safe to hand back unchanged after the
+    // loop.
+    let inner_env = crate::Environment::new_enclosed(interp.env.clone());
+    let saved_env = std::mem::replace(&mut interp.env, inner_env);
 
     let mut result = match kind {
         QuantifierKind::Forall => true,


### PR DESCRIPTION
Closes #1376

Apply the RES-1320 `mem::replace` pattern to the interpreter's quantifier evaluator. The previous shape did two `Environment::clone`s per `eval_quantifier` call:

```rust
let saved_env = interp.env.clone();                                  // #1
let inner_env = Environment::new_enclosed(saved_env.clone());        // #2
```

`Environment` wraps `Rc<RefCell<EnvFrame>>` so each clone is a refcount bump rather than a deep clone, but the second bump is still pure overhead. Build the inner from a single `interp.env.clone()`, then `mem::replace` to swap it into `interp.env` while capturing the original outer for the post-loop restore:

```rust
let inner_env = Environment::new_enclosed(interp.env.clone());
let saved_env = std::mem::replace(&mut interp.env, inner_env);
```

`eval_quantifier` fires once per `forall` / `exists` at **runtime** (not just typecheck) — the interpreter is the dominant path for REPL / playground / spec-execution flows. Mirrors the pattern already in use in `Interpreter::eval_for_in` and the contract-env scope entry elsewhere in `lib.rs`.

## Test changes
None. All 12 quantifier tests pass unchanged because the visible scope semantics are identical — only the count of refcount-bump ops changes.