### PR TITLE
RES-1756: pre-size program-level collect/analyze allocators

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -8,26 +8,6 @@
       "branch": "res-1192-cargo-config-linker",
       "claimed_at": "2026-05-12T01:09:57Z"
     },
-    "resilient/src/vibe_debt.rs": {
-      "branch": "res-1507-vibe-refs-borrow",
-      "claimed_at": "2026-05-12T12:55:00Z"
-    },
-    "resilient/src/behavioral_fingerprint.rs": {
-      "branch": "res-1206-kill-dead-work-checks",
-      "claimed_at": "2026-05-12T01:43:21Z"
-    },
-    "resilient/src/contract_inference.rs": {
-      "branch": "res-1206-kill-dead-work-checks",
-      "claimed_at": "2026-05-12T01:43:21Z"
-    },
-    "resilient/src/resilience_score.rs": {
-      "branch": "res-1507-vibe-refs-borrow",
-      "claimed_at": "2026-05-12T12:55:00Z"
-    },
-    "resilient/src/property_tests.rs": {
-      "branch": "res-1206-kill-dead-work-checks",
-      "claimed_at": "2026-05-12T01:43:21Z"
-    },
     "resilient/src/incremental_verify.rs": {
       "branch": "res-1210-incremental-verify-dead-work",
       "claimed_at": "2026-05-12T01:53:15Z"
@@ -168,10 +148,6 @@
       "branch": "res-1522-deadlock-actors-borrow",
       "claimed_at": "2026-05-12T13:34:45Z"
     },
-    "resilient/src/typestate_types.rs": {
-      "branch": "res-1549-typestate-validate-call-borrow",
-      "claimed_at": "2026-05-12T14:27:56Z"
-    },
     "resilient/src/lint.rs": {
       "branch": "res-1533-lint-l0001-borrow",
       "claimed_at": "2026-05-12T14:35:00Z"
@@ -227,6 +203,34 @@
     "resilient/src/semantic_regression.rs": {
       "branch": "res-1754-collect-presize",
       "claimed_at": "2026-05-13T11:24:43Z"
+    },
+    "resilient/src/probabilistic_contracts.rs": {
+      "branch": "res-1756-program-collect-presize",
+      "claimed_at": "2026-05-13T11:30:51Z"
+    },
+    "resilient/src/typestate_types.rs": {
+      "branch": "res-1756-program-collect-presize",
+      "claimed_at": "2026-05-13T11:30:51Z"
+    },
+    "resilient/src/behavioral_fingerprint.rs": {
+      "branch": "res-1756-program-collect-presize",
+      "claimed_at": "2026-05-13T11:30:51Z"
+    },
+    "resilient/src/contract_inference.rs": {
+      "branch": "res-1756-program-collect-presize",
+      "claimed_at": "2026-05-13T11:30:51Z"
+    },
+    "resilient/src/vibe_debt.rs": {
+      "branch": "res-1756-program-collect-presize",
+      "claimed_at": "2026-05-13T11:30:51Z"
+    },
+    "resilient/src/resilience_score.rs": {
+      "branch": "res-1756-program-collect-presize",
+      "claimed_at": "2026-05-13T11:30:51Z"
+    },
+    "resilient/src/lean_spec.rs": {
+      "branch": "res-1756-program-collect-presize",
+      "claimed_at": "2026-05-13T11:30:51Z"
     }
   }
 }

--- a/resilient/src/behavioral_fingerprint.rs
+++ b/resilient/src/behavioral_fingerprint.rs
@@ -41,10 +41,13 @@ pub struct Fingerprint {
 }
 
 pub fn fingerprint_program(program: &Node) -> HashMap<String, Fingerprint> {
-    let mut out = HashMap::new();
     let Node::Program(stmts) = program else {
-        return out;
+        return HashMap::new();
     };
+    // RES-1756: pre-size to stmts.len() — every top-level statement
+    // could be a function and produce one insert. Same shape as the
+    // semantic_regression / call-graph pre-sizes.
+    let mut out = HashMap::with_capacity(stmts.len());
     for s in stmts {
         if let Node::Function {
             name,

--- a/resilient/src/contract_inference.rs
+++ b/resilient/src/contract_inference.rs
@@ -33,10 +33,13 @@ pub struct InferredContracts {
 }
 
 pub fn infer_program(program: &Node) -> Vec<InferredContracts> {
-    let mut out = Vec::new();
     let Node::Program(stmts) = program else {
-        return out;
+        return Vec::new();
     };
+    // RES-1756: pre-size to stmts.len() — every top-level statement
+    // could be a function and push one inferred entry. Same shape as
+    // semantic_regression's extract_contracts pre-size.
+    let mut out = Vec::with_capacity(stmts.len());
     for s in stmts {
         if let Node::Function {
             name,

--- a/resilient/src/lean_spec.rs
+++ b/resilient/src/lean_spec.rs
@@ -287,13 +287,16 @@ pub fn try_emit_for_fn(program: &Node, fn_name: &str) -> Result<String, String> 
 }
 
 pub fn list_emittable(program: &Node) -> Vec<String> {
-    let mut out = Vec::new();
-    if let Node::Program(stmts) = program {
-        for s in stmts {
-            if let Node::Function { name, .. } = &s.node {
-                if lower_function(&s.node).is_ok() {
-                    out.push(name.clone());
-                }
+    let Node::Program(stmts) = program else {
+        return Vec::new();
+    };
+    // RES-1756: pre-size to stmts.len() — at most one push per
+    // top-level function (conditional on `lower_function` succeeding).
+    let mut out = Vec::with_capacity(stmts.len());
+    for s in stmts {
+        if let Node::Function { name, .. } = &s.node {
+            if lower_function(&s.node).is_ok() {
+                out.push(name.clone());
             }
         }
     }

--- a/resilient/src/probabilistic_contracts.rs
+++ b/resilient/src/probabilistic_contracts.rs
@@ -27,7 +27,9 @@ static CONTRACTS: LazyLock<RwLock<HashMap<String, ProbContract>>> =
 
 pub fn collect() -> Vec<ProbContract> {
     let attrs = crate::feature_attrs::find_kind("probabilistic");
-    let mut out = Vec::new();
+    // RES-1756: pre-size to attrs.len() — exactly one push per
+    // attribute record, exact bound. Same shape as RES-1754.
+    let mut out = Vec::with_capacity(attrs.len());
     for (item, rec) in attrs {
         let mut clause = String::new();
         let mut p = 1.0_f64;

--- a/resilient/src/resilience_score.rs
+++ b/resilient/src/resilience_score.rs
@@ -62,7 +62,10 @@ pub fn score_program(program: &Node) -> Vec<ResilienceScore> {
         collect_call_names(&s.node, &mut call_refs);
     }
 
-    let mut out = Vec::new();
+    // RES-1756: pre-size to stmts.len() — one push per top-level
+    // function, upper-bounded by stmts.len(). Same pattern as the
+    // semantic_regression / vibe_debt pre-sizes.
+    let mut out = Vec::with_capacity(stmts.len());
     for s in stmts {
         if let Node::Function {
             name,

--- a/resilient/src/typestate_types.rs
+++ b/resilient/src/typestate_types.rs
@@ -35,7 +35,9 @@ static SPECS: RwLock<Vec<TypestateSpec>> = RwLock::new(Vec::new());
 
 pub fn collect() -> Vec<TypestateSpec> {
     let attrs = crate::feature_attrs::find_kind("typestate");
-    let mut out = Vec::new();
+    // RES-1756: pre-size to attrs.len() — exactly one push per
+    // attribute record. Same shape as RES-1754.
+    let mut out = Vec::with_capacity(attrs.len());
     for (item, rec) in attrs {
         let mut spec = TypestateSpec {
             struct_name: item,

--- a/resilient/src/vibe_debt.rs
+++ b/resilient/src/vibe_debt.rs
@@ -71,7 +71,9 @@ pub fn analyze(program: &Node) -> VibeDebtReport {
         collect_refs(&s.node, &mut refs);
     }
 
-    let mut entries = Vec::new();
+    // RES-1756: pre-size to stmts.len() — every top-level statement
+    // is potentially a function and pushes one entry.
+    let mut entries = Vec::with_capacity(stmts.len());
     for s in stmts {
         if let Node::Function {
             name,


### PR DESCRIPTION
Closes #1756

## Summary
- Seven more `collect_*` / `analyze` / `fingerprint_program` helpers allocated their result `Vec` / `HashMap` from `0` and grew through several `realloc` rounds even though the upper bound is trivially known at the call site.
- Pre-size to that bound.

## Changes
- `probabilistic_contracts::collect`, `typestate_types::collect` — `Vec::with_capacity(attrs.len())`.
- `behavioral_fingerprint::fingerprint_program` — `HashMap::with_capacity(stmts.len())`.
- `contract_inference::infer_program`, `vibe_debt::analyze` (entries), `resilience_score::score_program`, `lean_spec::list_emittable` — `Vec::with_capacity(stmts.len())`.

Same shape as the pre-size series (RES-1742…RES-1754).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass; full suite green
- [x] No behavioural change — only allocation sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)