### PR TITLE
RES-1688: pre-size Z3 verdict / tautology / BV caches

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,9 +264,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/pass_gate.rs": {
-      "branch": "res-1686-presize-markers",
-      "claimed_at": "2026-05-13T08:45:35Z"
+    "resilient/src/verifier_z3.rs": {
+      "branch": "res-1688-presize-z3-caches",
+      "claimed_at": "2026-05-13T08:53:32Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -680,7 +680,7 @@ thread_local! {
             u64,
             (Option<bool>, Option<ProofCertificate>, Option<String>, bool),
         >,
-    > = std::cell::RefCell::new(std::collections::HashMap::new());
+    > = std::cell::RefCell::new(std::collections::HashMap::with_capacity(64));
 
     /// RES-1309 / RES-1635: thread-local cache for the tautology-only
     /// fast path. Disjoint key namespace from `Z3_VERDICT_CACHE` (the
@@ -688,7 +688,7 @@ thread_local! {
     #[allow(clippy::type_complexity)]
     static Z3_TAUTOLOGY_CACHE: std::cell::RefCell<
         std::collections::HashMap<u64, (bool, Option<ProofCertificate>, bool)>,
-    > = std::cell::RefCell::new(std::collections::HashMap::new());
+    > = std::cell::RefCell::new(std::collections::HashMap::with_capacity(64));
 
     /// RES-1316 / RES-1635: thread-local cache for the BV32 entry
     /// point. Disjoint key namespace (`|BV` suffix).
@@ -698,7 +698,7 @@ thread_local! {
             u64,
             (Option<bool>, Option<ProofCertificate>, Option<String>, bool),
         >,
-    > = std::cell::RefCell::new(std::collections::HashMap::new());
+    > = std::cell::RefCell::new(std::collections::HashMap::with_capacity(64));
 }
 
 /// RES-1635: a `fmt::Write` adapter that streams formatted bytes


### PR DESCRIPTION
## Summary

Same shape as RES-1686 for Markers, applied to the three thread-local Z3 caches (`Z3_VERDICT_CACHE`, `Z3_TAUTOLOGY_CACHE`, `Z3_BV_CACHE`). Each was initialised with `HashMap::new()` (capacity 0). As a typecheck accumulates Z3 queries, each cache grows via doubling (0 → 4 → 8 → 16 → 32 → 64). For ~100 obligations, that's 5-6 rehashes per cache, ~15-18 wasted rehash rounds per typecheck across the three.

Pre-size each with `with_capacity(64)`. `thread_local!` accepts non-const initialisers — one-line change per cache.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.

Closes #1688