### PR TITLE
RES-1467: supervisor::check duplicate-id detector — borrow ids as &str instead of cloning

### DIFF
--- a/resilient/src/supervisor.rs
+++ b/resilient/src/supervisor.rs
@@ -298,13 +298,19 @@ pub(crate) fn check(node: &Node, env: &TypeEnvironment) -> Result<(), String> {
                 return Err("supervisor must have at least one child".to_string());
             }
 
-            // Track child IDs to detect duplicates
-            let mut seen_ids = std::collections::HashSet::new();
+            // Track child IDs to detect duplicates.
+            //
+            // RES-1467: store `&str` borrows from the AST instead of
+            // cloning each child id into an owned `String`. Lifetime
+            // is tied to `children` (owned by the AST node passed
+            // in). Same shape as RES-1431 (pattern_bindings) /
+            // RES-1439 (info_flow walk_calls).
+            let mut seen_ids: std::collections::HashSet<&str> = std::collections::HashSet::new();
 
             // Validate each child
             for child in children {
                 // Check for duplicate IDs
-                if !seen_ids.insert(child.id.clone()) {
+                if !seen_ids.insert(child.id.as_str()) {
                     return Err(format!("duplicate child id `{}` in supervisor", child.id));
                 }
 


### PR DESCRIPTION
Closes #1469

The duplicate-child-id check in \`supervisor::check\` built a \`HashSet<String>\` by cloning each child id. The HashSet is only used inside the validation loop, so entries never outlive the AST node.

Switch to \`HashSet<&str>\` and \`child.id.as_str()\`.

Mirror of RES-1431 (\`pattern_bindings\`) and RES-1439 / RES-1441 / RES-1445 (the walk_calls trifecta).

## Test changes
None. All 3206 lib tests pass.