### PR TITLE
RES-1684: generalize boolean-comparison fold to recurse on both sides

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,8 +265,8 @@
       "claimed_at": "2026-05-13T07:09:45Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1682-prove-auto-fastpath",
-      "claimed_at": "2026-05-13T08:33:53Z"
+      "branch": "res-1684-generalized-bool-fold",
+      "claimed_at": "2026-05-13T08:38:36Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -233,21 +233,25 @@ fn try_const_eval_bool(expr: &Node) -> Option<bool> {
                     _ => None,
                 };
             }
-            // RES-1680: BooleanLiteral-vs-BooleanLiteral equality
-            // / disequality. Appears after constant propagation on
-            // boolean values (e.g. `flag == true` where `flag` was
-            // inlined to `true`). Other operators (`&&`, `||`,
-            // `<`/`<=`/...) fall through to the bool-combinator
-            // arm below — `BooleanLiteral(true) && BooleanLiteral(true)`
+            // RES-1680 / RES-1684: generalized boolean-comparison
+            // fold. When the operator is `==` or `!=`, recursively
+            // fold both sides as bool expressions; if both fold,
+            // return the comparison verdict directly. Subsumes the
+            // pre-RES-1684 BoolLit-vs-BoolLit arm and also catches
+            // mixed shapes like `(x == x) == true` (left folds via
+            // RES-1673 reflexive, right is a bool literal).
+            //
+            // Termination: the recursion strictly shrinks the AST
+            // subtree so we always halt at the leaf level.
+            //
+            // Other operators (`&&`, `||`, `<`, ...) fall through to
+            // the bool-combinator arm below — `BoolLit(true) && BoolLit(true)`
             // must still fold via the `&&` combinator path.
-            if let (Node::BooleanLiteral { value: a, .. }, Node::BooleanLiteral { value: b, .. }) =
-                (left.as_ref(), right.as_ref())
+            if matches!(operator.as_str(), "==" | "!=")
+                && let (Some(la), Some(rb)) =
+                    (try_const_eval_bool(left), try_const_eval_bool(right))
             {
-                match operator.as_str() {
-                    "==" => return Some(a == b),
-                    "!=" => return Some(a != b),
-                    _ => {} // fall through to bool combinator arm
-                }
+                return Some(if operator == "==" { la == rb } else { la != rb });
             }
             // Boolean combinators — recurse to fold known sides,
             // short-circuiting before the other side has to fold.
@@ -4421,6 +4425,74 @@ mod tests {
         assert_eq!(
             after.bv_misses, before.bv_misses,
             "Z3Theory::Bv must not force BV dispatch for foldable inputs"
+        );
+    }
+
+    /// RES-1684: generalized fold catches `(x == x) == true` — left
+    /// folds via RES-1673 reflexive Identifier, right is a bool
+    /// literal, the outer `==` compares them.
+    #[test]
+    fn const_eval_reflexive_compared_to_bool_literal_folds() {
+        let reflexive_eq = infix(ident("x"), "==", ident("x")); // → true
+        assert_eq!(
+            try_const_eval_bool(&infix(reflexive_eq.clone(), "==", bool_lit(true))),
+            Some(true)
+        );
+        assert_eq!(
+            try_const_eval_bool(&infix(reflexive_eq.clone(), "==", bool_lit(false))),
+            Some(false)
+        );
+        assert_eq!(
+            try_const_eval_bool(&infix(reflexive_eq, "!=", bool_lit(false))),
+            Some(true)
+        );
+    }
+
+    /// RES-1684: generalized fold catches `(5 > 3) != false` — left
+    /// folds via int-literal comparison.
+    #[test]
+    fn const_eval_int_compare_compared_to_bool_literal_folds() {
+        let int_gt = infix(int(5), ">", int(3)); // → true
+        assert_eq!(
+            try_const_eval_bool(&infix(int_gt.clone(), "==", bool_lit(true))),
+            Some(true)
+        );
+        assert_eq!(
+            try_const_eval_bool(&infix(int_gt, "!=", bool_lit(true))),
+            Some(false)
+        );
+    }
+
+    /// RES-1684: both sides may be compound bool expressions —
+    /// `(5 > 3) == (10 == 10)` folds to true. Validates that the
+    /// recursion bottoms out at the leaves on both sides.
+    #[test]
+    fn const_eval_compound_bool_equality_folds() {
+        let lhs = infix(int(5), ">", int(3)); // → true
+        let rhs = infix(int(10), "==", int(10)); // → true
+        assert_eq!(
+            try_const_eval_bool(&infix(lhs.clone(), "==", rhs.clone())),
+            Some(true)
+        );
+        let rhs_false = infix(int(10), "<", int(5)); // → false
+        assert_eq!(
+            try_const_eval_bool(&infix(lhs, "==", rhs_false)),
+            Some(false)
+        );
+    }
+
+    /// RES-1684: when either side does NOT fold (free variable), the
+    /// generalized fold returns None and the caller falls through to
+    /// Z3.
+    #[test]
+    fn const_eval_generalized_falls_through_on_non_foldable_side() {
+        assert_eq!(
+            try_const_eval_bool(&infix(bool_lit(true), "==", ident("flag"))),
+            None
+        );
+        assert_eq!(
+            try_const_eval_bool(&infix(ident("a"), "==", ident("b"))),
+            None
         );
     }
 }


### PR DESCRIPTION
## Summary

Replace the RES-1680 BooleanLiteral-vs-BooleanLiteral arm with a more general fold. When the operator is `==` or `!=`, recursively call `try_const_eval_bool` on BOTH sides; if both fold, compare the boolean verdicts directly.

This subsumes the literal-only arm (literals fold to their own value) and catches mixed shapes:

- `(x == x) == true` — left via RES-1673 reflexive, right is literal.
- `(5 > 3) != false` — left via int-literal compare.
- `(a && b) == (c || d)` — both sides fold via combinators.

## Termination

The recursion strictly shrinks the AST subtree, so it always halts at the leaf level. Other operators (`&&`, `||`, `<`, ...) deliberately fall through to the bool-combinator arm — `BoolLit(true) && BoolLit(true)` must still take the `&&` path.

## Test plan

- [x] 4 new tests cover reflexive-vs-literal, int-compare-vs-literal, both-sides-compound, and free-variable fall-through.
- [x] Pre-existing RES-1680 BoolLit-vs-BoolLit tests still pass — the general fold subsumes them.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.

Closes #1684