### PR TITLE
RES-1523: generics — borrow generic_locals into lookup set

### DIFF
--- a/resilient/src/generics.rs
+++ b/resilient/src/generics.rs
@@ -239,11 +239,16 @@ fn check_node(node: &Node) -> Result<(), String> {
             // canonical body-consistency violation.
             let tp_set: std::collections::HashSet<&str> =
                 type_params.iter().map(String::as_str).collect();
-            let generic_locals: std::collections::HashSet<String> = parameters
+            // RES-1523: borrow each generic-typed parameter name
+            // as `&str` from the AST rather than cloning. The set
+            // is only used for `contains(name)` lookups inside
+            // `identifier_in_set` — the cloned `String` keys were
+            // pure overhead. Same pattern as RES-1495 / RES-1500 etc.
+            let generic_locals: std::collections::HashSet<&str> = parameters
                 .iter()
                 .filter_map(|(ty, pname)| {
                     if tp_set.contains(ty.as_str()) {
-                        Some(pname.clone())
+                        Some(pname.as_str())
                     } else {
                         None
                     }
@@ -264,7 +269,7 @@ fn check_body_for_constraints(
     body: &Node,
     fn_name: &str,
     type_params: &[String],
-    generic_locals: &std::collections::HashSet<String>,
+    generic_locals: &std::collections::HashSet<&str>,
 ) -> Result<(), String> {
     match body {
         Node::Block { stmts, .. } => {
@@ -338,9 +343,9 @@ fn check_body_for_constraints(
 
 /// True when `node` is a bare `Identifier { name }` whose name is in
 /// the supplied set.
-fn identifier_in_set(node: &Node, names: &std::collections::HashSet<String>) -> bool {
+fn identifier_in_set(node: &Node, names: &std::collections::HashSet<&str>) -> bool {
     if let Node::Identifier { name, .. } = node {
-        names.contains(name)
+        names.contains(name.as_str())
     } else {
         false
     }


### PR DESCRIPTION
## Summary

`generic_locals: HashSet<String>` was built by cloning every
generic-typed parameter name from the AST, then passed to
`check_body_for_constraints` → `identifier_in_set` for read-only
lookups. `HashSet` contains accepts `&str` via `Borrow<str>`, so
the cloned `String` keys were pure overhead.

Switch `generic_locals` and the supporting helper signatures to
`HashSet<&str>` borrowed from the AST. `identifier_in_set`'s
`names.contains(name)` becomes `names.contains(name.as_str())`.

Same pattern as RES-1495 / RES-1500 / RES-1507 / RES-1520. Gated
behind the `has_generic_fn` fast-reject (RES-1288) so this fires
only on programs that declare generic functions.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib generics` — 12 generics tests pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)