### PR TITLE
RES-1541: verifier_actors flatten_body — borrow Assignment statements

### DIFF
--- a/resilient/src/verifier_actors.rs
+++ b/resilient/src/verifier_actors.rs
@@ -233,7 +233,7 @@ fn straight_line_post(body: &Node, state_name: &str) -> Option<Node> {
     };
 
     let stmts = flatten_body(body)?;
-    for stmt in &stmts {
+    for stmt in stmts {
         match stmt {
             Node::FieldAssignment {
                 target,
@@ -268,7 +268,13 @@ fn straight_line_post(body: &Node, state_name: &str) -> Option<Node> {
 /// Unwrap nested `Block` nodes into a flat `Vec` of direct
 /// statements. Returns `None` if anything other than an assignment
 /// appears at a nesting level — callers treat that as Unsupported.
-fn flatten_body(body: &Node) -> Option<Vec<Node>> {
+///
+/// RES-1541: returns `Vec<&Node>` borrowed from `body` so the caller
+/// (`straight_line_post`) can pattern-match on each statement without
+/// paying a recursive `Node` clone per `FieldAssignment` /
+/// `Assignment`. The only consumer reads the entries through
+/// `target.as_ref()` / `value.as_ref()` and never moves them.
+fn flatten_body(body: &Node) -> Option<Vec<&Node>> {
     match body {
         Node::Block { stmts, .. } => {
             let mut out = Vec::new();
@@ -278,7 +284,7 @@ fn flatten_body(body: &Node) -> Option<Vec<Node>> {
                         out.extend(flatten_body(s)?);
                     }
                     Node::FieldAssignment { .. } | Node::Assignment { .. } => {
-                        out.push(s.clone());
+                        out.push(s);
                     }
                     // ExpressionStatement wrapping a pure expression
                     // could be allowed too, but we conservatively
@@ -288,7 +294,7 @@ fn flatten_body(body: &Node) -> Option<Vec<Node>> {
             }
             Some(out)
         }
-        Node::FieldAssignment { .. } | Node::Assignment { .. } => Some(vec![body.clone()]),
+        Node::FieldAssignment { .. } | Node::Assignment { .. } => Some(vec![body]),
         _ => None,
     }
 }


### PR DESCRIPTION
Closes #1541.

## Problem

`verifier_actors::flatten_body` clones every `FieldAssignment` / `Assignment` statement when flattening a straight-line handler body. The only caller, `straight_line_post`, then iterates the returned `Vec<Node>` by reference and never moves the elements — the clones are pure waste.

```rust
fn flatten_body(body: &Node) -> Option<Vec<Node>> {
    // ...
    out.push(s.clone());   // ← Node clone (recursive enum with Box children)
    // ...
    Some(vec![body.clone()])  // ← clone the whole body node
}
```

## Fix

Return `Option<Vec<&Node>>` and adjust the caller. Every borrowed statement is a child of the input `body`, so lifetimes work cleanly with a single elided lifetime parameter.

For every actor's inductive step (one per `receive` handler with a non-empty body), this drops one recursive `Node` clone per assignment statement. The `straight_line_post_public` wrapper used by `verifier_liveness` is unaffected — it consumes `straight_line_post`'s `Option<Node>`, not `flatten_body`.

## Test changes

None — the existing handler-walk tests still cover the path; the API/visible behavior is identical.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>