### PR TITLE
RES-1487: ghost_types + async_await — validate before install, drop the HashSet clone

### DIFF
--- a/resilient/src/async_await.rs
+++ b/resilient/src/async_await.rs
@@ -56,7 +56,12 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     if async_fns.is_empty() {
         return Ok(());
     }
-    install(async_fns.clone());
+    // RES-1487: validate before `install` so `async_fns` moves into
+    // install instead of cloning. The previous shape did
+    // `install(async_fns.clone())` up front; the validation loop
+    // borrowed `&async_fns` and ran after. Reorder so install takes
+    // ownership at the end of the success path. Same shape as
+    // RES-1481 (derives) / RES-1485 (recursive_types).
     let Node::Program(stmts) = program else {
         return Ok(());
     };
@@ -79,6 +84,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             }
         }
     }
+    install(async_fns);
     Ok(())
 }
 

--- a/resilient/src/ghost_types.rs
+++ b/resilient/src/ghost_types.rs
@@ -49,7 +49,12 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     if ghosts.is_empty() {
         return Ok(());
     }
-    install(ghosts.clone());
+    // RES-1487: validate before `install` so `ghosts` can be moved
+    // into install instead of cloned. The previous shape did
+    // `install(ghosts.clone())` up front; the validation loop
+    // borrowed `&ghosts` and ran after. Reorder so install takes
+    // ownership at the end of the success path. Same shape as
+    // RES-1481 (derives) / RES-1485 (recursive_types).
     let Node::Program(stmts) = program else {
         return Ok(());
     };
@@ -71,6 +76,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             }
         }
     }
+    install(ghosts);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1489

\`ghost_types::check\` and \`async_await::check\` both did \`install(set.clone())\` ahead of the leak-detection loop. Reorder: validate first, then move \`set\` into \`install\`. Same shape as RES-1481 (derives) / RES-1485 (recursive_types).

Side benefit: if validation finds a leak, install never runs — the global registry isn't polluted with names from a program that failed validation.

## Test changes
None. All 3206 lib tests pass; clippy + fmt clean.