### PR TITLE
RES-1824: pre-size string_lit out + hex unicode escape buffer

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -333,8 +333,8 @@
       "claimed_at": "2026-05-13T13:34:15Z"
     },
     "resilient/src/lexer_logos.rs": {
-      "branch": "res-1820-radix-int-fast-reject",
-      "claimed_at": "2026-05-13T13:43:38Z"
+      "branch": "res-1824-string-lit-out-presize",
+      "claimed_at": "2026-05-13T13:52:22Z"
     }
   }
 }

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -487,7 +487,12 @@ fn string_lit(lex: &mut logos::Lexer<Tok>) -> String {
     if !inner.contains('\\') {
         return inner.to_string();
     }
-    let mut out = String::new();
+    // RES-1824: pre-size to inner.len() — each unescaped char becomes
+    // one char in output; escapes (`\n`, `\xNN`, `\u{HHHH}`) consume
+    // multiple source chars but emit one (or zero). This is an upper
+    // bound that slightly over-allocates for escape-heavy strings,
+    // but avoids the 0→8→16 doubling chain on the slow path.
+    let mut out = String::with_capacity(inner.len());
     let mut chars = inner.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '\\' {
@@ -525,7 +530,9 @@ fn string_lit(lex: &mut logos::Lexer<Tok>) -> String {
                     // \u{HHHH} — 1–6 hex digits, any valid Unicode scalar value.
                     if chars.peek() == Some(&'{') {
                         chars.next(); // consume '{'
-                        let mut hex = String::new();
+                        // RES-1824: pre-size to 6 — Unicode escapes are
+                        // 1-6 hex digits.
+                        let mut hex = String::with_capacity(6);
                         while let Some(&d) = chars.peek() {
                             if d == '}' {
                                 chars.next();


### PR DESCRIPTION
Closes #1824

## Summary
- `lexer_logos::string_lit`'s escape-slow-path built `out: String::new()` without pre-allocation. Pre-size to `inner.len()`.
- Per-`\u{...}` `hex` String pre-sized to 6.

## Changes
- `lexer_logos::string_lit` — `out: String::with_capacity(inner.len())`.
- `lexer_logos::string_lit` `\u{...}` arm — `hex: String::with_capacity(6)`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)