### PR TITLE
RES-1599: gate iterator_protocol on Iterator-trait ImplBlock presence

### DIFF
--- a/resilient/src/pass_gate.rs
+++ b/resilient/src/pass_gate.rs
@@ -65,6 +65,9 @@ pub(crate) struct Markers {
     /// `Node::CallExpression`. Used by the `epoch_ordering` and
     /// `toctou_guard` gates.
     pub call_idents: HashSet<String>,
+    /// Trait names from `Node::ImplBlock { trait_name: Some(...), .. }`.
+    /// Used by the `iterator_protocol` gate (matches `"Iterator"`).
+    pub impl_trait_names: HashSet<String>,
 }
 
 impl Markers {
@@ -98,6 +101,12 @@ impl Markers {
                 if let Node::Identifier { name, .. } = function.as_ref() {
                     m.call_idents.insert(name.clone());
                 }
+            }
+            Node::ImplBlock {
+                trait_name: Some(t),
+                ..
+            } => {
+                m.impl_trait_names.insert(t.clone());
             }
             _ => {}
         });
@@ -199,6 +208,13 @@ impl Markers {
         self.call_idents
             .iter()
             .any(|n| substrs.iter().any(|s| n.contains(s)))
+    }
+
+    /// True if the program has at least one `Node::ImplBlock` with
+    /// `trait_name == Some(trait_name)`. Backs the `iterator_protocol`
+    /// gate (matches `"Iterator"`).
+    pub(crate) fn has_impl_for_trait(&self, trait_name: &str) -> bool {
+        self.impl_trait_names.contains(trait_name)
     }
 }
 
@@ -542,5 +558,40 @@ mod tests {
         let m = Markers::scan(&program);
         assert!(m.any_call_ident_containing(&["_epoch"]));
         assert!(!m.any_call_ident_containing(&["_zzz"]));
+    }
+
+    fn impl_block(trait_name: Option<&str>, struct_name: &str) -> span::Spanned<Node> {
+        span::Spanned {
+            node: Node::ImplBlock {
+                trait_name: trait_name.map(String::from),
+                struct_name: struct_name.to_string(),
+                methods: Vec::new(),
+                associated_type_impls: Vec::new(),
+                span: span::Span::default(),
+            },
+            span: span::Span::default(),
+        }
+    }
+
+    #[test]
+    fn scan_collects_impl_trait_names() {
+        let program = Node::Program(vec![
+            impl_block(Some("Iterator"), "MyVec"),
+            impl_block(Some("Drawable"), "Circle"),
+            impl_block(None, "Plain"),
+        ]);
+        let m = Markers::scan(&program);
+        assert!(m.impl_trait_names.contains("Iterator"));
+        assert!(m.impl_trait_names.contains("Drawable"));
+        // Inherent impls (no trait) aren't included.
+        assert_eq!(m.impl_trait_names.len(), 2);
+    }
+
+    #[test]
+    fn has_impl_for_trait_matches() {
+        let program = Node::Program(vec![impl_block(Some("Iterator"), "Buf")]);
+        let m = Markers::scan(&program);
+        assert!(m.has_impl_for_trait("Iterator"));
+        assert!(!m.has_impl_for_trait("Drawable"));
     }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4214,7 +4214,6 @@ impl TypeChecker {
                 if markers.call_idents.contains("Err") {
                     crate::coverage_warnings::check(program, source_path)?;
                 }
->>>>>>> origin/main
                 crate::param_destructuring::check(program, source_path)?;
                 crate::format_builtin::check(program, source_path)?;
                 // RES-1597: `struct_exhaustiveness::check` is a no-op

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4181,7 +4181,21 @@ impl TypeChecker {
                 crate::macros::check(program, source_path)?;
                 crate::full_modules::check(program, source_path)?;
                 crate::package_manager::check(program, source_path)?;
-                crate::iterator_protocol::check(program, source_path)?;
+                // RES-1599 gate: pass scans for `Node::ImplBlock` with
+                // `trait_name == Some("Iterator")`. Markers already
+                // collects every `impl_trait_names` from the RES-1593
+                // whole-AST walk, so the gate is an O(1) HashSet
+                // lookup. The pass unconditionally calls
+                // `install_iterator_impls(...)` so a prior program's
+                // registration doesn't leak; preserve that semantics
+                // by calling the wipe directly in the else branch.
+                if markers.has_impl_for_trait("Iterator") {
+                    crate::iterator_protocol::check(program, source_path)?;
+                } else {
+                    crate::iterator_protocol::install_iterator_impls(
+                        std::collections::HashSet::new(),
+                    );
+                }
                 crate::mutation_testing::check(program, source_path)?;
                 crate::causal_trace::check(program, source_path)?;
                 crate::snapshot_regression::check(program, source_path)?;


### PR DESCRIPTION
## Summary

`iterator_protocol::check` has its own `any_node` fast-reject that walks the AST looking for a top-level `ImplBlock` whose `trait_name` is `"Iterator"`. [RES-1593](https://github.com/EricSpencer00/Resilient/pull/1596) added the shared whole-AST `Markers` scan but didn't collect `ImplBlock.trait_name`.

Extend `Markers` with:

- `impl_trait_names: HashSet<String>` — collected during the existing whole-AST visitor. Only `ImplBlock { trait_name: Some(t), .. }` insertions, so inherent impls (`impl Foo { ... }`) aren't included.
- `has_impl_for_trait(name) -> bool` — O(1) helper.

Gate `iterator_protocol::check` at the typechecker call site. The pass unconditionally calls `install_iterator_impls(...)` to clear stale registrations from the process-global `ITERATORS` map, so preserving those semantics requires calling the wipe directly in the else branch:

```rust
if markers.has_impl_for_trait("Iterator") {
    crate::iterator_protocol::check(program, source_path)?;
} else {
    crate::iterator_protocol::install_iterator_impls(HashSet::new());
}
```

`install_iterator_impls` is already `pub` and used by the pass itself for the same purpose, so this isn't new public API.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed (2 new pass_gate tests)
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Test changes

None. New tests in `pass_gate::tests` cover the new field and helper.

## Risk

Low. Gate condition is structurally equivalent to the pass's own fast-reject. The wipe semantics are preserved by calling `install_iterator_impls(HashSet::new())` directly in the else branch — same call the pass would have made.

Closes #1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)