### PR TITLE
RES-1379: Interpreter Match arm — skip env clone on bindings-empty + drop redundant clone otherwise

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -195,6 +195,10 @@
     "resilient/src/quantifiers.rs": {
       "branch": "res-1376-quantifier-eval-clone",
       "claimed_at": "2026-05-12T08:58:44Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "res-1379-match-arm-clone",
+      "claimed_at": "2026-05-12T09:02:14Z"
     }
   }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -22264,22 +22264,33 @@ impl Interpreter {
                         // two (outer name + inner pattern bindings). The
                         // enclosed scope is restored on arm exit so bindings
                         // don't leak into subsequent arms or outer scope.
-                        let saved = self.env.clone();
-                        let had_scope = !bindings.is_empty();
-                        if had_scope {
-                            self.env = Environment::new_enclosed(saved.clone());
+                        //
+                        // RES-1379: skip the env clone when the pattern
+                        // binds nothing (Wildcard / Literal), and when it
+                        // does bind, build the enclosed inner from a
+                        // single `self.env.clone()` and `mem::replace` it
+                        // in — mirroring the RES-1320 typechecker shape.
+                        // `Environment::clone` is an `Rc` bump, but every
+                        // skipped bump matters in match-heavy code where
+                        // most arms are wildcard / literal patterns.
+                        let saved = if bindings.is_empty() {
+                            None
+                        } else {
+                            let inner = Environment::new_enclosed(self.env.clone());
+                            let outer = std::mem::replace(&mut self.env, inner);
                             for (name, value) in bindings {
                                 self.env.set(name, value);
                             }
-                        }
+                            Some(outer)
+                        };
                         let guard_pass = match guard {
                             Some(g) => {
                                 let gv = self.eval(g);
                                 match gv {
                                     Ok(v) => self.is_truthy(&v),
                                     Err(e) => {
-                                        if had_scope {
-                                            self.env = saved.clone();
+                                        if let Some(s) = saved {
+                                            self.env = s;
                                         }
                                         return Err(e);
                                     }
@@ -22288,14 +22299,14 @@ impl Interpreter {
                             None => true,
                         };
                         if !guard_pass {
-                            if had_scope {
-                                self.env = saved;
+                            if let Some(s) = saved {
+                                self.env = s;
                             }
                             continue; // try next arm
                         }
                         let result = self.eval(body);
-                        if had_scope {
-                            self.env = saved;
+                        if let Some(s) = saved {
+                            self.env = s;
                         }
                         return result;
                     }


### PR DESCRIPTION
Closes #1379

The match-arm scope entry in `Interpreter::eval(Node::Match)` paid one unconditional `Environment::clone` per arm tried, plus a second clone inside `new_enclosed` when the pattern actually bound anything. For `Pattern::Wildcard` and `Pattern::Literal` arms the bindings list is empty — no scope to enter, no restore needed — yet `self.env.clone()` still fired. Match-heavy code (enum dispatch, AST visitors written in Resilient, exhaustive boolean matches, etc.) burned one Rc bump per arm checked.

Two-part fix:

1. Gate the clone on `bindings.is_empty()` — only allocate `saved` when there's actually a scope to restore.
2. When there *is* a scope, build the inner enclosed env from a single `self.env.clone()` and `mem::replace` it in (RES-1320 shape).

Restore sites change from `self.env = saved;` / `self.env = saved.clone();` (error path) to `if let Some(s) = saved { self.env = s; }` — the `Option<Environment>` encodes "had a scope to restore" inline, eliminating the parallel `had_scope: bool` and the third clone in the guard-error path.

## Test changes
None. All 3206 lib tests pass unchanged because the visible scope semantics are identical — only the count of `Environment::clone` (`Rc` bump) operations changes.