### PR TITLE
RES-1520: crash_only — borrow fn names into lookup set

### DIFF
--- a/resilient/src/crash_only.rs
+++ b/resilient/src/crash_only.rs
@@ -38,11 +38,15 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     if !has_crash {
         return Ok(());
     }
-    let names: HashSet<String> = stmts
+    // RES-1520: borrow each top-level fn name as `&str` from the
+    // AST into the lookup set. The contains check below uses
+    // `&str` (via `Borrow<str>`), so the cloned `String` keys were
+    // pure overhead. Same pattern as RES-1495 / RES-1500 etc.
+    let names: HashSet<&str> = stmts
         .iter()
         .filter_map(|s| {
             if let Node::Function { name, .. } = &s.node {
-                Some(name.clone())
+                Some(name.as_str())
             } else {
                 None
             }
@@ -51,7 +55,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     for n in &names {
         if let Some(suffix) = n.strip_prefix("crash_") {
             let needed = format!("recover_{suffix}");
-            if !names.contains(&needed) {
+            if !names.contains(needed.as_str()) {
                 eprintln!(
                     "warning: crash-only contract: '{n}' has no matching \
                      recovery function '{needed}' — crash path is unrecoverable"


### PR DESCRIPTION
## Summary

`names: HashSet<String>` was built by cloning every top-level
fn name in the program, then queried with `names.contains(&needed)`
where `needed` was an owned `String` from `format!`. `HashSet`
lookups accept `&str` via `Borrow<str>`, so the cloned `String`
keys were pure overhead.

Switch `names` to `HashSet<&str>` borrowed from
`Node::Function::name`. The `contains` check passes
`needed.as_str()`. Same pattern as RES-1495 / RES-1500 / RES-1507
etc.

Gated behind the `has_crash` fast-reject (RES-1218 family) so
this fires only on programs that declare `crash_*` functions.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib crash_only` — passes
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)