### PR TITLE
RES-1598: gate coverage_warnings on Err-call presence

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,13 +264,9 @@
       "branch": "res-1539-lock-priority-borrow",
       "claimed_at": "2026-05-12T15:25:00Z"
     },
-    "resilient/src/pass_gate.rs": {
-      "branch": "res-1593-deep-ast-gate",
-      "claimed_at": "2026-05-13T05:06:52Z"
-    },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1593-deep-ast-gate",
-      "claimed_at": "2026-05-13T05:06:52Z"
+      "branch": "res-1598-gate-coverage-warnings",
+      "claimed_at": "2026-05-13T05:16:06Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4185,7 +4185,14 @@ impl TypeChecker {
                 crate::mutation_testing::check(program, source_path)?;
                 crate::causal_trace::check(program, source_path)?;
                 crate::snapshot_regression::check(program, source_path)?;
-                crate::coverage_warnings::check(program, source_path)?;
+                // RES-1598 gate: pass scans for `CallExpression` whose
+                // function is the `Err` identifier (the `Result` failure
+                // constructor). `markers.call_idents` already records
+                // every such ident from the RES-1593 shared AST walk,
+                // so the gate is an O(1) HashSet lookup.
+                if markers.call_idents.contains("Err") {
+                    crate::coverage_warnings::check(program, source_path)?;
+                }
                 crate::param_destructuring::check(program, source_path)?;
                 crate::format_builtin::check(program, source_path)?;
                 crate::struct_exhaustiveness::check(program, source_path)?;


### PR DESCRIPTION
## Summary

`coverage_warnings::check` has its own `any_node` fast-reject that walks the AST looking for any `CallExpression` whose function is the `Err` identifier (the `Result` failure constructor). For programs that don't use the `Result` error path — most fixtures in `examples/` and the test suite — that's another full AST walk per type-check.

[RES-1593](https://github.com/EricSpencer00/Resilient/pull/1596) added `Markers.call_idents` (a `HashSet<String>` of every call-target identifier in the program) populated during the shared whole-AST scan. The gate is an O(1) `markers.call_idents.contains("Err")` check.

The pass's own fast-reject stays as defense in depth and for callers that bypass the typechecker entry point (LSP per-doc re-check).

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3223 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Test changes

None.

## Risk

Trivial. Gate condition matches the pass's existing fast-reject exactly. Defense in depth keeps the pass's own check in place.

Closes #1598

🤖 Generated with [Claude Code](https://claude.com/claude-code)