### PR TITLE
RES-1593: pass_gate AST visitor — gate 6 deep-scan Ralph-Loop passes

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,12 +265,12 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/pass_gate.rs": {
-      "branch": "res-1590-extended-pass-gate",
-      "claimed_at": "2026-05-13T04:59:16Z"
+      "branch": "res-1593-deep-ast-gate",
+      "claimed_at": "2026-05-13T05:06:52Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1590-extended-pass-gate",
-      "claimed_at": "2026-05-13T04:59:16Z"
+      "branch": "res-1593-deep-ast-gate",
+      "claimed_at": "2026-05-13T05:06:52Z"
     }
   }
 }

--- a/resilient/src/pass_gate.rs
+++ b/resilient/src/pass_gate.rs
@@ -19,45 +19,88 @@
 //! that don't go through `Markers`, e.g. the LSP server's
 //! per-document re-check path).
 //!
-//! Scope: only top-level `Node::Function` statements, matching the
-//! existing per-pass fast-rejects (which all destructure
-//! `Node::Program(stmts)` and look at `stmt.node`). Functions nested
-//! inside `ImplBlock` / `ModuleDecl` are deliberately not part of the
-//! pre-scan — adding them would change behaviour vs the existing
-//! passes' fast-reject, which the gate must match exactly to avoid
-//! suppressing diagnostics.
+//! Scope: walks the program AST via `uniqueness_walk::visit`, the
+//! same recursion the per-pass `any_node` calls use. That descends
+//! into `Function` bodies, `Block` statements, `LetStatement`
+//! values, `IfStatement` arms, `CallExpression` arguments,
+//! `FieldAccess` / `FieldAssignment` targets, etc. — but stops at
+//! `ImplBlock` / `ModuleDecl` (the same boundary as the existing
+//! `walk_children` impl). Functions nested in those constructs are
+//! not visible to the existing per-pass fast-rejects either, so the
+//! gate-vs-pass equivalence holds.
 
 use crate::Node;
 use std::collections::HashSet;
 
-/// Aggregated markers from a single top-level walk of the program.
+/// Aggregated markers from a single whole-AST walk of the program.
+///
+/// Top-level fields (`fn_names`, `param_types`) back the RES-1585 /
+/// RES-1590 gates on attribute-driven Ralph-Loop passes. Whole-AST
+/// fields (`param_names`, `let_names`, `field_names_*`,
+/// `call_idents`) back the RES-1593 gates on deep-scan passes that
+/// previously each ran their own early-terminating `any_node` walk.
 #[derive(Debug, Default)]
 pub(crate) struct Markers {
-    /// Names of every top-level `Node::Function` in the program.
+    /// Names of every `Node::Function` in the program (top-level and
+    /// nested via the standard `uniqueness_walk::visit` descent).
     pub fn_names: HashSet<String>,
-    /// Distinct parameter types across every top-level
-    /// `Node::Function`'s parameter list.
+    /// Distinct parameter types across every `Node::Function`'s
+    /// parameter list.
     pub param_types: HashSet<String>,
+    /// Distinct parameter *names* across every `Node::Function`'s
+    /// parameter list. Used by the `numeric_units` gate, which seeds
+    /// its units map from both let bindings and fn parameters.
+    pub param_names: HashSet<String>,
+    /// Names of every `Node::LetStatement` binding anywhere in the
+    /// program. Used by the `saturation_required` and `numeric_units`
+    /// gates.
+    pub let_names: HashSet<String>,
+    /// Field names appearing on the left of `Node::FieldAssignment`
+    /// (`x.f = …`). Used by the `audit_log_required` gate.
+    pub field_names_assigned: HashSet<String>,
+    /// Field names appearing on `Node::FieldAccess` (`x.f`). Used by
+    /// the `age_bounded_data` gate.
+    pub field_names_accessed: HashSet<String>,
+    /// Identifier names that appear as the *function* of a
+    /// `Node::CallExpression`. Used by the `epoch_ordering` and
+    /// `toctou_guard` gates.
+    pub call_idents: HashSet<String>,
 }
 
 impl Markers {
-    /// One top-level walk; collects every top-level fn name and the
-    /// distinct set of parameter types its parameters reference.
+    /// One whole-AST walk via `uniqueness_walk::visit`. Collects
+    /// every marker source the gates below consult. Cost: O(N) for
+    /// an N-node AST, paid once per type-check; saves up to six
+    /// early-terminating `any_node` walks in the deep-scan passes
+    /// below (RES-1593) plus the top-level walks (RES-1585 / 1590).
     pub(crate) fn scan(program: &Node) -> Self {
         let mut m = Markers::default();
-        if let Node::Program(stmts) = program {
-            for stmt in stmts {
-                if let Node::Function {
-                    name, parameters, ..
-                } = &stmt.node
-                {
-                    m.fn_names.insert(name.clone());
-                    for (ty, _) in parameters {
-                        m.param_types.insert(ty.clone());
-                    }
+        crate::uniqueness_walk::visit(program, &mut |n| match n {
+            Node::Function {
+                name, parameters, ..
+            } => {
+                m.fn_names.insert(name.clone());
+                for (ty, pname) in parameters {
+                    m.param_types.insert(ty.clone());
+                    m.param_names.insert(pname.clone());
                 }
             }
-        }
+            Node::LetStatement { name, .. } => {
+                m.let_names.insert(name.clone());
+            }
+            Node::FieldAssignment { field, .. } => {
+                m.field_names_assigned.insert(field.clone());
+            }
+            Node::FieldAccess { field, .. } => {
+                m.field_names_accessed.insert(field.clone());
+            }
+            Node::CallExpression { function, .. } => {
+                if let Node::Identifier { name, .. } = function.as_ref() {
+                    m.call_idents.insert(name.clone());
+                }
+            }
+            _ => {}
+        });
         m
     }
 
@@ -96,6 +139,66 @@ impl Markers {
         self.param_types
             .iter()
             .any(|t| prefixes.iter().any(|p| t.starts_with(p)))
+    }
+
+    /// True if any `Node::LetStatement` binding name ends with one
+    /// of `suffixes`. Backs the `saturation_required` and
+    /// `numeric_units` gates.
+    pub(crate) fn any_let_name_with_suffix(&self, suffixes: &[&str]) -> bool {
+        self.let_names
+            .iter()
+            .any(|n| suffixes.iter().any(|s| n.ends_with(s)))
+    }
+
+    /// True if any fn parameter name ends with one of `suffixes`.
+    /// Used together with `any_let_name_with_suffix` by the
+    /// `numeric_units` gate, which seeds units from both sources.
+    pub(crate) fn any_param_name_with_suffix(&self, suffixes: &[&str]) -> bool {
+        self.param_names
+            .iter()
+            .any(|n| suffixes.iter().any(|s| n.ends_with(s)))
+    }
+
+    /// True if any field name appearing on the left of a
+    /// `Node::FieldAssignment` starts with one of `prefixes` or ends
+    /// with one of `suffixes`. The `audit_log_required` gate fires
+    /// on `audited_*` field prefix OR `*_audited` field suffix.
+    pub(crate) fn any_field_assigned_with_prefix_or_suffix(
+        &self,
+        prefixes: &[&str],
+        suffixes: &[&str],
+    ) -> bool {
+        self.field_names_assigned.iter().any(|f| {
+            prefixes.iter().any(|p| f.starts_with(p)) || suffixes.iter().any(|s| f.ends_with(s))
+        })
+    }
+
+    /// True if any field name appearing on `Node::FieldAccess` ends
+    /// with one of `suffixes`. Backs the `age_bounded_data` gate
+    /// (looks for `*_at` fields).
+    pub(crate) fn any_field_accessed_with_suffix(&self, suffixes: &[&str]) -> bool {
+        self.field_names_accessed
+            .iter()
+            .any(|f| suffixes.iter().any(|s| f.ends_with(s)))
+    }
+
+    /// True if any `Node::CallExpression` whose function is an
+    /// `Identifier` has a name ending with one of `suffixes`. Backs
+    /// the `toctou_guard` gate (`*_exists` / `*_is_valid` / …).
+    pub(crate) fn any_call_ident_with_suffix(&self, suffixes: &[&str]) -> bool {
+        self.call_idents
+            .iter()
+            .any(|n| suffixes.iter().any(|s| n.ends_with(s)))
+    }
+
+    /// True if any `Node::CallExpression` whose function is an
+    /// `Identifier` has a name containing one of `substrs`. Backs
+    /// the `epoch_ordering` gate, which matches names of shape
+    /// `*_epoch<N>` via `rfind("_epoch")` rather than a fixed suffix.
+    pub(crate) fn any_call_ident_containing(&self, substrs: &[&str]) -> bool {
+        self.call_idents
+            .iter()
+            .any(|n| substrs.iter().any(|s| n.contains(s)))
     }
 }
 
@@ -217,5 +320,227 @@ mod tests {
         let m = Markers::scan(&Node::Program(Vec::new()));
         assert!(m.fn_names.is_empty());
         assert!(m.param_types.is_empty());
+    }
+
+    // RES-1593: helpers for deep-scan markers. The constructed AST
+    // fragments below intentionally use only the fields each gate
+    // exercises (the rest stay default) — building a fully-populated
+    // `Node::Function` for every test would be noise.
+
+    fn id(name: &str) -> Box<Node> {
+        Box::new(Node::Identifier {
+            name: name.to_string(),
+            span: span::Span::default(),
+        })
+    }
+
+    fn let_stmt(name: &str) -> Node {
+        Node::LetStatement {
+            name: name.to_string(),
+            value: Box::new(Node::IntegerLiteral {
+                value: 0,
+                span: span::Span::default(),
+            }),
+            type_annot: None,
+            span: span::Span::default(),
+        }
+    }
+
+    fn field_access(target: &str, field: &str) -> Node {
+        Node::FieldAccess {
+            target: id(target),
+            field: field.to_string(),
+            span: span::Span::default(),
+        }
+    }
+
+    fn field_assign(target: &str, field: &str) -> Node {
+        Node::FieldAssignment {
+            target: id(target),
+            field: field.to_string(),
+            value: Box::new(Node::IntegerLiteral {
+                value: 1,
+                span: span::Span::default(),
+            }),
+            span: span::Span::default(),
+        }
+    }
+
+    fn call(fn_name: &str) -> Node {
+        Node::CallExpression {
+            function: id(fn_name),
+            arguments: Vec::new(),
+            span: span::Span::default(),
+        }
+    }
+
+    fn fn_with_body(name: &str, params: Vec<(&str, &str)>, body: Vec<Node>) -> span::Spanned<Node> {
+        span::Spanned {
+            node: Node::Function {
+                name: name.to_string(),
+                parameters: params
+                    .into_iter()
+                    .map(|(t, n)| (t.to_string(), n.to_string()))
+                    .collect(),
+                defaults: Vec::new(),
+                body: Box::new(Node::Block {
+                    stmts: body,
+                    span: span::Span::default(),
+                }),
+                requires: Vec::new(),
+                ensures: Vec::new(),
+                recovers_to: None,
+                return_type: None,
+                span: span::Span::default(),
+                pure: false,
+                effects: crate::EffectSet::io(),
+                type_params: Vec::new(),
+                type_param_bounds: Vec::new(),
+                fails: Vec::new(),
+            },
+            span: span::Span::default(),
+        }
+    }
+
+    #[test]
+    fn scan_collects_let_names_and_param_names() {
+        let program = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![("int", "duration_ms"), ("int", "n")],
+            vec![let_stmt("brightness_pwm"), let_stmt("plain")],
+        )]);
+        let m = Markers::scan(&program);
+        assert!(m.let_names.contains("brightness_pwm"));
+        assert!(m.let_names.contains("plain"));
+        assert!(m.param_names.contains("duration_ms"));
+        assert!(m.param_names.contains("n"));
+    }
+
+    #[test]
+    fn scan_collects_field_assignments_and_accesses() {
+        let program = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![],
+            vec![
+                field_assign("self", "audited_balance"),
+                Node::ExpressionStatement {
+                    expr: Box::new(field_access("self", "updated_at")),
+                    span: span::Span::default(),
+                },
+            ],
+        )]);
+        let m = Markers::scan(&program);
+        assert!(m.field_names_assigned.contains("audited_balance"));
+        assert!(m.field_names_accessed.contains("updated_at"));
+    }
+
+    #[test]
+    fn scan_collects_call_idents() {
+        let program = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![],
+            vec![
+                Node::ExpressionStatement {
+                    expr: Box::new(call("file_exists")),
+                    span: span::Span::default(),
+                },
+                Node::ExpressionStatement {
+                    expr: Box::new(call("read_epoch3")),
+                    span: span::Span::default(),
+                },
+            ],
+        )]);
+        let m = Markers::scan(&program);
+        assert!(m.call_idents.contains("file_exists"));
+        assert!(m.call_idents.contains("read_epoch3"));
+    }
+
+    #[test]
+    fn any_let_name_with_suffix_matches() {
+        let program = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![],
+            vec![let_stmt("led_pwm"), let_stmt("plain")],
+        )]);
+        let m = Markers::scan(&program);
+        assert!(m.any_let_name_with_suffix(&["_pwm", "_duty"]));
+        assert!(!m.any_let_name_with_suffix(&["_zzz"]));
+    }
+
+    #[test]
+    fn any_param_name_with_suffix_matches() {
+        let program = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![("int", "delay_ms"), ("int", "n")],
+            vec![],
+        )]);
+        let m = Markers::scan(&program);
+        assert!(m.any_param_name_with_suffix(&["_ms"]));
+        assert!(!m.any_param_name_with_suffix(&["_kg"]));
+    }
+
+    #[test]
+    fn any_field_assigned_with_prefix_or_suffix_matches() {
+        let program = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![],
+            vec![field_assign("self", "audited_balance")],
+        )]);
+        let m = Markers::scan(&program);
+        assert!(m.any_field_assigned_with_prefix_or_suffix(&["audited_"], &[]));
+        assert!(!m.any_field_assigned_with_prefix_or_suffix(&[], &["_zzz"]));
+
+        let program2 = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![],
+            vec![field_assign("self", "balance_audited")],
+        )]);
+        let m2 = Markers::scan(&program2);
+        assert!(m2.any_field_assigned_with_prefix_or_suffix(&[], &["_audited"]));
+    }
+
+    #[test]
+    fn any_field_accessed_with_suffix_matches() {
+        let program = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![],
+            vec![Node::ExpressionStatement {
+                expr: Box::new(field_access("sensor", "read_at")),
+                span: span::Span::default(),
+            }],
+        )]);
+        let m = Markers::scan(&program);
+        assert!(m.any_field_accessed_with_suffix(&["_at"]));
+        assert!(!m.any_field_accessed_with_suffix(&["_zzz"]));
+    }
+
+    #[test]
+    fn any_call_ident_with_suffix_matches() {
+        let program = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![],
+            vec![Node::ExpressionStatement {
+                expr: Box::new(call("file_exists")),
+                span: span::Span::default(),
+            }],
+        )]);
+        let m = Markers::scan(&program);
+        assert!(m.any_call_ident_with_suffix(&["_exists", "_is_valid"]));
+        assert!(!m.any_call_ident_with_suffix(&["_zzz"]));
+    }
+
+    #[test]
+    fn any_call_ident_containing_matches() {
+        let program = Node::Program(vec![fn_with_body(
+            "fixture",
+            vec![],
+            vec![Node::ExpressionStatement {
+                expr: Box::new(call("read_epoch3")),
+                span: span::Span::default(),
+            }],
+        )]);
+        let m = Markers::scan(&program);
+        assert!(m.any_call_ident_containing(&["_epoch"]));
+        assert!(!m.any_call_ident_containing(&["_zzz"]));
     }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4019,11 +4019,36 @@ impl TypeChecker {
                     crate::monotonic_field::check(program, source_path)?;
                 }
                 // Ralph-Loop-Uniqueness #11: saturation-required arithmetic.
-                crate::saturation_required::check(program, source_path)?;
+                // RES-1593 gate: pass scans `LetStatement` names with
+                // SAT_NAME_SUFFIXES.
+                if markers.any_let_name_with_suffix(&[
+                    "_pwm",
+                    "_duty",
+                    "_brightness",
+                    "_pct",
+                    "_throttle",
+                ]) {
+                    crate::saturation_required::check(program, source_path)?;
+                }
                 // Ralph-Loop-Uniqueness #12: numeric units mixing.
-                crate::numeric_units::check(program, source_path)?;
+                // RES-1593 gate: pass seeds its units map from both
+                // let bindings AND fn parameter names whose name ends
+                // with a unit suffix.
+                if markers.any_let_name_with_suffix(&[
+                    "_ms", "_s", "_us", "_ns", "_m", "_cm", "_mm", "_km", "_kg", "_g", "_n", "_v",
+                    "_mv", "_a", "_ma", "_hz", "_khz", "_mhz",
+                ]) || markers.any_param_name_with_suffix(&[
+                    "_ms", "_s", "_us", "_ns", "_m", "_cm", "_mm", "_km", "_kg", "_g", "_n", "_v",
+                    "_mv", "_a", "_ma", "_hz", "_khz", "_mhz",
+                ]) {
+                    crate::numeric_units::check(program, source_path)?;
+                }
                 // Ralph-Loop-Uniqueness #13: age-bounded data freshness.
-                crate::age_bounded_data::check(program, source_path)?;
+                // RES-1593 gate: pass scans `FieldAccess` field names
+                // ending in `_at` to detect age-comparison gates.
+                if markers.any_field_accessed_with_suffix(&["_at"]) {
+                    crate::age_bounded_data::check(program, source_path)?;
+                }
                 // Ralph-Loop-Uniqueness #14: rate-limit static.
                 // RES-1590 gate: pass scans fn names with ONCE_SUFFIXES
                 // (`_oncepertick`, `_singleshot`) or FEW_SUFFIX (`_few`).
@@ -4061,7 +4086,11 @@ impl TypeChecker {
                     crate::bounded_blocking::check(program, source_path)?;
                 }
                 // Ralph-Loop-Uniqueness #19: audit-log-required mutations.
-                crate::audit_log_required::check(program, source_path)?;
+                // RES-1593 gate: pass scans `FieldAssignment` field
+                // names with `audited_` prefix or `_audited` suffix.
+                if markers.any_field_assigned_with_prefix_or_suffix(&["audited_"], &["_audited"]) {
+                    crate::audit_log_required::check(program, source_path)?;
+                }
                 // Ralph-Loop-Uniqueness #20: degraded mode after critical assert.
                 // RES-1585 gate: pass scans fn names with CRITICAL_PREFIXES
                 // (and RECOVERY_PREFIXES are looked up only when CRITICAL
@@ -4080,14 +4109,27 @@ impl TypeChecker {
                     crate::idempotent_handler::check(program, source_path)?;
                 }
                 // Ralph-Loop-Uniqueness #23: epoch ordering.
-                crate::epoch_ordering::check(program, source_path)?;
+                // RES-1593 gate: pass matches call identifiers
+                // containing `_epoch` (then parses the numeric tail).
+                if markers.any_call_ident_containing(&["_epoch"]) {
+                    crate::epoch_ordering::check(program, source_path)?;
+                }
                 // Ralph-Loop-Uniqueness #24: priority-inheritance discipline.
                 // RES-1585 gate: pass scans fn names with LOW_PRI_PREFIXES.
                 if markers.any_fn_name_with_prefix(&["low_pri_", "bg_", "idle_"]) {
                     crate::priority_inheritance::check(program, source_path)?;
                 }
                 // Ralph-Loop-Uniqueness #25: TOCTOU guard.
-                crate::toctou_guard::check(program, source_path)?;
+                // RES-1593 gate: pass scans call identifiers with
+                // CHECK_SUFFIXES (`_exists`/`_is_valid`/`_status`/`_check`).
+                if markers.any_call_ident_with_suffix(&[
+                    "_exists",
+                    "_is_valid",
+                    "_status",
+                    "_check",
+                ]) {
+                    crate::toctou_guard::check(program, source_path)?;
+                }
                 // 50-feature missing-language-features pass.
                 // Each module owns one or more of the 50+1 features in
                 // the design doc; see per-module docs for what each


### PR DESCRIPTION
## Summary

RES-1585 / RES-1590 gated 17 attribute-driven typechecker passes on a single top-level marker pre-scan. Six more Ralph-Loop passes use *whole-AST* fast-rejects (`any_node` from RES-1238) that scan field names, let-binding names, or call identifiers — they were left unconditional because the original `Markers` only saw top-level fn signatures.

Extend `Markers::scan` to do **one** shared whole-AST walk via `uniqueness_walk::visit` (the same recursion the per-pass `any_node` calls use). Collect five new marker sources and gate the 6 deep-scan passes:

| Pass                   | Gate                                                                   |
|------------------------|------------------------------------------------------------------------|
| `saturation_required`  | `any_let_name_with_suffix(SAT_NAME_SUFFIXES)`                          |
| `numeric_units`        | `any_let_name_with_suffix(UNIT_SUFFIXES)` OR `any_param_name_with_suffix(UNIT_SUFFIXES)` |
| `age_bounded_data`     | `any_field_accessed_with_suffix(&["_at"])`                             |
| `audit_log_required`   | `any_field_assigned_with_prefix_or_suffix(&["audited_"], &["_audited"])` |
| `epoch_ordering`       | `any_call_ident_containing(&["_epoch"])`                                |
| `toctou_guard`         | `any_call_ident_with_suffix(CHECK_SUFFIXES)`                            |

## Trade-off

One full AST walk replaces up to six early-terminating `any_node` walks. On the typical "no markers present" case (most `examples/` and test inputs), the shared walk wins by ~6×. On the rare "all markers present" case the per-pass early termination is theoretically faster, but a program that hits all six markers has so much real work to do that the extra walk is negligible. Each pass keeps its own fast-reject as defense in depth.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3223 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

9 new unit tests cover the new scan fields + helpers (17 `pass_gate` tests total). End-to-end smoke-tested with each of the 6 examples (`audit_log_required.rz`, `age_bounded_data.rz`, `saturation_required.rz`, `numeric_units.rz`, `epoch_ordering.rz`, `toctou_guard.rz`) — all execute correctly with the gates in place.

## Test changes

None. Existing tests untouched.

## Risk

Low. `Markers::scan` now does one whole-AST walk instead of a top-level walk, so the cost grows from O(N-statements) to O(N-nodes). Mitigation: the walk replaces up to six per-pass `any_node` walks, so the net effect is a reduction in the common no-marker case. Each pass's own fast-reject stays in place; an over-restrictive gate would still let the pass's fast-reject run and harmlessly skip.

Closes #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)