### PR TITLE
RES-1391: traits::check — proper fast-reject when no trait work exists

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -188,6 +188,10 @@
       "branch": "res-1341-cache-opt-env-vars",
       "claimed_at": "2026-05-12T06:52:39Z"
     },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1372-typeenv-outer-rc",
+      "claimed_at": "2026-05-12T08:45:01Z"
+    },
     "resilient/src/quantifiers.rs": {
       "branch": "res-1376-quantifier-eval-clone",
       "claimed_at": "2026-05-12T08:58:44Z"
@@ -196,13 +200,13 @@
       "branch": "res-1381-apply-hop-counter",
       "claimed_at": "2026-05-12T09:05:25Z"
     },
-    "resilient/src/inline.rs": {
-      "branch": "res-1389-inline-skip-clones",
-      "claimed_at": "2026-05-12T09:25:18Z"
+    "resilient/src/verifier_loop_invariants.rs": {
+      "branch": "res-1386-vli-if-snap-clone",
+      "claimed_at": "2026-05-12T09:18:45Z"
     },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1390-let-fold-single-call",
-      "claimed_at": "2026-05-12T09:30:23Z"
+    "resilient/src/traits.rs": {
+      "branch": "res-1391-traits-fast-reject",
+      "claimed_at": "2026-05-12T09:32:26Z"
     }
   }
 }

--- a/resilient/src/traits.rs
+++ b/resilient/src/traits.rs
@@ -326,19 +326,38 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         _ => return Ok(()),
     };
 
-    // RES-1230 NOTE: an earlier draft of this PR added a
-    // `if !any TraitDecl return Ok(())` fast-reject here. It broke
-    // `unknown_trait_in_bound_errors` / `unknown_trait_in_impl_errors`
-    // because `traits::check` also validates trait *references* in
-    // impl blocks (`impl Drawable for Foo`) and generic bounds
-    // (`fn pick<T: Comparable>(...)`), both of which can appear in
-    // programs that never declare a trait themselves. A correct
-    // fast-reject would need to also scan ImplBlock and the
-    // type-params lists — at which point we're doing roughly the
-    // same walk as `traits::check` itself. Left without a fast-
-    // reject; `type_aliases::check` (in the same PR) keeps its
-    // simpler pre-scan because nothing references a type alias
-    // without it being declared.
+    // RES-1391: complete fast-reject. The earlier RES-1230 draft
+    // checked only `TraitDecl` and broke the unknown-trait
+    // diagnostics, because the pass also validates trait *references*
+    // in `impl Trait for Type` blocks and `<T: Trait>` bounds — both
+    // of which can appear in programs without any TraitDecl.
+    //
+    // A correct fast-reject needs all three signals: any TraitDecl,
+    // any ImplBlock carrying a `trait_name`, or any Function with
+    // type-params / non-empty type-param bounds. Programs without
+    // any of these have no trait-validation work to do — Pass 1's
+    // collection is empty, Pass 2's impl scan finds nothing to
+    // validate, Pass 3 has no bounds to check, and
+    // `walk_call_sites` would early-return at
+    // `if type_params.is_empty()` for every callee. Same
+    // fast-reject pattern as RES-1281 / RES-1290 / RES-1294 /
+    // RES-1297 / RES-1311 / RES-1316 / RES-1320 / RES-1376.
+    let has_trait_work = stmts.iter().any(|s| match &s.node {
+        Node::TraitDecl { .. } => true,
+        Node::ImplBlock {
+            trait_name: Some(_),
+            ..
+        } => true,
+        Node::Function {
+            type_params,
+            type_param_bounds,
+            ..
+        } => !type_params.is_empty() || type_param_bounds.iter().any(|bs| !bs.is_empty()),
+        _ => false,
+    });
+    if !has_trait_work {
+        return Ok(());
+    }
 
     // Pass 1: collect trait declarations.
     let mut traits: HashMap<String, (Vec<TraitMethodSig>, Vec<AssociatedTypeDecl>, Span)> =


### PR DESCRIPTION
Closes #1391

## Summary

The earlier RES-1230 fast-reject was incomplete and broke unknown-trait diagnostics (the note in traits.rs:329-341 explains why). \`traits::check\` validates trait *references* in \`impl Trait for Type\` blocks and \`<T: Trait>\` bounds, both of which can appear in programs without any TraitDecl. The note concluded a complete fast-reject would be "roughly the same walk" — but that's not quite right.

The fast-reject pre-scan walks top-level statements ONLY (no recursion into function bodies), while \`check()\` runs:
- Pass 1's full HashMap collection
- Pass 2's impl-coverage loop
- Pass 3's bound-validation
- \`walk_call_sites\`' recursive AST walk that descends into every call expression in every function body

The pre-scan is materially cheaper than the work it skips.

Three-signal fast-reject:
- \`Node::TraitDecl\` (Pass 1 collects something)
- \`Node::ImplBlock\` with \`trait_name: Some(_)\` (Pass 2 validates it)
- \`Node::Function\` with non-empty \`type_params\` or any non-empty \`type_param_bounds\` slot (Pass 3 validates bounds; walk_call_sites descends for generic-call checks)

If none of these appear among top-level statements, return Ok(()) immediately.

Confirmed the unknown-trait diagnostics still fire: \`unknown_trait_in_bound_errors\` and \`unknown_trait_in_impl_errors\` both pass — the bound/impl signals correctly route those programs into \`check()\`.

For programs without any traits or generics — the overwhelming majority — saves the full \`traits::check\` pass.

## Test plan

- [x] cargo build
- [x] cargo test --lib traits (17 tests pass, incl. previously-broken unknown_trait_*)
- [x] cargo test --lib full suite (3206 tests)
- [x] cargo clippy clean
- [x] cargo fmt --check clean