### PR TITLE
RES-1515: lint::run — skip allow-filter loop when no allow comments

### DIFF
--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -202,19 +202,30 @@ pub fn check(program: &Node, source: &str) -> Vec<Lint> {
     // Treat the L0001 allow as implying the L0011 allow for the
     // same line, so dual emission stays user-suppressible with
     // a single comment.
+    //
+    // RES-1515: skip the per-lint clone+contains pair entirely when
+    // no `// resilient: allow ...` comments exist in the source.
+    // The common case for every fixture in `examples/` and every
+    // CI input is an empty `allows` set; the retain closure was
+    // cloning `l.code` per lint just to ask a HashSet that was
+    // guaranteed empty. The `safety_critical && l.code == "L0006"`
+    // gate is also a no-op when nothing would otherwise drop the
+    // lint — early-out keeps every lint in that case too.
     let allows = collect_allow_comments(source);
-    out.retain(|l| {
-        if safety_critical && l.code == "L0006" {
-            return true;
-        }
-        if allows.contains(&(l.line, l.code.clone())) {
-            return false;
-        }
-        if l.code == "L0011" && allows.contains(&(l.line, "L0001".to_string())) {
-            return false;
-        }
-        true
-    });
+    if !allows.is_empty() {
+        out.retain(|l| {
+            if safety_critical && l.code == "L0006" {
+                return true;
+            }
+            if allows.contains(&(l.line, l.code.clone())) {
+                return false;
+            }
+            if l.code == "L0011" && allows.contains(&(l.line, "L0001".to_string())) {
+                return false;
+            }
+            true
+        });
+    }
     out.sort_by(|a, b| a.line.cmp(&b.line).then(a.column.cmp(&b.column)));
     out
 }


### PR DESCRIPTION
Closes #1516

## What changed

Gate the `retain` filter loop on `!allows.is_empty()`. If no `// resilient: allow LXXXX` comments appear in the source, the per-lint `l.code.clone()` and `HashSet::contains` work is skipped entirely.

## Why

For every fixture in `examples/` and every CI input, no allow comments exist. The `retain` was paying:
- 1 `String::clone` per lint (for the `l.code.clone()` in the tuple key)
- 1 `HashSet::contains` per lint (always returning false)
- Potentially a second pair for L0011 → L0001 alias

The `safety_critical && l.code == "L0006"` branch is also a no-op when nothing else would drop the lint. Skipping the whole `retain` is observationally equivalent on the empty-allows path.

## Test plan

- [x] `cargo build --locked` clean
- [x] `cargo test --lib lint` — 90 tests pass (including all `_suppressed_by_allow_comment` cases)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean