### PR TITLE
RES-1396: inline pass — chunk-level fast-reject when no Op::Call ops

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -208,9 +208,9 @@
       "branch": "res-1391-traits-fast-reject",
       "claimed_at": "2026-05-12T09:32:26Z"
     },
-    "resilient/src/derives.rs": {
-      "branch": "res-1402-derives-empty-install",
-      "claimed_at": "2026-05-12T10:01:28Z"
+    "resilient/src/inline.rs": {
+      "branch": "res-1396-inline-chunk-fast-reject",
+      "claimed_at": "2026-05-12T09:48:19Z"
     }
   }
 }

--- a/resilient/src/inline.rs
+++ b/resilient/src/inline.rs
@@ -287,6 +287,27 @@ fn inline_into_chunk(
     callees: &[Option<Function>],
     own_idx: Option<u16>,
 ) -> Result<bool, InlineError> {
+    // RES-1396: fast-reject. The inliner only ever rewrites
+    // `Op::Call(idx)` opcodes (the `if let Op::Call(callee_idx) =
+    // chunk.code[i]` arm below). Chunks containing zero call sites
+    // — which is most chunks in a typical program: every leaf
+    // helper, every arithmetic-only top-level statement, every
+    // chunk that has already been fully inlined in a prior pass —
+    // walk to the end emitting `new_code.push(chunk.code[i])` and
+    // then memcpy the result back over `chunk.code` unchanged. The
+    // four pre-allocated Vecs (`orig_targets`, `new_code`,
+    // `new_lines`, `old_to_new`) plus the re-linking jump-fixup
+    // loop after the rewrite are all dead work in that case.
+    //
+    // A single linear scan for any `Op::Call` short-circuits the
+    // entire transform. Each pass of the inliner re-asks the same
+    // question on every callee chunk plus main; for programs where
+    // few chunks carry calls, this avoids the 4-Vec allocate-and-
+    // copy churn per pass per call-less chunk.
+    if !chunk.code.iter().any(|op| matches!(op, Op::Call(_))) {
+        return Ok(false);
+    }
+
     // Build the new code stream linearly. Internal jump offsets within
     // the inlined body are pre-relative and unchanged; the caller's
     // own jumps need relinking through an old→new PC fixup table the


### PR DESCRIPTION
Closes #1396

## Summary

\`inline_into_chunk\` runs per function chunk + main per inline pass. It pre-allocates four Vecs (\`orig_targets\`, \`new_code\`, \`new_lines\`, \`old_to_new\`), walks chunk emitting unchanged ops, then runs the jump-fixup re-linking loop. For chunks with zero \`Op::Call\` opcodes — every leaf helper, every arithmetic-only top-level chunk, every chunk already fully inlined — the rewrite emits chunk.code verbatim and memcpys it back. Pure dead work.

Add \`chunk.code.iter().any(Op::Call)\` early-return at entry; saves the per-call-less-chunk 4-Vec allocate-and-copy churn per pass.

Same pattern as RES-1284, RES-1294, RES-1311.

## Test plan

- [x] cargo build
- [x] cargo test --lib inline (22 tests pass)
- [x] cargo test --lib full (3206 tests pass)
- [x] cargo clippy clean
- [x] cargo fmt --check clean