### PR TITLE
RES-1696: share one Z3 Solver via push/pop across tautology + contradiction

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,9 +264,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/bounds_check.rs": {
-      "branch": "res-1694-presize-proven-sites",
-      "claimed_at": "2026-05-13T09:06:43Z"
+    "resilient/src/verifier_z3.rs": {
+      "branch": "res-1696-shared-solver-pushpop",
+      "claimed_at": "2026-05-13T09:13:10Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -1209,8 +1209,12 @@ fn prove_with_axioms_and_timeout_in(
         .filter_map(|ax| translate_bool(ctx, ax, bindings))
         .collect();
 
-    // Tautology check: is `NOT formula` unsatisfiable? If yes, formula
-    // is always true regardless of any free variables.
+    // RES-1696: share one Solver across the tautology + contradiction
+    // checks via push/pop scopes. The axioms (`len_axioms` and
+    // `user_axioms`) are common to both phases and only need to be
+    // asserted once; previously they were re-asserted on a second
+    // freshly-allocated Solver, paying both the duplicate Solver setup
+    // and the duplicate axiom-assert work.
     let solver = z3::Solver::new(ctx);
     apply_timeout(&solver);
     for axiom in &len_axioms {
@@ -1219,7 +1223,13 @@ fn prove_with_axioms_and_timeout_in(
     for axiom in &user_axioms {
         solver.assert(axiom);
     }
+
+    // Tautology check: is `NOT formula` unsatisfiable? If yes, formula
+    // is always true regardless of any free variables. Pushed onto a
+    // scope so we can drop the negated assertion before re-using the
+    // solver for the contradiction check.
     let negated = formula.not();
+    solver.push();
     solver.assert(&negated);
     let check = solver.check();
     let tautology = matches!(check, z3::SatResult::Unsat);
@@ -1231,13 +1241,15 @@ fn prove_with_axioms_and_timeout_in(
     // is satisfiable — the model is an assignment that falsifies the
     // clause, which is what a user needs to see to debug a failing
     // contract. We harvest it eagerly so the later contradiction
-    // check (which reuses a fresh solver) doesn't need to re-derive
-    // it.
+    // check (after `solver.pop`) doesn't need to re-derive it. Done
+    // BEFORE the `pop` because the model goes away when the scope
+    // is dropped.
     let counterexample = if matches!(check, z3::SatResult::Sat) {
         extract_counterexample(ctx, &solver, expr, bindings)
     } else {
         None
     };
+    solver.pop(1);
 
     if tautology {
         // Build a self-contained re-verifiable SMT-LIB2 file.
@@ -1306,17 +1318,13 @@ fn prove_with_axioms_and_timeout_in(
     }
 
     // Contradiction check: is `formula` unsatisfiable? If yes, the
-    // contract can never hold.
-    let solver = z3::Solver::new(ctx);
-    apply_timeout(&solver);
-    for axiom in &len_axioms {
-        solver.assert(axiom);
-    }
-    for axiom in &user_axioms {
-        solver.assert(axiom);
-    }
+    // contract can never hold. Re-uses the same `solver` instance —
+    // axioms are still asserted from the pre-push setup above; we
+    // only need to push the positive formula into a fresh scope.
+    solver.push();
     solver.assert(&formula);
     let contradiction = matches!(solver.check(), z3::SatResult::Unsat);
+    solver.pop(1);
 
     if contradiction {
         return (Some(false), None, counterexample, false);


### PR DESCRIPTION
## Summary

Refactor `prove_with_axioms_and_timeout_in` to share a single `z3::Solver` across the tautology + contradiction phases via `push` / `pop` scopes. Axioms (`len_axioms` + `user_axioms`) are now asserted once, outside any scope. Each phase pushes its own formula, checks, pops.

## Savings per Z3 prove call

- One `Solver::new()` avoided.
- One full pass of axiom assertions avoided.
- Z3's incremental solver can reuse learned facts across the push/pop boundary.

## Correctness

Counterexample extraction must happen BEFORE the first `pop(1)` because the model goes away when the scope is dropped. Caught locally by the full z3 test suite — all 3375 tests pass, covering verdict + counterexample + certificate-emission semantics across all entry points.

## Test plan

- [x] Perf refactor, no new tests — pre-existing 3375 z3 tests cover all behaviour paths.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.

Closes #1696