### PR TITLE
RES-1816: fast-reject parse_template on no-placeholder strings

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -272,14 +272,6 @@
       "branch": "res-1774-recovery-lint-presize",
       "claimed_at": "2026-05-13T12:06:03Z"
     },
-    "resilient/src/lexer_logos.rs": {
-      "branch": "res-1778-lexer-format-presize",
-      "claimed_at": "2026-05-13T12:14:23Z"
-    },
-    "resilient/src/format_builtin.rs": {
-      "branch": "res-1778-lexer-format-presize",
-      "claimed_at": "2026-05-13T12:14:23Z"
-    },
     "resilient/src/hw_state_machine.rs": {
       "branch": "res-1784-attr-collects-3",
       "claimed_at": "2026-05-13T12:28:38Z"
@@ -335,6 +327,10 @@
     "resilient/src/vm.rs": {
       "branch": "res-1814-vm-locals-presize",
       "claimed_at": "2026-05-13T13:30:39Z"
+    },
+    "resilient/src/format_builtin.rs": {
+      "branch": "res-1816-format-template-fast-reject",
+      "claimed_at": "2026-05-13T13:34:15Z"
     }
   }
 }

--- a/resilient/src/format_builtin.rs
+++ b/resilient/src/format_builtin.rs
@@ -34,6 +34,21 @@ pub enum FormatSegment {
 /// error. Previously the parser silently emitted an empty
 /// `Placeholder("")`, masking malformed templates.
 pub fn parse_template(s: &str) -> Result<Vec<FormatSegment>, String> {
+    // RES-1816: fast-reject for templates with no placeholders and no
+    // `}}` escape. The char-by-char loop below would walk every byte
+    // only to deposit them all into a single trailing Literal. Format
+    // strings without any `{` are extremely common (logging,
+    // diagnostics, hard-coded messages); `fmt_validation` calls this
+    // on every `format(...)` at typecheck time. The contains-`{` check
+    // is one O(N) byte scan, far cheaper than the full chars-peekable
+    // walk that follows on the slow path.
+    if !s.contains('{') && !s.contains("}}") {
+        return Ok(if s.is_empty() {
+            Vec::new()
+        } else {
+            vec![FormatSegment::Literal(s.to_string())]
+        });
+    }
     // RES-1778: pre-size to (placeholder-count * 2 + 1) — at most one
     // Literal per `{...}` placeholder plus a trailing Literal, so this
     // matches the typical 1-3-placeholder shape. fmt_validation calls


### PR DESCRIPTION
Closes #1816

## Summary
- Format templates without any `{` placeholder went through the full chars-peekable walk only to deposit every byte into a single trailing Literal. Add a fast-reject gate.

## Changes
- `format_builtin::parse_template` — return `[Literal(s)]` (or empty Vec for `""`) when `!s.contains('{') && !s.contains("}}")` before the main loop.

`fmt_validation::check` invokes `parse_template` on every `format(...)` at typecheck time, so logging-heavy programs benefit proportionally to their template count.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass; existing format-template tests (parse_simple_template, parse_unterminated_brace_errors, …) all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)