### PR TITLE
RES-1406: atomic_types::declare — drop redundant ensure() write-lock acquire

### DIFF
--- a/resilient/src/atomic_types.rs
+++ b/resilient/src/atomic_types.rs
@@ -32,16 +32,14 @@ pub fn collect_names() -> Vec<String> {
         .collect()
 }
 
-fn ensure() {
-    if let Ok(mut g) = REGISTRY.write() {
-        if g.is_none() {
-            *g = Some(AtomicRegistry::default());
-        }
-    }
-}
+// RES-1406: removed `fn ensure()` — its sole caller was `declare`,
+// and `declare`'s own `g.get_or_insert_with(AtomicRegistry::default)`
+// already creates the registry on first use. `ensure()` was acquiring
+// the `RwLock` write guard purely to check / initialise the Option,
+// then `declare` immediately re-acquired the same write guard to do
+// the actual insert. One acquire is enough.
 
 pub fn declare(name: &str, initial: i64) {
-    ensure();
     if let Ok(mut g) = REGISTRY.write() {
         let r = g.get_or_insert_with(AtomicRegistry::default);
         r.cells.insert(name.to_string(), AtomicI64::new(initial));


### PR DESCRIPTION
Closes #1407

\`atomic_types::declare\` called \`ensure()\` immediately followed by another write-lock acquire to do the insert. \`ensure()\` acquired the \`RwLock\` write guard purely to init \`Option\` from \`None → Some(default)\`, then \`declare\` re-acquired the same guard to do the actual insert.

The two acquires are redundant: \`g.get_or_insert_with(default)\` in the second block already creates the registry on first use. \`ensure()\` was pure overhead — one wasted \`RwLock\` write acquisition per call.

Drop the \`ensure()\` call and remove the now-unused function.

## Test changes
None. The \`atomic_types\` tests (\`fetch_add_is_atomic\`, \`store_overwrites\`) pass unchanged because the registry initialisation is still handled inline by \`get_or_insert_with\`.