### PR TITLE
RES-1778: pre-size bytes_lit + parse_template Vecs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -295,6 +295,14 @@
     "resilient/src/lint.rs": {
       "branch": "res-1774-recovery-lint-presize",
       "claimed_at": "2026-05-13T12:06:03Z"
+    },
+    "resilient/src/lexer_logos.rs": {
+      "branch": "res-1778-lexer-format-presize",
+      "claimed_at": "2026-05-13T12:14:23Z"
+    },
+    "resilient/src/format_builtin.rs": {
+      "branch": "res-1778-lexer-format-presize",
+      "claimed_at": "2026-05-13T12:14:23Z"
     }
   }
 }

--- a/resilient/src/format_builtin.rs
+++ b/resilient/src/format_builtin.rs
@@ -34,7 +34,11 @@ pub enum FormatSegment {
 /// error. Previously the parser silently emitted an empty
 /// `Placeholder("")`, masking malformed templates.
 pub fn parse_template(s: &str) -> Result<Vec<FormatSegment>, String> {
-    let mut out = Vec::new();
+    // RES-1778: pre-size to (placeholder-count * 2 + 1) — at most one
+    // Literal per `{...}` placeholder plus a trailing Literal, so this
+    // matches the typical 1-3-placeholder shape. fmt_validation calls
+    // this on every `format(...)` expression at typecheck time.
+    let mut out = Vec::with_capacity(s.matches('{').count() * 2 + 1);
     let mut buf = String::new();
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -385,7 +385,11 @@ fn bytes_lit(lex: &mut logos::Lexer<Tok>) -> Vec<u8> {
     // trailing `"`.
     let slice = lex.slice();
     let inner = &slice[2..slice.len().saturating_sub(1)];
-    let mut out: Vec<u8> = Vec::new();
+    // RES-1778: pre-size to inner.len() — each unescaped char yields
+    // one byte; escape sequences (`\n`, `\xNN`) yield one byte but
+    // consume 2-4 source chars, so this is an upper bound that
+    // slightly over-allocates only for escape-heavy literals.
+    let mut out: Vec<u8> = Vec::with_capacity(inner.len());
     let mut chars = inner.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '\\' {


### PR DESCRIPTION
Closes #1778

## Summary
- Two more allocators that ran from `0`. Pre-size them.

## Changes
- `lexer_logos::bytes_lit` — `Vec::with_capacity(inner.len())` (upper bound on output bytes).
- `format_builtin::parse_template` — `Vec::with_capacity(s.matches('{').count() * 2 + 1)`. Called by `fmt_validation` on every `format(...)` at typecheck time.

Same shape as the pre-size series (RES-1742…RES-1776).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)