### PR TITLE
RES-1525: try_catch::check — borrow fn name + fails slice into fn_fails

### DIFF
--- a/resilient/src/try_catch.rs
+++ b/resilient/src/try_catch.rs
@@ -188,11 +188,20 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // Collect the table of each fn's declared `fails` set so we can
     // resolve call sites inside try bodies without round-tripping
     // through the main typechecker.
-    let mut fn_fails: std::collections::HashMap<String, Vec<String>> =
-        std::collections::HashMap::new();
+    //
+    // RES-1525: borrow function names and `fails` slices straight out
+    // of the AST instead of cloning. The map only lives for the
+    // duration of this `check` call, and `statements` is a `&[Spanned<Node>]`
+    // we hold across that call, so the borrows outlast every read.
+    // The previous shape cloned the fn name `String` and the `fails:
+    // Vec<String>` per function — pure overhead, since `HashMap<&str,
+    // _>::get(&str)` works as well for the lookup. Pre-size to the
+    // statement count since the upper bound is every stmt being a fn.
+    let mut fn_fails: std::collections::HashMap<&str, &[String]> =
+        std::collections::HashMap::with_capacity(statements.len());
     for stmt in statements {
         if let Node::Function { name, fails, .. } = &stmt.node {
-            fn_fails.insert(name.clone(), fails.clone());
+            fn_fails.insert(name.as_str(), fails.as_slice());
         }
     }
     for stmt in statements {
@@ -206,7 +215,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
 /// Walk an AST subtree and validate every `TryCatch` encountered.
 fn walk(
     node: &Node,
-    fn_fails: &std::collections::HashMap<String, Vec<String>>,
+    fn_fails: &std::collections::HashMap<&str, &[String]>,
     source_path: &str,
 ) -> Result<(), String> {
     match node {
@@ -271,7 +280,7 @@ fn walk(
 /// MVP, so a `catch` arm covering them would always be spurious.
 fn collect_emitted_variants(
     body: &[Node],
-    fn_fails: &std::collections::HashMap<String, Vec<String>>,
+    fn_fails: &std::collections::HashMap<&str, &[String]>,
 ) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     for stmt in body {
@@ -282,7 +291,7 @@ fn collect_emitted_variants(
 
 fn collect_from_node(
     node: &Node,
-    fn_fails: &std::collections::HashMap<String, Vec<String>>,
+    fn_fails: &std::collections::HashMap<&str, &[String]>,
     out: &mut Vec<String>,
 ) {
     match node {
@@ -292,9 +301,9 @@ fn collect_from_node(
             ..
         } => {
             if let Node::Identifier { name, .. } = function.as_ref()
-                && let Some(variants) = fn_fails.get(name)
+                && let Some(variants) = fn_fails.get(name.as_str())
             {
-                for v in variants {
+                for v in *variants {
                     if !out.iter().any(|x| x == v) {
                         out.push(v.clone());
                     }


### PR DESCRIPTION
Closes #1526

## What changed

Replace `HashMap<String, Vec<String>>` (fn name → fails set) with `HashMap<&str, &[String]>` borrowed from the AST. Pre-size to `statements.len()` since the upper bound is every stmt being a function.

`walk` and `collect_emitted_variants` / `collect_from_node` signatures updated to match. The inner iteration over `*variants` walks the AST `fails` slot directly.

## Why

The map only lives for the `check` call, and `statements: &[Spanned<Node>]` outlives it, so the borrows outlast every read. The historic shape cloned the fn name String AND the `fails: Vec<String>` per function — pure overhead.

Per program with N functions, this drops N String clones + N Vec clones from the try/catch validation pass.

## Pattern

Same borrow-not-clone shape as RES-1465 (mutual_recursion_scc), RES-1471 (apply_function), RES-1474 (isr_call_graph), RES-1477 (deadlock_freedom), RES-1483 (traits::walk_call_sites), RES-1511 (recovery_checker).

## Test plan

- [x] `cargo build --locked` clean
- [x] `cargo test --lib try_catch` — 6 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean