### PR TITLE
RES-1534: recovery_checker — borrow extract_identifier return + extern_fns lookup

### DIFF
--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -121,16 +121,23 @@ impl Context {
                 arguments,
                 ..
             } => {
-                if let Some(fn_name) = self.extract_identifier(function) {
-                    if self.extern_fns.contains(&fn_name) {
+                // RES-1534: borrow the callee name as `&str` from the
+                // function-position AST node. The previous shape cloned
+                // every call-site name into an owned `String` even though
+                // both branches only read it: `extern_fns.contains(...)`
+                // accepts `&str` via `Borrow<str>`, and the self-call
+                // check compares against `current.as_deref()`. Same
+                // pattern as RES-1500 / RES-1525 / RES-1533.
+                if let Some(fn_name) = Self::extract_identifier(function) {
+                    if self.extern_fns.contains(fn_name) {
                         eprintln!(
                             "warning: opaque FFI call to '{}' in recovery body \
                             cannot be modeled as TLA+ action",
                             fn_name
                         );
-                    } else if let Some(ref current) = self.current_fn {
+                    } else if let Some(current) = self.current_fn.as_deref() {
                         #[allow(clippy::collapsible_if)]
-                        if &fn_name == current {
+                        if fn_name == current {
                             eprintln!(
                                 "warning: function '{}' recursively calls itself in recovery body",
                                 current
@@ -217,9 +224,9 @@ impl Context {
         }
     }
 
-    fn extract_identifier(&self, node: &Node) -> Option<String> {
+    fn extract_identifier(node: &Node) -> Option<&str> {
         match node {
-            Node::Identifier { name, .. } => Some(name.clone()),
+            Node::Identifier { name, .. } => Some(name.as_str()),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

`extract_identifier` cloned the callee name into an owned `String`
on every call-expression visit, returning `Option<String>`. The
single consumer (`check_node`'s call-expression arm) only used it
for (a) `self.extern_fns.contains(&fn_name)` membership and
(b) comparing against `self.current_fn` — both work fine on `&str`.
The clone served no purpose.

Switch `extract_identifier` to return `Option<&str>` borrowed from
the function-position AST node, change `extern_fns.contains(...)`
to take the `&str` directly, and replace `if let Some(ref current)`
with `if let Some(current) = self.current_fn.as_deref()` so the
comparison is `&str == &str`.

Also makes `extract_identifier` a `Self::` associated fn (no
`&self` needed since it only reads the node argument). Mirror of
RES-1500 / RES-1525 / RES-1533.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib recovery` — 8 tests pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)