### PR TITLE
RES-1552: session_types::validate_step — borrow under read guard

### DIFF
--- a/resilient/src/session_types.rs
+++ b/resilient/src/session_types.rs
@@ -87,8 +87,14 @@ pub fn install(specs: Vec<SessionSpec>) {
 }
 
 pub fn validate_step(channel: &str, step: usize, op: &SessionOp) -> Result<(), String> {
-    let specs = SPECS.read().ok().map(|g| g.clone()).unwrap_or_default();
-    let spec = specs
+    // RES-1552: hold the read guard so we don't clone the whole
+    // `HashMap<String, SessionSpec>` (each spec owns a `Vec<SessionOp>`)
+    // just to look up one channel by name. Same lock-then-borrow
+    // shape as RES-1544 / RES-1547 / RES-1549.
+    let g = SPECS
+        .read()
+        .map_err(|_| format!("no session protocol for `{channel}`"))?;
+    let spec = g
         .get(channel)
         .ok_or_else(|| format!("no session protocol for `{channel}`"))?;
     let expected = spec.protocol.get(step).ok_or_else(|| {


### PR DESCRIPTION
Closes #1552.

## Problem

`session_types::validate_step` cloned the entire `HashMap<String, SessionSpec>` on every channel-step validation, just to look up one channel:

```rust
let specs = SPECS.read().ok().map(|g| g.clone()).unwrap_or_default();
let spec = specs.get(channel)...
```

Each `SessionSpec` owns a `Vec<SessionOp>` — so the per-call clone scales with the number of session-annotated channels in the program.

## Fix

Hold the `RwLockReadGuard` for the function's body, look up the channel in place, return early. Same lock-then-borrow shape as RES-1544 (callers_of), RES-1547 (snapshot), RES-1549 (typestate).

## Test changes

None — `validates_in_order` already exercises `validate_step` and still passes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>