### PR TITLE
RES-1698: pre-size TypeEnvironment for BUILTIN_ENV

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,9 +264,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/verifier_z3.rs": {
-      "branch": "res-1696-shared-solver-pushpop",
-      "claimed_at": "2026-05-13T09:13:10Z"
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1698-presize-type-env",
+      "claimed_at": "2026-05-13T09:21:42Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -626,9 +626,26 @@ pub struct TypeEnvironment {
 }
 
 impl TypeEnvironment {
+    /// RES-1698: kept `pub` so the supervisor test module
+    /// (`supervisor.rs:362`) can still build a default-capacity env;
+    /// every non-test caller uses `with_capacity` below.
+    #[allow(dead_code)]
     pub fn new() -> Self {
         TypeEnvironment {
             store: HashMap::new(),
+            outer: None,
+        }
+    }
+
+    /// RES-1698: pre-sized variant. The `BUILTIN_ENV` LazyLock seeds
+    /// ~490 built-in fn names into a `TypeEnvironment`, growing the
+    /// inner HashMap from 0 → 4 → ... → 512 (~9 rehashes). Calling
+    /// `with_capacity(512)` once per process avoids every one of
+    /// those — the cloned per-`TypeChecker` envs inherit the
+    /// preserved capacity.
+    pub fn with_capacity(cap: usize) -> Self {
+        TypeEnvironment {
+            store: HashMap::with_capacity(cap),
             outer: None,
         }
     }
@@ -1236,7 +1253,10 @@ impl TypeChecker {
         // populated `HashMap` is one bulk allocation plus per-entry
         // clones (~970 heap allocs) — ~30-50% faster.
         static BUILTIN_ENV: std::sync::LazyLock<TypeEnvironment> = std::sync::LazyLock::new(|| {
-            let mut env = TypeEnvironment::new();
+            // RES-1698: pre-size to fit the ~490 builtin entries.
+            // Saves 9 rehash rounds on the one-time LazyLock init;
+            // every cloned `TypeChecker` env inherits the capacity.
+            let mut env = TypeEnvironment::with_capacity(512);
 
             // Built-in function signatures. Any-typed parameters keep the
             // type checker permissive for heterogeneous inputs until real


### PR DESCRIPTION
## Summary

Sixth in the pre-size series. The `BUILTIN_ENV` LazyLock seeds ~490 fn-name/type entries into a fresh `TypeEnvironment`, growing the inner HashMap from capacity 0 → 4 → ... → 512 (9 rehashes).

Add a new `TypeEnvironment::with_capacity(cap)` constructor; have the LazyLock init use `with_capacity(512)`. One-time saving on the LazyLock init, but every cloned `TypeChecker` env inherits the preserved capacity — so the gain compounds across all the per-scope envs forked from BUILTIN_ENV.

## Test plan

- [x] `TypeEnvironment::new()` retained with `#[allow(dead_code)]` for the supervisor test module's `make_fn_env`.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.