### PR TITLE
RES-1726: pre-size match-pattern binding-types Vecs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -257,8 +257,8 @@
       "claimed_at": "2026-05-13T07:09:45Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1724-param-types-presize",
-      "claimed_at": "2026-05-13T10:29:38Z"
+      "branch": "res-1726-match-pattern-presize",
+      "claimed_at": "2026-05-13T10:32:39Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4640,7 +4640,11 @@ impl TypeChecker {
             Pattern::EnumVariant { payload, .. } => match payload {
                 crate::EnumPatternPayload::None => Ok(vec![]),
                 crate::EnumPatternPayload::Named(fields) => {
-                    let mut out = Vec::new();
+                    // RES-1726: pre-size to fields.len() — lower bound
+                    // (each sub-pattern produces >=0 binding entries via
+                    // extend), but typically each named field contributes
+                    // ~1 binding. Same shape as the broader pre-size series.
+                    let mut out = Vec::with_capacity(fields.len());
                     for (_, sub) in fields {
                         let sub_bt = self.match_pattern_binding_types(sub.as_ref(), &Type::Any)?;
                         out.extend(sub_bt);
@@ -4648,7 +4652,8 @@ impl TypeChecker {
                     Ok(out)
                 }
                 crate::EnumPatternPayload::Tuple(subs) => {
-                    let mut out = Vec::new();
+                    // RES-1726: pre-size to subs.len() — same heuristic.
+                    let mut out = Vec::with_capacity(subs.len());
                     for sub in subs {
                         let sub_bt = self.match_pattern_binding_types(sub, &Type::Any)?;
                         out.extend(sub_bt);
@@ -4685,7 +4690,8 @@ impl TypeChecker {
                         fields.len()
                     ));
                 }
-                let mut out = Vec::new();
+                // RES-1726: pre-size to fields.len().
+                let mut out = Vec::with_capacity(fields.len());
                 for (i, sub) in fields.iter().enumerate() {
                     let key = i.to_string();
                     let Some((_, fty)) = decl.iter().find(|(n, _)| n == &key) else {
@@ -4704,7 +4710,8 @@ impl TypeChecker {
             // typechecker doesn't track per-position tuple element
             // types yet, mirroring how Some/Ok bindings are widened.
             Pattern::Tuple(items) => {
-                let mut out = Vec::new();
+                // RES-1726: pre-size to items.len().
+                let mut out = Vec::with_capacity(items.len());
                 for sub in items {
                     let sub_bt = self.match_pattern_binding_types(sub, &Type::Any)?;
                     out.extend(sub_bt);


### PR DESCRIPTION
## Summary

`match_pattern_binding_types` builds `out: Vec<(String, Type)>` for four pattern variants (EnumVariant::Named, EnumVariant::Tuple, TupleStruct, Tuple). Each was `Vec::new()` and grew via `out.extend(sub_bt)`.

Pre-size each to the pattern's field/sub count. Lower bound — each sub-pattern contributes >=0 binding entries — but the common case is one binding per field, which fits exactly without reallocs.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo clippy` clean.
- [x] `cargo fmt --check` clean.