### PR TITLE
RES-1399: actor typecheck — pre-size resolved_fields Vec to state_fields.len()

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -5359,7 +5359,13 @@ impl TypeChecker {
                 // miss, so the saved chain stays observable for free.
                 let mut actor_env = TypeEnvironment::new_enclosed(self.env.clone());
                 std::mem::swap(&mut self.env, &mut actor_env);
-                let mut resolved_fields: Vec<(String, Type)> = Vec::new();
+                // RES-1399: pre-size to state_fields.len() so the push
+                // loop below doesn't reallocate as the Vec grows.
+                // Actors with N>4 state fields previously paid 2-3 Vec
+                // reallocations (4-elt default + doubling); the count
+                // is statically known here, so use it.
+                let mut resolved_fields: Vec<(String, Type)> =
+                    Vec::with_capacity(state_fields.len());
                 for (ty, field, init) in state_fields {
                     // RES-777: reject reference types in actor state
                     if is_reference_type(ty) {


### PR DESCRIPTION
Closes #1404

The \`Node::ActorDecl\` arm of \`check_node\` built \`resolved_fields\` via \`Vec::new()\` then pushed per state field. The expected length is statically known from \`state_fields.len()\`, so use \`Vec::with_capacity\` to skip the growth reallocations.

Mirror of the existing pattern in \`StructDecl\` (typechecker.rs:5441), where the same shape — known field count followed by per-field push — already uses \`Vec::with_capacity(fields.len())\`.

For actors with ≤ 4 state fields no realloc happens either way; for larger actor types this saves the realloc + memcpy as the Vec grows through 5, 9, 17 entries.

## Test changes
None. The Vec capacity is implementation detail; no observable behavior changes.