### PR TITLE
RES-1547: causal_trace::snapshot — borrow under read guard

### DIFF
--- a/resilient/src/causal_trace.rs
+++ b/resilient/src/causal_trace.rs
@@ -44,11 +44,16 @@ pub fn record(entry: TraceEntry) {
 }
 
 pub fn snapshot() -> Vec<TraceEntry> {
+    // RES-1547: hold the read guard so we can borrow through the
+    // `Option<VecDeque<TraceEntry>>` and collect via `iter().cloned()`
+    // in one pass. The previous shape did `g.clone()` (clones the
+    // entire `VecDeque<TraceEntry>` inside the Option) and then
+    // `.into_iter().collect()` — paid an extra container allocation
+    // and discard for nothing.
     GLOBAL_TRACE
         .read()
         .ok()
-        .and_then(|g| g.clone())
-        .map(|d| d.into_iter().collect())
+        .and_then(|g| g.as_ref().map(|d| d.iter().cloned().collect()))
         .unwrap_or_default()
 }
 


### PR DESCRIPTION
Closes #1547. Replacement for #1548 which auto-closed on rebase. Hold read guard, borrow Option<&VecDeque> via as_ref(), iter().cloned().collect() in one pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>