### PR TITLE
RES-1531: lsp completion — defer label clone until prefix match

### DIFF
--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -945,22 +945,29 @@ pub(crate) fn completion_candidates(program: &Node, prefix: &str) -> Vec<Candida
         Node::Program(s) => s,
         _ => return out,
     };
+    // RES-1531: borrow the decl name as `&str` for the prefix
+    // filter; only allocate the owned label string when the entry
+    // is actually going to land in `out`. The previous shape
+    // cloned every top-level decl name, then dropped most of them
+    // on the `!name.starts_with(prefix)` continue — wasted work
+    // proportional to the program's top-level decl count for every
+    // completion request.
     for spanned in stmts {
         let (name, kind, detail) = match &spanned.node {
             Node::Function {
                 name, parameters, ..
             } => (
-                name.clone(),
+                name.as_str(),
                 CandidateKind::Function,
                 Some(format!("fn ({} params)", parameters.len())),
             ),
             Node::StructDecl { name, fields, .. } => (
-                name.clone(),
+                name.as_str(),
                 CandidateKind::Struct,
                 Some(format!("struct ({} fields)", fields.len())),
             ),
             Node::TypeAlias { name, .. } => (
-                name.clone(),
+                name.as_str(),
                 CandidateKind::TypeAlias,
                 Some("type".to_string()),
             ),
@@ -970,7 +977,7 @@ pub(crate) fn completion_candidates(program: &Node, prefix: &str) -> Vec<Candida
             continue;
         }
         out.push(Candidate {
-            label: name,
+            label: name.to_string(),
             kind,
             detail,
         });


### PR DESCRIPTION
## Summary

`collect_completion_candidates` cloned every top-level decl name
(`name.clone()` per `Function`/`StructDecl`/`TypeAlias`) before
checking whether the name actually matched the requested prefix.
For a typical completion request the matching prefix narrows the
result set to a handful of entries out of dozens or hundreds of
top-level decls — so the bulk of the per-request clones were
thrown away on the very next line via `continue`.

Borrow `name.as_str()` for the prefix check; only call
`to_string()` on the matching path that actually pushes a
`Candidate`. The owned label allocation now scales with the
result-set size, not the program's decl count.

## Test plan

- [x] `cargo build --features lsp` clean
- [x] `cargo clippy --features lsp --all-targets -- -D warnings` clean
- [x] `cargo test --features lsp --lib completion` — 4 tests pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)