### PR TITLE
RES-1564: free_vars::truncate_to — use BTreeSet::split_off

### DIFF
--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -627,10 +627,14 @@ fn truncate_to(set: &mut BTreeSet<String>, len: usize) {
     if set.len() <= len {
         return;
     }
-    let drained: Vec<String> = set.iter().cloned().collect();
-    set.clear();
-    for name in drained.into_iter().take(len) {
-        set.insert(name);
+    // RES-1564: use `BTreeSet::split_off` to discard the tail in
+    // place. The previous shape cloned every entry into a Vec,
+    // cleared the set, and reinserted the prefix — N String clones
+    // plus N reinserts for an N-entry set. `split_off(&pivot)`
+    // splits the BTreeSet in-place; we clone exactly one String
+    // (the pivot at index `len`).
+    if let Some(pivot) = set.iter().nth(len).cloned() {
+        let _tail = set.split_off(&pivot);
     }
 }
 


### PR DESCRIPTION
Closes #1564. Replace clone-clear-reinsert with single split_off — one String clone instead of N.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>