### PR TITLE
RES-1746: pre-size bounded_blocking call-graph collections

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -32,10 +32,6 @@
       "branch": "res-1210-incremental-verify-dead-work",
       "claimed_at": "2026-05-12T01:53:15Z"
     },
-    "resilient/src/bounded_blocking.rs": {
-      "branch": "res-1511-bounded-blocking-name-borrow",
-      "claimed_at": "2026-05-12T13:10:00Z"
-    },
     "resilient/src/watchdog_feed.rs": {
       "branch": "res-1218-param-type-fast-reject",
       "claimed_at": "2026-05-12T02:11:38Z"
@@ -240,9 +236,9 @@
       "branch": "res-1659-cli-persistent-cache",
       "claimed_at": "2026-05-13T07:09:45Z"
     },
-    "resilient/src/isr_call_graph.rs": {
-      "branch": "res-1744-isr-presize",
-      "claimed_at": "2026-05-13T11:03:59Z"
+    "resilient/src/bounded_blocking.rs": {
+      "branch": "res-1746-bounded-blocking-presize",
+      "claimed_at": "2026-05-13T11:08:15Z"
     }
   }
 }

--- a/resilient/src/bounded_blocking.rs
+++ b/resilient/src/bounded_blocking.rs
@@ -65,9 +65,12 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // that can't bind the AST lifetime (same limitation as
     // RES-1509 for `isr_call_graph::collect_callees`). Mirror of
     // RES-1495 / RES-1500 / RES-1503 / RES-1507 / RES-1509.
-    let mut callees: HashMap<&str, Vec<String>> = HashMap::new();
-    let mut blocking_calls: HashMap<&str, usize> = HashMap::new();
-    let mut decls: Vec<&str> = Vec::new();
+    // RES-1746: pre-size the three call-graph collections to stmts.len()
+    // (upper bound). Same shape as RES-1742 / RES-1744 for the
+    // sibling call-graph passes.
+    let mut callees: HashMap<&str, Vec<String>> = HashMap::with_capacity(stmts.len());
+    let mut blocking_calls: HashMap<&str, usize> = HashMap::with_capacity(stmts.len());
+    let mut decls: Vec<&str> = Vec::with_capacity(stmts.len());
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {
             decls.push(name.as_str());


### PR DESCRIPTION
Pre-size to stmts.len(). cargo test 3232 pass.