### PR TITLE
RES-1523: imports::expand_uses — move canon into loaded set instead of cloning

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -231,6 +231,10 @@
     "resilient/src/mutual_recursion_scc.rs": {
       "branch": "res-1514-scc-dfs-borrow",
       "claimed_at": "2026-05-12T13:13:18Z"
+    },
+    "resilient/src/imports.rs": {
+      "branch": "res-1523-imports-canon-move",
+      "claimed_at": "2026-05-12T13:18:45Z"
     }
   }
 }

--- a/resilient/src/imports.rs
+++ b/resilient/src/imports.rs
@@ -90,7 +90,12 @@ pub fn expand_uses(
                     // brought in.
                     continue;
                 }
-                loaded.insert(canon.clone());
+                // RES-1523: move `canon` into the `loaded` set instead of
+                // cloning. `canon` isn't referenced again on this branch
+                // — only `target` is used to load and parse the file
+                // below — so the historic `canon.clone()` was a
+                // per-import wasted `PathBuf` allocation.
+                loaded.insert(canon);
             }
 
             let imported_program = load_and_parse(&target)?;


### PR DESCRIPTION
Closes #1524

## What changed

`loaded.insert(canon.clone())` → `loaded.insert(canon)`. The `canon` PathBuf isn't referenced again on the unaliased-import branch (the loop body uses `target` and `imported_program`), so the clone was wasted overhead.

## Why

Per program with N non-aliased `use` statements, this drops N `PathBuf` clones from the import-expansion pass. `PathBuf` is a heap-allocated `OsString`, so each clone copies the full path bytes.

## Test plan

- [x] `cargo build --locked` clean
- [x] `cargo test --lib imports` — 2 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean