### PR TITLE
RES-1603: pass_gate Markers borrow &str from AST, drop ~500 String clones

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -267,6 +267,10 @@
     "resilient/src/typechecker.rs": {
       "branch": "res-1598-gate-coverage-warnings",
       "claimed_at": "2026-05-13T05:16:06Z"
+    },
+    "resilient/src/pass_gate.rs": {
+      "branch": "res-1603-markers-borrow",
+      "claimed_at": "2026-05-13T05:25:11Z"
     }
   }
 }

--- a/resilient/src/pass_gate.rs
+++ b/resilient/src/pass_gate.rs
@@ -40,73 +40,80 @@ use std::collections::HashSet;
 /// `call_idents`) back the RES-1593 gates on deep-scan passes that
 /// previously each ran their own early-terminating `any_node` walk.
 #[derive(Debug, Default)]
-pub(crate) struct Markers {
+pub(crate) struct Markers<'a> {
     /// Names of every `Node::Function` in the program (top-level and
     /// nested via the standard `uniqueness_walk::visit` descent).
-    pub fn_names: HashSet<String>,
+    pub fn_names: HashSet<&'a str>,
     /// Distinct parameter types across every `Node::Function`'s
     /// parameter list.
-    pub param_types: HashSet<String>,
+    pub param_types: HashSet<&'a str>,
     /// Distinct parameter *names* across every `Node::Function`'s
     /// parameter list. Used by the `numeric_units` gate, which seeds
     /// its units map from both let bindings and fn parameters.
-    pub param_names: HashSet<String>,
+    pub param_names: HashSet<&'a str>,
     /// Names of every `Node::LetStatement` binding anywhere in the
     /// program. Used by the `saturation_required` and `numeric_units`
     /// gates.
-    pub let_names: HashSet<String>,
+    pub let_names: HashSet<&'a str>,
     /// Field names appearing on the left of `Node::FieldAssignment`
     /// (`x.f = …`). Used by the `audit_log_required` gate.
-    pub field_names_assigned: HashSet<String>,
+    pub field_names_assigned: HashSet<&'a str>,
     /// Field names appearing on `Node::FieldAccess` (`x.f`). Used by
     /// the `age_bounded_data` gate.
-    pub field_names_accessed: HashSet<String>,
+    pub field_names_accessed: HashSet<&'a str>,
     /// Identifier names that appear as the *function* of a
     /// `Node::CallExpression`. Used by the `epoch_ordering` and
     /// `toctou_guard` gates.
-    pub call_idents: HashSet<String>,
+    pub call_idents: HashSet<&'a str>,
     /// Trait names from `Node::ImplBlock { trait_name: Some(...), .. }`.
     /// Used by the `iterator_protocol` gate (matches `"Iterator"`).
-    pub impl_trait_names: HashSet<String>,
+    pub impl_trait_names: HashSet<&'a str>,
 }
 
-impl Markers {
+impl<'a> Markers<'a> {
     /// One whole-AST walk via `uniqueness_walk::visit`. Collects
     /// every marker source the gates below consult. Cost: O(N) for
     /// an N-node AST, paid once per type-check; saves up to six
     /// early-terminating `any_node` walks in the deep-scan passes
     /// below (RES-1593) plus the top-level walks (RES-1585 / 1590).
-    pub(crate) fn scan(program: &Node) -> Self {
+    ///
+    /// RES-1603: the `HashSet<&'a str>` shape borrows directly from
+    /// the AST, so the per-marker insertions are pointer-and-length
+    /// pairs instead of `String` allocations. For a typical program
+    /// with ~500 markers across the seven sets, that's ~500
+    /// `String::clone()` + matching free operations saved per
+    /// type-check.
+    pub(crate) fn scan(program: &'a Node) -> Self {
         let mut m = Markers::default();
         crate::uniqueness_walk::visit(program, &mut |n| match n {
             Node::Function {
                 name, parameters, ..
             } => {
-                m.fn_names.insert(name.clone());
+                m.fn_names.insert(name.as_str());
                 for (ty, pname) in parameters {
-                    m.param_types.insert(ty.clone());
-                    m.param_names.insert(pname.clone());
+                    m.param_types.insert(ty.as_str());
+                    m.param_names.insert(pname.as_str());
                 }
             }
             Node::LetStatement { name, .. } => {
-                m.let_names.insert(name.clone());
+                m.let_names.insert(name.as_str());
             }
             Node::FieldAssignment { field, .. } => {
-                m.field_names_assigned.insert(field.clone());
+                m.field_names_assigned.insert(field.as_str());
             }
             Node::FieldAccess { field, .. } => {
-                m.field_names_accessed.insert(field.clone());
+                m.field_names_accessed.insert(field.as_str());
             }
             Node::CallExpression { function, .. } => {
                 if let Node::Identifier { name, .. } = function.as_ref() {
-                    m.call_idents.insert(name.clone());
+                    m.call_idents.insert(name.as_str());
                 }
             }
             Node::ImplBlock {
                 trait_name: Some(t),
                 ..
             } => {
-                m.impl_trait_names.insert(t.clone());
+                m.impl_trait_names.insert(t.as_str());
             }
             _ => {}
         });
@@ -323,17 +330,19 @@ mod tests {
 
     #[test]
     fn scan_on_non_program_node_is_empty() {
-        let m = Markers::scan(&Node::Block {
+        let node = Node::Block {
             stmts: Vec::new(),
             span: span::Span::default(),
-        });
+        };
+        let m = Markers::scan(&node);
         assert!(m.fn_names.is_empty());
         assert!(m.param_types.is_empty());
     }
 
     #[test]
     fn scan_on_empty_program_is_empty() {
-        let m = Markers::scan(&Node::Program(Vec::new()));
+        let program = Node::Program(Vec::new());
+        let m = Markers::scan(&program);
         assert!(m.fn_names.is_empty());
         assert!(m.param_types.is_empty());
     }

--- a/resilient/src/uniqueness_walk.rs
+++ b/resilient/src/uniqueness_walk.rs
@@ -22,13 +22,22 @@
 use crate::Node;
 
 /// Pre-order traversal calling `f` on every node in the subtree, root first.
-pub(crate) fn visit(node: &Node, f: &mut impl FnMut(&Node)) {
+///
+/// RES-1603: the `<'a>` lifetime parameter ties the closure's `&Node`
+/// argument to the same lifetime as the input subtree. This lets
+/// callers borrow sub-data (`&String` → `&'a str`, slices, etc.)
+/// directly into structures that outlive the closure body — the
+/// `pass_gate::Markers::scan` shared pre-scan is the first
+/// consumer. Existing callers that pass closures whose body is
+/// lifetime-agnostic (`|n| match n { ... }`) are unaffected because
+/// the closure trait was inferred to accept any lifetime regardless.
+pub(crate) fn visit<'a>(node: &'a Node, f: &mut impl FnMut(&'a Node)) {
     f(node);
     walk_children(node, f);
 }
 
 /// Apply `f` to each direct child of `node`, recursively descending.
-pub(crate) fn walk_children(node: &Node, f: &mut impl FnMut(&Node)) {
+pub(crate) fn walk_children<'a>(node: &'a Node, f: &mut impl FnMut(&'a Node)) {
     match node {
         Node::Program(items) => {
             for s in items {


### PR DESCRIPTION
## Summary

`pass_gate::Markers::scan` does a whole-AST walk and inserts every fn name, param type, param name, let name, field name (access + assign), call ident, and impl-trait name into seven `HashSet<String>`s. Each insert clones the underlying `String` from the AST.

For a typical program — say 20 fns × 5 params + 100 lets + 50 field reads + 30 field writes + 200 call sites + 10 impl blocks — that's ~510 `String` clones per type-check. None are necessary: the AST outlives the `Markers` value, so the HashSets can hold `&str` references.

This PR parameterises `Markers<'a>` over the program reference's lifetime and switches all seven fields to `HashSet<&'a str>`. Insertions become pointer-and-length pairs instead of allocations.

## Blocker

`uniqueness_walk::visit`'s HRTB closure shape was the blocker: the closure body received `&Node` with an anonymous (universal) lifetime, so it couldn't borrow into structures outliving the closure body. Parametrize `visit` and `walk_children` over `'a` to thread the AST lifetime through to the closure argument.

The signature change is backwards-compatible — every existing caller passes a closure whose body doesn't constrain the node's lifetime, so type inference picks `'a` automatically. Full test suite confirms.

## Test changes

Two `Markers::scan(&Node::X { ... })` tests had to bind the temporary to a local first; the AST node must outlive the `Markers` value, which the older `HashSet<String>` shape masked.

```rust
// Before
let m = Markers::scan(&Node::Program(Vec::new()));

// After
let program = Node::Program(Vec::new());
let m = Markers::scan(&program);
```

Same intent, just lifetime-explicit. No semantic change.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Low. The visit signature change is structurally a generalization — anything that worked under the HRTB shape still works under the explicit-lifetime shape (the closure's inferred lifetime quantifier is now `'a` instead of `for<'r>`). All 11 callers of `uniqueness_walk::visit` continue to compile and test without modification.

Closes #1603

🤖 Generated with [Claude Code](https://claude.com/claude-code)