### PR TITLE
RES-1641: verifier_z3 cache-hit telemetry

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -261,8 +261,8 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1639-spanless-more-variants",
-      "claimed_at": "2026-05-13T06:42:49Z"
+      "branch": "res-1641-z3-cache-stats",
+      "claimed_at": "2026-05-13T06:45:30Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -263,14 +263,66 @@ pub fn prove_with_axioms_and_timeout(
         h.finish()
     };
     if let Some(cached) = Z3_VERDICT_CACHE.with(|c| c.borrow().get(&key).cloned()) {
+        Z3_CACHE_STATS.with(|s| {
+            let mut v = s.get();
+            v.verdict_hits += 1;
+            s.set(v);
+        });
         return cached;
     }
+    Z3_CACHE_STATS.with(|s| {
+        let mut v = s.get();
+        v.verdict_misses += 1;
+        s.set(v);
+    });
     let result = Z3_CTX
         .with(|ctx| prove_with_axioms_and_timeout_in(ctx, expr, bindings, axioms, timeout_ms));
     Z3_VERDICT_CACHE.with(|c| {
         c.borrow_mut().insert(key, result.clone());
     });
     result
+}
+
+/// RES-1641: cache-hit telemetry. Snapshot of the three thread-local
+/// verifier caches' hit + miss counts since the last `reset_cache_stats`.
+/// Returned by [`cache_stats`] for contributors who want to measure
+/// cache effectiveness across the RES-1635 / RES-1637 / RES-1639
+/// optimization series.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Z3CacheStats {
+    pub verdict_hits: u64,
+    pub verdict_misses: u64,
+    pub tautology_hits: u64,
+    pub tautology_misses: u64,
+    pub bv_hits: u64,
+    pub bv_misses: u64,
+}
+
+thread_local! {
+    /// RES-1641: hit/miss counters for the three caches below.
+    /// Thread-local so concurrent test runs don't cross-contaminate.
+    static Z3_CACHE_STATS: std::cell::Cell<Z3CacheStats> =
+        std::cell::Cell::new(Z3CacheStats {
+            verdict_hits: 0,
+            verdict_misses: 0,
+            tautology_hits: 0,
+            tautology_misses: 0,
+            bv_hits: 0,
+            bv_misses: 0,
+        });
+}
+
+/// RES-1641: return the current `Z3CacheStats` snapshot for this
+/// thread. Counters accumulate from process start (or the last
+/// [`reset_cache_stats`] call).
+pub fn cache_stats() -> Z3CacheStats {
+    Z3_CACHE_STATS.with(|s| s.get())
+}
+
+/// RES-1641: zero out all six counters. Useful for measuring a
+/// single compilation in isolation.
+pub fn reset_cache_stats() {
+    Z3_CACHE_STATS.with(|s| s.set(Z3CacheStats::default()));
 }
 
 thread_local! {
@@ -729,8 +781,18 @@ pub fn prove_tautology_with_axioms_and_timeout(
         h.finish()
     };
     if let Some(cached) = Z3_TAUTOLOGY_CACHE.with(|c| c.borrow().get(&key).cloned()) {
+        Z3_CACHE_STATS.with(|s| {
+            let mut v = s.get();
+            v.tautology_hits += 1;
+            s.set(v);
+        });
         return cached;
     }
+    Z3_CACHE_STATS.with(|s| {
+        let mut v = s.get();
+        v.tautology_misses += 1;
+        s.set(v);
+    });
     let result = Z3_CTX.with(|ctx| {
         prove_tautology_with_axioms_and_timeout_in(ctx, expr, bindings, axioms, timeout_ms)
     });
@@ -883,8 +945,18 @@ pub fn prove_bv(
         h.finish()
     };
     if let Some(cached) = Z3_BV_CACHE.with(|c| c.borrow().get(&key).cloned()) {
+        Z3_CACHE_STATS.with(|s| {
+            let mut v = s.get();
+            v.bv_hits += 1;
+            s.set(v);
+        });
         return cached;
     }
+    Z3_CACHE_STATS.with(|s| {
+        let mut v = s.get();
+        v.bv_misses += 1;
+        s.set(v);
+    });
     let result = Z3_CTX.with(|ctx| prove_bv_in(ctx, expr, bindings, timeout_ms));
     Z3_BV_CACHE.with(|c| {
         c.borrow_mut().insert(key, result.clone());


### PR DESCRIPTION
## Summary

The Z3 proof cache series (RES-1206 / RES-1309 / RES-1316 / RES-1635 / RES-1637 / RES-1639) works but produced no measurable signal — PRs in this series couldn't quantify their impact.

Add thread-local hit + miss counters for each of the three caches (`verdict`, `tautology`, `bv`). Expose via:

- `pub fn cache_stats() -> Z3CacheStats` — snapshot of all six counters
- `pub fn reset_cache_stats()` — zero out for isolated measurement

## Verification

```
cargo check  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Zero — pure observability addition. Counters increment by 1 per cache lookup (negligible overhead). Z3-feature-gated like the rest of the module.

## Follow-up

A `--verifier-stats` CLI flag that calls `cache_stats()` and prints them at end-of-typecheck is the natural next step but out of scope here.

Closes #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)