### PR TITLE
RES-1762: pre-size loop_invariants / property_tests / cluster_verifier

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -243,6 +243,18 @@
     "resilient/src/semver_behavior.rs": {
       "branch": "res-1758-more-collect-presize",
       "claimed_at": "2026-05-13T11:38:11Z"
+    },
+    "resilient/src/loop_invariants.rs": {
+      "branch": "res-1762-more-collect-presize",
+      "claimed_at": "2026-05-13T11:42:44Z"
+    },
+    "resilient/src/property_tests.rs": {
+      "branch": "res-1762-more-collect-presize",
+      "claimed_at": "2026-05-13T11:42:44Z"
+    },
+    "resilient/src/cluster_verifier.rs": {
+      "branch": "res-1762-more-collect-presize",
+      "claimed_at": "2026-05-13T11:42:44Z"
     }
   }
 }

--- a/resilient/src/cluster_verifier.rs
+++ b/resilient/src/cluster_verifier.rs
@@ -143,7 +143,9 @@ pub(crate) fn verify_program(program: &Node, timeout_ms: u32) -> Vec<ClusterDiag
 
     // Build an `actor name → &ActorDecl-fields` lookup so the
     // cluster verifier can resolve member types.
-    let mut actors: ActorTable = HashMap::new();
+    // RES-1762: pre-size to stmts.len() — every top-level statement
+    // could be an ActorDecl and produce one insert.
+    let mut actors: ActorTable = HashMap::with_capacity(stmts.len());
     for spanned in stmts {
         if let Node::ActorDecl {
             name,
@@ -159,7 +161,9 @@ pub(crate) fn verify_program(program: &Node, timeout_ms: u32) -> Vec<ClusterDiag
         }
     }
 
-    let mut out = Vec::new();
+    // RES-1762: pre-size to stmts.len() — verify_cluster pushes one
+    // result per ClusterDecl, upper-bounded by stmts.len().
+    let mut out = Vec::with_capacity(stmts.len());
     for spanned in stmts {
         if let Node::ClusterDecl {
             name,

--- a/resilient/src/loop_invariants.rs
+++ b/resilient/src/loop_invariants.rs
@@ -152,12 +152,18 @@ pub(crate) fn typecheck_invariant_statement(
 /// participate in the iteration-top check. Loop-top invariants must
 /// hold over the loop's full state, not a branch-conditional state.
 pub(crate) fn collect_body_invariants(body: &Node) -> Vec<&Node> {
-    let mut out = Vec::new();
-    if let Node::Block { stmts, .. } = body {
-        for s in stmts {
-            if let Node::InvariantStatement { expr, .. } = s {
-                out.push(expr.as_ref());
-            }
+    let Node::Block { stmts, .. } = body else {
+        return Vec::new();
+    };
+    // RES-1762: pre-size to stmts.len() — at most one invariant push
+    // per body statement, so this is an upper bound. The interpreter
+    // calls this on every loop iteration via
+    // `check_invariants_at_iteration`, so the 0→4 doubling chain
+    // was paid on a hot path.
+    let mut out = Vec::with_capacity(stmts.len());
+    for s in stmts {
+        if let Node::InvariantStatement { expr, .. } = s {
+            out.push(expr.as_ref());
         }
     }
     out

--- a/resilient/src/property_tests.rs
+++ b/resilient/src/property_tests.rs
@@ -30,7 +30,9 @@ pub struct PropertyResult {
 
 pub fn collect() -> Vec<PropertySpec> {
     let attrs = crate::feature_attrs::find_kind("property_test");
-    let mut out = Vec::new();
+    // RES-1762: pre-size to attrs.len() — exactly one push per
+    // attribute record, exact bound. Same shape as RES-1754 / 1756.
+    let mut out = Vec::with_capacity(attrs.len());
     for (item, rec) in attrs {
         let mut samples = 100_u32;
         for chunk in rec.args.split(',') {


### PR DESCRIPTION
Closes #1762

## Summary
- Four more allocators that knew their upper bound at the call site but allocated from `0`.
- Pre-size them.

## Changes
- `loop_invariants::collect_body_invariants` — `Vec::with_capacity(stmts.len())`. Hot path: interpreter calls this on every loop iteration.
- `property_tests::collect` — `Vec::with_capacity(attrs.len())`.
- `cluster_verifier::check` — actors `HashMap::with_capacity(stmts.len())` and out `Vec::with_capacity(stmts.len())`.

Same shape as the pre-size series (RES-1742…RES-1760).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass; full suite green
- [x] No behavioural change — only allocation sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)