### PR TITLE
RES-1554: heap_budget::parse_budget — drop 9 String allocs per check

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -251,6 +251,10 @@
     "resilient/src/typestate_types.rs": {
       "branch": "res-1549-typestate-validate-call-borrow",
       "claimed_at": "2026-05-12T14:27:56Z"
+    },
+    "resilient/src/lint.rs": {
+      "branch": "res-1533-lint-l0001-borrow",
+      "claimed_at": "2026-05-12T14:35:00Z"
     }
   }
 }

--- a/resilient/src/heap_budget.rs
+++ b/resilient/src/heap_budget.rs
@@ -62,14 +62,28 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     Ok(())
 }
 
+// RES-1554: static `_alloc{N}` suffix table — the previous shape
+// allocated 9 `String`s per `parse_budget` call via `format!`. The
+// fast-reject `has_budget` check (scans every top-level fn) and the
+// `for_each_function` enforcement loop both call it, so allocation
+// volume scaled as 9·N for an N-function program with zero budgets.
+const ALLOC_BUDGET_SUFFIXES: &[(&str, usize)] = &[
+    ("_alloc0", 0),
+    ("_alloc1", 1),
+    ("_alloc2", 2),
+    ("_alloc3", 3),
+    ("_alloc4", 4),
+    ("_alloc5", 5),
+    ("_alloc6", 6),
+    ("_alloc7", 7),
+    ("_alloc8", 8),
+];
+
 fn parse_budget(name: &str) -> Option<usize> {
-    for n in 0..=8 {
-        let suf = format!("_alloc{n}");
-        if name.ends_with(&suf) {
-            return Some(n);
-        }
-    }
-    None
+    ALLOC_BUDGET_SUFFIXES
+        .iter()
+        .find(|(suf, _)| name.ends_with(suf))
+        .map(|(_, n)| *n)
 }
 
 fn count_allocs(body: &Node) -> usize {


### PR DESCRIPTION
Closes #1554.

## Problem

`heap_budget::parse_budget` called `format!(\"_alloc{n}\")` inside a 0..=8 loop, allocating a fresh `String` per iteration just to check if a function name has a budget suffix:

```rust
for n in 0..=8 {
    let suf = format!(\"_alloc{n}\");  // String alloc per iteration
    if name.ends_with(&suf) { return Some(n); }
}
```

It's called twice per top-level fn — once by the `has_budget` fast-reject scan and once inside `for_each_function`. For an N-function program with zero `_alloc{N}` declarations (the common case), that's `2·9·N = 18·N` String allocations per `cargo test` compile, all immediately dropped.

## Fix

Hold the suffix → budget table as a `&'static [(&'static str, usize)]` and walk it via `slice::iter().find` — zero heap traffic per call. The fast-reject path was already free of allocation in `bandwidth_budget` / `stack_budget`; this brings `heap_budget` in line.

## Test changes

None — the unit tests in `heap_budget` exercise this through the public `check` path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>