### PR TITLE
RES-1647: extend hash_node_spanless to 5 more statement variants

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -261,8 +261,8 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1645-pattern-hasher",
-      "claimed_at": "2026-05-13T06:50:17Z"
+      "branch": "res-1647-five-more-variants",
+      "claimed_at": "2026-05-13T06:53:00Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -533,6 +533,52 @@ fn hash_node_spanless<H: std::hash::Hasher>(node: &Node, h: &mut H) {
                 hash_node_spanless(fval, h);
             }
         }
+        // RES-1647: five more statement variants — same
+        // discriminator + non-span-fields shape as RES-1639's batch.
+        Node::Const { name, value, .. } => {
+            b'c'.hash(h);
+            name.hash(h);
+            hash_node_spanless(value, h);
+        }
+        Node::StaticLet { name, value, .. } => {
+            b'$'.hash(h);
+            name.hash(h);
+            hash_node_spanless(value, h);
+        }
+        Node::WhileStatement {
+            condition,
+            body,
+            invariants,
+            ..
+        } => {
+            b'w'.hash(h);
+            hash_node_spanless(condition, h);
+            hash_node_spanless(body, h);
+            (invariants.len() as u32).hash(h);
+            for inv in invariants {
+                hash_node_spanless(inv, h);
+            }
+        }
+        Node::ForInStatement {
+            name,
+            iterable,
+            body,
+            invariants,
+            ..
+        } => {
+            b'f'.hash(h);
+            name.hash(h);
+            hash_node_spanless(iterable, h);
+            hash_node_spanless(body, h);
+            (invariants.len() as u32).hash(h);
+            for inv in invariants {
+                hash_node_spanless(inv, h);
+            }
+        }
+        Node::ExpressionStatement { expr, .. } => {
+            b';'.hash(h);
+            hash_node_spanless(expr, h);
+        }
         // RES-1645: Match — sub-hashes Pattern arms via
         // `hash_pattern_spanless` so pattern-shaped obligations
         // dedupe across sites just like the rest.


### PR DESCRIPTION
## Summary

After RES-1645 the span-free hasher covers 21 Node variants + all 14 Pattern variants. Five common statement variants still fell back to span-inclusive `format!`:

- `Const` — `const NAME: T = expr`
- `StaticLet` — `static let NAME = expr`
- `WhileStatement` — with optional invariants
- `ForInStatement` — with optional invariants
- `ExpressionStatement` — bare-expression statement

These appear inside function bodies and `recovers_to` clauses passed to Z3 callers in `cluster_verifier`, `bounds_check`, etc.

Each new variant follows the discriminator + non-span-fields pattern from RES-1639. `WhileStatement` and `ForInStatement` also hash their `invariants` vector.

Brings covered count to 26 Node variants + 14 Pattern variants.

## Verification

```
cargo check  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

`--features z3` validated by CI.

## Risk

Low. Same pattern as RES-1639 / RES-1645. Fallback path stays for unsupported variants.

Closes #1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)