### PR TITLE
RES-1724: pre-size param_types Vec in Function check arm

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -256,9 +256,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/region_inference.rs": {
-      "branch": "res-1722-region-inference-presize",
-      "claimed_at": "2026-05-13T10:23:48Z"
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1724-param-types-presize",
+      "claimed_at": "2026-05-13T10:29:38Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4813,7 +4813,10 @@ impl TypeChecker {
                 fails,
                 ..
             } => {
-                let mut param_types = Vec::new();
+                // RES-1724: pre-size to `parameters.len()` — exact upper
+                // bound, the loop below pushes one entry per parameter.
+                // Same shape as the rest of the pre-size series.
+                let mut param_types = Vec::with_capacity(parameters.len());
 
                 // Create a new enclosed environment for function body
                 let mut function_env = TypeEnvironment::new_enclosed(self.env.clone());


### PR DESCRIPTION
## Summary

The typechecker's `Node::Function` arm builds `param_types: Vec<Type>` by pushing one entry per parameter. Was `Vec::new()`; now `Vec::with_capacity(parameters.len())` — exact upper bound, the loop pushes exactly that many entries.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo clippy` clean.
- [x] `cargo fmt --check` clean.