### PR TITLE
RES-1639: extend hash_node_spanless to 7 more Node variants

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -261,8 +261,8 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1637-span-free-hash",
-      "claimed_at": "2026-05-13T06:37:38Z"
+      "branch": "res-1639-spanless-more-variants",
+      "claimed_at": "2026-05-13T06:42:49Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -416,12 +416,77 @@ fn hash_node_spanless<H: std::hash::Hasher>(node: &Node, h: &mut H) {
             hash_node_spanless(lo, h);
             hash_node_spanless(hi, h);
         }
+        // RES-1639: additional variants that appear in non-typechecker
+        // Z3 callers (`cluster_verifier`, `bounds_check`,
+        // `verifier_actors`, `verifier_loop_invariants`). The same
+        // shape — one-byte discriminant + non-span fields + recursion.
+        Node::Block { stmts, .. } => {
+            b'{'.hash(h);
+            (stmts.len() as u32).hash(h);
+            for s in stmts {
+                hash_node_spanless(s, h);
+            }
+        }
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            b'?'.hash(h);
+            b'I'.hash(h); // distinct from the fallback's b'?'
+            hash_node_spanless(condition, h);
+            hash_node_spanless(consequence, h);
+            match alternative {
+                Some(alt) => {
+                    b'E'.hash(h);
+                    hash_node_spanless(alt, h);
+                }
+                None => b'N'.hash(h),
+            }
+        }
+        Node::TryExpression { expr, .. } => {
+            b'T'.hash(h);
+            hash_node_spanless(expr, h);
+        }
+        Node::LetStatement { name, value, .. } => {
+            b'L'.hash(h);
+            name.hash(h);
+            hash_node_spanless(value, h);
+        }
+        Node::Assignment { name, value, .. } => {
+            b'='.hash(h);
+            name.hash(h);
+            hash_node_spanless(value, h);
+        }
+        Node::ReturnStatement { value, .. } => {
+            b'r'.hash(h);
+            match value {
+                Some(v) => {
+                    b'V'.hash(h);
+                    hash_node_spanless(v, h);
+                }
+                None => b'N'.hash(h),
+            }
+        }
+        Node::StructLiteral { name, fields, .. } => {
+            b's'.hash(h);
+            name.hash(h);
+            (fields.len() as u32).hash(h);
+            // Field iteration order matters; struct literals don't
+            // normalize field order (the parser preserves source
+            // order). Same source → same iteration → same hash.
+            for (fname, fval) in fields {
+                fname.hash(h);
+                hash_node_spanless(fval, h);
+            }
+        }
         // Fallback: variant not in the covered subset. Use the
         // existing span-inclusive Debug — strictly no-worse than
         // pre-RES-1637, and the same key still uniquely identifies
         // the obligation (just doesn't dedupe across sites).
         other => {
-            b'?'.hash(h);
+            b'@'.hash(h);
             format!("{:?}", other).hash(h);
         }
     }


### PR DESCRIPTION
## Summary

[RES-1637](https://github.com/EricSpencer00/Resilient/pull/1638) covered 13 variants that dominate `requires`/`ensures` contract clauses. Other Z3 callers (`cluster_verifier`, `bounds_check`, `verifier_actors`, `verifier_loop_invariants`) also pass obligations containing additional shapes that fell back to the span-inclusive `format!` Debug path.

Add 7 more variants with one-byte discriminants + non-span fields:

| Variant            | Hashed fields                  |
|--------------------|--------------------------------|
| `Block`            | stmts (len + recursive)         |
| `IfStatement`      | condition + consequence + alt   |
| `TryExpression`    | expr                            |
| `LetStatement`     | name + value                    |
| `Assignment`       | name + value                    |
| `ReturnStatement`  | optional value                  |
| `StructLiteral`    | name + (field name + value)*    |

`Match` stays in the fallback (its `Pattern` enum needs a separate hasher).

## Verification

```
cargo check  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Low. Each new variant follows the established discriminant + non-span fields pattern. Unsupported variants stay in the fallback path that's safe by construction.

Closes #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)