### PR TITLE
RES-1808: pre-size verifier_actors::flatten_body out Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -327,6 +327,10 @@
     "resilient/src/traits.rs": {
       "branch": "res-1802-traits-presize",
       "claimed_at": "2026-05-13T13:02:04Z"
+    },
+    "resilient/src/verifier_actors.rs": {
+      "branch": "res-1808-flatten-body-presize",
+      "claimed_at": "2026-05-13T13:15:06Z"
     }
   }
 }

--- a/resilient/src/verifier_actors.rs
+++ b/resilient/src/verifier_actors.rs
@@ -283,7 +283,11 @@ fn straight_line_post(body: &Node, state_name: &str) -> Option<Node> {
 fn flatten_body(body: &Node) -> Option<Vec<&Node>> {
     match body {
         Node::Block { stmts, .. } => {
-            let mut out = Vec::new();
+            // RES-1808: pre-size to stmts.len() — each stmt either
+            // pushes one item directly or recurses into a nested
+            // Block whose contributions can exceed this upper bound,
+            // but stmts.len() is a reasonable starting cap.
+            let mut out = Vec::with_capacity(stmts.len());
             for s in stmts {
                 match s {
                     Node::Block { .. } => {


### PR DESCRIPTION
Closes #1808

## Summary
- `flatten_body`'s Block arm allocated `out: Vec::new()`. Pre-size to `stmts.len()`.

## Changes
- `verifier_actors::flatten_body` Block arm — `Vec::with_capacity(stmts.len())`.

Same shape as the pre-size series (RES-1742…RES-1806).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)