### PR TITLE
RES-1526: distributed_invariants — borrow actor names into Vec

### DIFF
--- a/resilient/src/distributed_invariants.rs
+++ b/resilient/src/distributed_invariants.rs
@@ -90,16 +90,21 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         install(invs);
         return Ok(());
     };
-    let actor_names: Vec<String> = stmts
+    // RES-1526: borrow each actor name as `&str` from the AST
+    // into the lookup Vec. The contains check below works on
+    // `Vec<&str>` (passing `&a.as_str()` matches the `&T` shape
+    // `Vec::contains` requires). Same pattern as RES-1495 / RES-1500
+    // etc.
+    let actor_names: Vec<&str> = stmts
         .iter()
         .filter_map(|s| match &s.node {
-            Node::ActorDecl { name, .. } => Some(name.clone()),
+            Node::ActorDecl { name, .. } => Some(name.as_str()),
             _ => None,
         })
         .collect();
     for inv in &invs {
         for a in &inv.actors {
-            if !actor_names.contains(a) {
+            if !actor_names.contains(&a.as_str()) {
                 eprintln!(
                     "warning: distributed_invariant `{}` references unknown actor `{}`",
                     inv.name, a


### PR DESCRIPTION
## Summary

The actor-name lookup `Vec<String>` was populated by cloning every
`Node::ActorDecl::name` from the AST, then used only for
`actor_names.contains(a)` lookup against invariant-declared
actor names. The cloned String elements served no purpose beyond
satisfying `Vec`'s ownership.

Switch to `Vec<&str>` borrowed from the AST. The contains check
becomes `actor_names.contains(&a.as_str())` — same `&T`-shape
argument the `Vec::contains` method requires.

Same pattern as RES-1495 / RES-1500 / RES-1520 / RES-1522.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib distributed` — passes
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)