### PR TITLE
RES-1732: pre-size actor commutativity pairs Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -252,9 +252,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/verifier_liveness.rs": {
-      "branch": "res-1730-liveness-presize",
-      "claimed_at": "2026-05-13T10:38:59Z"
+    "resilient/src/verifier_z3.rs": {
+      "branch": "res-1732-actor-commute-presize",
+      "claimed_at": "2026-05-13T10:42:32Z"
     }
   }
 }

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -2411,7 +2411,15 @@ pub struct ActorVerification {
 /// `receive` handlers in the given actor. See module docs above
 /// for the semantic contract.
 pub fn check_actor_commutativity(actor_name: &str, handlers: &[ActorHandler]) -> ActorVerification {
-    let mut pairs: Vec<(String, String, CommutativityResult)> = Vec::new();
+    // RES-1732: pre-size to N*(N-1)/2 — exact pair count. For an
+    // actor with 4 handlers, 6 pairs; with 8 handlers, 28 pairs.
+    // The original `Vec::new()` doubled from 0, paying multiple
+    // reallocations on the inner-loop push.
+    let cap = handlers
+        .len()
+        .saturating_mul(handlers.len().saturating_sub(1))
+        / 2;
+    let mut pairs: Vec<(String, String, CommutativityResult)> = Vec::with_capacity(cap);
     for i in 0..handlers.len() {
         for j in (i + 1)..handlers.len() {
             let a = &handlers[i];


### PR DESCRIPTION
## Summary

`check_actor_commutativity` builds `pairs` over the N*(N-1)/2 unordered handler pairs. Was `Vec::new()`; pre-size to the exact pair count.

## Test plan

- [x] Perf-only, no new tests.
- [x] `cargo test`: 3232 default-features pass.
- [x] `cargo test --features z3`: 3375 pass.
- [x] `cargo clippy` clean.
- [x] `cargo fmt --check` clean.