### PR TITLE
RES-1511: recovery_checker — borrow callee identifier as &str

### DIFF
--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -121,21 +121,27 @@ impl Context {
                 arguments,
                 ..
             } => {
-                if let Some(fn_name) = self.extract_identifier(function) {
-                    if self.extern_fns.contains(&fn_name) {
+                // RES-1511: borrow the callee identifier as `&str` instead
+                // of cloning it. `extract_identifier` previously returned
+                // an owned `String` so the warning branches could compare
+                // against `current_fn`; both lookups
+                // (`HashSet<String>::contains` and the equality check
+                // against `self.current_fn`) accept a `&str` directly via
+                // `Borrow<str>`, so the clone-per-call-site was wasted.
+                if let Some(fn_name) = extract_identifier(function) {
+                    if self.extern_fns.contains(fn_name) {
                         eprintln!(
                             "warning: opaque FFI call to '{}' in recovery body \
                             cannot be modeled as TLA+ action",
                             fn_name
                         );
-                    } else if let Some(ref current) = self.current_fn {
-                        #[allow(clippy::collapsible_if)]
-                        if &fn_name == current {
-                            eprintln!(
-                                "warning: function '{}' recursively calls itself in recovery body",
-                                current
-                            );
-                        }
+                    } else if let Some(current) = self.current_fn.as_deref()
+                        && fn_name == current
+                    {
+                        eprintln!(
+                            "warning: function '{}' recursively calls itself in recovery body",
+                            current
+                        );
                     }
                 }
                 for arg in arguments {
@@ -216,11 +222,15 @@ impl Context {
             _ => {}
         }
     }
+}
 
-    fn extract_identifier(&self, node: &Node) -> Option<String> {
-        match node {
-            Node::Identifier { name, .. } => Some(name.clone()),
-            _ => None,
-        }
+/// RES-1511: borrow the identifier name out of the AST node instead of
+/// cloning it. The previous shape returned `Option<String>` so every
+/// call site paid a `to_string()` for a value only used as a lookup key
+/// or for a single `eprintln!`.
+fn extract_identifier(node: &Node) -> Option<&str> {
+    match node {
+        Node::Identifier { name, .. } => Some(name.as_str()),
+        _ => None,
     }
 }


### PR DESCRIPTION
Closes #1511

## What changed

Replace `Context::extract_identifier(&self) -> Option<String>` with a free function `extract_identifier(&Node) -> Option<&str>` and rewrite the lone call site to use `HashSet<String>::contains(&str)` via `Borrow<str>` plus `current_fn.as_deref()` for the recursion equality check.

## Why

Every `CallExpression` inside a `live{}` block was paying a `name.clone()` in `extract_identifier`, then either:
1. an unused clone (FFI-name path), or
2. a wasted second comparison via `&String == &String` (recursion path).

Both downstream consumers accept `&str` directly. The clone-per-call-site was pure overhead.

## Pattern

Same borrow-not-clone shape as RES-1483 (traits::walk_call_sites), RES-1465 (mutual_recursion_scc), RES-1471 (apply_function), RES-1474 (isr_call_graph), RES-1477 (deadlock_freedom).

## Test plan

- [x] `cargo build --locked` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --lib` — 3206 tests pass