### PR TITLE
RES-1485: recursive_types::check — validate before install, drop the HashSet clone

### DIFF
--- a/resilient/src/recursive_types.rs
+++ b/resilient/src/recursive_types.rs
@@ -53,11 +53,17 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     if set.is_empty() {
         return Ok(());
     }
-    install(set.clone());
-    // Validation: a recursive type must syntactically reference itself.
+    // RES-1485: run validation before `install` so we can move
+    // `set` into install rather than cloning. The previous shape
+    // did `install(set.clone())` ahead of the for-loop just so
+    // `&set` could still be iterated. Same shape as RES-1481 for
+    // `derives::check`. The warnings emitted during validation
+    // are eprintln only — no early return — so the install always
+    // runs at the same point in the success path.
     let Node::Program(stmts) = program else {
         return Ok(());
     };
+    // Validation: a recursive type must syntactically reference itself.
     for s in stmts {
         if let Node::StructDecl { name, fields, .. } = &s.node {
             if set.contains(name) {
@@ -71,6 +77,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
             }
         }
     }
+    install(set);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1485

\`recursive_types::check\` ran \`install(set.clone())\` ahead of the struct-validation loop, just so the loop could keep iterating \`&set\`. Reorder: validate first, then move \`set\` into \`install\`. Same shape as RES-1481 for \`derives::check\`.

The validation loop only emits warnings via \`eprintln!\` (no early return), so the install runs at the same point on the success path either way.

## Test changes
None. All 3206 lib tests pass; clippy + fmt clean.