### PR TITLE
RES-1509: cfg_attr::from_predicate — borrow active config instead of cloning

### DIFF
--- a/resilient/src/cfg_attr.rs
+++ b/resilient/src/cfg_attr.rs
@@ -86,15 +86,24 @@ pub fn set_active_config(cfg: CfgConfig) {
     }
 }
 
-/// Read the currently installed config. Returns the default (no features,
-/// no target) when nothing has been installed — that way unit tests that
-/// drive the parser directly don't need to set anything up.
-pub fn active_config() -> CfgConfig {
-    ACTIVE_CFG
-        .read()
-        .ok()
-        .and_then(|g| g.clone())
-        .unwrap_or_default()
+/// RES-1509: evaluate a predicate against the active config without
+/// cloning. The previous shape went through a `pub active_config()` that
+/// returned an owned `CfgConfig` clone — including the
+/// `features: HashSet<String>` — on every read, then dropped it after
+/// one `predicate.eval(&cfg)` call. For programs with N `#[cfg(...)]`
+/// attributes and a feature set of size S, that's N O(S) wasted
+/// HashSet clones per parse. Borrowing through the `RwLock` for the
+/// duration of `eval` keeps the predicate evaluation single-allocation-
+/// free in the common path. Falls back to the default config when the
+/// lock is poisoned or the slot is `None` (parser unit tests that
+/// don't install a config).
+fn eval_predicate(predicate: &CfgPredicate) -> bool {
+    if let Ok(guard) = ACTIVE_CFG.read()
+        && let Some(cfg) = guard.as_ref()
+    {
+        return predicate.eval(cfg);
+    }
+    predicate.eval(&CfgConfig::default())
 }
 
 /// Reset the active config. Used by `#[cfg(test)]` to keep tests
@@ -156,7 +165,9 @@ impl CfgAttribute {
     /// Build from a predicate, evaluating against the currently installed
     /// config. Centralised so every call site uses the same evaluator.
     pub fn from_predicate(predicate: CfgPredicate) -> Self {
-        let is_active = predicate.eval(&active_config());
+        // RES-1509: borrow the active config in-place instead of
+        // cloning the full `CfgConfig` per attribute.
+        let is_active = eval_predicate(&predicate);
         CfgAttribute {
             predicate,
             is_active,


### PR DESCRIPTION
Closes #1508

## What changed

Replace the per-attribute `predicate.eval(&active_config())` (which cloned the full `CfgConfig` including the `features: HashSet<String>` on every read) with an `eval_predicate(&CfgPredicate)` helper that borrows the `RwLock`-guarded config in place and evaluates the predicate under the read guard.

## Why

For programs with N `#[cfg(...)]` attributes and a feature set of size S, this drops N O(S) wasted HashSet clones per parse. Each `#[cfg(...)]` attribute parsed in `parse_cfg_attribute` triggered a fresh `CfgConfig::clone()` that copied the entire feature set just to immediately drop it after one `predicate.eval()` call.

The public `active_config()` had no remaining callers (verified via grep across the workspace) and is removed; `from_predicate` was the only consumer.

## Pattern

Mirrors the borrow-not-clone shape used in RES-1465 (mutual_recursion_scc::entry/get_mut), RES-1471 (apply_function::into_iter), RES-1474 (isr_call_graph::BFS borrow), RES-1477 (deadlock_freedom::detect_cycles), RES-1483 (traits::walk_call_sites).

## Test plan

- [x] `cargo build --locked` clean
- [x] `cargo test --lib cfg_attr` — 13 tests pass
- [x] `cargo test --lib` — 3206 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean