### PR TITLE
RES-1702: share one Z3 Solver via push/pop in prove_bv_in

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,8 +265,8 @@
       "claimed_at": "2026-05-13T07:09:45Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1700-presize-persistent-fastpath",
-      "claimed_at": "2026-05-13T09:29:14Z"
+      "branch": "res-1702-prove-bv-pushpop",
+      "claimed_at": "2026-05-13T09:33:27Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -1678,30 +1678,41 @@ fn prove_bv_in(
         }
     };
 
-    // Tautology check.
+    // RES-1702: share one Solver across the tautology + contradiction
+    // checks via push/pop scopes. Same shape as RES-1696 for the LIA
+    // path. Saves one `Solver::new()` allocation + one `apply_timeout`
+    // setup per BV prove call; Z3's incremental solver can also reuse
+    // learned facts across the push/pop boundary.
     let solver = z3::Solver::new(ctx);
     apply_timeout(&solver);
+
+    // Tautology check.
     let negated = formula.not();
+    solver.push();
     solver.assert(&negated);
     let check = solver.check();
     let tautology = matches!(check, z3::SatResult::Unsat);
     let timed_out = matches!(check, z3::SatResult::Unknown);
 
     if tautology {
+        // Don't bother popping — function returns and the solver is
+        // dropped anyway.
         return (Some(true), None, None, false);
     }
 
     let counterexample = if matches!(check, z3::SatResult::Sat) {
+        // Extract counterexample BEFORE pop — model is scope-bound.
         extract_counterexample_bv(ctx, &solver, expr, bindings)
     } else {
         None
     };
+    solver.pop(1);
 
     // Contradiction check.
-    let solver2 = z3::Solver::new(ctx);
-    apply_timeout(&solver2);
-    solver2.assert(&formula);
-    let contradiction = matches!(solver2.check(), z3::SatResult::Unsat);
+    solver.push();
+    solver.assert(&formula);
+    let contradiction = matches!(solver.check(), z3::SatResult::Unsat);
+    solver.pop(1);
 
     if contradiction {
         return (Some(false), None, counterexample, false);


### PR DESCRIPTION
## Summary

Apply the RES-1696 push/pop refactor to `prove_bv_in` (the BV32 prove path). Was constructing two separate Solvers + two `apply_timeout` setups. Now shares one Solver, push/pop the two phase-specific formulas.

The BV path has no `len_axioms` / `user_axioms`, so the win is smaller than the LIA path's, but still saves one Solver allocation + one timeout-Params setup per BV prove call. Z3's incremental solver can also reuse learned facts across the push/pop boundary.

## Test plan

- [x] Perf refactor, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.