### PR TITLE
RES-1606: gate fmt_validation on format-call presence

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,13 +264,13 @@
       "branch": "res-1539-lock-priority-borrow",
       "claimed_at": "2026-05-12T15:25:00Z"
     },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1598-gate-coverage-warnings",
-      "claimed_at": "2026-05-13T05:16:06Z"
-    },
     "resilient/src/pass_gate.rs": {
       "branch": "res-1603-markers-borrow",
       "claimed_at": "2026-05-13T05:25:11Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1606-gate-fmt-validation",
+      "claimed_at": "2026-05-13T05:32:23Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4220,7 +4220,15 @@ impl TypeChecker {
                 // stub for a future feature.
                 // RES-1597: `labeled_break::check` is a no-op stub; the
                 // parser already enforces label well-formedness.
-                crate::fmt_validation::check(program, source_path)?;
+                // RES-1606 gate: pass scans for `CallExpression` whose
+                // function is the `format` identifier — same shape as
+                // RES-1598's `coverage_warnings` gate on `"Err"`.
+                // `markers.call_idents` already records every such ident
+                // from the shared whole-AST walk (RES-1593), so the gate
+                // is an O(1) HashSet lookup.
+                if markers.call_idents.contains("format") {
+                    crate::fmt_validation::check(program, source_path)?;
+                }
                 crate::no_panic_cert::check(program, source_path)?;
                 crate::ai_threat_model::check(program, source_path)?;
                 // RES-1597: `lean_spec::check` is a no-op stub; Lean


### PR DESCRIPTION
## Summary

`fmt_validation::check` has its own `any_node` fast-reject that walks the AST looking for any `CallExpression` whose function is the `format` identifier. For programs that don't use `format(...)` — most fixtures in `examples/` and the test suite — that's another full AST walk per type-check.

[RES-1593](https://github.com/EricSpencer00/Resilient/pull/1596) added `Markers.call_idents` (a `HashSet<&str>` of every call-target identifier in the program). The gate is an O(1) `markers.call_idents.contains("format")` check — identical shape to [RES-1598](https://github.com/EricSpencer00/Resilient/pull/1601)'s `coverage_warnings` gate on `"Err"`.

The pass's own fast-reject stays as defense in depth.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Trivial. Gate condition matches the pass's existing fast-reject exactly.

Closes #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)