### PR TITLE
RES-1686: pre-size Markers HashSets to reduce rehashing

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,9 +264,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/verifier_z3.rs": {
-      "branch": "res-1684-generalized-bool-fold",
-      "claimed_at": "2026-05-13T08:38:36Z"
+    "resilient/src/pass_gate.rs": {
+      "branch": "res-1686-presize-markers",
+      "claimed_at": "2026-05-13T08:45:35Z"
     }
   }
 }

--- a/resilient/src/pass_gate.rs
+++ b/resilient/src/pass_gate.rs
@@ -151,7 +151,26 @@ impl<'a> Markers<'a> {
     /// `String::clone()` + matching free operations saved per
     /// type-check.
     pub(crate) fn scan(program: &'a Node) -> Self {
-        let mut m = Markers::default();
+        // RES-1686: pre-size HashSets with a small initial capacity
+        // so medium-to-large programs avoid 2-3 rehash rounds per
+        // marker set during the walk. 16 fits typical programs
+        // (~5-15 names per set on `medium.rz`-shaped inputs) and
+        // costs eight allocations of ~144 bytes each for tiny
+        // programs — small enough not to matter against the rest of
+        // a typecheck. Bool fields default to false; only the
+        // HashSets benefit from pre-sizing.
+        const PRESIZE: usize = 16;
+        let mut m = Markers {
+            fn_names: HashSet::with_capacity(PRESIZE),
+            param_types: HashSet::with_capacity(PRESIZE),
+            param_names: HashSet::with_capacity(PRESIZE),
+            let_names: HashSet::with_capacity(PRESIZE),
+            field_names_assigned: HashSet::with_capacity(PRESIZE),
+            field_names_accessed: HashSet::with_capacity(PRESIZE),
+            call_idents: HashSet::with_capacity(PRESIZE),
+            impl_trait_names: HashSet::with_capacity(PRESIZE),
+            ..Markers::default()
+        };
         crate::uniqueness_walk::visit(program, &mut |n| match n {
             Node::Function {
                 name,


### PR DESCRIPTION
## Summary

`Markers::default()` creates each HashSet field at capacity 0. As `Markers::scan` walks the AST inserting names, the HashSets grow via doubling (0 → 4 → 8 → 16 → 32 → ...). Each rehash relocates every existing entry, paying O(N) per rehash.

For a program with ~50 functions, `fn_names` sees 4-5 rehashes during the walk; same pattern repeats across the seven other name-HashSets. That's ~30 wasted rehash rounds per typecheck on medium-to-large inputs.

Pre-size each HashSet with `with_capacity(16)` — fits typical medium-sized programs without rehashing while costing eight ~144-byte allocations for tiny programs (small enough to disappear into the noise of the rest of a typecheck). Bool fields default to false; only the HashSets benefit from pre-sizing.

## Test plan

- [x] No new test — perf-only change to an existing function.
- [x] 26 pre-existing `pass_gate::tests` pass.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.

Closes #1686