### PR TITLE
RES-1758: pre-size autopilot / iterator_protocol / semver_behavior

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -227,6 +227,18 @@
     "resilient/src/semantic_regression.rs": {
       "branch": "res-1754-collect-presize",
       "claimed_at": "2026-05-13T11:24:43Z"
+    },
+    "resilient/src/autopilot.rs": {
+      "branch": "res-1758-more-collect-presize",
+      "claimed_at": "2026-05-13T11:34:18Z"
+    },
+    "resilient/src/iterator_protocol.rs": {
+      "branch": "res-1758-more-collect-presize",
+      "claimed_at": "2026-05-13T11:34:18Z"
+    },
+    "resilient/src/semver_behavior.rs": {
+      "branch": "res-1758-more-collect-presize",
+      "claimed_at": "2026-05-13T11:34:18Z"
     }
   }
 }

--- a/resilient/src/autopilot.rs
+++ b/resilient/src/autopilot.rs
@@ -42,7 +42,9 @@ pub fn run(program: &Node) -> AutopilotReport {
     let vibe = crate::vibe_debt::analyze(program);
     let inferred = crate::contract_inference::infer_program(program);
 
-    let mut entries = Vec::new();
+    // RES-1758: pre-size to scores.len() — exactly one push per
+    // score entry, exact bound.
+    let mut entries = Vec::with_capacity(scores.len());
     for s in &scores {
         let v = vibe
             .entries

--- a/resilient/src/iterator_protocol.rs
+++ b/resilient/src/iterator_protocol.rs
@@ -54,7 +54,11 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         install_iterator_impls(HashSet::new());
         return Ok(());
     }
-    let mut iters = HashSet::new();
+    // RES-1758: pre-size to stmts.len() — every top-level statement
+    // could be a matching ImplBlock and contribute one insert. We
+    // already paid the `any_node` early-reject (RES-1291), so when
+    // we reach here we know at least one Iterator impl exists.
+    let mut iters = HashSet::with_capacity(stmts.len());
     for s in stmts {
         if let Node::ImplBlock {
             trait_name,

--- a/resilient/src/semver_behavior.rs
+++ b/resilient/src/semver_behavior.rs
@@ -47,7 +47,12 @@ pub fn classify(old_program: &Node, new_program: &Node) -> SemverDecision {
     let new_c = crate::semantic_regression::extract_contracts(new_program);
     let changes = crate::semantic_regression::diff(&old_c, &new_c);
 
-    let mut reasons = Vec::new();
+    // RES-1758: pre-size to changes.len() + 1 — the loop below pushes
+    // exactly one reason per `SemanticChange`, plus an optional
+    // fingerprint-regressed line. Saves the 0→4→8 doubling chain on
+    // realistic semver classifications (a typical refactor produces
+    // 5–20 reasons).
+    let mut reasons = Vec::with_capacity(changes.len() + 1);
     let mut kind = SemverKind::Patch;
 
     let old_fp = crate::behavioral_fingerprint::fingerprint_program(old_program);


### PR DESCRIPTION
Closes #1758

## Summary
- Three more program-walk allocators allocated their result `Vec` / `HashSet` from `0` even though the upper bound is trivially known at the call site.
- Pre-size them.

## Changes
- `autopilot::run` — `Vec::with_capacity(scores.len())` (exactly one push per resilience-score entry).
- `iterator_protocol::check` — `HashSet::with_capacity(stmts.len())` (every top-level statement could be an Iterator impl; RES-1291 already filtered out programs with zero matches before reaching the loop).
- `semver_behavior::classify` — `Vec::with_capacity(changes.len() + 1)` (one reason per SemanticChange plus optional fingerprint-regressed prefix).

Same shape as the pre-size series (RES-1742…RES-1756).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass; full suite green
- [x] No behavioural change — only allocation sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)