### PR TITLE
RES-1712: pre-size counterexample String to 64 bytes

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,8 +265,8 @@
       "claimed_at": "2026-05-13T07:09:45Z"
     },
     "resilient/src/verifier_z3.rs": {
-      "branch": "res-1710-bindings-vec-sort",
-      "claimed_at": "2026-05-13T09:53:51Z"
+      "branch": "res-1712-counterexample-presize",
+      "claimed_at": "2026-05-13T09:59:03Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -1878,7 +1878,10 @@ fn extract_counterexample_bv(
     // RES-1704: write directly into one accumulator — same shape as
     // the LIA counterexample fn above.
     use std::fmt::Write;
-    let mut out = String::new();
+    // RES-1712: a typical counterexample has 1-3 idents with short
+    // names + small int values — well under 64 bytes total. Pre-size
+    // to skip the initial 8 / 16 / 32-byte grow steps.
+    let mut out = String::with_capacity(64);
     for name in &idents {
         if bindings.contains_key(*name) {
             continue;
@@ -2016,7 +2019,10 @@ fn extract_counterexample(
     // is mechanical and the join allocation always matched the
     // intermediate Vec's total length anyway.
     use std::fmt::Write;
-    let mut out = String::new();
+    // RES-1712: a typical counterexample has 1-3 idents with short
+    // names + small int values — well under 64 bytes total. Pre-size
+    // to skip the initial 8 / 16 / 32-byte grow steps.
+    let mut out = String::with_capacity(64);
     for name in &idents {
         if bindings.contains_key(*name) {
             continue;


### PR DESCRIPTION
## Summary

Pre-size the LIA + BV32 counterexample `String::new()` to `with_capacity(64)`. Typical counterexamples have 1-3 idents with short names — stays under 64 bytes, skipping the initial 8/16/32-byte grow steps.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.