### PR TITLE
RES-1524: lock_ordering — borrow lock-name pair into reported set

### DIFF
--- a/resilient/src/lock_ordering.rs
+++ b/resilient/src/lock_ordering.rs
@@ -66,16 +66,23 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
             collect_pairs(name, body, &mut pair_sites);
         }
     }
-    let mut reported: HashSet<(String, String)> = HashSet::new();
+    // RES-1524: borrow lock-name pairs into the dedup set instead
+    // of cloning. The `pair_sites` map already owns the strings;
+    // `reported` only checks "have I warned on this canonical
+    // pair before". Same pattern as RES-1495 / RES-1500 / RES-1520
+    // applied to a tuple key. The `key_ba` lookup also doesn't
+    // need owned strings — `(&str, &str)` works via `Borrow` on
+    // tuple-of-borrows.
+    let mut reported: HashSet<(&str, &str)> = HashSet::new();
     for ((a, b), fns_ab) in &pair_sites {
         let key_ba = (b.clone(), a.clone());
         if let Some(fns_ba) = pair_sites.get(&key_ba) {
-            let canon = if a < b {
-                (a.clone(), b.clone())
+            let canon: (&str, &str) = if a < b {
+                (a.as_str(), b.as_str())
             } else {
-                (b.clone(), a.clone())
+                (b.as_str(), a.as_str())
             };
-            if !reported.insert(canon.clone()) {
+            if !reported.insert(canon) {
                 continue;
             }
             eprintln!(


### PR DESCRIPTION
## Summary

The cycle-pair dedup set `reported: HashSet<(String, String)>`
required owned String pairs, even though `pair_sites` already owns
the canonical strings for the duration of the inversion-check
loop. The `canon` tuple was built via four `.clone()`s (two
branches) and inserted via a fifth on the `.insert(canon.clone())`
line — pure overhead.

Switch `reported` to `HashSet<(&str, &str)>` borrowed from
`pair_sites`. The canon tuple becomes `(a.as_str(), b.as_str())`
(or the swapped form) with no allocation; `insert(canon)` moves
the small tuple directly.

Same pattern as RES-1495 / RES-1500 / RES-1520, applied to a
tuple key. Gated behind the `has_lock_call` fast-reject so this
fires only on programs that use lock/unlock primitives.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib lock` — 43 lock-related tests pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)