### PR TITLE
RES-1728: pre-size verify_actor obligations Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -256,9 +256,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1726-match-pattern-presize",
-      "claimed_at": "2026-05-13T10:32:39Z"
+    "resilient/src/verifier_actors.rs": {
+      "branch": "res-1728-actor-obligations-presize",
+      "claimed_at": "2026-05-13T10:35:57Z"
     }
   }
 }

--- a/resilient/src/verifier_actors.rs
+++ b/resilient/src/verifier_actors.rs
@@ -80,7 +80,13 @@ pub(crate) fn verify_actor(
     receive_handlers: &[crate::ReceiveHandler],
     timeout_ms: u32,
 ) -> Vec<ActorObligation> {
-    let mut out = Vec::new();
+    // RES-1728: pre-size to the exact obligation count. Each
+    // always-clause emits one base-case + one inductive-step per
+    // receive handler. Same shape as the rest of the pre-size series.
+    let cap = always_clauses
+        .len()
+        .saturating_mul(1 + receive_handlers.len());
+    let mut out = Vec::with_capacity(cap);
 
     // MVP: single `state` field. Actors without state have nothing
     // to prove — skip. Multi-field support is a follow-up.


### PR DESCRIPTION
## Summary

`verify_actor` emits one base-case obligation per `always` clause + one inductive-step obligation per (clause, receive_handler) pair. The output `Vec<ActorObligation>` was `Vec::new()`. Pre-size to the exact upper bound.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo clippy` clean.
- [x] `cargo fmt --check` clean.