### PR TITLE
RES-1544: blame_attribution::callers_of — borrow under read guard

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -255,6 +255,9 @@
     "resilient/src/lint.rs": {
       "branch": "res-1533-lint-l0001-borrow",
       "claimed_at": "2026-05-12T14:35:00Z"
+    "resilient/src/blame_attribution.rs": {
+      "branch": "res-1544-blame-attribution-callers-borrow",
+      "claimed_at": "2026-05-12T14:23:18Z"
     }
   }
 }

--- a/resilient/src/blame_attribution.rs
+++ b/resilient/src/blame_attribution.rs
@@ -107,11 +107,16 @@ pub fn install(map: BlameMap) {
 }
 
 pub fn callers_of(callee: &str) -> Vec<(String, usize)> {
+    // RES-1544: hold the read guard for the lookup so we can borrow
+    // through the `Option<BlameMap>` and clone only the value Vec.
+    // The previous shape cloned the entire `BlameMap` (a HashMap
+    // keyed by every callee in the program) on every call before
+    // looking up one row — pure waste when the diagnostic path only
+    // wants the callers of one specific callee.
     BLAME_MAP
         .read()
         .ok()
-        .and_then(|g| g.clone())
-        .and_then(|m| m.edges.get(callee).cloned())
+        .and_then(|g| g.as_ref()?.edges.get(callee).cloned())
         .unwrap_or_default()
 }
 


### PR DESCRIPTION
Closes #1544.

## Problem

`blame_attribution::callers_of` cloned the entire `BlameMap` (`HashMap<String, Vec<(String, usize)>>`) on every call, just to look up one key:

```rust
.and_then(|g| g.clone())                      // clones full HashMap
.and_then(|m| m.edges.get(callee).cloned())  // then clones one Vec
```

For programs with non-trivial call graphs, every runtime-error diagnostic that walks blame edges pays one full-table clone per call-site lookup.

## Fix

Hold the `RwLockReadGuard` through the closure, borrow `&BlameMap` via `as_ref()`, look up the key in-place, clone only the value Vec we actually want. Same lock-then-borrow shape as `dependent_arrays::SPECS.read().ok().and_then(|g| g.get(item).cloned())` already in the codebase.

## Test changes

None — the existing `install_and_lookup_works` test still covers the read path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>