### PR TITLE
RES-1619: drop 4 more dead-pass calls from EXTENSION_PASSES

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,13 +264,9 @@
       "branch": "res-1539-lock-priority-borrow",
       "claimed_at": "2026-05-12T15:25:00Z"
     },
-    "resilient/src/pass_gate.rs": {
-      "branch": "res-1616-five-more-gates",
-      "claimed_at": "2026-05-13T05:47:33Z"
-    },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1616-five-more-gates",
-      "claimed_at": "2026-05-13T05:47:33Z"
+      "branch": "res-1619-drop-4-more-dead",
+      "claimed_at": "2026-05-13T05:53:29Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4214,14 +4214,21 @@ impl TypeChecker {
                 // does. Order is mostly independent (analysis-only
                 // passes), but blame_attribution must run before
                 // anti_regression so the latter has the call graph.
-                crate::resilience_score::check(program, source_path)?;
+                // RES-1619: `resilience_score::check` is a no-op stub
+                // (RES-1206); real `score_program` runs from the
+                // `--score` CLI flag and external integrators.
                 crate::vibe_debt::check(program, source_path)?;
-                crate::behavioral_fingerprint::check(program, source_path)?;
-                crate::contract_inference::check(program, source_path)?;
+                // RES-1619: `behavioral_fingerprint::check` is a no-op
+                // stub (RES-1206); real `fingerprint_program` runs
+                // from `--check-fingerprints` and external integrators.
+                // RES-1619: `contract_inference::check` is a no-op stub
+                // (RES-1206); real `infer_program` runs from
+                // `--suggest-contracts` and external integrators.
                 crate::semantic_regression::check(program, source_path)?;
                 crate::semver_behavior::check(program, source_path)?;
                 crate::blame_attribution::check(program, source_path)?;
-                crate::autopilot::check(program, source_path)?;
+                // RES-1619: `autopilot::check` is a no-op stub; the
+                // `--autopilot` CLI flag drives the actual `run()`.
                 crate::crash_only_cert::check(program, source_path)?;
                 crate::intent_blocks::check(program, source_path)?;
                 crate::anti_regression::check(program, source_path)?;


### PR DESCRIPTION
## Summary

Four more passes in the dead-stub pattern dropped from `<EXTENSION_PASSES>`:

| Pass                       | Why dead                                                                |
|----------------------------|-------------------------------------------------------------------------|
| `resilience_score::check`  | RES-1206 discarded `score_program` output; real path is `--score` CLI    |
| `behavioral_fingerprint::check` | RES-1206 discarded `fingerprint_program`; real path is `--check-fingerprints` |
| `contract_inference::check`| RES-1206 discarded `infer_program`; real path is `--suggest-contracts`   |
| `autopilot::check`         | `Ok(())` no-op; real path is `--autopilot` CLI flag                      |

Module files untouched (each already has `dead_code` allow from the RES-1206 era). Only the per-typecheck dispatch goes away.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Trivial. Removing calls to fns whose body is `Ok(())`.

Closes #1619

🤖 Generated with [Claude Code](https://claude.com/claude-code)