### PR TITLE
RES-1436: eval IndexExpression — swap_remove instead of clone-and-drop

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -208,21 +208,17 @@
       "branch": "res-1391-traits-fast-reject",
       "claimed_at": "2026-05-12T09:32:26Z"
     },
-    "resilient/src/derives.rs": {
-      "branch": "res-1402-derives-empty-install",
-      "claimed_at": "2026-05-12T10:01:28Z"
-    },
-    "resilient/src/peephole.rs": {
-      "branch": "res-1407-peephole-skip-fixup",
-      "claimed_at": "2026-05-12T10:12:24Z"
+    "resilient/src/inline.rs": {
+      "branch": "res-1396-inline-chunk-fast-reject",
+      "claimed_at": "2026-05-12T09:48:19Z"
     },
     "resilient/src/compiler.rs": {
-      "branch": "res-1419-compile-expr-no-clone",
-      "claimed_at": "2026-05-12T10:26:41Z"
+      "branch": "res-1430-compile-target-borrow",
+      "claimed_at": "2026-05-12T10:45:02Z"
     },
-    "resilient/src/vm.rs": {
-      "branch": "res-1433-vm-constant-as-str",
-      "claimed_at": "2026-05-12T10:48:25Z"
+    "resilient/src/lib.rs": {
+      "branch": "res-1436-eval-index-swap-remove",
+      "claimed_at": "2026-05-12T10:54:12Z"
     }
   }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -22519,7 +22519,7 @@ impl Interpreter {
                 let target_val = self.eval(target)?;
                 let index_val = self.eval(index)?;
                 match (target_val, index_val) {
-                    (Value::Array(items), Value::Int(i)) => {
+                    (Value::Array(mut items), Value::Int(i)) => {
                         // RES-921: negative indices wrap from the end —
                         // `-1` is the last element, `-len` is the first.
                         // `i < -len` and `i >= len` are both out of
@@ -22533,7 +22533,22 @@ impl Interpreter {
                                 items.len()
                             ))
                         } else {
-                            Ok(items[resolved as usize].clone())
+                            // RES-1436: `items` is owned (moved out of
+                            // `Value::Array(items)` by the destructure).
+                            // The previous `items[i].clone()` shape
+                            // cloned the element and then dropped the
+                            // entire `items` Vec — for arrays of
+                            // heap-allocated values (strings, nested
+                            // arrays, structs), the clone was the
+                            // expensive part. `swap_remove(i)` returns
+                            // the element by move (O(1) — swaps the
+                            // last element into position `i`); the rest
+                            // of `items` drops at end of scope as
+                            // before. Net effect: one fewer Value clone
+                            // per array index in the tree-walker.
+                            // Element order in `items` is irrelevant
+                            // since `items` is about to be dropped.
+                            Ok(items.swap_remove(resolved as usize))
                         }
                     }
                     (Value::Array(_), other) => {


### PR DESCRIPTION
Closes #1435

## Summary

Interpreter's \`Node::IndexExpression\` arm destructures the array via \`match\` (moving \`items\` out of the popped Value), then cloned the indexed element:

\`\`\`rust
Ok(items[resolved as usize].clone())
\`\`\`

— and dropped the entire \`items\` Vec at end of scope. For arrays of heap-allocated Values (strings, nested arrays, structs), the clone was the expensive part.

Use \`swap_remove(idx)\`: returns the element by move (O(1) — swaps the last element into position \`idx\`); the rest of \`items\` drops at end of scope as before. Order in \`items\` doesn't matter because it's about to drop.

Net effect: one fewer Value clone per array index in the tree-walker.

## Test plan

- [x] cargo build
- [x] cargo test --lib (3206 tests pass)
- [x] cargo clippy clean
- [x] cargo fmt --check clean