### PR TITLE
RES-1655: hoist Z3 timeout Params out of apply_timeout closure

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -261,8 +261,8 @@
       "claimed_at": "2026-05-12T15:25:00Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1653-cert-presize",
-      "claimed_at": "2026-05-13T07:02:09Z"
+      "branch": "res-1655-params-hoist",
+      "claimed_at": "2026-05-13T07:04:12Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -817,11 +817,20 @@ fn prove_with_axioms_and_timeout_in(
 
     // RES-137: apply the per-query timeout to both solvers below.
     // Z3's `"timeout"` param is in milliseconds; 0 disables it.
+    // RES-1655: build the Params once per prove call rather than
+    // per invocation of the closure — the closure runs twice (once
+    // for the tautology solver, once for the contradiction solver),
+    // and both invocations built an identical Params from scratch.
+    let timeout_params = if timeout_ms > 0 {
+        let mut p = z3::Params::new(ctx);
+        p.set_u32("timeout", timeout_ms);
+        Some(p)
+    } else {
+        None
+    };
     let apply_timeout = |solver: &z3::Solver<'_>| {
-        if timeout_ms > 0 {
-            let mut params = z3::Params::new(ctx);
-            params.set_u32("timeout", timeout_ms);
-            solver.set_params(&params);
+        if let Some(ref p) = timeout_params {
+            solver.set_params(p);
         }
     };
 
@@ -1076,11 +1085,18 @@ fn prove_tautology_with_axioms_and_timeout_in(
         None => return (false, None, false),
     };
 
+    // RES-1655: hoist the timeout Params out of the closure so it
+    // builds once per prove instead of once per solver.
+    let timeout_params = if timeout_ms > 0 {
+        let mut p = z3::Params::new(ctx);
+        p.set_u32("timeout", timeout_ms);
+        Some(p)
+    } else {
+        None
+    };
     let apply_timeout = |solver: &z3::Solver<'_>| {
-        if timeout_ms > 0 {
-            let mut params = z3::Params::new(ctx);
-            params.set_u32("timeout", timeout_ms);
-            solver.set_params(&params);
+        if let Some(ref p) = timeout_params {
+            solver.set_params(p);
         }
     };
 
@@ -1240,11 +1256,17 @@ fn prove_bv_in(
         None => return (None, None, None, false),
     };
 
+    // RES-1655: hoist the timeout Params out of the closure (BV path).
+    let timeout_params = if timeout_ms > 0 {
+        let mut p = z3::Params::new(ctx);
+        p.set_u32("timeout", timeout_ms);
+        Some(p)
+    } else {
+        None
+    };
     let apply_timeout = |solver: &z3::Solver<'_>| {
-        if timeout_ms > 0 {
-            let mut params = z3::Params::new(ctx);
-            params.set_u32("timeout", timeout_ms);
-            solver.set_params(&params);
+        if let Some(ref p) = timeout_params {
+            solver.set_params(p);
         }
     };
 


### PR DESCRIPTION
## Summary

Three Z3 inner functions shared this pattern:

```rust
let apply_timeout = |solver: &z3::Solver<'_>| {
    if timeout_ms > 0 {
        let mut params = z3::Params::new(ctx);
        params.set_u32("timeout", timeout_ms);
        solver.set_params(&params);
    }
};
```

The closure ran twice per prove call (tautology + contradiction solver), constructing a fresh `z3::Params` each invocation. Hoist the Params construction out of the closure into an `Option<z3::Params>` — built once per prove, applied at each solver.

Same shape applied across `prove_with_axioms_and_timeout_in`, `prove_tautology_with_axioms_and_timeout_in`, and `prove_bv_in`.

## Verification

```
cargo check  --manifest-path resilient/Cargo.toml                  # green
cargo test   --manifest-path resilient/Cargo.toml --lib            # 3225 passed, 0 failed
cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings  # clean
cargo fmt    --manifest-path resilient/Cargo.toml -- --check       # clean
```

## Risk

Trivial. `z3::Params` is set on the solver by reference; same Params object shared across solvers is sound.

Closes #1655

🤖 Generated with [Claude Code](https://claude.com/claude-code)