### PR TITLE
RES-1828: pre-size eval_expressions + match_pattern bindings

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -320,10 +320,6 @@
       "branch": "res-1808-flatten-body-presize",
       "claimed_at": "2026-05-13T13:17:34Z"
     },
-    "resilient/src/lib.rs": {
-      "branch": "res-1812-parse-program-presize",
-      "claimed_at": "2026-05-13T13:22:43Z"
-    },
     "resilient/src/vm.rs": {
       "branch": "res-1814-vm-locals-presize",
       "claimed_at": "2026-05-13T13:30:39Z"
@@ -339,6 +335,10 @@
     "resilient/src/string_interp.rs": {
       "branch": "res-1822-string-interp-expr-presize",
       "claimed_at": "2026-05-13T13:50:23Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "res-1828-eval-expressions-presize",
+      "claimed_at": "2026-05-13T14:08:18Z"
     }
   }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -23988,7 +23988,10 @@ impl Interpreter {
     }
 
     fn eval_expressions(&mut self, expressions: &[Node]) -> RResult<Vec<Value>> {
-        let mut result = Vec::new();
+        // RES-1828: pre-size to expressions.len() — exactly one push
+        // per expression on the happy path. Hot: every CallExpression
+        // and tuple-literal evaluation goes through here.
+        let mut result = Vec::with_capacity(expressions.len());
 
         for expr in expressions {
             let value = self.eval(expr)?;
@@ -24324,7 +24327,9 @@ impl Interpreter {
                 if *has_rest && fields.is_empty() {
                     return Ok(Some(vec![]));
                 }
-                let mut bindings = Vec::new();
+                // RES-1828: pre-size to fields.len() — each sub-pattern
+                // contributes at least one binding on the happy path.
+                let mut bindings = Vec::with_capacity(fields.len());
                 for (fname, sub) in fields {
                     let Some((_, fv)) = val_fields.iter().find(|(n, _)| n == fname) else {
                         return Ok(None);
@@ -24366,7 +24371,9 @@ impl Interpreter {
                 if pat_items.len() != val_items.len() {
                     return Ok(None);
                 }
-                let mut bindings = Vec::new();
+                // RES-1828: pre-size to pat_items.len() — each
+                // sub-pattern contributes at least one binding.
+                let mut bindings = Vec::with_capacity(pat_items.len());
                 for (sub, fv) in pat_items.iter().zip(val_items.iter()) {
                     match self.match_pattern(sub, fv)? {
                         None => return Ok(None),
@@ -24396,7 +24403,9 @@ impl Interpreter {
                 if fields.len() != vfields.len() {
                     return Ok(None);
                 }
-                let mut bindings = Vec::new();
+                // RES-1828: pre-size to fields.len() — same shape as
+                // the other match_pattern bindings.
+                let mut bindings = Vec::with_capacity(fields.len());
                 for (i, sub) in fields.iter().enumerate() {
                     let key = i.to_string();
                     let Some((_, fv)) = vfields.iter().find(|(n, _)| n == &key) else {
@@ -24517,7 +24526,9 @@ impl Interpreter {
                         EnumPatternPayload::Named(pat_fields),
                         EnumValuePayload::Named(val_fields),
                     ) => {
-                        let mut bindings = Vec::new();
+                        // RES-1828: pre-size to pat_fields.len() — one
+                        // sub-pattern per named payload field.
+                        let mut bindings = Vec::with_capacity(pat_fields.len());
                         for (fname, sub) in pat_fields {
                             let Some((_, fv)) = val_fields.iter().find(|(n, _)| n == fname) else {
                                 return Ok(None);
@@ -24533,7 +24544,9 @@ impl Interpreter {
                         if pat_items.len() != val_items.len() {
                             return Ok(None);
                         }
-                        let mut bindings = Vec::new();
+                        // RES-1828: pre-size to pat_items.len() — one
+                        // sub-pattern per tuple-payload position.
+                        let mut bindings = Vec::with_capacity(pat_items.len());
                         for (sub, fv) in pat_items.iter().zip(val_items.iter()) {
                             match self.match_pattern(sub, fv)? {
                                 None => return Ok(None),


### PR DESCRIPTION
Closes #1828

## Summary
- Six more interpreter hot-path allocations grew from `0`. Pre-size them.

## Changes
- `eval_expressions::result` — `Vec::with_capacity(expressions.len())`.
- `match_pattern` struct/Tuple/TupleStruct/EnumVariant Named/EnumVariant Tuple arms — `bindings: Vec::with_capacity(...)`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)