### PR TITLE
RES-1549: typestate_types::validate_call — borrow under read guard

### DIFF
--- a/resilient/src/typestate_types.rs
+++ b/resilient/src/typestate_types.rs
@@ -84,8 +84,15 @@ pub fn validate_call(
     current_state: &str,
     method: &str,
 ) -> Result<String, String> {
-    let specs = SPECS.read().ok().map(|g| g.clone()).unwrap_or_default();
-    let spec = specs
+    // RES-1549: hold the read guard for the lookup so the
+    // `Vec<TypestateSpec>` (each entry owns Vec<String> + HashMap)
+    // doesn't get cloned just to find one spec by name. The
+    // transition value's String is still cloned (cheap, small)
+    // since it's the function's return value.
+    let g = SPECS
+        .read()
+        .map_err(|_| format!("no typestate for {struct_name}"))?;
+    let spec = g
         .iter()
         .find(|s| s.struct_name == struct_name)
         .ok_or_else(|| format!("no typestate for {struct_name}"))?;


### PR DESCRIPTION
Closes #1549.

## Problem

`typestate_types::validate_call` cloned the entire `Vec<TypestateSpec>` (each entry owns a `Vec<String>` plus a `HashMap<(String,String),String>`) on every call:

```rust
let specs = SPECS.read().ok().map(|g| g.clone()).unwrap_or_default();
```

Every runtime method call routed through the typestate verifier paid this clone just to find one spec by name.

## Fix

Hold the `RwLockReadGuard` for the function's body and iterate the borrowed Vec in place. The transition's value String is still cloned (return value), but the surrounding Vec/HashMap clones go away.

Same lock-then-borrow shape as `blame_attribution::callers_of` (#1546) and `causal_trace::snapshot` (#1548).

## Test changes

None — `file_protocol_validates_close_after_open` exercises the path and still passes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>