### PR TITLE
RES-1611: drop dead region_inference::infer from EXTENSION_PASSES

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,13 +264,9 @@
       "branch": "res-1539-lock-priority-borrow",
       "claimed_at": "2026-05-12T15:25:00Z"
     },
-    "resilient/src/pass_gate.rs": {
-      "branch": "res-1607-gate-full-modules",
-      "claimed_at": "2026-05-13T05:34:17Z"
-    },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1607-gate-full-modules",
-      "claimed_at": "2026-05-13T05:34:17Z"
+      "branch": "res-1611-drop-region-inference",
+      "claimed_at": "2026-05-13T05:39:21Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -3956,7 +3956,10 @@ impl TypeChecker {
                 crate::generics::check(program, source_path)?;
                 crate::newtypes::check(program, source_path)?;
                 crate::traits::check(program, source_path)?;
-                crate::region_inference::infer(program, source_path)?;
+                // RES-1611: `region_inference::infer` is a no-op stub
+                // (`Ok(())`); the real region-aliasing logic lives in
+                // `check_call_site_region_aliasing` which runs from a
+                // different path. Drop the per-typecheck dispatch.
                 // Ralph-Loop-Uniqueness #1: watchdog-feed enforcement.
                 // RES-1585 gate: pass scans param types ∈ WATCHDOG_TYPES.
                 if markers.any_param_type_in(&["Watchdog", "&Watchdog", "&mut Watchdog"]) {


### PR DESCRIPTION
## Summary

`region_inference::infer` is a no-op stub (`Ok(())`) called once per type-check from `<EXTENSION_PASSES>`. The real region-aliasing logic lives in `check_call_site_region_aliasing` (called from two sites in `lib.rs`) and `build_region_map`, so the module stays alive — only the stub dispatch goes away. Same pattern as RES-1594 / RES-1597 / RES-1605.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Trivial. Removing a call to a fn whose body is `Ok(())` cannot change observable behaviour.

Closes #1611

🤖 Generated with [Claude Code](https://claude.com/claude-code)