### PR TITLE
RES-1530: PURE_BUILTINS — O(1) HashSet lookup instead of O(N) slice scan

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -7345,7 +7345,16 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "map_get_or",
         "hashmap_get_or",
     ];
-    PURE_BUILTINS.contains(&name)
+    // RES-1530: lookup against a `HashSet<&'static str>` built once
+    // per process from `PURE_BUILTINS`. The previous shape called
+    // `PURE_BUILTINS.contains(&name)` which is O(N=442) per call —
+    // and every `CallExpression { function: Identifier { name, .. } }`
+    // in every fn body purity check hits this path. Converting to a
+    // `LazyLock<HashSet<&str>>` drops the lookup to O(1) without
+    // changing observable behaviour.
+    static PURE_BUILTINS_SET: std::sync::LazyLock<std::collections::HashSet<&'static str>> =
+        std::sync::LazyLock::new(|| PURE_BUILTINS.iter().copied().collect());
+    PURE_BUILTINS_SET.contains(name)
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

`is_known_pure_builtin(name)` was called from every body-purity
walker (`check_body_purity`, `body_reaches_io`, the linear-tracker)
on every `CallExpression { function: Identifier { name } }` —
i.e. once per call site in every function body, for every typecheck.
The lookup itself was a linear scan against a 442-entry `&[&str]`,
so the steady-state cost was N(callsites) × 442 byte-level
equality checks per program.

Wrap the slice in a `LazyLock<HashSet<&'static str>>` built once
per process from the existing const array. Lookup becomes
`HashSet::contains` — one hash + one bucket compare. The static
lives inside the function so the array stays adjacent to its
consumer (and the LazyLock pays its cost lazily, on first call).

Same pattern as RES-1349's `BUILTIN_ENV` and the `IMPURE_BUILTINS`
HashSet that already serves the complementary path.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib pur` — 41 purity tests pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)