### PR TITLE
RES-1527: info_flow — single-pass partition + skip walk on empty public_fns

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -240,9 +240,13 @@
       "branch": "res-1517-full-modules-dfs-borrow",
       "claimed_at": "2026-05-12T13:25:00Z"
     },
-    "resilient/src/info_flow.rs": {
-      "branch": "res-1527-info-flow-public-empty",
-      "claimed_at": "2026-05-12T13:30:48Z"
+    "resilient/src/crash_only.rs": {
+      "branch": "res-1520-crash-only-name-borrow",
+      "claimed_at": "2026-05-12T13:33:00Z"
+    },
+    "resilient/src/deadlock_freedom.rs": {
+      "branch": "res-1522-deadlock-actors-borrow",
+      "claimed_at": "2026-05-12T13:34:45Z"
     }
   }
 }

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -240,13 +240,9 @@
       "branch": "res-1517-full-modules-dfs-borrow",
       "claimed_at": "2026-05-12T13:25:00Z"
     },
-    "resilient/src/crash_only.rs": {
-      "branch": "res-1520-crash-only-name-borrow",
-      "claimed_at": "2026-05-12T13:33:00Z"
-    },
-    "resilient/src/deadlock_freedom.rs": {
-      "branch": "res-1522-deadlock-actors-borrow",
-      "claimed_at": "2026-05-12T13:34:45Z"
+    "resilient/src/info_flow.rs": {
+      "branch": "res-1527-info-flow-public-empty",
+      "claimed_at": "2026-05-12T13:30:48Z"
     }
   }
 }

--- a/resilient/src/info_flow.rs
+++ b/resilient/src/info_flow.rs
@@ -43,16 +43,38 @@ pub fn check_program(program: &Node) -> Vec<String> {
     // `&str` borrows of identifier names (skipping the per-callee
     // `String::clone` it used to do), and the set membership check
     // `secret_fns.contains(callee)` works directly on `&str`.
-    let secret_fns: HashSet<&str> = labels
-        .iter()
-        .filter(|(_, l)| **l == Label::Secret)
-        .map(|(k, _)| k.as_str())
-        .collect();
-    let public_fns: HashSet<&str> = labels
-        .iter()
-        .filter(|(_, l)| **l == Label::Public)
-        .map(|(k, _)| k.as_str())
-        .collect();
+    //
+    // RES-1527: single-pass partition into `secret_fns` / `public_fns`
+    // instead of two filter walks over `labels`. The historic shape
+    // iterated `labels` twice with a filter+map per pass; this one walk
+    // dispatches each entry to its set in one match. Marginal on small
+    // registries but cleaner and reads better.
+    let mut secret_fns: HashSet<&str> = HashSet::new();
+    let mut public_fns: HashSet<&str> = HashSet::new();
+    for (k, l) in &labels {
+        match l {
+            Label::Secret => {
+                secret_fns.insert(k.as_str());
+            }
+            Label::Public => {
+                public_fns.insert(k.as_str());
+            }
+            _ => {}
+        }
+    }
+
+    // RES-1527: skip the program walk when no `#[public]` function
+    // exists. The leak check only fires inside a `public_fns`-named
+    // function body, so without any public sink there is no possible
+    // diagnostic — and `walk_calls` produces nothing useful. The
+    // overwhelming majority of programs that ship `#[secret]` /
+    // `#[public]` attributes only tag a couple of fns with one or the
+    // other (not both); whichever side is empty, the walk is dead
+    // work. Same shape as the `crate::secret_erasure::check`
+    // empty-set fast-reject.
+    if public_fns.is_empty() {
+        return errors;
+    }
 
     let Node::Program(stmts) = program else {
         return errors;


### PR DESCRIPTION
Closes #1530

## What changed

1. **Single-pass partition.** Replace two `filter().map().collect()` walks of `labels` with one match-arm dispatch that populates `secret_fns` and `public_fns` in one pass.
2. **Skip the program walk when `public_fns.is_empty()`.** The leak diagnostic only fires inside a `public_fns`-named function body; without any public sink, the per-function `public_fns.contains(name.as_str())` guard is always false, so the walk produces nothing.

## Why

For programs that tag only `#[secret]` (the common case for security-sensitive code in early development — secrets exist before sinks are written), the program walk is dead work. Same empty-set fast-reject pattern as `crate::secret_erasure::check`.

## Test plan

- [x] `cargo build --locked` clean
- [x] `cargo test --lib info_flow` — passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean