### PR TITLE
RES-1437: vm LoadIndex/LoadIndexUnchecked — swap_remove instead of clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -208,17 +208,21 @@
       "branch": "res-1391-traits-fast-reject",
       "claimed_at": "2026-05-12T09:32:26Z"
     },
+    "resilient/src/derives.rs": {
+      "branch": "res-1402-derives-empty-install",
+      "claimed_at": "2026-05-12T10:01:28Z"
+    },
+    "resilient/src/peephole.rs": {
+      "branch": "res-1407-peephole-skip-fixup",
+      "claimed_at": "2026-05-12T10:12:24Z"
+    },
     "resilient/src/compiler.rs": {
-      "branch": "res-1430-compile-target-borrow",
-      "claimed_at": "2026-05-12T10:45:02Z"
+      "branch": "res-1419-compile-expr-no-clone",
+      "claimed_at": "2026-05-12T10:26:41Z"
     },
-    "resilient/src/lib.rs": {
-      "branch": "res-1436-eval-index-swap-remove",
-      "claimed_at": "2026-05-12T10:54:12Z"
-    },
-    "resilient/src/inline.rs": {
-      "branch": "res-1443-inline-const-string-intern",
-      "claimed_at": "2026-05-12T11:05:54Z"
+    "resilient/src/vm.rs": {
+      "branch": "res-1437-vm-load-index-swap-remove",
+      "claimed_at": "2026-05-12T10:59:54Z"
     }
   }
 }

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -742,7 +742,7 @@ fn run_inner(
                 let Value::Int(idx) = idx_val else {
                     return Err(VmError::TypeMismatch("LoadIndex (non-int index)"));
                 };
-                let Value::Array(items) = arr_val else {
+                let Value::Array(mut items) = arr_val else {
                     return Err(VmError::TypeMismatch("LoadIndex (non-array target)"));
                 };
                 if idx < 0 || (idx as usize) >= items.len() {
@@ -751,7 +751,16 @@ fn run_inner(
                         len: items.len(),
                     });
                 }
-                stack.push(items[idx as usize].clone());
+                // RES-1437: `items` is owned (destructured from
+                // `Value::Array`). The popped array is the clone
+                // emitted by `LoadLocal` — the original local still
+                // holds the array, so consuming this stack copy is
+                // correct. Use `swap_remove` to move the element out
+                // (O(1)); the remaining `items` drops at end of scope
+                // as before. Saves one `Value::clone` per array index
+                // dispatch — significant for arrays of Strings or
+                // nested Arrays. Mirrors RES-1436 (tree-walker).
+                stack.push(items.swap_remove(idx as usize));
             }
             // RES-407: emitted only when `bounds_check::check_array_bounds`
             // discharged the bounds obligation for this site. Skips the
@@ -762,12 +771,14 @@ fn run_inner(
                 let Value::Int(idx) = idx_val else {
                     return Err(VmError::TypeMismatch("LoadIndexUnchecked (non-int index)"));
                 };
-                let Value::Array(items) = arr_val else {
+                let Value::Array(mut items) = arr_val else {
                     return Err(VmError::TypeMismatch(
                         "LoadIndexUnchecked (non-array target)",
                     ));
                 };
-                stack.push(items[idx as usize].clone());
+                // RES-1437: swap_remove instead of clone — see the
+                // bounds-checked LoadIndex arm above for justification.
+                stack.push(items.swap_remove(idx as usize));
             }
             Op::StoreIndex => {
                 // Stack layout on entry (top → bottom):
@@ -1511,7 +1522,7 @@ fn h_load_index(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
     let Value::Int(idx) = idx_val else {
         return Err(VmError::TypeMismatch("LoadIndex (non-int index)"));
     };
-    let Value::Array(items) = arr_val else {
+    let Value::Array(mut items) = arr_val else {
         return Err(VmError::TypeMismatch("LoadIndex (non-array target)"));
     };
     if idx < 0 || (idx as usize) >= items.len() {
@@ -1520,7 +1531,9 @@ fn h_load_index(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
             len: items.len(),
         });
     }
-    state.stack.push(items[idx as usize].clone());
+    // RES-1437: swap_remove instead of clone — see the match-dispatch
+    // LoadIndex arm in run_inner for the full justification.
+    state.stack.push(items.swap_remove(idx as usize));
     Ok(Step::Continue)
 }
 
@@ -1534,12 +1547,14 @@ fn h_load_index_unchecked(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmEr
     let Value::Int(idx) = idx_val else {
         return Err(VmError::TypeMismatch("LoadIndexUnchecked (non-int index)"));
     };
-    let Value::Array(items) = arr_val else {
+    let Value::Array(mut items) = arr_val else {
         return Err(VmError::TypeMismatch(
             "LoadIndexUnchecked (non-array target)",
         ));
     };
-    state.stack.push(items[idx as usize].clone());
+    // RES-1437: swap_remove instead of clone — see the LoadIndex
+    // sibling above.
+    state.stack.push(items.swap_remove(idx as usize));
     Ok(Step::Continue)
 }
 


### PR DESCRIPTION
Closes #1441

## Summary

Mirror RES-1436's tree-walker optimization to the VM dispatch paths. Both \`Op::LoadIndex\` and \`Op::LoadIndexUnchecked\` (match-dispatch + direct-dispatch handlers) destructure the array, clone the indexed element, and drop the rest.

\`swap_remove(idx)\` returns the element by move (O(1)) — the remaining \`items\` drops at end of scope as before. Saves one \`Value::clone\` per array index dispatch, significant for arrays of strings/nested arrays.

Correctness: the stack array is the clone made by \`Op::LoadLocal\`; the user's original local is untouched. Consuming this stack copy is the existing contract.

Four sites updated:
- run_inner Op::LoadIndex arm
- run_inner Op::LoadIndexUnchecked arm
- h_load_index direct handler
- h_load_index_unchecked direct handler

## Test plan

- [x] cargo build
- [x] cargo test --lib (3206 tests pass)
- [x] cargo clippy clean
- [x] cargo fmt --check clean