### PR TITLE
RES-1814: pre-size VM locals Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -331,6 +331,10 @@
     "resilient/src/verifier_actors.rs": {
       "branch": "res-1808-flatten-body-presize",
       "claimed_at": "2026-05-13T13:17:34Z"
+    },
+    "resilient/src/vm.rs": {
+      "branch": "res-1814-vm-locals-presize",
+      "claimed_at": "2026-05-13T13:28:08Z"
     }
   }
 }

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -374,7 +374,12 @@ fn run_inner(
     overflow_mode: OverflowMode,
 ) -> Result<Value, VmError> {
     let mut stack: Vec<Value> = Vec::with_capacity(64);
-    let mut locals: Vec<Value> = Vec::new();
+    // RES-1814: pre-size to 32 — typical VM runs have 5-30 locals
+    // across main + frames. Same fixed-capacity shape as `stack` and
+    // `frames`. The locals slot is grown via Op::AllocLocal as
+    // frames push, so this is a starting capacity that absorbs the
+    // common case without rehash churn.
+    let mut locals: Vec<Value> = Vec::with_capacity(32);
     let mut frames: Vec<CallFrame> = Vec::with_capacity(16);
     frames.push(CallFrame {
         chunk_idx: usize::MAX, // main


### PR DESCRIPTION
Closes #1814

## Summary
- `vm::run_inner` allocated `locals: Vec::new()`. Pre-size to 32 to match `stack`/`frames` shape.

## Changes
- `vm::run_inner` — `locals: Vec::with_capacity(32)`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass; VM tests (vm::tests::*) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)