### PR TITLE
RES-1714: pre-size lexer token Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,9 +264,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/verifier_z3.rs": {
-      "branch": "res-1712-counterexample-presize",
-      "claimed_at": "2026-05-13T09:59:03Z"
+    "resilient/src/lexer_logos.rs": {
+      "branch": "res-1714-presize-token-vec",
+      "claimed_at": "2026-05-13T10:04:23Z"
     }
   }
 }

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -625,7 +625,14 @@ pub fn tokenize(src: &str) -> Vec<(Token, Span)> {
         Pos::new(line, column, offset)
     };
 
-    let mut out: Vec<(Token, Span)> = Vec::new();
+    // RES-1714: pre-size the token Vec. Resilient source averages
+    // ~4-6 bytes per token (whitespace, idents, literals, single-byte
+    // punctuation), so `src.len() / 4` is a reasonable upper bound
+    // that fits typical inputs in one allocation. For a 100 KB
+    // source that's ~25k tokens; without pre-sizing the Vec would
+    // double-grow ~12 times during the tokenize loop, each rehoming
+    // every prior entry.
+    let mut out: Vec<(Token, Span)> = Vec::with_capacity(src.len() / 4);
     // Feed only the post-shebang slice to logos, and offset every
     // reported byte range by `shebang_bytes` when converting to a
     // `Pos` against the full-source table.


### PR DESCRIPTION
## Summary

`tokenize` (the entry point in lexer_logos.rs called for every `.rz` file) accumulates `(Token, Span)` pairs into a `Vec::new()`. Resilient source averages ~4-6 bytes per token, so a 100KB source yields ~25K tokens — that's ~12 reallocations during the loop, each relocating every prior entry.

Pre-size with `Vec::with_capacity(src.len() / 4)`. Single allocation fits typical inputs; for tiny sources the overshoot is < 1KB.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.