### PR TITLE
RES-1615: drop dead default_params::check from EXTENSION_PASSES

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,13 +264,9 @@
       "branch": "res-1539-lock-priority-borrow",
       "claimed_at": "2026-05-12T15:25:00Z"
     },
-    "resilient/src/pass_gate.rs": {
-      "branch": "res-1612-variant-gates",
-      "claimed_at": "2026-05-13T05:40:25Z"
-    },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1612-variant-gates",
-      "claimed_at": "2026-05-13T05:40:25Z"
+      "branch": "res-1615-drop-default-params",
+      "claimed_at": "2026-05-13T05:45:59Z"
     }
   }
 }

--- a/resilient/src/default_params.rs
+++ b/resilient/src/default_params.rs
@@ -8,6 +8,16 @@
 //! cloned defaults for any trailing arguments that were omitted.
 //!
 //! This keeps the hot interpreter path completely free of
+
+// RES-1615: `check` is no longer called from `EXTENSION_PASSES`
+// (the body is `Ok(())`; the real default-arg rewrite happens via
+// `collect_defaults` + `rewrite_calls` from a different path).
+// The module-level `dead_code` allow matches the pattern used in
+// `causal_trace.rs`, `package_manager.rs`, `mutation_testing.rs`,
+// etc. when those passes were dropped from the extension-passes
+// fan-out.
+#![allow(dead_code)]
+
 //! default-parameter awareness — the call site, after lowering, looks
 //! identical to a fully-explicit positional call.
 //!

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -3976,7 +3976,10 @@ impl TypeChecker {
                 // `string_interp::parse`, not here.
                 // RES-1605: `modules::check` is a no-op stub; see
                 // `full_modules` for the actual module-graph build.
-                crate::default_params::check(program, source_path)?;
+                // RES-1615: `default_params::check` is a no-op stub
+                // (`Ok(())`); the real default-arg rewrite happens via
+                // `collect_defaults` + `rewrite_calls` from a different
+                // path.
                 crate::generics::check(program, source_path)?;
                 // RES-1612 gate: pass loops top-level statements for
                 // `Node::NewtypeDecl`.


### PR DESCRIPTION
## Summary

`default_params::check` is a no-op stub (body is just `Ok(())`). The real default-arg work happens via `collect_defaults` + `rewrite_calls` from a different path. Same pattern as RES-1594 / RES-1597 / RES-1605 / RES-1611.

Add module-level `#![allow(dead_code)]` to silence the "function never used" warning, matching the established pattern.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Trivial. Removing a call to a fn whose body is `Ok(())`.

Closes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)