### PR TITLE
RES-1694: pre-size bounds_check::PROVEN_SITES

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,9 +264,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1692-presize-typechecker-fields",
-      "claimed_at": "2026-05-13T09:00:38Z"
+    "resilient/src/bounds_check.rs": {
+      "branch": "res-1694-presize-proven-sites",
+      "claimed_at": "2026-05-13T09:06:43Z"
     }
   }
 }

--- a/resilient/src/bounds_check.rs
+++ b/resilient/src/bounds_check.rs
@@ -71,7 +71,15 @@ thread_local! {
     /// elided/runtime breakdown. Per-thread so the parallel test
     /// runner stays correct (the `TEST_LOCK` mutex serialises the few
     /// tests that read this).
-    static PROVEN_SITES: std::cell::RefCell<HashSet<Span>> = std::cell::RefCell::new(HashSet::new());
+    // RES-1694: pre-size with capacity 32 — same pattern as RES-1686 /
+    // RES-1688 / RES-1690 / RES-1692. PROVEN_SITES accumulates one
+    // entry per proven `IndexExpression` site within a typecheck; for
+    // programs with many array accesses, doubling growth from 0 paid
+    // for 2-3 rehash rounds. `reset_stats` clears but retains
+    // capacity, so this only benefits the first typecheck per process
+    // (CI / `cargo test` runs).
+    static PROVEN_SITES: std::cell::RefCell<HashSet<Span>> =
+        std::cell::RefCell::new(HashSet::with_capacity(32));
 }
 
 /// Read the last-run counters. Tests use this to confirm the pass


### PR DESCRIPTION
## Summary

Fifth in the pre-size series. `PROVEN_SITES` is the thread-local HashSet that tracks spans of `IndexExpression` sites the bounds-check pass discharged via Z3. The bytecode compiler reads it to emit `LoadIndexUnchecked` for proven sites; `--audit` reports per-site elision counts.

Pre-size from `capacity(0)` to `capacity(32)`. For programs with many array accesses, doubling growth previously paid 2-3 rehash rounds per typecheck.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.