### PR TITLE
RES-1788: pre-size rate_limit + sum_types parser collections

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -32,10 +32,6 @@
       "branch": "res-1217-handler-suffix-fast-reject",
       "claimed_at": "2026-05-12T02:07:46Z"
     },
-    "resilient/src/rate_limit_static.rs": {
-      "branch": "res-1515-rate-limit-name-borrow",
-      "claimed_at": "2026-05-12T13:18:00Z"
-    },
     "resilient/src/priority_inheritance.rs": {
       "branch": "res-1232-priority-fast-reject",
       "claimed_at": "2026-05-12T02:35:05Z"
@@ -323,6 +319,14 @@
     "resilient/src/default_trait_methods.rs": {
       "branch": "res-1784-attr-collects-3",
       "claimed_at": "2026-05-13T12:28:38Z"
+    },
+    "resilient/src/rate_limit_static.rs": {
+      "branch": "res-1788-rate-limit-presize",
+      "claimed_at": "2026-05-13T12:33:38Z"
+    },
+    "resilient/src/sum_types.rs": {
+      "branch": "res-1788-rate-limit-presize",
+      "claimed_at": "2026-05-13T12:35:40Z"
     }
   }
 }

--- a/resilient/src/rate_limit_static.rs
+++ b/resilient/src/rate_limit_static.rs
@@ -54,7 +54,9 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // when the callee is new, falling back to `get_mut` for repeat
     // hits. Mirrors RES-1495 / RES-1500 / RES-1503 / RES-1507 /
     // RES-1508 / RES-1509 / RES-1511.
-    let mut decls: Vec<&str> = Vec::new();
+    // RES-1788: pre-size decls to stmts.len() (every top-level
+    // statement could be a Function, one push each).
+    let mut decls: Vec<&str> = Vec::with_capacity(stmts.len());
     let mut counts: HashMap<String, usize> = HashMap::new();
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {

--- a/resilient/src/sum_types.rs
+++ b/resilient/src/sum_types.rs
@@ -106,8 +106,9 @@ pub(crate) fn parse_enum_decl(parser: &mut Parser) -> Node {
     }
     parser.next_token(); // consume '{'
 
-    let mut variants: Vec<EnumVariant> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
+    // RES-1788: pre-size both to 4 — typical enum has 2-8 variants.
+    let mut variants: Vec<EnumVariant> = Vec::with_capacity(4);
+    let mut seen: HashSet<String> = HashSet::with_capacity(4);
 
     loop {
         match &parser.current_token {
@@ -210,8 +211,10 @@ fn skip_to_variant_separator(parser: &mut Parser) {
 /// continues parsing.
 fn parse_named_payload(parser: &mut Parser, enum_name: &str, variant_name: &str) -> EnumPayload {
     parser.next_token(); // consume '{'
-    let mut fields: Vec<EnumField> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
+    // RES-1788: pre-size both to 4 — variant payloads typically have
+    // 1-4 fields.
+    let mut fields: Vec<EnumField> = Vec::with_capacity(4);
+    let mut seen: HashSet<String> = HashSet::with_capacity(4);
     loop {
         match &parser.current_token {
             Token::RightBrace => {
@@ -284,7 +287,8 @@ fn parse_named_payload(parser: &mut Parser, enum_name: &str, variant_name: &str)
 /// Consumes from the `(` through (and including) the closing `)`.
 fn parse_tuple_payload(parser: &mut Parser, enum_name: &str, variant_name: &str) -> EnumPayload {
     parser.next_token(); // consume '('
-    let mut tys: Vec<String> = Vec::new();
+    // RES-1788: pre-size to 2 — tuple variants typically have 1-3 types.
+    let mut tys: Vec<String> = Vec::with_capacity(2);
     loop {
         match &parser.current_token {
             Token::RightParen => {
@@ -362,7 +366,8 @@ fn parse_payload_type(parser: &mut Parser) -> Option<String> {
 /// payload field under the same identifier.
 pub(crate) fn parse_named_pattern_payload(parser: &mut Parser) -> EnumPatternPayload {
     parser.next_token(); // past `{`
-    let mut fields: Vec<(String, Box<Pattern>)> = Vec::new();
+    // RES-1788: pre-size to 4 — pattern payloads typically bind 1-4 fields.
+    let mut fields: Vec<(String, Box<Pattern>)> = Vec::with_capacity(4);
     loop {
         match &parser.current_token {
             Token::RightBrace => return EnumPatternPayload::Named(fields),
@@ -408,7 +413,8 @@ pub(crate) fn parse_named_pattern_payload(parser: &mut Parser) -> EnumPatternPay
 /// the closing `)`.
 pub(crate) fn parse_tuple_pattern_payload(parser: &mut Parser) -> EnumPatternPayload {
     parser.next_token(); // past `(`
-    let mut subs: Vec<Pattern> = Vec::new();
+    // RES-1788: pre-size to 2 — tuple-variant patterns typically have 1-3 subs.
+    let mut subs: Vec<Pattern> = Vec::with_capacity(2);
     loop {
         match &parser.current_token {
             Token::RightParen => return EnumPatternPayload::Tuple(subs),


### PR DESCRIPTION
Closes #1788

## Summary
- Six more allocators on hot parser / pass paths grew from `0`. Pre-size them.

## Changes
- `rate_limit_static::check` — `decls: Vec::with_capacity(stmts.len())`.
- `sum_types::parse_enum`, `parse_named_payload`, `parse_tuple_payload`, `parse_named_pattern_payload`, `parse_tuple_pattern_payload` — Vec/HashSet pre-sized to 2 or 4 matching typical enum/variant shape.

Same shape as the pre-size series (RES-1742…RES-1786).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)