### PR TITLE
RES-1452: eval_tuple_index — swap_remove instead of clone-and-drop

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -223,6 +223,10 @@
     "resilient/src/vm.rs": {
       "branch": "res-1437-vm-load-index-swap-remove",
       "claimed_at": "2026-05-12T10:59:54Z"
+    },
+    "resilient/src/tuples.rs": {
+      "branch": "res-1452-tuples-index-swap-remove",
+      "claimed_at": "2026-05-12T11:24:39Z"
     }
   }
 }

--- a/resilient/src/tuples.rs
+++ b/resilient/src/tuples.rs
@@ -183,15 +183,29 @@ pub(crate) fn eval_tuple_index(
 ) -> RResult<Value> {
     let v = interp.eval(tuple)?;
     match v {
-        Value::Tuple(items) => items.get(index).cloned().ok_or_else(|| {
-            format!(
-                "{}:{}: tuple index {} out of range (length {})",
-                span.start.line,
-                span.start.column,
-                index,
-                items.len()
-            )
-        }),
+        Value::Tuple(mut items) => {
+            // RES-1452: `items` is owned (destructured from
+            // `Value::Tuple`). The previous shape did
+            // `items.get(index).cloned()` which cloned the element
+            // and then dropped the remaining `items` Vec — for tuples
+            // containing heap-allocated values (Strings, nested
+            // tuples/arrays, structs), the clone was the expensive
+            // part. `swap_remove` moves the element out by ownership
+            // (O(1)); the remaining `items` drops at end of scope as
+            // before. Mirrors RES-1436 (eval IndexExpression) /
+            // RES-1437 (vm LoadIndex).
+            if index < items.len() {
+                Ok(items.swap_remove(index))
+            } else {
+                Err(format!(
+                    "{}:{}: tuple index {} out of range (length {})",
+                    span.start.line,
+                    span.start.column,
+                    index,
+                    items.len()
+                ))
+            }
+        }
         // RES-928: tuple-struct constructors produce a `Value::Struct`
         // with synthesized field names "0", "1", ..., so `.N` against a
         // struct should look up the field with that name rather than


### PR DESCRIPTION
Closes #1455

## Summary

\`tuples::eval_tuple_index\` did \`items.get(index).cloned()\` — same wasteful clone-and-drop pattern as RES-1436/RES-1437/RES-1447.

Migrate to \`items.swap_remove(index)\` with an explicit bounds check (since swap_remove panics on out-of-range). For tuples containing heap-allocated values, saves one Value clone per tuple-index dispatch.

## Test plan

- [x] cargo build
- [x] cargo test --lib (3206 tests pass)
- [x] cargo clippy clean
- [x] cargo fmt --check clean