### PR TITLE
RES-1616: gate 5 more passes via Markers (type_aliases, generics, traits, lock_ordering, verifier_liveness)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,12 +265,12 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/pass_gate.rs": {
-      "branch": "res-1612-variant-gates",
-      "claimed_at": "2026-05-13T05:40:25Z"
+      "branch": "res-1616-five-more-gates",
+      "claimed_at": "2026-05-13T05:47:33Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1612-variant-gates",
-      "claimed_at": "2026-05-13T05:40:25Z"
+      "branch": "res-1616-five-more-gates",
+      "claimed_at": "2026-05-13T05:47:33Z"
     }
   }
 }

--- a/resilient/src/pass_gate.rs
+++ b/resilient/src/pass_gate.rs
@@ -95,6 +95,20 @@ pub(crate) struct Markers<'a> {
     /// True if any `Node::NewtypeDecl` appears anywhere. Used by
     /// the `newtypes` gate (RES-1612).
     pub has_newtype_decl: bool,
+    /// True if any `Node::TypeAlias` appears anywhere. Used by the
+    /// `type_aliases` gate (RES-1616).
+    pub has_type_alias: bool,
+    /// True if any `Node::Function` declares a non-empty
+    /// `type_params` vector. Used by the `generics` gate (RES-1616).
+    pub has_generic_fn: bool,
+    /// True if any `Node::TraitDecl` appears anywhere. Used by the
+    /// `traits` gate (RES-1616), which also consults
+    /// `impl_trait_names` and `has_generic_fn`.
+    pub has_trait_decl: bool,
+    /// True if any `Node::ActorDecl` declares a non-empty
+    /// `eventually_clauses` vector. Used by the `verifier_liveness`
+    /// gate (RES-1616).
+    pub has_actor_with_eventually: bool,
 }
 
 impl<'a> Markers<'a> {
@@ -114,12 +128,18 @@ impl<'a> Markers<'a> {
         let mut m = Markers::default();
         crate::uniqueness_walk::visit(program, &mut |n| match n {
             Node::Function {
-                name, parameters, ..
+                name,
+                parameters,
+                type_params,
+                ..
             } => {
                 m.fn_names.insert(name.as_str());
                 for (ty, pname) in parameters {
                     m.param_types.insert(ty.as_str());
                     m.param_names.insert(pname.as_str());
+                }
+                if !type_params.is_empty() {
+                    m.has_generic_fn = true;
                 }
             }
             Node::LetStatement { name, .. } => {
@@ -168,6 +188,17 @@ impl<'a> Markers<'a> {
             }
             Node::NewtypeDecl { .. } => {
                 m.has_newtype_decl = true;
+            }
+            Node::TypeAlias { .. } => {
+                m.has_type_alias = true;
+            }
+            Node::TraitDecl { .. } => {
+                m.has_trait_decl = true;
+            }
+            Node::ActorDecl {
+                eventually_clauses, ..
+            } if !eventually_clauses.is_empty() => {
+                m.has_actor_with_eventually = true;
             }
             _ => {}
         });
@@ -259,6 +290,15 @@ impl<'a> Markers<'a> {
         self.call_idents
             .iter()
             .any(|n| suffixes.iter().any(|s| n.ends_with(s)))
+    }
+
+    /// True if any `Node::CallExpression` whose function is an
+    /// `Identifier` has a name starting with one of `prefixes`.
+    /// Backs the `lock_ordering` gate (`lock_*` / `unlock_*`).
+    pub(crate) fn any_call_ident_with_prefix(&self, prefixes: &[&str]) -> bool {
+        self.call_idents
+            .iter()
+            .any(|n| prefixes.iter().any(|p| n.starts_with(p)))
     }
 
     /// True if any `Node::CallExpression` whose function is an

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -3942,7 +3942,12 @@ impl TypeChecker {
                 if markers.has_try_catch {
                     crate::try_catch::check(program, source_path)?;
                 }
-                crate::verifier_liveness::check(program, source_path)?;
+                // RES-1616 gate: pass walks `Node::ActorDecl` looking
+                // for non-empty `eventually_clauses`. Markers records
+                // the presence flag during the shared whole-AST walk.
+                if markers.has_actor_with_eventually {
+                    crate::verifier_liveness::check(program, source_path)?;
+                }
                 // RES-1612 gate: pass scans for `Node::LiveBlock`.
                 if markers.has_live_block {
                     crate::recovery_checker::check(program, source_path)?;
@@ -3966,7 +3971,10 @@ impl TypeChecker {
                     crate::loop_invariants::check(program, source_path)?;
                 }
                 crate::verifier_loop_invariants::verify_and_capture(self, program);
-                crate::type_aliases::check(program, source_path)?;
+                // RES-1616 gate: pass scans for `Node::TypeAlias`.
+                if markers.has_type_alias {
+                    crate::type_aliases::check(program, source_path)?;
+                }
                 // RES-1612 gate: pass scans for `Node::Range`.
                 if markers.has_range {
                     crate::ranges::check(program, source_path)?;
@@ -3977,13 +3985,27 @@ impl TypeChecker {
                 // RES-1605: `modules::check` is a no-op stub; see
                 // `full_modules` for the actual module-graph build.
                 crate::default_params::check(program, source_path)?;
-                crate::generics::check(program, source_path)?;
+                // RES-1616 gate: pass scans for `Node::Function` with
+                // non-empty `type_params`. Markers records the flag
+                // during the shared whole-AST walk.
+                if markers.has_generic_fn {
+                    crate::generics::check(program, source_path)?;
+                }
                 // RES-1612 gate: pass loops top-level statements for
                 // `Node::NewtypeDecl`.
                 if markers.has_newtype_decl {
                     crate::newtypes::check(program, source_path)?;
                 }
-                crate::traits::check(program, source_path)?;
+                // RES-1616 gate: composite — pass validates trait
+                // decls, trait refs in impl blocks, and trait bounds
+                // on generic fn type-params. Any of the three signals
+                // means the pass has work.
+                if markers.has_trait_decl
+                    || !markers.impl_trait_names.is_empty()
+                    || markers.has_generic_fn
+                {
+                    crate::traits::check(program, source_path)?;
+                }
                 // RES-1611: `region_inference::infer` is a no-op stub
                 // (`Ok(())`); the real region-aliasing logic lives in
                 // `check_call_site_region_aliasing` which runs from a
@@ -4029,7 +4051,22 @@ impl TypeChecker {
                     crate::isr_call_graph::check(program, source_path)?;
                 }
                 // Ralph-Loop-Uniqueness #6: lock-ordering inversion.
-                crate::lock_ordering::check(program, source_path)?;
+                // RES-1616 gate: pass walks bodies for calls to
+                // `lock`/`acquire`/`mutex_lock` or `unlock`/`release`/
+                // `mutex_unlock` (LOCK_FNS / UNLOCK_FNS) or any
+                // identifier starting with `lock_` / `unlock_`. All
+                // three signals come from `markers.call_idents`,
+                // populated by the shared whole-AST walk (RES-1593).
+                let has_lock_call = markers.call_idents.contains("lock")
+                    || markers.call_idents.contains("acquire")
+                    || markers.call_idents.contains("mutex_lock")
+                    || markers.call_idents.contains("unlock")
+                    || markers.call_idents.contains("release")
+                    || markers.call_idents.contains("mutex_unlock")
+                    || markers.any_call_ident_with_prefix(&["lock_", "unlock_"]);
+                if has_lock_call {
+                    crate::lock_ordering::check(program, source_path)?;
+                }
                 // Ralph-Loop-Uniqueness #7: reentrancy guard.
                 // RES-1585 gate: pass scans for NR_PREFIXES on fn names.
                 if markers.any_fn_name_with_prefix(&["nonreentrant_", "exclusive_"]) {


### PR DESCRIPTION
## Summary

Five more typechecker passes have whole-AST fast-rejects keyed on AST shape that the shared `Markers::scan` can record cheaply:

| Pass                  | Marker source                                            |
|-----------------------|----------------------------------------------------------|
| `type_aliases`        | `Node::TypeAlias` presence                                |
| `generics`            | Any `Node::Function` with non-empty `type_params`         |
| `traits`              | `Node::TraitDecl` OR `ImplBlock` with `trait_name` OR generic fn |
| `verifier_liveness`   | `Node::ActorDecl` with non-empty `eventually_clauses`     |
| `lock_ordering`       | `CallExpression` to LOCK_FNS/UNLOCK_FNS or ident `lock_*`/`unlock_*` |

Extends `Markers` with `has_type_alias`, `has_generic_fn`, `has_trait_decl`, `has_actor_with_eventually` plus `any_call_ident_with_prefix(prefixes)` helper. `has_generic_fn` also serves as the third leg of the composite `traits` gate.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Low. Each gate's marker maps directly onto the pass's own fast-reject signal. Pass-side fast-rejects stay in place as defense in depth.

Closes #1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)