### PR TITLE
RES-1419: bytecode add_string_constant — lazy String alloc on cache miss

### DIFF
--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -289,6 +289,32 @@ impl Chunk {
         self.constants.push(v);
         Ok(idx)
     }
+
+    /// RES-1419: intern a `String` constant without the caller having
+    /// to clone the source first. The `add_constant(Value::String(s.clone()))`
+    /// callers cloned the source `String` unconditionally — even when
+    /// the constant was already in the pool. The cache-hit case
+    /// allocated and dropped the clone for nothing.
+    ///
+    /// Look up by `&str` (Rust's `String == &str` comparison works via
+    /// `Borrow<str>`), then allocate the owned `String` only on cache
+    /// miss. For programs with repeated string literals (assertion
+    /// messages, field name lookups in struct field-access code, etc.)
+    /// the savings compound across every duplicate.
+    pub fn add_string_constant(&mut self, s: &str) -> Result<u16, CompileError> {
+        if let Some(existing) = self.constants.iter().position(|c| match c {
+            Value::String(x) => x == s,
+            _ => false,
+        }) {
+            return Ok(existing as u16);
+        }
+        if self.constants.len() >= u16::MAX as usize {
+            return Err(CompileError::TooManyConstants);
+        }
+        let idx = self.constants.len() as u16;
+        self.constants.push(Value::String(s.to_string()));
+        Ok(idx)
+    }
 }
 
 /// Constant pool dedup. Only used for compile-time interning so we

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -350,7 +350,7 @@ fn compile_stmt(
                 .ok_or_else(|| CompileError::UnknownIdentifier(local_name.clone()))?;
             chunk.emit(Op::LoadLocal(slot), line);
             compile_expr(value, chunk, locals, fn_index, ffi_index, line)?;
-            let fname_idx = chunk.add_constant(Value::String(field.clone()))?;
+            let fname_idx = chunk.add_string_constant(field)?;
             chunk.emit(
                 Op::SetField {
                     name_const: fname_idx,
@@ -566,7 +566,7 @@ fn compile_stmt_in_fn(
                 .ok_or_else(|| CompileError::UnknownIdentifier(local_name.clone()))?;
             chunk.emit(Op::LoadLocal(slot), line);
             compile_expr(value, chunk, locals, fn_index, ffi_index, line)?;
-            let fname_idx = chunk.add_constant(Value::String(field.clone()))?;
+            let fname_idx = chunk.add_string_constant(field)?;
             chunk.emit(
                 Op::SetField {
                     name_const: fname_idx,
@@ -754,7 +754,7 @@ fn compile_for_in(
     //    with the tree walker's iteration semantics — `len` on
     //    a non-array surfaces a typed error rather than a silent
     //    miscompile.
-    let len_name_const = chunk.add_constant(Value::String("len".to_string()))?;
+    let len_name_const = chunk.add_string_constant("len")?;
     chunk.emit(Op::LoadLocal(arr_slot), line);
     chunk.emit(
         Op::CallBuiltin {
@@ -847,7 +847,7 @@ fn compile_expr(
         // and dedup); routing the literal nodes here lets builtin args
         // round-trip without touching the runtime.
         Node::StringLiteral { value: s, .. } => {
-            let idx = chunk.add_constant(Value::String(s.clone()))?;
+            let idx = chunk.add_string_constant(s)?;
             chunk.emit(Op::Const(idx), line);
             Ok(())
         }
@@ -1005,7 +1005,7 @@ fn compile_expr(
                 if arguments.len() > u8::MAX as usize {
                     return Err(CompileError::Unsupported("builtin call with > 255 args"));
                 }
-                let name_const = chunk.add_constant(Value::String(callee_name.to_string()))?;
+                let name_const = chunk.add_string_constant(callee_name)?;
                 for arg in arguments {
                     compile_expr(arg, chunk, locals, fn_index, ffi_index, line)?;
                 }


### PR DESCRIPTION
Closes #1421

\`chunk.add_constant(Value::String(s.clone()))\` cloned the source \`String\` unconditionally — even when the constant was already in the pool. The existing \`add_constant\` linear-scan dedup found the prior entry and returned its index, but only after the eagerly-cloned \`String\` had been allocated and was about to be dropped.

Add \`Chunk::add_string_constant(&str)\` that compares pool entries by \`&str\` borrow and allocates the owned \`String\` only on cache miss.

Migrates 5 \`compile_expr\` / \`compile_stmt\` call sites that previously cloned \`field\`, \`s\`, \`\"len\"\`, \`callee_name\` etc. before handing off to \`add_constant\`. Each call site now skips the clone when the string is already interned.

## Test changes
None. All 3206 lib tests pass; clippy clean. The visible bytecode is identical because \`add_string_constant\` returns the same indices the existing dedup would have.