### PR TITLE
RES-1495: power/wcet/stack contracts — borrow function names in bodies HashMap

### DIFF
--- a/resilient/src/power_contracts.rs
+++ b/resilient/src/power_contracts.rs
@@ -92,15 +92,20 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
-    let bodies: HashMap<String, &Node> = stmts
+    // RES-1495: borrow each function name as `&str` instead of
+    // cloning into the HashMap key. The map's only consumer is
+    // `bodies.get(spec.fn_name.as_str())` below — `&str` works for
+    // both insert and lookup, so the per-function `name.clone()` is
+    // pure overhead.
+    let bodies: HashMap<&str, &Node> = stmts
         .iter()
         .filter_map(|s| match &s.node {
-            Node::Function { name, body, .. } => Some((name.clone(), body.as_ref())),
+            Node::Function { name, body, .. } => Some((name.as_str(), body.as_ref())),
             _ => None,
         })
         .collect();
     for spec in &specs {
-        if let Some(body) = bodies.get(&spec.fn_name) {
+        if let Some(body) = bodies.get(spec.fn_name.as_str()) {
             let est = estimate_uj(body);
             if est > spec.budget_uj {
                 return Err(format!(

--- a/resilient/src/stack_contracts.rs
+++ b/resilient/src/stack_contracts.rs
@@ -86,15 +86,18 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
-    let bodies: HashMap<String, &Node> = stmts
+    // RES-1495: borrow each function name as `&str` instead of
+    // cloning into the HashMap key — same pattern applied across
+    // `power_contracts` / `wcet_contracts` in this PR.
+    let bodies: HashMap<&str, &Node> = stmts
         .iter()
         .filter_map(|s| match &s.node {
-            Node::Function { name, body, .. } => Some((name.clone(), body.as_ref())),
+            Node::Function { name, body, .. } => Some((name.as_str(), body.as_ref())),
             _ => None,
         })
         .collect();
     for spec in &specs {
-        if let Some(body) = bodies.get(&spec.fn_name) {
+        if let Some(body) = bodies.get(spec.fn_name.as_str()) {
             let depth = max_call_depth(body, 1);
             let bytes = depth * FRAME_BYTES;
             if bytes > spec.budget_bytes {

--- a/resilient/src/wcet_contracts.rs
+++ b/resilient/src/wcet_contracts.rs
@@ -84,15 +84,18 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
-    let bodies: HashMap<String, &Node> = stmts
+    // RES-1495: borrow each function name as `&str` instead of
+    // cloning into the HashMap key — same pattern applied across
+    // `power_contracts` / `stack_contracts` in this PR.
+    let bodies: HashMap<&str, &Node> = stmts
         .iter()
         .filter_map(|s| match &s.node {
-            Node::Function { name, body, .. } => Some((name.clone(), body.as_ref())),
+            Node::Function { name, body, .. } => Some((name.as_str(), body.as_ref())),
             _ => None,
         })
         .collect();
     for spec in &specs {
-        if let Some(body) = bodies.get(&spec.fn_name) {
+        if let Some(body) = bodies.get(spec.fn_name.as_str()) {
             let est = estimate_wcet(body);
             if est > spec.budget_cycles {
                 return Err(format!(


### PR DESCRIPTION
Closes #1497

All three budget-check passes built \`HashMap<String, &Node>\` by cloning each function name. The map's only use is one \`get(...)\` per spec; the entries never escape the function.

Switch to \`HashMap<&str, &Node>\` keyed by \`name.as_str()\` (borrowing into the AST). Lookup becomes \`bodies.get(spec.fn_name.as_str())\`.

For programs with N top-level functions, saves N \`String::clone\` calls per pass. All three passes (\`power_contracts\`, \`wcet_contracts\`, \`stack_contracts\`) updated symmetrically.

## Test changes
None. All 3206 lib tests pass; clippy + fmt clean.