### PR TITLE
RES-1413: typechecker contract-call site — pre-size bindings HashMap to parameter count

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -5993,7 +5993,13 @@ impl TypeChecker {
                     // is gated.
                     if !info.requires.is_empty() {
                         self.stats.contracted_call_sites += 1;
-                        let mut bindings: HashMap<String, i64> = HashMap::new();
+                        // RES-1413: pre-size bindings to the parameter
+                        // count. The fold loop below inserts at most
+                        // one entry per parameter (`zip` truncates to
+                        // the shorter of params/args), so the capacity
+                        // is known up front.
+                        let mut bindings: HashMap<String, i64> =
+                            HashMap::with_capacity(info.parameters.len());
                         for ((_ty, pname), arg) in info.parameters.iter().zip(arguments.iter()) {
                             if let Some(v) = fold_const_i64(arg, &self.const_bindings) {
                                 bindings.insert(pname.clone(), v);


### PR DESCRIPTION
Closes #1415

The \`CallExpression\` arm of \`check_node\` allocated a fresh \`HashMap<String, i64>\` per contracted call site (gated on \`info.requires.is_empty()\` per RES-1399) and populated it via a \`zip(parameters, arguments)\` fold loop. The HashMap holds at most one entry per declared parameter — \`zip\` truncates to the shorter of params/args — so the capacity is statically knowable up front.

Use \`HashMap::with_capacity(info.parameters.len())\`. For callees with few parameters the default capacity is already sufficient; for callees with 10+ parameters this saves one or two rehashes per call site.

## Test changes
None. The HashMap capacity is implementation detail — no observable behavior changes.