### PR TITLE
RES-1651: lift Int::from_i64(ctx, 0) out of len_axioms map loops

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -261,8 +261,8 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1649-four-more-variants",
-      "claimed_at": "2026-05-13T06:56:16Z"
+      "branch": "res-1651-zero-hoist",
+      "claimed_at": "2026-05-13T06:59:53Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -840,11 +840,15 @@ fn prove_with_axioms_and_timeout_in(
     // for the tuple element.
     let mut len_args: BTreeSet<&str> = BTreeSet::new();
     collect_len_args(expr, &mut len_args);
+    // RES-1651: lift the zero constant out of the per-arg map closure.
+    // Z3 `Int::from_i64(ctx, 0)` allocates a new AST node each call —
+    // sharing one across all `len_X >= 0` axioms saves N-1 constructions
+    // per Z3 prove on the cache-miss path.
+    let zero = Int::from_i64(ctx, 0);
     let len_axioms: Vec<Bool<'_>> = len_args
         .iter()
         .map(|arg| {
             let c = Int::new_const(ctx, format!("len_{}", arg));
-            let zero = Int::from_i64(ctx, 0);
             c.ge(&zero)
         })
         .collect();
@@ -1088,11 +1092,13 @@ fn prove_tautology_with_axioms_and_timeout_in(
     // for the tuple element.
     let mut len_args: BTreeSet<&str> = BTreeSet::new();
     collect_len_args(expr, &mut len_args);
+    // RES-1651: lift the zero constant out of the per-arg map closure
+    // (same shape as the verdict path above).
+    let zero = Int::from_i64(ctx, 0);
     let len_axioms: Vec<Bool<'_>> = len_args
         .iter()
         .map(|arg| {
             let c = Int::new_const(ctx, format!("len_{}", arg));
-            let zero = Int::from_i64(ctx, 0);
             c.ge(&zero)
         })
         .collect();


### PR DESCRIPTION
## Summary

Two map loops in `verifier_z3.rs` rebuilt the Z3 zero constant on every iteration of their `len_axioms` construction:

```rust
let len_axioms: Vec<Bool<'_>> = len_args
    .iter()
    .map(|arg| {
        let c = Int::new_const(ctx, format!("len_{}", arg));
        let zero = Int::from_i64(ctx, 0);   // ← re-created per arg
        c.ge(&zero)
    })
    .collect();
```

For programs with N `len(...)` references in the formula, that's N redundant Z3 constant constructions per cache-miss prove call. Hoist `zero` out of the closure so the same AST node is shared across all N axioms.

Two sites fixed:
- `prove_with_axioms_and_timeout_in`
- `prove_tautology_with_axioms_and_timeout_in`

## Verification

```
cargo check  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Trivial. Same AST node reused; Z3 ASTs are immutable references into the Context.

Closes #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)