### PR TITLE
RES-1818: fast-reject lexer_logos string_lit + bytes_lit on no-escapes

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -272,14 +272,6 @@
       "branch": "res-1774-recovery-lint-presize",
       "claimed_at": "2026-05-13T12:06:03Z"
     },
-    "resilient/src/lexer_logos.rs": {
-      "branch": "res-1778-lexer-format-presize",
-      "claimed_at": "2026-05-13T12:14:23Z"
-    },
-    "resilient/src/format_builtin.rs": {
-      "branch": "res-1778-lexer-format-presize",
-      "claimed_at": "2026-05-13T12:14:23Z"
-    },
     "resilient/src/hw_state_machine.rs": {
       "branch": "res-1784-attr-collects-3",
       "claimed_at": "2026-05-13T12:28:38Z"
@@ -335,6 +327,10 @@
     "resilient/src/vm.rs": {
       "branch": "res-1814-vm-locals-presize",
       "claimed_at": "2026-05-13T13:30:39Z"
+    },
+    "resilient/src/lexer_logos.rs": {
+      "branch": "res-1818-lexer-string-fast-reject",
+      "claimed_at": "2026-05-13T13:36:57Z"
     }
   }
 }

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -385,6 +385,12 @@ fn bytes_lit(lex: &mut logos::Lexer<Tok>) -> Vec<u8> {
     // trailing `"`.
     let slice = lex.slice();
     let inner = &slice[2..slice.len().saturating_sub(1)];
+    // RES-1818: fast-reject for byte literals without escape
+    // sequences. The escape-handling loop below walks every char
+    // only to push it back unchanged when there's no `\`.
+    if !inner.contains('\\') {
+        return inner.as_bytes().to_vec();
+    }
     // RES-1778: pre-size to inner.len() — each unescaped char yields
     // one byte; escape sequences (`\n`, `\xNN`) yield one byte but
     // consume 2-4 source chars, so this is an upper bound that
@@ -454,6 +460,16 @@ fn string_lit(lex: &mut logos::Lexer<Tok>) -> String {
     // The matched slice includes surrounding quotes; strip them.
     let slice = lex.slice();
     let inner = &slice[1..slice.len().saturating_sub(1)];
+    // RES-1818: fast-reject for strings without escape sequences.
+    // Most source-code strings contain no `\` — `b"hello"`,
+    // `"identifier"`, format templates, error messages with simple
+    // text. The escape-handling loop below allocates a fresh
+    // `String` and walks every char only to deposit them unchanged.
+    // A `contains('\\')` check is one O(N) byte scan, far cheaper
+    // than the chars-peekable walk plus `String::push` per char.
+    if !inner.contains('\\') {
+        return inner.to_string();
+    }
     let mut out = String::new();
     let mut chars = inner.chars().peekable();
     while let Some(c) = chars.next() {


### PR DESCRIPTION
Closes #1818

## Summary
- `string_lit` and `bytes_lit` walked every char only to deposit them unchanged when the literal had no escape sequences. Add fast-reject.

## Changes
- `lexer_logos::string_lit` — early return `inner.to_string()` when `!inner.contains('\\')`.
- `lexer_logos::bytes_lit` — early return `inner.as_bytes().to_vec()` when `!inner.contains('\\')`.

Same shape as RES-1816 (parse_template fast-reject).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass
- [x] `cargo test --features logos-lexer` — same 3164/69 pass/fail count as `main` (failures are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)