### PR TITLE
RES-1489: distributed_invariants — install by move after validation

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -144,38 +144,6 @@
       "branch": "res-1303-feature-attrs-kind-index",
       "claimed_at": "2026-05-12T05:08:27Z"
     },
-    "resilient/src/associated_constants.rs": {
-      "branch": "res-1308-skip-empty-install-8-passes",
-      "claimed_at": "2026-05-12T05:18:02Z"
-    },
-    "resilient/src/macros.rs": {
-      "branch": "res-1308-skip-empty-install-8-passes",
-      "claimed_at": "2026-05-12T05:18:02Z"
-    },
-    "resilient/src/phantom_types.rs": {
-      "branch": "res-1308-skip-empty-install-8-passes",
-      "claimed_at": "2026-05-12T05:18:02Z"
-    },
-    "resilient/src/recursive_types.rs": {
-      "branch": "res-1308-skip-empty-install-8-passes",
-      "claimed_at": "2026-05-12T05:18:02Z"
-    },
-    "resilient/src/probabilistic_contracts.rs": {
-      "branch": "res-1308-skip-empty-install-8-passes",
-      "claimed_at": "2026-05-12T05:18:02Z"
-    },
-    "resilient/src/row_polymorphism.rs": {
-      "branch": "res-1308-skip-empty-install-8-passes",
-      "claimed_at": "2026-05-12T05:18:02Z"
-    },
-    "resilient/src/distributed_invariants.rs": {
-      "branch": "res-1308-skip-empty-install-8-passes",
-      "claimed_at": "2026-05-12T05:18:02Z"
-    },
-    "resilient/src/ghost_types.rs": {
-      "branch": "res-1308-skip-empty-install-8-passes",
-      "claimed_at": "2026-05-12T05:18:02Z"
-    },
     "resilient/src/default_params.rs": {
       "branch": "res-1312-default-params-fast-reject",
       "claimed_at": "2026-05-12T05:26:51Z"
@@ -219,6 +187,10 @@
     "resilient/src/lib.rs": {
       "branch": "res-1471-apply-fn-consume-args",
       "claimed_at": "2026-05-12T11:51:21Z"
+    },
+    "resilient/src/distributed_invariants.rs": {
+      "branch": "res-1489-distributed-invariants-reorder",
+      "claimed_at": "2026-05-12T12:14:37Z"
     }
   }
 }

--- a/resilient/src/distributed_invariants.rs
+++ b/resilient/src/distributed_invariants.rs
@@ -71,16 +71,22 @@ pub fn for_actor(actor: &str) -> Vec<DistributedInvariant> {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1308: gate `install` on the non-empty case. The historical
-    // wiring called `install(invs.clone())` before the early-out,
-    // burning a RwLock write per compile and creating the
-    // wipe-on-empty test race documented in RES-1302.
+    // RES-1308: gate `install` on the non-empty case. Skips a
+    // wasted RwLock write per compile and the wipe-on-empty race
+    // documented in RES-1302.
     let invs = collect();
     if invs.is_empty() {
         return Ok(());
     }
-    install(invs.clone());
+    // RES-1489: validate against actor names BEFORE installing
+    // (validation reads `invs` locally, not via the installed
+    // global), then `install(invs)` by move. The previous shape
+    // did `install(invs.clone())` ahead of validation, paying a
+    // `Vec` clone for nothing — the validation loop never reads
+    // through the global registry. Mirrors RES-1481 (derives) and
+    // RES-1485 (recursive_types).
     let Node::Program(stmts) = program else {
+        install(invs);
         return Ok(());
     };
     let actor_names: Vec<String> = stmts
@@ -100,6 +106,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
             }
         }
     }
+    install(invs);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1491

## Summary

\`check\` did \`install(invs.clone())\` before validation. The validation reads \`invs\` locally (\`for inv in &invs\`), never through the global registry. The clone was pure waste.

Reorder: validate first, then \`install(invs)\` by move. Same pattern as RES-1481 / RES-1485.

## Test plan

- [x] cargo build
- [x] cargo test --lib (3206 tests pass)
- [x] cargo clippy clean
- [x] cargo fmt --check clean