### PR TITLE
RES-1830: pre-size VM run_direct locals Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -320,10 +320,6 @@
       "branch": "res-1808-flatten-body-presize",
       "claimed_at": "2026-05-13T13:17:34Z"
     },
-    "resilient/src/vm.rs": {
-      "branch": "res-1814-vm-locals-presize",
-      "claimed_at": "2026-05-13T13:30:39Z"
-    },
     "resilient/src/format_builtin.rs": {
       "branch": "res-1816-format-template-fast-reject",
       "claimed_at": "2026-05-13T13:34:15Z"
@@ -339,6 +335,10 @@
     "resilient/src/lib.rs": {
       "branch": "res-1826-parse-method-presize",
       "claimed_at": "2026-05-13T14:04:02Z"
+    },
+    "resilient/src/vm.rs": {
+      "branch": "res-1830-vm-run-direct-locals-presize",
+      "claimed_at": "2026-05-13T14:15:49Z"
     }
   }
 }

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -1132,10 +1132,14 @@ fn run_direct(
     last_pc: &mut (usize, usize),
     overflow_mode: OverflowMode,
 ) -> Result<Value, VmError> {
+    // RES-1830: pre-size `locals` to 32 — mirrors RES-1814 for the
+    // tree-walker `run_inner` path. `run_direct` is the second VM
+    // entry point and pays the same 0→4→… doubling chain without
+    // pre-sizing.
     let mut state = VmState {
         program,
         stack: Vec::with_capacity(64),
-        locals: Vec::new(),
+        locals: Vec::with_capacity(32),
         frames: Vec::with_capacity(16),
         overflow_mode,
     };


### PR DESCRIPTION
Closes #1830

## Summary
- `vm::run_direct` had `locals: Vec::new()`. Pre-size to 32 to mirror RES-1814.

## Changes
- `vm::run_direct` — `locals: Vec::with_capacity(32)`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass; VM tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)