### PR TITLE
RES-1623: drop 4 more dead-pass calls from EXTENSION_PASSES

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,13 +264,9 @@
       "branch": "res-1539-lock-priority-borrow",
       "claimed_at": "2026-05-12T15:25:00Z"
     },
-    "resilient/src/pass_gate.rs": {
-      "branch": "res-1620-gate-vli",
-      "claimed_at": "2026-05-13T05:54:34Z"
-    },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1620-gate-vli",
-      "claimed_at": "2026-05-13T05:54:34Z"
+      "branch": "res-1623-drop-4-more-dead",
+      "claimed_at": "2026-05-13T05:59:01Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4227,15 +4227,17 @@ impl TypeChecker {
                 // RES-1619: `resilience_score::check` is a no-op stub
                 // (RES-1206); real `score_program` runs from the
                 // `--score` CLI flag and external integrators.
-                crate::vibe_debt::check(program, source_path)?;
+                // RES-1623: `vibe_debt::check` is a no-op stub
+                // (RES-1206); real `analyze` runs from `autopilot::run`.
                 // RES-1619: `behavioral_fingerprint::check` is a no-op
                 // stub (RES-1206); real `fingerprint_program` runs
                 // from `--check-fingerprints` and external integrators.
                 // RES-1619: `contract_inference::check` is a no-op stub
                 // (RES-1206); real `infer_program` runs from
                 // `--suggest-contracts` and external integrators.
-                crate::semantic_regression::check(program, source_path)?;
-                crate::semver_behavior::check(program, source_path)?;
+                // RES-1623: `semantic_regression::check` is a no-op
+                // stub; real diff runs from the test harness.
+                // RES-1623: `semver_behavior::check` is a no-op stub.
                 crate::blame_attribution::check(program, source_path)?;
                 // RES-1619: `autopilot::check` is a no-op stub; the
                 // `--autopilot` CLI flag drives the actual `run()`.
@@ -4259,7 +4261,9 @@ impl TypeChecker {
                 // no-op (`Ok(())`) until the cache lookup-side is wired
                 // — see the RES-1210 comment in `incremental_verify.rs`.
                 // Skip the dispatch until that lands.
-                crate::property_tests::check(program, source_path)?;
+                // RES-1623: `property_tests::check` is a no-op stub
+                // (RES-1206); real `collect` runs from the
+                // `--run-property-tests` driver.
                 crate::mmio_regmap::check(program, source_path)?;
                 crate::power_contracts::check(program, source_path)?;
                 crate::stack_contracts::check(program, source_path)?;


### PR DESCRIPTION
## Summary

Four more passes in the dead-stub pattern dropped from `<EXTENSION_PASSES>`:

| Pass                            | Why dead                                                         |
|---------------------------------|------------------------------------------------------------------|
| `vibe_debt::check`              | RES-1206: discarded `analyze` output; consumer is `autopilot::run` |
| `semantic_regression::check`    | `Ok(())`; consumer is the test-harness diff                       |
| `semver_behavior::check`        | `Ok(())`; consumer is the `--check-semver` CLI driver             |
| `property_tests::check`         | RES-1206: discarded `collect` output; consumer is `--run-property-tests` |

Same pattern as RES-1594 / RES-1597 / RES-1605 / RES-1611 / RES-1615 / RES-1619. Module files stay alive (each already has `dead_code` allow from RES-1206 era).

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Trivial.

Closes #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)