### PR TITLE
RES-1450: eval Slice on Array — drain by move instead of slice.to_vec() clones

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -22599,7 +22599,7 @@ impl Interpreter {
                 let normalize =
                     |v: i64, len: i64| -> i64 { if v < 0 { (v + len).max(0) } else { v } };
                 match target_val {
-                    Value::Array(items) => {
+                    Value::Array(mut items) => {
                         let len = items.len() as i64;
                         let lo_i = normalize(lo_raw.unwrap_or(0), len);
                         let hi_norm = match hi_raw_opt {
@@ -22616,7 +22616,20 @@ impl Interpreter {
                         }
                         let lo_clamp = lo_i.min(len) as usize;
                         let hi_clamp = hi_excl.min(len) as usize;
-                        Ok(Value::Array(items[lo_clamp..hi_clamp].to_vec()))
+                        // RES-1450: `items` is owned (moved out of
+                        // `Value::Array(items)`); drain the slice
+                        // range by move rather than `to_vec()`
+                        // cloning each element. The remainder of
+                        // `items` drops at end of scope. Same shape
+                        // as RES-1436's `swap_remove` for the
+                        // IndexExpression dispatch — for arrays of
+                        // heap-allocated Values (strings, nested
+                        // arrays, structs), this saves N element
+                        // clones per slice operation where N is the
+                        // slice length.
+                        let sliced: Vec<Value> =
+                            items.drain(lo_clamp..hi_clamp).collect();
+                        Ok(Value::Array(sliced))
                     }
                     Value::String(s) => {
                         // RES-916: index by Unicode scalar, not bytes.


### PR DESCRIPTION
Closes #1451

\`Interpreter::eval\` for \`Node::Slice\` on \`Value::Array(items)\` destructured \`items\` then cloned the slice range via \`items[lo..hi].to_vec()\`. For arrays of heap-allocated Values (strings, nested arrays, structs), each element clone allocates.

Switch to \`items.drain(lo_clamp..hi_clamp).collect()\`. \`Vec::drain\` moves the slice range out and returns an iterator; element ordering preserved.

Same shape as RES-1436 (IndexExpression \`swap_remove\`). For arrays of heap-allocated Values, this saves N element clones per slice operation.

## Test changes
None. All 3206 lib tests pass; clippy clean. The 16 existing slice tests cover this path.