### PR TITLE
RES-1822: pre-size string_interp expr_src placeholder buffer

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -335,6 +335,10 @@
     "resilient/src/lexer_logos.rs": {
       "branch": "res-1820-radix-int-fast-reject",
       "claimed_at": "2026-05-13T13:43:38Z"
+    },
+    "resilient/src/string_interp.rs": {
+      "branch": "res-1822-string-interp-expr-presize",
+      "claimed_at": "2026-05-13T13:50:23Z"
     }
   }
 }

--- a/resilient/src/string_interp.rs
+++ b/resilient/src/string_interp.rs
@@ -87,7 +87,11 @@ pub(crate) fn parse_parts(raw: &str) -> Result<Option<Vec<StringPart>>, String> 
                 }
 
                 // Collect source up to the matching `}`.
-                let mut expr_src = String::new();
+                // RES-1822: pre-size to 16 — typical interpolation
+                // expressions are 5-30 chars (`name`, `arr[i]`,
+                // `x + 1`). Saves the 0→8→16→… doubling chain on
+                // every placeholder collected.
+                let mut expr_src = String::with_capacity(16);
                 let mut found_close = false;
                 for inner in chars.by_ref() {
                     if inner == '}' {


### PR DESCRIPTION
Closes #1822

## Summary
- `parse_parts`'s per-placeholder `expr_src` collected chars without pre-allocation. Pre-size to 16.

## Changes
- `string_interp::parse_parts` — `expr_src: String::with_capacity(16)`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)