### PR TITLE
RES-1653: pre-size SMT-LIB2 cert String to avoid reallocations

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -261,8 +261,8 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1651-zero-hoist",
-      "claimed_at": "2026-05-13T06:59:53Z"
+      "branch": "res-1653-cert-presize",
+      "claimed_at": "2026-05-13T07:02:09Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -916,7 +916,11 @@ fn prove_with_axioms_and_timeout_in(
         // machinery copies straight into the buffer with no
         // intermediate `String` allocations from `format!`. The
         // emitted text is byte-identical to the previous shape.
-        let mut smt2 = String::new();
+        // RES-1653: pre-size to 512 bytes — typical cert is 300-600
+        // bytes, so the growth path hit 4-6 doubling reallocations
+        // before. Capacity is per-Some(true)-tautology cost, so the
+        // pre-size pays for itself on the first cert built.
+        let mut smt2 = String::with_capacity(512);
         smt2.push_str("; RES-071 verification certificate\n");
         smt2.push_str("; expected solver result: unsat (proves the contract is a tautology)\n");
         smt2.push_str("(set-logic AUFLIA)\n");
@@ -1136,7 +1140,8 @@ fn prove_tautology_with_axioms_and_timeout_in(
     // RES-1383: same `writeln!`-into-buffer fix as the LIA verifier's
     // cert builder above — eliminates the intermediate `format!`
     // String allocations per declaration / axiom / assertion.
-    let mut smt2 = String::new();
+    // RES-1653: pre-size to 512 bytes (same shape as the LIA path).
+    let mut smt2 = String::with_capacity(512);
     smt2.push_str("; RES-071 verification certificate\n");
     smt2.push_str("; expected solver result: unsat (proves the contract is a tautology)\n");
     smt2.push_str("(set-logic AUFLIA)\n");


### PR DESCRIPTION
## Summary

Two SMT-LIB2 cert builders in `verifier_z3.rs` started from `String::new()` (capacity 0) and grew through ~5 fixed lines + N writeln calls. Typical certs are 300-600 bytes — the growth path hit 4-6 doubling reallocations before settling.

Pre-size to 512 bytes. Typical certs land in zero-realloc territory; oversize certs still grow normally with one or two doublings instead of four to six.

Cert generation only fires on `Some(true)` tautology proofs but those dominate Z3 results for well-shaped contracts.

## Verification

```
cargo check  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Trivial. `String::with_capacity` semantics are identical to `String::new` aside from initial capacity.

Closes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)