### PR TITLE
RES-1423: compile_expr StructLiteral + FieldAccess — migrate to add_string_constant

### DIFF
--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1073,9 +1073,9 @@ fn compile_expr(
             if fields.len() > u16::MAX as usize {
                 return Err(CompileError::TooManyFields(name.clone()));
             }
-            let name_const = chunk.add_constant(Value::String(name.clone()))?;
+            let name_const = chunk.add_string_constant(name)?;
             for (field_name, field_expr) in fields {
-                let fname_idx = chunk.add_constant(Value::String(field_name.clone()))?;
+                let fname_idx = chunk.add_string_constant(field_name)?;
                 chunk.emit(Op::Const(fname_idx), line);
                 compile_expr(field_expr, chunk, locals, fn_index, ffi_index, line)?;
             }
@@ -1094,7 +1094,7 @@ fn compile_expr(
         // `FieldAccess` nodes.
         Node::FieldAccess { target, field, .. } => {
             compile_expr(target, chunk, locals, fn_index, ffi_index, line)?;
-            let fname_idx = chunk.add_constant(Value::String(field.clone()))?;
+            let fname_idx = chunk.add_string_constant(field)?;
             chunk.emit(
                 Op::GetField {
                     name_const: fname_idx,


### PR DESCRIPTION
Closes #1425

RES-1419 added \`Chunk::add_string_constant(&str)\` and migrated 5 \`compile_expr\` call sites. Three more sites still use the old shape:
- \`Node::StructLiteral\` — both the struct name and each field name.
- \`Node::FieldAccess\` — the field name.

Migrate all three to \`add_string_constant\` for the same cache-hit savings. Particularly relevant here because struct literals and field accesses commonly reuse the same struct + field names across a program — every \`Point { x: ..., y: ... }\` triggers the same three string clones at construction, even though the constant-pool dedup would have returned the existing indices.

## Test changes
None. All 3206 lib tests pass; emitted bytecode is byte-identical because \`add_string_constant\` returns the same indices the existing dedup would have.