### PR TITLE
RES-1612: gate 7 more passes on Node-variant presence

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,12 +265,12 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/pass_gate.rs": {
-      "branch": "res-1607-gate-full-modules",
-      "claimed_at": "2026-05-13T05:34:17Z"
+      "branch": "res-1612-variant-gates",
+      "claimed_at": "2026-05-13T05:40:25Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1607-gate-full-modules",
-      "claimed_at": "2026-05-13T05:34:17Z"
+      "branch": "res-1612-variant-gates",
+      "claimed_at": "2026-05-13T05:40:25Z"
     }
   }
 }

--- a/resilient/src/pass_gate.rs
+++ b/resilient/src/pass_gate.rs
@@ -74,6 +74,27 @@ pub(crate) struct Markers<'a> {
     /// True if any `Node::Use` appears anywhere in the AST. Used
     /// together with `has_module_decl` by the `full_modules` gate.
     pub has_use: bool,
+    /// True if any `Node::Assume` appears anywhere. Used by the
+    /// `assume_false_checker` gate (RES-1612).
+    pub has_assume: bool,
+    /// True if any `Node::InvariantStatement` appears anywhere. Used
+    /// by the `loop_invariants` gate (RES-1612).
+    pub has_invariant_statement: bool,
+    /// True if any `Node::Range` appears anywhere. Used by the
+    /// `ranges` gate (RES-1612).
+    pub has_range: bool,
+    /// True if any `Node::LiveBlock` appears anywhere. Used by the
+    /// `recovery_checker` gate (RES-1612).
+    pub has_live_block: bool,
+    /// True if any `Node::TryCatch` appears anywhere. Used by the
+    /// `try_catch` gate (RES-1612).
+    pub has_try_catch: bool,
+    /// True if any `Node::IndexExpression` appears anywhere. Used
+    /// by the `bounds_check` gate (RES-1612).
+    pub has_index_expression: bool,
+    /// True if any `Node::NewtypeDecl` appears anywhere. Used by
+    /// the `newtypes` gate (RES-1612).
+    pub has_newtype_decl: bool,
 }
 
 impl<'a> Markers<'a> {
@@ -126,6 +147,27 @@ impl<'a> Markers<'a> {
             }
             Node::Use { .. } => {
                 m.has_use = true;
+            }
+            Node::Assume { .. } => {
+                m.has_assume = true;
+            }
+            Node::InvariantStatement { .. } => {
+                m.has_invariant_statement = true;
+            }
+            Node::Range { .. } => {
+                m.has_range = true;
+            }
+            Node::LiveBlock { .. } => {
+                m.has_live_block = true;
+            }
+            Node::TryCatch { .. } => {
+                m.has_try_catch = true;
+            }
+            Node::IndexExpression { .. } => {
+                m.has_index_expression = true;
+            }
+            Node::NewtypeDecl { .. } => {
+                m.has_newtype_decl = true;
             }
             _ => {}
         });

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -3938,15 +3938,39 @@ impl TypeChecker {
                 // Add new compiler pass calls here (append-only).
                 // Pattern: crate::your_feature::check(program, source_path)?;
                 // Merge conflicts: keep ALL calls from both sides.
-                crate::try_catch::check(program, source_path)?;
+                // RES-1612 gate: pass scans for `Node::TryCatch`.
+                if markers.has_try_catch {
+                    crate::try_catch::check(program, source_path)?;
+                }
                 crate::verifier_liveness::check(program, source_path)?;
-                crate::recovery_checker::check(program, source_path)?;
-                crate::assume_false_checker::check(program, source_path)?;
-                crate::bounds_check::check_array_bounds(program, source_path)?;
-                crate::loop_invariants::check(program, source_path)?;
+                // RES-1612 gate: pass scans for `Node::LiveBlock`.
+                if markers.has_live_block {
+                    crate::recovery_checker::check(program, source_path)?;
+                }
+                // RES-1612 gate: pass scans for `Node::Assume`.
+                if markers.has_assume {
+                    crate::assume_false_checker::check(program, source_path)?;
+                }
+                // RES-1612 gate: pass scans for `Node::IndexExpression`.
+                // The pass's first call is `reset_stats()` to clear
+                // stale PROVEN_SITES from a prior compile — that only
+                // matters when this typecheck queries `is_proven_site`,
+                // which only happens when the program has index
+                // expressions. So skipping the call entirely on the
+                // gate-false case leaves stale state unobserved.
+                if markers.has_index_expression {
+                    crate::bounds_check::check_array_bounds(program, source_path)?;
+                }
+                // RES-1612 gate: pass scans for `Node::InvariantStatement`.
+                if markers.has_invariant_statement {
+                    crate::loop_invariants::check(program, source_path)?;
+                }
                 crate::verifier_loop_invariants::verify_and_capture(self, program);
                 crate::type_aliases::check(program, source_path)?;
-                crate::ranges::check(program, source_path)?;
+                // RES-1612 gate: pass scans for `Node::Range`.
+                if markers.has_range {
+                    crate::ranges::check(program, source_path)?;
+                }
                 // RES-1605: `string_interp::check` is a no-op stub; the
                 // parser-side interpolation handling lives in
                 // `string_interp::parse`, not here.
@@ -3954,7 +3978,11 @@ impl TypeChecker {
                 // `full_modules` for the actual module-graph build.
                 crate::default_params::check(program, source_path)?;
                 crate::generics::check(program, source_path)?;
-                crate::newtypes::check(program, source_path)?;
+                // RES-1612 gate: pass loops top-level statements for
+                // `Node::NewtypeDecl`.
+                if markers.has_newtype_decl {
+                    crate::newtypes::check(program, source_path)?;
+                }
                 crate::traits::check(program, source_path)?;
                 crate::region_inference::infer(program, source_path)?;
                 // Ralph-Loop-Uniqueness #1: watchdog-feed enforcement.


### PR DESCRIPTION
## Summary

Seven typechecker passes have whole-AST `any_node` (or top-level loop) fast-rejects that look for a specific `Node` variant. Each runs its own walk per type-check despite the shared `Markers::scan` already visiting every node:

| Pass                    | Variant                  |
|-------------------------|--------------------------|
| `assume_false_checker`  | `Node::Assume`           |
| `loop_invariants`       | `Node::InvariantStatement` |
| `ranges`                | `Node::Range`            |
| `recovery_checker`      | `Node::LiveBlock`        |
| `try_catch`             | `Node::TryCatch`         |
| `bounds_check`          | `Node::IndexExpression`  |
| `newtypes`              | `Node::NewtypeDecl`      |

Extend `Markers` with 7 `has_<variant>: bool` fields populated during the existing whole-AST visitor. Gate each pass on the relevant flag. Each pass keeps its own fast-reject as defense in depth.

## Notes

- `bounds_check`'s `reset_stats()` is intentionally not called in the else branch. The reset only matters when `is_proven_site` is later queried, which itself only happens when the program has index expressions — so leaving stale `PROVEN_SITES` unobserved is sound.
- `Node::Range` (line 2667 of `lib.rs`) is the AST construct; `Pattern::Range` (line 1774) is a different enum variant the match doesn't reach.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Test changes

None.

## Risk

Low. Each gate matches its pass's existing fast-reject scope. Defense-in-depth keeps the pass's own check in place.

Closes #1612

🤖 Generated with [Claude Code](https://claude.com/claude-code)