### PR TITLE
RES-1402: derives::check — gate install() on non-empty sets

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -207,6 +207,10 @@
     "resilient/src/traits.rs": {
       "branch": "res-1391-traits-fast-reject",
       "claimed_at": "2026-05-12T09:32:26Z"
+    },
+    "resilient/src/derives.rs": {
+      "branch": "res-1402-derives-empty-install",
+      "claimed_at": "2026-05-12T10:01:28Z"
     }
   }
 }

--- a/resilient/src/derives.rs
+++ b/resilient/src/derives.rs
@@ -69,7 +69,21 @@ pub fn derives_trait(type_name: &str, trait_name: &str) -> bool {
 }
 
 pub(crate) fn check(_program: &Node, source_path: &str) -> Result<(), String> {
+    // RES-1402: gate `install` on the non-empty case. The historical
+    // wiring called `install(sets.clone())` before the trait-validation
+    // loop, burning a `DERIVES.write()` lock + `g.clear()` per compile
+    // regardless of whether any `#[derive]` attribute was present, AND
+    // creating the wipe-on-empty test race shape documented in
+    // RES-1302: a parallel test that called `install(...)` directly
+    // under `feature_attrs::lock_for_test()` would have its registry
+    // wiped by a concurrent typecheck whose `collect()` returned empty.
+    // Same pattern as RES-1306 / RES-1308 already applied to
+    // `async_await`, `default_trait_methods`, `mmio_regmap`,
+    // `distributed_invariants`, `ghost_types`, and friends.
     let sets = collect();
+    if sets.is_empty() {
+        return Ok(());
+    }
     install(sets.clone());
     for s in &sets {
         for t in &s.traits {


### PR DESCRIPTION
Closes #1402

## Summary

Apply the RES-1306 / RES-1308 pattern to \`derives::check\`. The pass was calling \`install(sets.clone())\` unconditionally, burning a \`DERIVES.write()\` lock + \`g.clear()\` per compile regardless of whether any \`#[derive(...)]\` attribute was declared. It also created the wipe-on-empty test race shape documented in RES-1302 against any parallel test that seeds DERIVES under \`feature_attrs::lock_for_test()\`.

Same pattern as \`async_await\`, \`ghost_types\`, \`distributed_invariants\`, \`mmio_regmap\`, \`default_trait_methods\`, \`refinement_types\`.

## Test plan

- [x] cargo build
- [x] cargo test --lib derives (2 tests pass)
- [x] cargo test --lib full (3206 tests pass)
- [x] cargo clippy clean
- [x] cargo fmt --check clean