### PR TITLE
RES-1463: Interpreter Assignment statics path — get_mut to drop redundant borrow + name clone

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -21763,8 +21763,15 @@ impl Interpreter {
                 }
                 if self.env.reassign(name, val.clone()) {
                     Ok(Value::Void)
-                } else if self.statics.borrow().contains_key(name) {
-                    self.statics.borrow_mut().insert(name.clone(), val);
+                } else if let Some(slot) = self.statics.borrow_mut().get_mut(name) {
+                    // RES-1463: `get_mut(&str)` does a single hashed
+                    // lookup AND skips both the redundant
+                    // `contains_key` (which used the shared borrow
+                    // before re-borrowing mutably) and the
+                    // `name.clone()` for the HashMap key. Mutate the
+                    // slot in place. Same shape as RES-1459 for
+                    // `Environment::reassign`.
+                    *slot = val;
                     Ok(Value::Void)
                 } else {
                     Err(format!("Cannot assign to undeclared variable '{}'", name))


### PR DESCRIPTION
Closes #1465

The \`Node::Assignment\` eval's statics-fallback branch did a shared \`borrow().contains_key\` followed by a mutable \`borrow_mut().insert(name.clone(), val)\` — two hashes, two borrows, and a \`String\` allocation when the key already exists.

Switch to \`self.statics.borrow_mut().get_mut(name)\` — single hashed lookup, mutate the slot in place on hit.

Mirror of RES-1459 for \`Environment::reassign\`. For programs with many static-variable updates (the \`live { static let counter = 0; ... counter = counter + 1; ... }\` idiom), this saves one \`String::clone\` per static assignment.

## Test changes
None. All 3206 lib tests pass; clippy clean.