### PR TITLE
RES-1820: fast-reject radix int literals without underscores

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -333,8 +333,8 @@
       "claimed_at": "2026-05-13T13:34:15Z"
     },
     "resilient/src/lexer_logos.rs": {
-      "branch": "res-1818-lexer-string-fast-reject",
-      "claimed_at": "2026-05-13T13:40:39Z"
+      "branch": "res-1820-radix-int-fast-reject",
+      "claimed_at": "2026-05-13T13:43:38Z"
     }
   }
 }

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -341,22 +341,39 @@ enum Tok {
     Ident(String),
 }
 
+/// RES-1820: fast-reject for radix literals without `_` separators.
+/// `&str::replace` always allocates a fresh `String`; the typical
+/// `0xff` / `0b1010` / `0o755` literal has no underscore so the
+/// allocation is pure overhead. Same shape as `int_lit` / `float_lit`
+/// which already gate on `contains('_')`.
 fn hex_int(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
-    let body = lex.slice()[2..].replace('_', "");
+    let body = &lex.slice()[2..];
     // Matches the hand-rolled lexer's best-effort fallback: on overflow
     // or an empty body (which the regex's `+` already forbids, but we
     // keep the guard to mirror semantics), emit 0.
-    Some(i64::from_str_radix(&body, 16).unwrap_or(0))
+    if body.contains('_') {
+        Some(i64::from_str_radix(&body.replace('_', ""), 16).unwrap_or(0))
+    } else {
+        Some(i64::from_str_radix(body, 16).unwrap_or(0))
+    }
 }
 
 fn bin_int(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
-    let body = lex.slice()[2..].replace('_', "");
-    Some(i64::from_str_radix(&body, 2).unwrap_or(0))
+    let body = &lex.slice()[2..];
+    if body.contains('_') {
+        Some(i64::from_str_radix(&body.replace('_', ""), 2).unwrap_or(0))
+    } else {
+        Some(i64::from_str_radix(body, 2).unwrap_or(0))
+    }
 }
 
 fn oct_int(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
-    let body = lex.slice()[2..].replace('_', "");
-    Some(i64::from_str_radix(&body, 8).unwrap_or(0))
+    let body = &lex.slice()[2..];
+    if body.contains('_') {
+        Some(i64::from_str_radix(&body.replace('_', ""), 8).unwrap_or(0))
+    } else {
+        Some(i64::from_str_radix(body, 8).unwrap_or(0))
+    }
 }
 
 /// RES-909: decimal int literal with optional `_` separators.


### PR DESCRIPTION
Closes #1820

## Summary
- `hex_int` / `bin_int` / `oct_int` unconditionally called `.replace('_', "")` which allocates a fresh `String` even for separator-free literals. Gate on `contains('_')` like `int_lit` / `float_lit`.

## Changes
- `lexer_logos::hex_int` / `bin_int` / `oct_int` — `if body.contains('_') { ... .replace(...) } else { parse body directly }`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)