### PR TITLE
RES-1720: pre-size bytecode Chunk for per-fn emit

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -260,9 +260,13 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/monomorph.rs": {
-      "branch": "res-1718-monomorph-presize",
-      "claimed_at": "2026-05-13T10:14:49Z"
+    "resilient/src/bytecode.rs": {
+      "branch": "res-1720-chunk-with-capacity",
+      "claimed_at": "2026-05-13T10:19:17Z"
+    },
+    "resilient/src/compiler.rs": {
+      "branch": "res-1720-chunk-with-capacity",
+      "claimed_at": "2026-05-13T10:19:17Z"
     }
   }
 }

--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -240,6 +240,24 @@ impl Chunk {
         Self::default()
     }
 
+    /// RES-1720: pre-sized constructor for the bytecode emitter. A
+    /// typical function body is 50-300 opcodes; the default
+    /// `Vec::new()` doubling growth (0 → 4 → 8 → ... → 256) paid
+    /// for ~6 reallocations during a single function's emit. With
+    /// hundreds of fns per typecheck on `large.rz`-shaped inputs,
+    /// that's a real chunk of work hidden in `Op::push`.
+    ///
+    /// `cap` is a hint — the caller estimates from AST body size
+    /// (one opcode per inner-expression Node is a rough lower bound).
+    /// Constants and `line_info` share the same opcode count.
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            code: Vec::with_capacity(cap),
+            constants: Vec::with_capacity(cap / 4),
+            line_info: Vec::with_capacity(cap),
+        }
+    }
+
     /// Append an instruction and its originating line. Returns the
     /// instruction's index for back-patching by jump emitters (used in
     /// RES-083).

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -134,7 +134,11 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
         } = &spanned.node
         {
             let arity = parameters.len() as u8;
-            let mut chunk = Chunk::new();
+            // RES-1720: pre-size the Chunk's opcode buffers. 128 fits
+            // the median Resilient fn body (~50-200 opcodes) without
+            // needing a Vec realloc; tiny functions overshoot by < 1
+            // KB. Same shape as RES-1716 / RES-1714 / RES-1718.
+            let mut chunk = Chunk::with_capacity(128);
             // Parameters occupy locals 0..arity. Map each param name
             // to its slot; additional `let` bindings in the body bump
             // `next_local` from there.
@@ -213,7 +217,9 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
     }
 
     // Pass 3: compile the remaining top-level statements into `main`.
-    let mut main = Chunk::new();
+    // RES-1720: pre-size — top-level body usually emits a handful of
+    // setup ops + per-stmt calls. 64 fits the common case.
+    let mut main = Chunk::with_capacity(64);
     // RES-1716: pre-size `main_locals` — same shape as RES-1461 for
     // `fn_index`. Top-level `let` / `const` / `static` bindings flow
     // into this map; typical programs have 5-20 entries. Pre-sizing


### PR DESCRIPTION
## Summary

Add `Chunk::with_capacity(cap)` (sibling of the existing `Chunk::new()`). Wires through to `compile()`:

- Per-fn body: `with_capacity(128)` — fits median fn body (50-200 opcodes).
- Top-level main: `with_capacity(64)` — usually fewer ops.

Each Chunk has `code` + `line_info` + `constants` Vecs that grew from 0. For a typical fn body (~100 ops), that's ~5-6 reallocations during emit. Per-typecheck this happens once per fn — hundreds of times on `large.rz`.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` + `cargo clippy --features z3` clean.
- [x] `cargo fmt --check` clean.