### PR TITLE
RES-1633: extend Z3 within-run cache to z3_prove_with_axioms_and_cert

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,8 +265,8 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1631-z3-prove-cache",
-      "claimed_at": "2026-05-13T06:13:16Z"
+      "branch": "res-1633-z3-axioms-cache",
+      "claimed_at": "2026-05-13T06:27:31Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -895,6 +895,37 @@ fn z3_prove_with_cert(
 /// invariant — the recovery point is reached only after the
 /// precondition has already been checked, so requires still
 /// hold. Without `--features z3`, returns all-`None` / `false`.
+/// RES-1633: cache key for `z3_prove_with_axioms_and_cert`. Same
+/// shape as `prove_cache_key` (RES-1631) but folds the axioms
+/// slice's Debug repr into the hash so two distinct axiom sets
+/// can't collide. The leading `with_axioms:` tag also prevents
+/// any collision with `prove_cache_key`'s no-axioms entries that
+/// share the same `PROVE_CACHE`.
+#[cfg(feature = "z3")]
+fn prove_cache_key_with_axioms(
+    expr: &Node,
+    bindings: &HashMap<String, i64>,
+    axioms: &[Node],
+    timeout_ms: u32,
+) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    "with_axioms:".hash(&mut h);
+    format!("{:?}", expr).hash(&mut h);
+    let mut sorted: Vec<(&String, &i64)> = bindings.iter().collect();
+    sorted.sort_by(|a, b| a.0.cmp(b.0));
+    for (k, v) in sorted {
+        k.hash(&mut h);
+        v.hash(&mut h);
+    }
+    for ax in axioms {
+        format!("{:?}", ax).hash(&mut h);
+    }
+    timeout_ms.hash(&mut h);
+    h.finish()
+}
+
 #[cfg(feature = "z3")]
 fn z3_prove_with_axioms_and_cert(
     expr: &Node,
@@ -902,9 +933,15 @@ fn z3_prove_with_axioms_and_cert(
     axioms: &[Node],
     timeout_ms: u32,
 ) -> (Option<bool>, Option<String>, Option<String>, bool) {
+    let key = prove_cache_key_with_axioms(expr, bindings, axioms, timeout_ms);
+    if let Some(cached) = PROVE_CACHE.with(|c| c.borrow().get(&key).cloned()) {
+        return cached;
+    }
     let (verdict, cert, cx, timed_out) =
         crate::verifier_z3::prove_with_axioms_and_timeout(expr, bindings, axioms, timeout_ms);
-    (verdict, cert.map(|c| c.smt2), cx, timed_out)
+    let result = (verdict, cert.map(|c| c.smt2), cx, timed_out);
+    PROVE_CACHE.with(|c| c.borrow_mut().insert(key, result.clone()));
+    result
 }
 #[cfg(not(feature = "z3"))]
 fn z3_prove_with_axioms_and_cert(


### PR DESCRIPTION
## Summary

RES-1631 wrapped `z3_prove_with_cert_theory` with a thread-local within-run cache. Its sibling `z3_prove_with_axioms_and_cert` follows the same shape but takes an additional `axioms: &[Node]` slice — used by the `recovers_to` discharge path to admit each `requires` clause as an assumption when proving the recovery invariant.

Reuse the existing `PROVE_CACHE` thread-local with a separate key shape:

- `prove_cache_key_with_axioms` prefixes the hash with `"with_axioms:"` so it can't collide with the no-axioms entries from `prove_cache_key`.
- Folds each axiom's Debug repr into the hash.

`reset_z3_prove_cache` from RES-1631 already clears the shared map at the start of every typecheck.

## Verification

```
cargo build  --manifest-path resilient/Cargo.toml                  # green (default features)
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Low. Same shape as RES-1631. Cache prefix prevents collisions between the two key types.

Closes #1633

🤖 Generated with [Claude Code](https://claude.com/claude-code)