### PR TITLE
RES-1802: pre-size 5 more traits collections

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -284,18 +284,6 @@
       "branch": "res-1778-lexer-format-presize",
       "claimed_at": "2026-05-13T12:14:23Z"
     },
-    "resilient/src/derives.rs": {
-      "branch": "res-1782-more-collect-presize",
-      "claimed_at": "2026-05-13T12:23:31Z"
-    },
-    "resilient/src/associated_constants.rs": {
-      "branch": "res-1782-more-collect-presize",
-      "claimed_at": "2026-05-13T12:23:31Z"
-    },
-    "resilient/src/traits.rs": {
-      "branch": "res-1782-more-collect-presize",
-      "claimed_at": "2026-05-13T12:23:31Z"
-    },
     "resilient/src/hw_state_machine.rs": {
       "branch": "res-1784-attr-collects-3",
       "claimed_at": "2026-05-13T12:28:38Z"
@@ -335,6 +323,10 @@
     "resilient/src/verifier_loop_invariants.rs": {
       "branch": "res-1798-vli-bindings-presize",
       "claimed_at": "2026-05-13T12:53:30Z"
+    },
+    "resilient/src/traits.rs": {
+      "branch": "res-1802-traits-presize",
+      "claimed_at": "2026-05-13T13:02:04Z"
     }
   }
 }

--- a/resilient/src/traits.rs
+++ b/resilient/src/traits.rs
@@ -124,8 +124,11 @@ pub(crate) fn parse(parser: &mut Parser) -> Node {
         parser.next_token(); // skip '{'
     }
 
-    let mut methods: Vec<TraitMethodSig> = Vec::new();
-    let mut associated_types: Vec<AssociatedTypeDecl> = Vec::new();
+    // RES-1802: pre-size to 4 — typical trait declares 1-4 methods
+    // and 0-2 associated types. Same fixed-capacity shape as
+    // RES-1768 / RES-1776 parser pre-sizes.
+    let mut methods: Vec<TraitMethodSig> = Vec::with_capacity(4);
+    let mut associated_types: Vec<AssociatedTypeDecl> = Vec::with_capacity(2);
 
     while parser.current_token != Token::RightBrace && parser.current_token != Token::Eof {
         match &parser.current_token {
@@ -421,9 +424,12 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // every `impl T { ... }` block plus every `impl Trait for T { ... }`
     // block. Used both to validate trait-impl coverage and to validate
     // call-site bounds.
-    let mut type_methods: HashMap<String, HashMap<String, usize>> = HashMap::new();
+    // RES-1802: pre-size to stmts.len() — at most one entry per
+    // top-level ImplBlock for each map.
+    let mut type_methods: HashMap<String, HashMap<String, usize>> =
+        HashMap::with_capacity(stmts.len());
     // Set of explicit `impl Trait for Type` declarations.
-    let mut explicit_impls: HashSet<(String, String)> = HashSet::new();
+    let mut explicit_impls: HashSet<(String, String)> = HashSet::with_capacity(stmts.len());
 
     for stmt in stmts {
         if let Node::ImplBlock {
@@ -474,7 +480,8 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             };
 
             // Build the set of methods this impl block actually provides.
-            let mut provided: HashMap<String, usize> = HashMap::new();
+            // RES-1802: pre-size to methods.len() — one insert per method.
+            let mut provided: HashMap<String, usize> = HashMap::with_capacity(methods.len());
             for m in methods {
                 if let Node::Function {
                     name, parameters, ..
@@ -515,7 +522,10 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             }
 
             // Build the set of associated types this impl block defines.
-            let mut provided_types: HashSet<String> = HashSet::new();
+            // RES-1802: pre-size to associated_type_impls.len() — one
+            // insert per associated_type impl on the happy path.
+            let mut provided_types: HashSet<String> =
+                HashSet::with_capacity(associated_type_impls.len());
             for (type_name, _type_expr) in associated_type_impls {
                 provided_types.insert(type_name.clone());
             }


### PR DESCRIPTION
Closes #1802

## Summary
- Five more allocators in `traits.rs` whose bound was knowable at the call site.

## Changes
- `parse_trait_decl` — `methods: Vec::with_capacity(4)` + `associated_types: Vec::with_capacity(2)`.
- `traits::check` — `type_methods` and `explicit_impls` pre-sized to `stmts.len()`.
- `traits::check` per-impl — `provided: HashMap::with_capacity(methods.len())` and `provided_types: HashSet::with_capacity(associated_type_impls.len())`.

Same shape as the pre-size series (RES-1742…RES-1800).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)