### PR TITLE
RES-1800: pre-size default_params sigs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -100,10 +100,6 @@
       "branch": "res-1396-inline-chunk-fast-reject",
       "claimed_at": "2026-05-12T09:48:19Z"
     },
-    "resilient/src/default_params.rs": {
-      "branch": "res-1475-default-params-skip-no-defaults",
-      "claimed_at": "2026-05-12T11:56:23Z"
-    },
     "resilient/src/lsp_server.rs": {
       "branch": "res-1531-lsp-completion-lazy-clone",
       "claimed_at": "2026-05-12T14:20:00Z"
@@ -335,6 +331,10 @@
     "resilient/src/named_args.rs": {
       "branch": "res-1794-infer-named-args-presize",
       "claimed_at": "2026-05-13T12:47:28Z"
+    },
+    "resilient/src/default_params.rs": {
+      "branch": "res-1800-default-params-sigs-presize",
+      "claimed_at": "2026-05-13T12:56:39Z"
     }
   }
 }

--- a/resilient/src/default_params.rs
+++ b/resilient/src/default_params.rs
@@ -60,7 +60,11 @@ struct FnDefaults {
 /// `FnDefaults` entry has a `Some(_)` slot, skip the walk entirely.
 /// `crate::newtypes::lower_program` follows the same shape.
 pub fn lower_program(program: &mut Node) {
-    let mut sigs: HashMap<String, FnDefaults> = HashMap::new();
+    // RES-1800: pre-size to 8 — `collect_defaults` only inserts fns
+    // that declare at least one default. Programs using defaults
+    // typically have a handful; 8 covers the common case without
+    // rehash churn. Same shape as RES-1794's `named_args::lower_program`.
+    let mut sigs: HashMap<String, FnDefaults> = HashMap::with_capacity(8);
     collect_defaults(program, &mut sigs);
     // RES-1475: `collect_defaults` now only inserts functions that
     // have at least one declared default, so `sigs.is_empty()`


### PR DESCRIPTION
Closes #1800

## Summary
- `default_params::lower_program` allocated `sigs: HashMap` from `0`. Pre-size to 8.

## Changes
- `default_params::lower_program` — `sigs: HashMap::with_capacity(8)`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)