### PR TITLE
RES-1810: pre-size parse_type_name alias-cycle Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -248,10 +248,6 @@
       "branch": "res-1764-attr-collect-presize",
       "claimed_at": "2026-05-13T11:45:18Z"
     },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1766-typechecker-hot-presize",
-      "claimed_at": "2026-05-13T11:55:37Z"
-    },
     "resilient/src/supervisor.rs": {
       "branch": "res-1770-verifier-presize",
       "claimed_at": "2026-05-13T11:59:58Z"
@@ -327,6 +323,10 @@
     "resilient/src/lib.rs": {
       "branch": "res-1806-misc-parser-presize",
       "claimed_at": "2026-05-13T13:11:05Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-1810-parse-type-name-presize",
+      "claimed_at": "2026-05-13T13:19:00Z"
     }
   }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -6753,7 +6753,12 @@ impl TypeChecker {
         // plain type-equality level, `linear T` and `T` are the same
         // type, so strip the prefix here before resolving.
         let base = crate::linear::strip_linear(name);
-        self.parse_type_name_inner(base, &mut Vec::new())
+        // RES-1810: pre-size the alias-cycle-detection Vec to 2 —
+        // typical alias chains are 0-2 deep (`type Meters = Float;`
+        // is single-step). Saves the 0→4 doubling chain on every
+        // type-name resolution, which is called per parameter type,
+        // return type, let annot, struct field, etc.
+        self.parse_type_name_inner(base, &mut Vec::with_capacity(2))
     }
 
     /// RES-128: alias-aware parse with cycle detection. `seen`


### PR DESCRIPTION
Closes #1810

## Summary
- `parse_type_name` allocated a fresh empty `Vec::new()` per call. Pre-size to 2.

## Changes
- `TypeChecker::parse_type_name` — `Vec::with_capacity(2)` as the alias-cycle-detection set.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)