### PR TITLE
RES-1407: peephole — skip jump-fixup pass when no rule fired

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -208,9 +208,13 @@
       "branch": "res-1391-traits-fast-reject",
       "claimed_at": "2026-05-12T09:32:26Z"
     },
-    "resilient/src/inline.rs": {
-      "branch": "res-1396-inline-chunk-fast-reject",
-      "claimed_at": "2026-05-12T09:48:19Z"
+    "resilient/src/derives.rs": {
+      "branch": "res-1402-derives-empty-install",
+      "claimed_at": "2026-05-12T10:01:28Z"
+    },
+    "resilient/src/peephole.rs": {
+      "branch": "res-1407-peephole-skip-fixup",
+      "claimed_at": "2026-05-12T10:12:24Z"
     }
   }
 }

--- a/resilient/src/peephole.rs
+++ b/resilient/src/peephole.rs
@@ -86,6 +86,11 @@ pub fn optimize(chunk: &mut Chunk) -> Result<(), OptimizeError> {
     let mut new_code: Vec<Op> = Vec::with_capacity(chunk.code.len());
     let mut new_line_info: Vec<u32> = Vec::with_capacity(chunk.code.len());
     let mut old_to_new: Vec<usize> = vec![usize::MAX; chunk.code.len() + 1];
+    // RES-1407: track whether any rule fired so the jump-fixup loop
+    // (O(n²) worst case per the comment below) can be skipped when
+    // no rewrite happened. Mirrors `const_fold.rs::fold_pass`'s
+    // `folded_any` early-out at line 230.
+    let mut optimized_any = false;
     let mut i = 0;
     while i < chunk.code.len() {
         // Record the mapping for the START of each rule window
@@ -97,6 +102,7 @@ pub fn optimize(chunk: &mut Chunk) -> Result<(), OptimizeError> {
         // Rule 1 — drop `Const(k==0); Add`. Skip if `Add` is a
         // jump target (a jump into the middle of the pattern).
         if rule_add_zero_identity(chunk, i, &targets) {
+            optimized_any = true;
             i += 2;
             continue;
         }
@@ -105,11 +111,13 @@ pub fn optimize(chunk: &mut Chunk) -> Result<(), OptimizeError> {
         if let Some(idx) = rule_inc_local(chunk, i, &targets) {
             new_code.push(Op::IncLocal(idx));
             new_line_info.push(chunk.line_info[i]);
+            optimized_any = true;
             i += 4;
             continue;
         }
         // Rule 3 — drop `Jump(0)` (fall-through).
         if rule_dead_jump(chunk, i) {
+            optimized_any = true;
             i += 1;
             continue;
         }
@@ -117,11 +125,13 @@ pub fn optimize(chunk: &mut Chunk) -> Result<(), OptimizeError> {
         if let Some(off) = rule_not_jif_to_jit(chunk, i, &targets) {
             new_code.push(Op::JumpIfTrue(off));
             new_line_info.push(chunk.line_info[i]);
+            optimized_any = true;
             i += 2;
             continue;
         }
         // Rule 5 — drop `Const(k==1); Mul` (×1 identity).
         if rule_mul_one_identity(chunk, i, &targets) {
+            optimized_any = true;
             i += 2;
             continue;
         }
@@ -138,6 +148,7 @@ pub fn optimize(chunk: &mut Chunk) -> Result<(), OptimizeError> {
             };
             new_code.push(Op::Const(zero_k));
             new_line_info.push(chunk.line_info[i]);
+            optimized_any = true;
             i += 2;
             continue;
         }
@@ -149,6 +160,18 @@ pub fn optimize(chunk: &mut Chunk) -> Result<(), OptimizeError> {
     }
     // Sentinel for "end of code" target (fall-off-end PC).
     old_to_new[chunk.code.len()] = new_code.len();
+
+    // RES-1407: if no rule fired, the rewritten stream is byte-
+    // identical to `chunk.code`. The jump-fixup loop below would
+    // recompute offsets that already equal themselves (mapping
+    // identity-PCs through `old_to_new`, which is also identity
+    // for every position when no fold happened). Skip the O(n²)
+    // worst-case scan + the unchanged `chunk.code = new_code`
+    // assignment entirely. The const-fold pass uses the same
+    // pattern (`folded_any` early-out at const_fold.rs:230).
+    if !optimized_any {
+        return Ok(());
+    }
 
     // Re-link jump offsets. For each JUMP op in new_code, look up
     // which old PC it originated from (scan old_to_new), fetch


### PR DESCRIPTION
Closes #1408

## Summary

\`peephole::optimize\` had no tracking for whether any rule actually rewrote bytecode. The function would walk the chunk emitting either folded or verbatim ops into \`new_code\`, then unconditionally run the post-pass that scans \`old_to_new[]\` for every jump op to re-link offsets — an O(jumps × code.len()) worst-case loop per the in-code comment.

When no rule fires, \`new_code\` is byte-identical to \`chunk.code\` and \`old_to_new[i] == i\` for every position, so the jump-fixup loop recomputes offsets that already equal themselves. Pure dead work that ran on every call regardless.

Add an \`optimized_any\` flag set inside each rule-fired branch. When still false at end of scan, early-return before the fixup loop (and skip \`chunk.code = new_code\` which would replace the Vec with identical content).

Mirrors the \`folded_any\` early-out in \`const_fold.rs::fold_pass\` at line 230 — same pattern, same justification.

For chunks where no rule fires, saves the post-pass jump scan + the \`chunk.code = new_code\` overwrite.

## Test plan

- [x] cargo build
- [x] cargo test --lib peephole (29 tests pass)
- [x] cargo test --lib full (3206 tests pass)
- [x] cargo clippy clean
- [x] cargo fmt --check clean