### PR TITLE
RES-1718: pre-size monomorph new_stmts Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -260,9 +260,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/compiler.rs": {
-      "branch": "res-1716-compiler-presize",
-      "claimed_at": "2026-05-13T10:09:16Z"
+    "resilient/src/monomorph.rs": {
+      "branch": "res-1718-monomorph-presize",
+      "claimed_at": "2026-05-13T10:14:49Z"
     }
   }
 }

--- a/resilient/src/monomorph.rs
+++ b/resilient/src/monomorph.rs
@@ -61,7 +61,12 @@ pub fn lower(program: &Node) -> Node {
     }
 
     // Phase 3: assemble the lowered program.
-    let mut new_stmts: Vec<span::Spanned<Node>> = Vec::new();
+    // RES-1718: pre-size to `stmts.len()` (every input statement is
+    // rewritten and pushed once via the loop below) plus a small
+    // margin for the appended specialised clones — saves ~3-4
+    // reallocations on programs with generic call sites.
+    let mut new_stmts: Vec<span::Spanned<Node>> =
+        Vec::with_capacity(stmts.len() + instantiations.len() * 2);
 
     // Copy every non-generic statement with call sites rewritten.
     // Keep generic functions too (erasure fallback for non-literal call sites).


### PR DESCRIPTION
## Summary

Pre-size the monomorphisation pass's `new_stmts: Vec<Spanned<Node>>` to `stmts.len() + instantiations.len() * 2`. The Vec receives one rewritten entry per input statement plus one specialised clone per instantiation; the original `Vec::new()` paid 3-4 reallocations on programs with generic call sites.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo clippy` clean.
- [x] `cargo fmt --check` clean.