### PR TITLE
RES-1620: gate verifier_loop_invariants on while-invariants/invariant-statement

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,12 +265,12 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/pass_gate.rs": {
-      "branch": "res-1616-five-more-gates",
-      "claimed_at": "2026-05-13T05:47:33Z"
+      "branch": "res-1620-gate-vli",
+      "claimed_at": "2026-05-13T05:54:34Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1616-five-more-gates",
-      "claimed_at": "2026-05-13T05:47:33Z"
+      "branch": "res-1620-gate-vli",
+      "claimed_at": "2026-05-13T05:54:34Z"
     }
   }
 }

--- a/resilient/src/pass_gate.rs
+++ b/resilient/src/pass_gate.rs
@@ -80,6 +80,11 @@ pub(crate) struct Markers<'a> {
     /// True if any `Node::InvariantStatement` appears anywhere. Used
     /// by the `loop_invariants` gate (RES-1612).
     pub has_invariant_statement: bool,
+    /// True if any `Node::WhileStatement` has a non-empty
+    /// `invariants` vector. Used together with
+    /// `has_invariant_statement` by the `verifier_loop_invariants`
+    /// gate (RES-1620).
+    pub has_while_with_invariants: bool,
     /// True if any `Node::Range` appears anywhere. Used by the
     /// `ranges` gate (RES-1612).
     pub has_range: bool,
@@ -199,6 +204,9 @@ impl<'a> Markers<'a> {
                 eventually_clauses, ..
             } if !eventually_clauses.is_empty() => {
                 m.has_actor_with_eventually = true;
+            }
+            Node::WhileStatement { invariants, .. } if !invariants.is_empty() => {
+                m.has_while_with_invariants = true;
             }
             _ => {}
         });

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -3970,7 +3970,17 @@ impl TypeChecker {
                 if markers.has_invariant_statement {
                     crate::loop_invariants::check(program, source_path)?;
                 }
-                crate::verifier_loop_invariants::verify_and_capture(self, program);
+                // RES-1620 gate: the Z3 verifier walks for
+                // `WhileStatement` with non-empty `invariants` OR
+                // any `InvariantStatement` — same shape as the
+                // pass's own RES-1297 fast-reject. Markers tracks
+                // both signals from the shared whole-AST walk, so
+                // the gate is two O(1) bool reads. The non-z3
+                // build's `verify_and_capture` is already a no-op
+                // stub, so skipping the call there is also free.
+                if markers.has_invariant_statement || markers.has_while_with_invariants {
+                    crate::verifier_loop_invariants::verify_and_capture(self, program);
+                }
                 // RES-1616 gate: pass scans for `Node::TypeAlias`.
                 if markers.has_type_alias {
                     crate::type_aliases::check(program, source_path)?;


### PR DESCRIPTION
## Summary

`verifier_loop_invariants::verify_and_capture` ran unconditionally from `EXTENSION_PASSES`. The Z3 implementation has its own RES-1297 `any_node` fast-reject looking for `WhileStatement` with non-empty `invariants` OR `InvariantStatement` anywhere.

`Markers` already has `has_invariant_statement` (RES-1612). Add `has_while_with_invariants` populated during the existing whole-AST walk. Gate the call on either flag.

The non-z3 build's `verify_and_capture` is already a no-op stub, so the gate also saves a dispatch on that build.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Low. The gate matches the pass's own RES-1297 fast-reject scope exactly.

Closes #1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)