### PR TITLE
RES-1500: traits::fns_by_name — borrow function names as &str

### DIFF
--- a/resilient/src/traits.rs
+++ b/resilient/src/traits.rs
@@ -535,11 +535,17 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // Pass 3: validate generic-bound annotations refer to known traits,
     // and that direct calls passing a struct-typed literal as a bounded
     // type parameter satisfy the bound.
-    let fns_by_name: HashMap<String, &Node> = stmts
+    // RES-1500: borrow each function name as `&str` instead of
+    // cloning it into the HashMap key. The map's only consumer is
+    // `walk_call_sites`, which performs `fns_by_name.get(callee_name)`
+    // with a `&str` lookup (RES-1483). The owned `String` key was
+    // pure overhead — same pattern applied to `power_contracts` /
+    // `wcet_contracts` / `stack_contracts` in RES-1495.
+    let fns_by_name: HashMap<&str, &Node> = stmts
         .iter()
         .filter_map(|s| {
             if let Node::Function { name, .. } = &s.node {
-                Some((name.clone(), &s.node as &Node))
+                Some((name.as_str(), &s.node as &Node))
             } else {
                 None
             }
@@ -597,7 +603,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
 /// corresponding type parameter.
 fn walk_call_sites(
     node: &Node,
-    fns_by_name: &HashMap<String, &Node>,
+    fns_by_name: &HashMap<&str, &Node>,
     traits: &HashMap<String, (Vec<TraitMethodSig>, Vec<AssociatedTypeDecl>, Span)>,
     type_methods: &HashMap<String, HashMap<String, usize>>,
     explicit_impls: &HashSet<(String, String)>,


### PR DESCRIPTION
## Summary

The HashMap built in `traits::check()` and consumed by `walk_call_sites`
keyed on owned `String`s cloned from each `Node::Function::name`. Its
only consumer is `fns_by_name.get(callee_name)`, where `callee_name`
is `&str` (RES-1483 fixed the lookup side). `HashMap<String, _>::get`
accepts `&str` via `Borrow<str>`, so the clone produced no behaviour
change — only allocation pressure on every program with generic
fn declarations.

Same pattern shipped in RES-1495 for the budget contracts
(power/wcet/stack). Identical reasoning here.

Closes #1487

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib traits` — 17/17 trait tests pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)