### PR TITLE
RES-1740: pre-size supervisor seen_ids HashSet

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -248,9 +248,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1738-audit-presize",
-      "claimed_at": "2026-05-13T10:53:49Z"
+    "resilient/src/supervisor.rs": {
+      "branch": "res-1740-supervisor-seen-presize",
+      "claimed_at": "2026-05-13T10:57:25Z"
     }
   }
 }

--- a/resilient/src/supervisor.rs
+++ b/resilient/src/supervisor.rs
@@ -305,7 +305,9 @@ pub(crate) fn check(node: &Node, env: &TypeEnvironment) -> Result<(), String> {
             // is tied to `children` (owned by the AST node passed
             // in). Same shape as RES-1431 (pattern_bindings) /
             // RES-1439 (info_flow walk_calls).
-            let mut seen_ids: std::collections::HashSet<&str> = std::collections::HashSet::new();
+            // RES-1740: pre-size to children.len() — exact upper bound.
+            let mut seen_ids: std::collections::HashSet<&str> =
+                std::collections::HashSet::with_capacity(children.len());
 
             // Validate each child
             for child in children {


### PR DESCRIPTION
Pre-size seen_ids HashSet to children.len(). Perf-only. cargo test passes 3232.