### PR TITLE
RES-1410: typechecker if-statement assumption — destructure by move to drop one name clone

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -5696,11 +5696,16 @@ impl TypeChecker {
                 // `LITERAL == IDENT`), assume that equality inside the
                 // consequence by pushing the binding. Restore on exit
                 // so the assumption doesn't leak.
-                let assumption = extract_eq_assumption(condition);
-                let saved = if let Some((ref name, value)) = assumption {
-                    let prev = self.const_bindings.get(name).copied();
+                // RES-1410: destructure `assumption` by move so the
+                // owned `name` String can be cloned once for the
+                // HashMap insert and then moved into the `saved`
+                // tuple. The previous shape took `ref name` and
+                // cloned twice — once for the HashMap key (which
+                // takes ownership) and once for the rollback tuple.
+                let saved = if let Some((name, value)) = extract_eq_assumption(condition) {
+                    let prev = self.const_bindings.get(&name).copied();
                     self.const_bindings.insert(name.clone(), value);
-                    Some((name.clone(), prev))
+                    Some((name, prev))
                 } else {
                     None
                 };


### PR DESCRIPTION
Closes #1411

The \`Node::IfStatement\` arm of \`check_node\` pushed an \`IDENT == VAL\` assumption into \`const_bindings\` using \`ref name\` to borrow. Two \`String\` clones per assumption-bearing if-statement — one for the HashMap key (insert takes ownership), one for the rollback tuple inside \`Some(...)\`.

Destructure by move instead. The owned \`name\` String can be cloned once for the HashMap and then moved into the \`saved\` tuple:

\`\`\`rust
let saved = if let Some((name, value)) = extract_eq_assumption(condition) {
    let prev = self.const_bindings.get(&name).copied();
    self.const_bindings.insert(name.clone(), value);   // clone #1
    Some((name, prev))                                  // move
} else { None };
\`\`\`

Same shape already used at the function-requires push at line 4595 — see that block for the canonical pattern.

## Test changes
None. All 3206 lib tests pass unchanged.