### PR TITLE
RES-1708: use IdentityU64Hasher for typechecker PROVE_CACHE

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,8 +265,12 @@
       "claimed_at": "2026-05-13T07:09:45Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1706-identity-hasher-z3-caches",
-      "claimed_at": "2026-05-13T09:43:54Z"
+      "branch": "res-1708-identity-hasher-prove-cache",
+      "claimed_at": "2026-05-13T09:48:16Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1708-identity-hasher-prove-cache",
+      "claimed_at": "2026-05-13T09:48:16Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -845,8 +845,17 @@ thread_local! {
     // distinct `(clause, bindings, theory, timeout)` tuple within a
     // single typecheck; programs with ~100 obligations would otherwise
     // pay 5-6 rehashes per typecheck.
-    static PROVE_CACHE: std::cell::RefCell<std::collections::HashMap<u64, ProveCacheEntry>> =
-        std::cell::RefCell::new(std::collections::HashMap::with_capacity(64));
+    //
+    // RES-1708: use the same `IdentityU64Hasher` the inner Z3 caches
+    // use (RES-1706). The `u64` key is already a high-quality hash
+    // from `hash_node_spanless` + SipHash via `DefaultHasher`;
+    // re-hashing it inside the HashMap costs ~5-10 cycles per
+    // lookup that we can skip.
+    static PROVE_CACHE: std::cell::RefCell<
+        crate::verifier_z3::U64CacheMap<ProveCacheEntry>,
+    > = std::cell::RefCell::new(
+        crate::verifier_z3::U64CacheMap::with_capacity_and_hasher(64, Default::default()),
+    );
 }
 
 /// RES-1631: reset the within-run Z3 proof cache. Called from

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -688,8 +688,12 @@ pub fn reset_cache_stats() {
 /// `DefaultHasher`; re-hashing it inside the cache HashMap is
 /// wasted work (~5-10 cycles per lookup with SipHash on u64).
 /// Skipping that on ~300 cache touches per typecheck saves ~1.5-3µs.
+///
+/// RES-1708: exported as `pub(crate)` so the typechecker's
+/// `PROVE_CACHE` (also keyed on `u64` from the same hash chain) can
+/// reuse it.
 #[derive(Default)]
-struct IdentityU64Hasher(u64);
+pub(crate) struct IdentityU64Hasher(u64);
 
 impl std::hash::Hasher for IdentityU64Hasher {
     fn write(&mut self, _bytes: &[u8]) {
@@ -707,7 +711,7 @@ impl std::hash::Hasher for IdentityU64Hasher {
     }
 }
 
-type U64CacheMap<V> =
+pub(crate) type U64CacheMap<V> =
     std::collections::HashMap<u64, V, std::hash::BuildHasherDefault<IdentityU64Hasher>>;
 
 thread_local! {


### PR DESCRIPTION
## Summary

`PROVE_CACHE` was the last `u64`-keyed Z3 cache still using `HashMap`'s default `RandomState`. Promote `IdentityU64Hasher` + `U64CacheMap` to `pub(crate)` in `verifier_z3.rs` and use them here.

Same shape as RES-1706. No new tests.

## Test plan

- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.