### PR TITLE
RES-1710: Vec + sort beats BTreeMap for small-N cache key bindings

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,12 +265,8 @@
       "claimed_at": "2026-05-13T07:09:45Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1708-identity-hasher-prove-cache",
-      "claimed_at": "2026-05-13T09:48:16Z"
-    },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1708-identity-hasher-prove-cache",
-      "claimed_at": "2026-05-13T09:48:16Z"
+      "branch": "res-1710-bindings-vec-sort",
+      "claimed_at": "2026-05-13T09:53:51Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -462,7 +462,13 @@ pub fn prove_with_axioms_and_timeout(
         // RES-1637: structural span-free hash for the obligation.
         hash_node_spanless(expr, &mut h);
         b'|'.hash(&mut h);
-        let bindings_sorted: std::collections::BTreeMap<&String, &i64> = bindings.iter().collect();
+        // RES-1710: Vec + sort beats BTreeMap allocation for the
+        // typical small-N binding sizes (0-5 entries). Vec collected
+        // from a HashMap iter pre-allocates via size_hint;
+        // sort_unstable_by_key is O(N log N) with no per-entry heap
+        // allocs (vs BTreeMap's per-insert tree-node).
+        let mut bindings_sorted: Vec<(&String, &i64)> = bindings.iter().collect();
+        bindings_sorted.sort_unstable_by_key(|(k, _)| k.as_str());
         for (k, v) in &bindings_sorted {
             k.hash(&mut h);
             v.hash(&mut h);
@@ -1434,7 +1440,13 @@ pub fn prove_tautology_with_axioms_and_timeout(
         let mut h = DefaultHasher::new();
         hash_node_spanless(expr, &mut h);
         b'|'.hash(&mut h);
-        let bindings_sorted: std::collections::BTreeMap<&String, &i64> = bindings.iter().collect();
+        // RES-1710: Vec + sort beats BTreeMap allocation for the
+        // typical small-N binding sizes (0-5 entries). Vec collected
+        // from a HashMap iter pre-allocates via size_hint;
+        // sort_unstable_by_key is O(N log N) with no per-entry heap
+        // allocs (vs BTreeMap's per-insert tree-node).
+        let mut bindings_sorted: Vec<(&String, &i64)> = bindings.iter().collect();
+        bindings_sorted.sort_unstable_by_key(|(k, _)| k.as_str());
         for (k, v) in &bindings_sorted {
             k.hash(&mut h);
             v.hash(&mut h);
@@ -1635,7 +1647,13 @@ pub fn prove_bv(
         let mut h = DefaultHasher::new();
         hash_node_spanless(expr, &mut h);
         b'|'.hash(&mut h);
-        let bindings_sorted: std::collections::BTreeMap<&String, &i64> = bindings.iter().collect();
+        // RES-1710: Vec + sort beats BTreeMap allocation for the
+        // typical small-N binding sizes (0-5 entries). Vec collected
+        // from a HashMap iter pre-allocates via size_hint;
+        // sort_unstable_by_key is O(N log N) with no per-entry heap
+        // allocs (vs BTreeMap's per-insert tree-node).
+        let mut bindings_sorted: Vec<(&String, &i64)> = bindings.iter().collect();
+        bindings_sorted.sort_unstable_by_key(|(k, _)| k.as_str());
         for (k, v) in &bindings_sorted {
             k.hash(&mut h);
             v.hash(&mut h);


### PR DESCRIPTION
## Summary

Replace `BTreeMap<&String, &i64>` bindings-sort with `Vec + sort_unstable_by_key` at all three Z3 cache key construction sites (`prove_with_axioms_and_timeout`, `prove_tautology_with_axioms_and_timeout`, `prove_bv`).

For the typical small-N case (0-5 bindings — most prove calls), BTreeMap allocates one tree node per insert; Vec collected from a HashMap iter pre-allocates once via size_hint. Sort comparisons are stack-resident. Hash output is bit-for-bit identical.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.