### PR TITLE
RES-1376: lint::check — single pre-scan to skip lints whose trigger is absent

### DIFF
--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -93,24 +93,95 @@ pub fn safety_critical_mode() -> bool {
     SAFETY_CRITICAL_MODE.load(Ordering::Relaxed)
 }
 
+/// RES-1376: cached trigger-presence flags for the 13 lint passes.
+/// Built by `scan_lint_triggers` in one AST visit; each lint pass is
+/// gated on the flag for its trigger node so passes whose trigger
+/// never appears in the program don't pay for a full AST walk.
+#[derive(Default)]
+struct LintTriggers {
+    has_assume: bool,
+    has_index: bool,
+    has_match: bool,
+    has_division: bool,
+    has_infix: bool,
+    has_function: bool,
+    has_let: bool,
+    has_block: bool,
+}
+
+fn scan_lint_triggers(program: &Node) -> LintTriggers {
+    let mut t = LintTriggers::default();
+    scan_node(program, &mut t);
+    t
+}
+
+fn scan_node(node: &Node, t: &mut LintTriggers) {
+    match node {
+        Node::Assume { .. } => t.has_assume = true,
+        Node::IndexExpression { .. } => t.has_index = true,
+        Node::Match { .. } => t.has_match = true,
+        Node::InfixExpression { operator, .. } => {
+            t.has_infix = true;
+            if operator == "/" || operator == "%" {
+                t.has_division = true;
+            }
+        }
+        Node::Function { .. } => t.has_function = true,
+        Node::LetStatement { .. } => t.has_let = true,
+        Node::Block { .. } => t.has_block = true,
+        _ => {}
+    }
+    recurse_children(node, &mut |child| scan_node(child, t));
+}
+
 /// RES-198: top-level entry. Runs every lint, filters via the
 /// `// resilient: allow LXXXX` comments found in `source`, and
 /// returns the surviving diagnostics sorted by (line, column).
+///
+/// RES-1376: a single `scan_lint_triggers` AST visit caches which
+/// lint trigger nodes appear; each `run_l00XX` is gated on the
+/// matching flag. Lints whose trigger never appears are skipped —
+/// single visit replaces up to 13 separate walks.
 pub fn check(program: &Node, source: &str) -> Vec<Lint> {
     let mut out = Vec::new();
-    run_l0001_unused_local(program, &mut out);
-    run_l0002_unreachable_arm(program, &mut out);
-    run_l0003_self_comparison(program, &mut out);
-    run_l0004_mixed_and_or(program, &mut out);
-    run_l0005_redundant_return(program, &mut out);
-    run_l0006_assume_false(program, &mut out);
-    run_l0007_unreachable_code(program, &mut out);
-    run_l0008_duplicate_struct_match_arm(program, &mut out);
-    run_l0009_division_by_zero(program, &mut out);
-    run_l0010_no_contract(program, &mut out);
-    run_l0011_unused_variable(program, &mut out);
-    run_l0012_spec_provenance(program, source, &mut out);
-    run_l0013_unchecked_indexing(program, &mut out);
+    let t = scan_lint_triggers(program);
+    if t.has_function {
+        run_l0001_unused_local(program, &mut out);
+    }
+    if t.has_match {
+        run_l0002_unreachable_arm(program, &mut out);
+    }
+    if t.has_infix {
+        run_l0003_self_comparison(program, &mut out);
+        run_l0004_mixed_and_or(program, &mut out);
+    }
+    if t.has_function {
+        run_l0005_redundant_return(program, &mut out);
+    }
+    if t.has_assume {
+        run_l0006_assume_false(program, &mut out);
+    }
+    if t.has_block {
+        run_l0007_unreachable_code(program, &mut out);
+    }
+    if t.has_match {
+        run_l0008_duplicate_struct_match_arm(program, &mut out);
+    }
+    if t.has_division {
+        run_l0009_division_by_zero(program, &mut out);
+    }
+    if t.has_function {
+        run_l0010_no_contract(program, &mut out);
+    }
+    if t.has_let {
+        run_l0011_unused_variable(program, &mut out);
+    }
+    if t.has_function {
+        run_l0012_spec_provenance(program, source, &mut out);
+    }
+    if t.has_index {
+        run_l0013_unchecked_indexing(program, &mut out);
+    }
 
     let safety_critical = safety_critical_mode();
     if safety_critical {

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -565,28 +565,31 @@ fn prove_tautology_with_axioms_and_timeout_in(
     let mut arr_args: BTreeSet<String> = BTreeSet::new();
     collect_array_args(expr, &mut arr_args);
 
+    // RES-1383: same `writeln!`-into-buffer fix as the LIA verifier's
+    // cert builder above — eliminates the intermediate `format!`
+    // String allocations per declaration / axiom / assertion.
     let mut smt2 = String::new();
     smt2.push_str("; RES-071 verification certificate\n");
     smt2.push_str("; expected solver result: unsat (proves the contract is a tautology)\n");
     smt2.push_str("(set-logic AUFLIA)\n");
     for name in &idents {
-        smt2.push_str(&format!("(declare-const {} Int)\n", name));
+        writeln!(&mut smt2, "(declare-const {} Int)", name).unwrap();
     }
     for arg in &len_args {
-        smt2.push_str(&format!("(declare-const len_{} Int)\n", arg));
+        writeln!(&mut smt2, "(declare-const len_{} Int)", arg).unwrap();
     }
     for arg in &arr_args {
-        smt2.push_str(&format!("(declare-const arr_{} (Array Int Int))\n", arg));
+        writeln!(&mut smt2, "(declare-const arr_{} (Array Int Int))", arg).unwrap();
     }
     for arg in &len_args {
-        smt2.push_str(&format!("(assert (>= len_{} 0))\n", arg));
+        writeln!(&mut smt2, "(assert (>= len_{} 0))", arg).unwrap();
     }
     for name in &idents {
         if let Some(v) = bindings.get(name) {
-            smt2.push_str(&format!("(assert (= {} {}))\n", name, v));
+            writeln!(&mut smt2, "(assert (= {} {}))", name, v).unwrap();
         }
     }
-    smt2.push_str(&format!("(assert {})\n", negated));
+    writeln!(&mut smt2, "(assert {})", negated).unwrap();
     smt2.push_str("(check-sat)\n");
 
     (true, Some(ProofCertificate { smt2 }), false)

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -31,6 +31,7 @@
 
 use crate::{ActorHandler, Node};
 use std::collections::{BTreeSet, HashMap};
+use std::fmt::Write as _;
 use z3::Sort;
 use z3::ast::{Array, Ast, BV, Bool, Int};
 


### PR DESCRIPTION
Closes #1377

## Summary

\`lint::check\` ran all 13 lint passes (L0001..L0013) unconditionally, each walking the entire program AST via \`recurse_children\` even when its trigger node never appeared. Most programs trigger only a handful of the 13 lints.

LSP calls \`lint::check\` on every parse (\`did_open\` / \`did_change\`); the safety-critical and \`rz lint\` paths also call it.

Add \`LintTriggers\` + \`scan_lint_triggers\`: one AST visit (via \`recurse_children\`, which descends into impl-block methods so the flags catch impl-method triggers) captures which trigger nodes exist. Each \`run_l00XX\` call is then gated on the matching flag. For a program with N of 13 triggers present, the pass count drops from 13 to N + 1.

No change to lint semantics: when a trigger is present, the matching lint runs exactly as before; when absent, the lint would have emitted nothing anyway.

## Test plan

- [x] cargo build
- [x] cargo test --lib lint (90 tests pass, including the impl-method ones)
- [x] cargo test full suite green
- [x] cargo clippy clean
- [x] cargo fmt --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)