### PR TITLE
RES-1690: pre-size typechecker PROVE_CACHE

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,9 +264,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/verifier_z3.rs": {
-      "branch": "res-1688-presize-z3-caches",
-      "claimed_at": "2026-05-13T08:53:32Z"
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1690-presize-prove-cache",
+      "claimed_at": "2026-05-13T08:57:00Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -823,8 +823,13 @@ type ProveCacheEntry = (Option<bool>, Option<String>, Option<String>, bool);
 
 #[cfg(feature = "z3")]
 thread_local! {
+    // RES-1690: pre-size with capacity 64 — same pattern as RES-1688
+    // for the inner Z3 caches. PROVE_CACHE accumulates one entry per
+    // distinct `(clause, bindings, theory, timeout)` tuple within a
+    // single typecheck; programs with ~100 obligations would otherwise
+    // pay 5-6 rehashes per typecheck.
     static PROVE_CACHE: std::cell::RefCell<std::collections::HashMap<u64, ProveCacheEntry>> =
-        std::cell::RefCell::new(std::collections::HashMap::new());
+        std::cell::RefCell::new(std::collections::HashMap::with_capacity(64));
 }
 
 /// RES-1631: reset the within-run Z3 proof cache. Called from


### PR DESCRIPTION
## Summary

Same pattern as RES-1686 (Markers HashSets) and RES-1688 (inner Z3 caches). `PROVE_CACHE` (RES-1631) is the within-run Z3 proof cache in `typechecker.rs`; was initialised with `HashMap::new()` (capacity 0). For ~100 obligations per typecheck, doubling growth = 5-6 rehashes.

Pre-size with `with_capacity(64)`. `reset_z3_prove_cache` clears but retains capacity, so this only benefits the first typecheck per process — but that's the typical CI scenario.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.