### PR TITLE
RES-1629: gate blame_attribution + deadlock_freedom via Markers

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,12 +265,12 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/pass_gate.rs": {
-      "branch": "res-1627-gate-actor-precheck",
-      "claimed_at": "2026-05-13T06:07:32Z"
+      "branch": "res-1629-blame-deadlock-gates",
+      "claimed_at": "2026-05-13T06:10:32Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1627-gate-actor-precheck",
-      "claimed_at": "2026-05-13T06:07:32Z"
+      "branch": "res-1629-blame-deadlock-gates",
+      "claimed_at": "2026-05-13T06:10:32Z"
     }
   }
 }

--- a/resilient/src/pass_gate.rs
+++ b/resilient/src/pass_gate.rs
@@ -117,7 +117,13 @@ pub(crate) struct Markers<'a> {
     /// True if any `Node::ActorDecl` appears anywhere. Used by the
     /// actor-invariant Z3 verifier pre-check (RES-1627) to skip
     /// `collect_actor_obligations` when the program has no actors.
+    /// Also used by the `deadlock_freedom` gate (RES-1629).
     pub has_actor_decl: bool,
+    /// True if any `Node::CallExpression` appears anywhere
+    /// (regardless of whether the callee is an `Identifier` —
+    /// method calls and indirect calls count too). Used by the
+    /// `blame_attribution` gate (RES-1629).
+    pub has_call_expression: bool,
 }
 
 impl<'a> Markers<'a> {
@@ -161,6 +167,7 @@ impl<'a> Markers<'a> {
                 m.field_names_accessed.insert(field.as_str());
             }
             Node::CallExpression { function, .. } => {
+                m.has_call_expression = true;
                 if let Node::Identifier { name, .. } = function.as_ref() {
                     m.call_idents.insert(name.as_str());
                 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4240,7 +4240,17 @@ impl TypeChecker {
                 // RES-1623: `semantic_regression::check` is a no-op
                 // stub; real diff runs from the test harness.
                 // RES-1623: `semver_behavior::check` is a no-op stub.
-                crate::blame_attribution::check(program, source_path)?;
+                // RES-1629 gate: pass walks bodies for `CallExpression`
+                // to build the (caller, callee) blame map. Without any
+                // call expressions, `build` returns an empty `BlameMap`
+                // — but the pass still installs `BlameMap::default()`
+                // to clear stale state from a previous compilation, so
+                // preserve that in the else branch.
+                if markers.has_call_expression {
+                    crate::blame_attribution::check(program, source_path)?;
+                } else {
+                    crate::blame_attribution::install(crate::blame_attribution::BlameMap::default());
+                }
                 // RES-1619: `autopilot::check` is a no-op stub; the
                 // `--autopilot` CLI flag drives the actual `run()`.
                 crate::crash_only_cert::check(program, source_path)?;
@@ -4253,7 +4263,13 @@ impl TypeChecker {
                 crate::info_flow::check(program, source_path)?;
                 crate::phantom_types::check(program, source_path)?;
                 crate::recursive_types::check(program, source_path)?;
-                crate::deadlock_freedom::check(program, source_path)?;
+                // RES-1629 gate: pass scans for `Node::ActorDecl` to
+                // build an actor→actors graph. With no ActorDecls,
+                // both `build` and `detect_cycles` are dead work.
+                // `markers.has_actor_decl` was added in RES-1627.
+                if markers.has_actor_decl {
+                    crate::deadlock_freedom::check(program, source_path)?;
+                }
                 crate::session_types::check(program, source_path)?;
                 crate::probabilistic_contracts::check(program, source_path)?;
                 crate::wcet_contracts::check(program, source_path)?;


### PR DESCRIPTION
## Summary

Two more passes still ungated after RES-1627:

| Pass                | Marker source                                |
|---------------------|----------------------------------------------|
| `blame_attribution` | `Node::CallExpression` presence              |
| `deadlock_freedom`  | `Node::ActorDecl` presence (`has_actor_decl` from RES-1627) |

Extend `Markers` with `has_call_expression: bool` set in the existing `CallExpression` visitor arm. Gate both passes.

`blame_attribution` has a wipe-on-empty pattern (`install(BlameMap::default())` clears stale process-global state), so the else branch calls that directly — same shape as RES-1599 used for `iterator_protocol`.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Low. Each gate matches the pass's own fast-reject scope; defense-in-depth preserved.

Closes #1629

🤖 Generated with [Claude Code](https://claude.com/claude-code)