### PR TITLE
RES-1386: verifier_loop_invariants if-walk — drop snap.clone() when no else branch

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -199,6 +199,10 @@
     "resilient/src/unify.rs": {
       "branch": "res-1381-apply-hop-counter",
       "claimed_at": "2026-05-12T09:05:25Z"
+    },
+    "resilient/src/verifier_loop_invariants.rs": {
+      "branch": "res-1386-vli-if-snap-clone",
+      "claimed_at": "2026-05-12T09:18:45Z"
     }
   }
 }

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -141,12 +141,25 @@ fn walk(
         } => {
             // Both branches walked under a snapshot — neither
             // branch's bindings outlive the if.
+            //
+            // RES-1386: branch on `alternative` so the snapshot
+            // restore between consequence and alternative is only
+            // paid for when there *is* an alternative. The previous
+            // shape always did `*bindings = snap.clone()` followed
+            // by `*bindings = snap` (move), so bare `if` (no else)
+            // paid one wasted `HashMap::clone` per such node walked
+            // by the Z3 invariant verifier.
             let snap = bindings.clone();
             walk(consequence, bindings, tc, next_idx, timeout_ms, verbose);
-            *bindings = snap.clone();
-            if let Some(alt) = alternative {
-                walk(alt, bindings, tc, next_idx, timeout_ms, verbose);
-                *bindings = snap;
+            match alternative {
+                Some(alt) => {
+                    *bindings = snap.clone();
+                    walk(alt, bindings, tc, next_idx, timeout_ms, verbose);
+                    *bindings = snap;
+                }
+                None => {
+                    *bindings = snap;
+                }
             }
         }
         Node::WhileStatement {


### PR DESCRIPTION
Closes #1386

The \`Node::IfStatement\` arm of \`verifier_loop_invariants::walk\` unconditionally did \`*bindings = snap.clone()\` before checking for an \`alternative\` branch, then \`*bindings = snap\` (move) inside the \`Some(alt)\` arm. When \`alternative\` is \`None\`, the clone is pure waste: \`snap\` is restored once and then dropped without further use.

Branch on \`alternative\` first, restoring via move where possible:

\`\`\`rust
match alternative {
    Some(alt) => {
        *bindings = snap.clone();
        walk(alt, ...);
        *bindings = snap;
    }
    None => {
        *bindings = snap;
    }
}
\`\`\`

Same semantic — bindings are restored to the pre-consequence state before walking the alternative; when there is no alternative, restored once and we move \`snap\` instead of cloning + dropping it. Programs with bare \`if\` (no \`else\`) in Z3-verified loop invariant context save one \`HashMap<String, i64>::clone\` per such node.

## Test changes
None. Feature-gated under \`z3\`. All 3206 default lib tests pass unchanged. The z3 test suite exercises this branch via every \`while\`-with-invariant fixture that contains an \`if\`.