### PR TITLE
RES-1507: vibe_debt + resilience_score — borrow call-name keys

### DIFF
--- a/resilient/src/resilience_score.rs
+++ b/resilient/src/resilience_score.rs
@@ -54,7 +54,10 @@ pub fn score_program(program: &Node) -> Vec<ResilienceScore> {
 
     // Build a call-reference index so we can credit a fn for being
     // called from somewhere. We only need names → reference count.
-    let mut call_refs: HashMap<String, u32> = HashMap::new();
+    // RES-1507: borrow each call-site name as `&str` from the AST
+    // instead of cloning. Same pattern applied to `vibe_debt::analyze`
+    // in this PR; mirrors RES-1495 / RES-1500 / RES-1503.
+    let mut call_refs: HashMap<&str, u32> = HashMap::new();
     for s in stmts {
         collect_call_names(&s.node, &mut call_refs);
     }
@@ -93,7 +96,7 @@ pub fn score_program(program: &Node) -> Vec<ResilienceScore> {
 
             // Subtract self-references so a recursive fn can't earn
             // coverage credit by calling itself.
-            let raw_refs = call_refs.get(name).copied().unwrap_or(0);
+            let raw_refs = call_refs.get(name.as_str()).copied().unwrap_or(0);
             let self_refs = count_self_calls(body, name);
             let external_refs = raw_refs.saturating_sub(self_refs);
             score.coverage_pts = match external_refs {
@@ -122,7 +125,7 @@ pub fn score_program(program: &Node) -> Vec<ResilienceScore> {
     out
 }
 
-fn collect_call_names(node: &Node, out: &mut HashMap<String, u32>) {
+fn collect_call_names<'a>(node: &'a Node, out: &mut HashMap<&'a str, u32>) {
     match node {
         Node::CallExpression {
             function,
@@ -130,7 +133,7 @@ fn collect_call_names(node: &Node, out: &mut HashMap<String, u32>) {
             ..
         } => {
             if let Node::Identifier { name, .. } = function.as_ref() {
-                *out.entry(name.clone()).or_insert(0) += 1;
+                *out.entry(name.as_str()).or_insert(0) += 1;
             }
             for a in arguments {
                 collect_call_names(a, out);
@@ -183,7 +186,7 @@ fn collect_call_names(node: &Node, out: &mut HashMap<String, u32>) {
 }
 
 fn count_self_calls(node: &Node, target: &str) -> u32 {
-    let mut tmp: HashMap<String, u32> = HashMap::new();
+    let mut tmp: HashMap<&str, u32> = HashMap::new();
     collect_call_names(node, &mut tmp);
     tmp.get(target).copied().unwrap_or(0)
 }

--- a/resilient/src/vibe_debt.rs
+++ b/resilient/src/vibe_debt.rs
@@ -61,7 +61,12 @@ pub fn analyze(program: &Node) -> VibeDebtReport {
         return VibeDebtReport::default();
     };
 
-    let mut refs: HashMap<String, u32> = HashMap::new();
+    // RES-1507: borrow each call-site name into the ref-count map
+    // instead of cloning. `collect_refs` previously paid a `String`
+    // allocation for *every* call expression in the program — the
+    // counters only need lookup-by-name, never owned storage. Same
+    // pattern as RES-1495 / RES-1500 / RES-1503.
+    let mut refs: HashMap<&str, u32> = HashMap::new();
     for s in stmts {
         collect_refs(&s.node, &mut refs);
     }
@@ -79,12 +84,12 @@ pub fn analyze(program: &Node) -> VibeDebtReport {
         } = &s.node
         {
             let self_calls = {
-                let mut tmp = HashMap::new();
+                let mut tmp: HashMap<&str, u32> = HashMap::new();
                 collect_refs(body, &mut tmp);
-                tmp.get(name).copied().unwrap_or(0)
+                tmp.get(name.as_str()).copied().unwrap_or(0)
             };
             let external = refs
-                .get(name)
+                .get(name.as_str())
                 .copied()
                 .unwrap_or(0)
                 .saturating_sub(self_calls);
@@ -115,7 +120,7 @@ pub fn analyze(program: &Node) -> VibeDebtReport {
     }
 }
 
-fn collect_refs(node: &Node, out: &mut HashMap<String, u32>) {
+fn collect_refs<'a>(node: &'a Node, out: &mut HashMap<&'a str, u32>) {
     match node {
         Node::CallExpression {
             function,
@@ -123,7 +128,7 @@ fn collect_refs(node: &Node, out: &mut HashMap<String, u32>) {
             ..
         } => {
             if let Node::Identifier { name, .. } = function.as_ref() {
-                *out.entry(name.clone()).or_insert(0) += 1;
+                *out.entry(name.as_str()).or_insert(0) += 1;
             }
             for a in arguments {
                 collect_refs(a, out);


### PR DESCRIPTION
## Summary

Both `vibe_debt::analyze` and `resilience_score::score_program` build
a `HashMap<String, u32>` of per-fn-name call-reference counts by
walking every `CallExpression` in the program and inserting via
`out.entry(name.clone()).or_insert(0) += 1`. The counters are
look-up-only — the owned `String` keys served no purpose beyond
satisfying `HashMap`'s ownership requirement.

Switch both modules' counter maps and their `collect_refs` /
`collect_call_names` walkers to `HashMap<&'a str, u32>` borrowed
from the AST. Net allocation: zero owned Strings in either pass
(the per-fn report-side `function_name: name.clone()` stays, because
the report struct itself outlives the AST borrow).

Same pattern as RES-1495 / RES-1500 / RES-1503. Both passes are
audit/autopilot opt-ins, so the gain is per-`--autopilot` /
`--resilience-score` run, not on the default check path.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib vibe` — 4 tests pass
- [x] `cargo test --lib resilience_score` — 3 tests pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)