### PR TITLE
RES-1505: per_fn stats counters — gate owned-key alloc on real insert

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -6093,19 +6093,29 @@ impl TypeChecker {
                                 }
                                 Some(true) => {
                                     self.stats.requires_discharged_at_compile += 1;
-                                    *self
-                                        .stats
-                                        .per_fn_discharged
-                                        .entry(callee_name.clone())
-                                        .or_insert(0) += 1;
+                                    // RES-1505: gate the owned-String key allocation
+                                    // on a real insertion. `HashMap::entry(K)` requires
+                                    // an owned key *every call*, allocating even on
+                                    // repeat hits — and the call-site loop hits the
+                                    // same callee many times for any fn with multiple
+                                    // `requires` clauses or many callers.
+                                    if let Some(c) =
+                                        self.stats.per_fn_discharged.get_mut(callee_name.as_str())
+                                    {
+                                        *c += 1;
+                                    } else {
+                                        self.stats.per_fn_discharged.insert(callee_name.clone(), 1);
+                                    }
                                 }
                                 None => {
                                     self.stats.requires_left_for_runtime += 1;
-                                    *self
-                                        .stats
-                                        .per_fn_runtime
-                                        .entry(callee_name.clone())
-                                        .or_insert(0) += 1;
+                                    if let Some(c) =
+                                        self.stats.per_fn_runtime.get_mut(callee_name.as_str())
+                                    {
+                                        *c += 1;
+                                    } else {
+                                        self.stats.per_fn_runtime.insert(callee_name.clone(), 1);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

After a successful or unverified Z3 discharge of a `requires` clause
at a call site, the typechecker bumped a per-fn counter via
`map.entry(callee_name.clone()).or_insert(0) += 1`.

`HashMap::entry(K)` takes an owned key on every call — even when
the entry already exists — so every call-site / clause combination
paid a `String` allocation just to bump a counter.

The same callee tends to appear many times across the program
(one entry per `requires` clause, multiplied by every call site).
After the first discharge, subsequent ones only need `+= 1` on an
existing counter; the allocation is wasted.

Switch to a `get_mut` fast path, falling back to a single
`callee_name.clone() + insert` on the first call only. Net
allocation: one owned String per *distinct* callee, matching the
map's actual key count instead of the full call-site fan-out.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib requires` — 16 contract tests pass
- [x] `cargo test --lib discharged` — `audit_counts_discharged_and_runtime` passes
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)