### PR TITLE
RES-1539: lock_priority — borrow callee name through walk_priorities

### DIFF
--- a/resilient/src/lock_priority.rs
+++ b/resilient/src/lock_priority.rs
@@ -61,11 +61,18 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn walk_priorities(
-    node: &Node,
+// RES-1539: borrow the callee name through to the diagnostic site
+// rather than cloning. The walker's only consumer (the priority-
+// inversion `format!` in `check`) just `Display`s the returned name
+// — `&str` works the same as `String`, and the borrow chain is
+// sound: `name` lives in `Node::Identifier` inside the program AST,
+// which outlives the walk + format call. Same pattern as RES-1500 /
+// RES-1525 etc.
+fn walk_priorities<'a>(
+    node: &'a Node,
     holding: u32,
     table: &HashMap<String, PrioritySpec>,
-) -> Option<(String, u32)> {
+) -> Option<(&'a str, u32)> {
     match node {
         Node::CallExpression {
             function,
@@ -75,7 +82,7 @@ fn walk_priorities(
             if let Node::Identifier { name, .. } = function.as_ref() {
                 if let Some(p) = table.get(name) {
                     if p.priority < holding {
-                        return Some((name.clone(), p.priority));
+                        return Some((name.as_str(), p.priority));
                     }
                 }
             }


### PR DESCRIPTION
## Summary

`walk_priorities` returned `Option<(String, u32)>` by cloning the
inversion-target's name out of the AST. The single caller in
`check` only `Display`s the name in a `format!` error message —
`&str` works identically and the borrow chain is sound: the
returned reference lives in `Node::Identifier { name }` inside the
program AST, which outlives both the walk and the format call.

Switch the return type to `Option<(&'a str, u32)>` borrowing from
the `node: &'a Node` parameter. Drops one `String` clone per
detected priority inversion.

Same pattern as RES-1500 / RES-1525 etc. Gated behind the
priority-spec fast-reject (RES-1232) so this only fires on
programs with priority-annotated functions.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib lock_priority` — 1 test passes
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)