### PR TITLE
RES-1421: vm CallBuiltin — borrow name from chunk constants instead of cloning

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -208,13 +208,21 @@
       "branch": "res-1391-traits-fast-reject",
       "claimed_at": "2026-05-12T09:32:26Z"
     },
-    "resilient/src/inline.rs": {
-      "branch": "res-1396-inline-chunk-fast-reject",
-      "claimed_at": "2026-05-12T09:48:19Z"
+    "resilient/src/derives.rs": {
+      "branch": "res-1402-derives-empty-install",
+      "claimed_at": "2026-05-12T10:01:28Z"
     },
-    "resilient/src/lib.rs": {
-      "branch": "res-1411-builtin-lookup-hashmap",
-      "claimed_at": "2026-05-12T10:17:10Z"
+    "resilient/src/peephole.rs": {
+      "branch": "res-1407-peephole-skip-fixup",
+      "claimed_at": "2026-05-12T10:12:24Z"
+    },
+    "resilient/src/compiler.rs": {
+      "branch": "res-1419-compile-expr-no-clone",
+      "claimed_at": "2026-05-12T10:26:41Z"
+    },
+    "resilient/src/vm.rs": {
+      "branch": "res-1421-vm-builtin-no-clone",
+      "claimed_at": "2026-05-12T10:33:10Z"
     }
   }
 }

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -689,16 +689,28 @@ fn run_inner(
             // builtin returns `RResult<Value>` (`Result<Value, String>`);
             // we wrap the error string in `BuiltinCallFailed`.
             Op::CallBuiltin { name_const, arity } => {
+                // RES-1421: hold the builtin name as `&str` borrowed
+                // from the chunk's constant pool. The previous shape
+                // cloned `s.clone()` into an owned `String` just to
+                // pass `&name` into `lookup_builtin`, then cloned again
+                // for the (rare) `UnknownBuiltin` error path. Builtin
+                // dispatch fires on every `println` / `len` / etc.
+                // call site — the per-call String alloc adds up.
+                // After RES-1411 made `lookup_builtin` O(1) on `&str`,
+                // dropping the alloc is the next obvious win. The
+                // `chunk` borrow lives for the dispatch arm; the
+                // `&str` is valid through `lookup_builtin` and the
+                // `to_string()` on the `UnknownBuiltin` path.
                 let name_val = chunk
                     .constants
                     .get(name_const as usize)
                     .ok_or(VmError::ConstantOutOfBounds(name_const))?;
-                let name = match name_val {
-                    Value::String(s) => s.clone(),
+                let name: &str = match name_val {
+                    Value::String(s) => s.as_str(),
                     _ => return Err(VmError::TypeMismatch("CallBuiltin (non-string name)")),
                 };
-                let func = crate::lookup_builtin(&name)
-                    .ok_or_else(|| VmError::UnknownBuiltin(name.clone()))?;
+                let func = crate::lookup_builtin(name)
+                    .ok_or_else(|| VmError::UnknownBuiltin(name.to_string()))?;
                 let n = arity as usize;
                 if stack.len() < n {
                     return Err(VmError::EmptyStack);
@@ -1558,16 +1570,21 @@ fn h_call_builtin(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
     let Op::CallBuiltin { name_const, arity } = op else {
         unreachable!()
     };
+    // RES-1421: hold the builtin name as `&str` borrowed from the
+    // chunk's constant pool — same justification as the match-dispatch
+    // arm in `run_inner`. Saves a `String::clone` per builtin
+    // dispatch in the direct-threaded VM path.
     let chunk = state.current_chunk();
     let name_val = chunk
         .constants
         .get(name_const as usize)
         .ok_or(VmError::ConstantOutOfBounds(name_const))?;
-    let name = match name_val {
-        Value::String(s) => s.clone(),
+    let name: &str = match name_val {
+        Value::String(s) => s.as_str(),
         _ => return Err(VmError::TypeMismatch("CallBuiltin (non-string name)")),
     };
-    let func = crate::lookup_builtin(&name).ok_or_else(|| VmError::UnknownBuiltin(name.clone()))?;
+    let func =
+        crate::lookup_builtin(name).ok_or_else(|| VmError::UnknownBuiltin(name.to_string()))?;
     let n = arity as usize;
     if state.stack.len() < n {
         return Err(VmError::EmptyStack);


### PR DESCRIPTION
Closes #1423

## Summary

Both \`run_inner\`'s \`Op::CallBuiltin\` arm and the direct-threaded \`h_call_builtin\` handler cloned the builtin name out of the chunk's constant pool just to pass into \`lookup_builtin\`.

After RES-1411 made \`lookup_builtin\` accept \`&str\` (and look up via an O(1) HashMap), the owned clone is unnecessary — we only need a \`&str\` view into the constant pool. The original \`String\` clone allocated on every builtin dispatch.

Replace \`s.clone()\` with \`s.as_str()\`. The borrow lives through the \`lookup_builtin\` call and the \`to_string()\` on the rare \`UnknownBuiltin\` error path.

For programs that invoke builtins (most do — \`println\` alone fires on every output line), saves one String allocation per Op::CallBuiltin dispatch.

## Test plan

- [x] cargo build
- [x] cargo test --lib vm (93 tests pass)
- [x] cargo test --lib full (3206 tests pass)
- [x] cargo clippy clean
- [x] cargo fmt --check clean