### PR TITLE
RES-1455: eval StructLiteral named-enum reorder — swap_remove instead of clone

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -22485,14 +22485,25 @@ impl Interpreter {
                             }
                             // Re-order fields into declared order so
                             // Display is stable.
+                            //
+                            // RES-1455: pull each value out of `out`
+                            // via `swap_remove` instead of cloning.
+                            // `out` is dropped at end of this arm —
+                            // we move every entry's value into
+                            // `ordered`, so the swap-induced reorder
+                            // in `out` has no observable effect.
+                            // Saves one `Value::clone` per named
+                            // enum-variant field — same shape as
+                            // RES-1436 (Array IndexExpression
+                            // `swap_remove`).
                             let mut ordered: Vec<(String, Value)> =
                                 Vec::with_capacity(declared_fields.len());
                             for f in declared_fields {
-                                let v = out
+                                let pos = out
                                     .iter()
-                                    .find(|(n, _)| n == &f.name)
-                                    .map(|(_, v)| v.clone())
+                                    .position(|(n, _)| n == &f.name)
                                     .expect("validated above");
+                                let (_n, v) = out.swap_remove(pos);
                                 ordered.push((f.name.clone(), v));
                             }
                             Ok(Value::EnumVariant {


### PR DESCRIPTION
Closes #1457

The enum-variant constructor with \`Named\` payload re-orders provided fields into declared order via \`out.iter().find(...).map(|(_, v)| v.clone())\`. The \`out\` buffer is dropped at end of arm — the \`v.clone()\` is gratuitous.

Switch to \`swap_remove\`: locate by \`position\`, then move out by \`swap_remove(pos)\`. The swap-induced reorder in \`out\` has no observable effect because \`out\` is dropped immediately after.

Same shape as RES-1436 (Array IndexExpression) and the open RES-1447 / RES-1452 (slice / tuple) parallel-agent PRs.

## Test changes
None. All 3206 lib tests pass.