### PR TITLE
RES-1774: pre-size recovery_checker extern_fns + lint dedup parts

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -120,10 +120,6 @@
       "branch": "res-1531-lsp-completion-lazy-clone",
       "claimed_at": "2026-05-12T14:20:00Z"
     },
-    "resilient/src/recovery_checker.rs": {
-      "branch": "res-1534-recovery-checker-borrow",
-      "claimed_at": "2026-05-12T14:50:00Z"
-    },
     "resilient/src/imports.rs": {
       "branch": "res-1523-imports-canon-move",
       "claimed_at": "2026-05-12T13:18:45Z"
@@ -139,10 +135,6 @@
     "resilient/src/deadlock_freedom.rs": {
       "branch": "res-1522-deadlock-actors-borrow",
       "claimed_at": "2026-05-12T13:34:45Z"
-    },
-    "resilient/src/lint.rs": {
-      "branch": "res-1533-lint-l0001-borrow",
-      "claimed_at": "2026-05-12T14:35:00Z"
     },
     "resilient/src/blame_attribution.rs": {
       "branch": "res-1544-blame-attribution-callers-borrow",
@@ -295,6 +287,14 @@
     "resilient/src/verifier_liveness.rs": {
       "branch": "res-1770-verifier-presize",
       "claimed_at": "2026-05-13T11:59:58Z"
+    },
+    "resilient/src/recovery_checker.rs": {
+      "branch": "res-1774-recovery-lint-presize",
+      "claimed_at": "2026-05-13T12:06:03Z"
+    },
+    "resilient/src/lint.rs": {
+      "branch": "res-1774-recovery-lint-presize",
+      "claimed_at": "2026-05-13T12:06:03Z"
     }
   }
 }

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -883,7 +883,9 @@ fn struct_literal_match_arm_key(pat: &Pattern) -> Option<String> {
     if *has_rest || fields.is_empty() {
         return None;
     }
-    let mut parts = Vec::new();
+    // RES-1774: pre-size to fields.len() — one push per field on the
+    // happy path (loop returns None early on any non-literal).
+    let mut parts = Vec::with_capacity(fields.len());
     for (fname, sub) in fields {
         match sub.as_ref() {
             Pattern::Literal(Node::IntegerLiteral { value, .. }) => {

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -49,6 +49,18 @@ impl Context {
         let Node::Program(statements) = program else {
             return;
         };
+        // RES-1774: pre-size to the exact extern-decl count. Each
+        // Extern statement contributes `decls.len()` inserts, so
+        // summing them up front avoids the 0→4→8→… doubling chain
+        // as we walk a program with many extern declarations.
+        let extern_decl_count: usize = statements
+            .iter()
+            .filter_map(|s| match &s.node {
+                Node::Extern { decls, .. } => Some(decls.len()),
+                _ => None,
+            })
+            .sum();
+        self.extern_fns.reserve(extern_decl_count);
         for stmt in statements {
             if let Node::Extern { decls, .. } = &stmt.node {
                 for decl in decls {


### PR DESCRIPTION
Closes #1774

## Summary
- Two more allocators whose bound was knowable at the call site.

## Changes
- `recovery_checker::Context::collect_declarations` — pre-compute total `decls.len()` sum across all `Extern` stmts, then `extern_fns.reserve(count)` before the insert loop.
- `lint::struct_match_arm_key` — `parts: Vec::with_capacity(fields.len())`.

Same shape as the pre-size series (RES-1742…RES-1772).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)