### PR TITLE
RES-1427: verifier_z3 len_axioms — drop unused tuple String element

### DIFF
--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -320,13 +320,17 @@ fn prove_with_axioms_and_timeout_in(
     // `len(xs) > 0 → len(xs) >= 1`.
     let mut len_args: BTreeSet<String> = BTreeSet::new();
     collect_len_args(expr, &mut len_args);
-    let len_axioms: Vec<(String, Bool<'_>)> = len_args
+    // RES-1427: build `len_axioms` as `Vec<Bool<'_>>` (not
+    // `Vec<(String, Bool<'_>)>`) — every consumer destructures with
+    // `for (_, axiom) in &len_axioms { ... }`, throwing away the
+    // string. Dropping the unused tuple element eliminates one
+    // `String::clone` per arg per Z3 prove call.
+    let len_axioms: Vec<Bool<'_>> = len_args
         .iter()
         .map(|arg| {
             let c = Int::new_const(ctx, format!("len_{}", arg));
             let zero = Int::from_i64(ctx, 0);
-            let axiom = c.ge(&zero);
-            (arg.clone(), axiom)
+            c.ge(&zero)
         })
         .collect();
 
@@ -344,7 +348,7 @@ fn prove_with_axioms_and_timeout_in(
     // is always true regardless of any free variables.
     let solver = z3::Solver::new(ctx);
     apply_timeout(&solver);
-    for (_, axiom) in &len_axioms {
+    for axiom in &len_axioms {
         solver.assert(axiom);
     }
     for axiom in &user_axioms {
@@ -436,7 +440,7 @@ fn prove_with_axioms_and_timeout_in(
     // contract can never hold.
     let solver = z3::Solver::new(ctx);
     apply_timeout(&solver);
-    for (_, axiom) in &len_axioms {
+    for axiom in &len_axioms {
         solver.assert(axiom);
     }
     for axiom in &user_axioms {
@@ -531,13 +535,17 @@ fn prove_tautology_with_axioms_and_timeout_in(
     // only the second `check()` (contradiction) is omitted.
     let mut len_args: BTreeSet<String> = BTreeSet::new();
     collect_len_args(expr, &mut len_args);
-    let len_axioms: Vec<(String, Bool<'_>)> = len_args
+    // RES-1427: build `len_axioms` as `Vec<Bool<'_>>` (not
+    // `Vec<(String, Bool<'_>)>`) — every consumer destructures with
+    // `for (_, axiom) in &len_axioms { ... }`, throwing away the
+    // string. Dropping the unused tuple element eliminates one
+    // `String::clone` per arg per Z3 prove call.
+    let len_axioms: Vec<Bool<'_>> = len_args
         .iter()
         .map(|arg| {
             let c = Int::new_const(ctx, format!("len_{}", arg));
             let zero = Int::from_i64(ctx, 0);
-            let axiom = c.ge(&zero);
-            (arg.clone(), axiom)
+            c.ge(&zero)
         })
         .collect();
 
@@ -548,7 +556,7 @@ fn prove_tautology_with_axioms_and_timeout_in(
 
     let solver = z3::Solver::new(ctx);
     apply_timeout(&solver);
-    for (_, axiom) in &len_axioms {
+    for axiom in &len_axioms {
         solver.assert(axiom);
     }
     for axiom in &user_axioms {


### PR DESCRIPTION
Closes #1429

\`len_axioms\` was typed as \`Vec<(String, Bool<'_>)>\` and built with \`(arg.clone(), axiom)\` tuples — but every consumer destructured with \`for (_, axiom) in &len_axioms { ... }\`, throwing the string away. The clone existed only to satisfy a tuple element nothing actually read.

Drop the tuple. Build \`Vec<Bool<'_>>\` directly:

\`\`\`rust
let len_axioms: Vec<Bool<'_>> = len_args
    .iter()
    .map(|arg| {
        let c = Int::new_const(ctx, format!(\"len_{}\", arg));
        let zero = Int::from_i64(ctx, 0);
        c.ge(&zero)
    })
    .collect();
\`\`\`

Consumers change from \`for (_, axiom) in &len_axioms\` to \`for axiom in &len_axioms\`. Same in both \`prove_*_in\` paths.

For Z3 prove calls on formulas referencing N distinct array names (via \`len(<name>)\`), this saves N \`String::clone\` calls per cache miss in both the LIA and tautology paths.

## Test changes
None. All 3206 lib tests pass. Feature-gated under \`z3\`; verified via local build and the existing z3 test suite.

(Initial attempt used \`into_iter()\` to consume \`len_args\` but missed that the cert-emission path iterates \`&len_args\` again later. Force-pushed to drop the unused tuple String element instead — same end result without touching the iteration shape.)