### PR TITLE
RES-1706: use IdentityU64Hasher for Z3 caches

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,8 +265,8 @@
       "claimed_at": "2026-05-13T07:09:45Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1704-counterexample-string",
-      "claimed_at": "2026-05-13T09:37:44Z"
+      "branch": "res-1706-identity-hasher-z3-caches",
+      "claimed_at": "2026-05-13T09:43:54Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -683,6 +683,33 @@ pub fn reset_cache_stats() {
     Z3_CACHE_STATS.with(|s| s.set(Z3CacheStats::default()));
 }
 
+/// RES-1706: identity hasher for `u64` cache keys. The key is already
+/// a high-quality hash from `hash_node_spanless` + SipHash via
+/// `DefaultHasher`; re-hashing it inside the cache HashMap is
+/// wasted work (~5-10 cycles per lookup with SipHash on u64).
+/// Skipping that on ~300 cache touches per typecheck saves ~1.5-3µs.
+#[derive(Default)]
+struct IdentityU64Hasher(u64);
+
+impl std::hash::Hasher for IdentityU64Hasher {
+    fn write(&mut self, _bytes: &[u8]) {
+        // The Z3 cache code only stores `u64` keys, so the byte-write
+        // path is unreachable. If a non-u64 ever flows in, the hash
+        // is intentionally garbage rather than panicking — `finish`
+        // returns 0, every key collides, and the HashMap degrades to
+        // a linear scan. Safer than panicking inside a hash impl.
+    }
+    fn write_u64(&mut self, n: u64) {
+        self.0 = n;
+    }
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+type U64CacheMap<V> =
+    std::collections::HashMap<u64, V, std::hash::BuildHasherDefault<IdentityU64Hasher>>;
+
 thread_local! {
     /// RES-1206: see `prove_with_axioms_and_timeout`. Stays the lifetime
     /// of the thread; reset between top-level compiles isn't needed
@@ -697,29 +724,23 @@ thread_local! {
     /// paid before.
     #[allow(clippy::type_complexity)]
     static Z3_VERDICT_CACHE: std::cell::RefCell<
-        std::collections::HashMap<
-            u64,
-            (Option<bool>, Option<ProofCertificate>, Option<String>, bool),
-        >,
-    > = std::cell::RefCell::new(std::collections::HashMap::with_capacity(64));
+        U64CacheMap<(Option<bool>, Option<ProofCertificate>, Option<String>, bool)>,
+    > = std::cell::RefCell::new(U64CacheMap::with_capacity_and_hasher(64, Default::default()));
 
     /// RES-1309 / RES-1635: thread-local cache for the tautology-only
     /// fast path. Disjoint key namespace from `Z3_VERDICT_CACHE` (the
     /// hash input ends with a `|TAUT` discriminator).
     #[allow(clippy::type_complexity)]
     static Z3_TAUTOLOGY_CACHE: std::cell::RefCell<
-        std::collections::HashMap<u64, (bool, Option<ProofCertificate>, bool)>,
-    > = std::cell::RefCell::new(std::collections::HashMap::with_capacity(64));
+        U64CacheMap<(bool, Option<ProofCertificate>, bool)>,
+    > = std::cell::RefCell::new(U64CacheMap::with_capacity_and_hasher(64, Default::default()));
 
     /// RES-1316 / RES-1635: thread-local cache for the BV32 entry
     /// point. Disjoint key namespace (`|BV` suffix).
     #[allow(clippy::type_complexity)]
     static Z3_BV_CACHE: std::cell::RefCell<
-        std::collections::HashMap<
-            u64,
-            (Option<bool>, Option<ProofCertificate>, Option<String>, bool),
-        >,
-    > = std::cell::RefCell::new(std::collections::HashMap::with_capacity(64));
+        U64CacheMap<(Option<bool>, Option<ProofCertificate>, Option<String>, bool)>,
+    > = std::cell::RefCell::new(U64CacheMap::with_capacity_and_hasher(64, Default::default()));
 }
 
 /// RES-1635: a `fmt::Write` adapter that streams formatted bytes


### PR DESCRIPTION
## Summary

The three Z3 caches key on `u64` produced by `DefaultHasher` (SipHash) over the obligation AST. `HashMap`'s default `RandomState` then runs SipHash AGAIN on the u64 to pick a bucket — ~5-10 cycles per lookup, wasted.

Add `IdentityU64Hasher` that passes the u64 through to `finish()`. Pair with `BuildHasherDefault` and apply to all three caches.

Net: ~1.5-3µs saved per typecheck (~300 cache touches × 5-10 cycles).

## Soundness

The hasher only handles `write_u64` correctly — its byte-write impl is a no-op. The Z3 cache code stores only `u64` keys, so this matches the existing invariant; misuse would degrade the HashMap to a linear scan but not corrupt data.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.