### PR TITLE
RES-1649: hash_node_spanless — Quantifier, InvariantStatement, ImplBlock, ModuleDecl

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -261,8 +261,8 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1647-five-more-variants",
-      "claimed_at": "2026-05-13T06:53:00Z"
+      "branch": "res-1649-four-more-variants",
+      "claimed_at": "2026-05-13T06:56:16Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -579,6 +579,67 @@ fn hash_node_spanless<H: std::hash::Hasher>(node: &Node, h: &mut H) {
             b';'.hash(h);
             hash_node_spanless(expr, h);
         }
+        // RES-1649: four more high-value variants.
+        Node::Quantifier {
+            kind,
+            var,
+            range,
+            body,
+            ..
+        } => {
+            b'Q'.hash(h);
+            // QuantifierKind doesn't derive Hash; match it.
+            match kind {
+                crate::quantifiers::QuantifierKind::Forall => b'A'.hash(h),
+                crate::quantifiers::QuantifierKind::Exists => b'E'.hash(h),
+            }
+            var.hash(h);
+            // QuantRange recurses into Node sub-trees.
+            match range {
+                crate::quantifiers::QuantRange::Range { lo, hi } => {
+                    b'R'.hash(h);
+                    hash_node_spanless(lo, h);
+                    hash_node_spanless(hi, h);
+                }
+                crate::quantifiers::QuantRange::Iterable(it) => {
+                    b'I'.hash(h);
+                    hash_node_spanless(it, h);
+                }
+            }
+            hash_node_spanless(body, h);
+        }
+        Node::InvariantStatement { expr, .. } => {
+            b'v'.hash(h);
+            hash_node_spanless(expr, h);
+        }
+        Node::ImplBlock {
+            trait_name,
+            struct_name,
+            methods,
+            ..
+        } => {
+            b'b'.hash(h);
+            match trait_name {
+                Some(t) => {
+                    b'T'.hash(h);
+                    t.hash(h);
+                }
+                None => b'N'.hash(h),
+            }
+            struct_name.hash(h);
+            (methods.len() as u32).hash(h);
+            for m in methods {
+                hash_node_spanless(m, h);
+            }
+        }
+        Node::ModuleDecl { name, body, .. } => {
+            b'm'.hash(h);
+            name.hash(h);
+            (body.len() as u32).hash(h);
+            for n in body {
+                hash_node_spanless(n, h);
+            }
+        }
         // RES-1645: Match — sub-hashes Pattern arms via
         // `hash_pattern_spanless` so pattern-shaped obligations
         // dedupe across sites just like the rest.


### PR DESCRIPTION
## Summary

Four more variants gain span-free hashing in the Z3 cache key path:

| Variant              | Why it matters                                                |
|----------------------|---------------------------------------------------------------|
| `Quantifier`         | `forall`/`exists` clauses — common in Z3 obligations from generic-fn callers; repeat across call sites |
| `InvariantStatement` | `invariant EXPR;` inside loop bodies — verifier-only proof aid |
| `ImplBlock`          | trait + inherent impls                                         |
| `ModuleDecl`         | `mod name { ... }` namespace blocks                            |

`QuantifierKind` and `QuantRange` don't derive `Hash`, so each is matched on its variants with a discriminator byte. `QuantRange::Range` recurses into `lo`/`hi` Node bounds; `QuantRange::Iterable` recurses into its iterable Node.

Brings covered count to 30 Node variants + 14 Pattern variants + 3 EnumPatternPayload variants.

## Verification

```
cargo check  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Low. Same discriminator-byte + non-span-fields pattern as RES-1639 / 1645 / 1647.

Closes #1649

🤖 Generated with [Claude Code](https://claude.com/claude-code)