### PR TITLE
RES-1832: pre-size template/interp String buffers

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -324,21 +324,21 @@
       "branch": "res-1814-vm-locals-presize",
       "claimed_at": "2026-05-13T13:30:39Z"
     },
-    "resilient/src/format_builtin.rs": {
-      "branch": "res-1816-format-template-fast-reject",
-      "claimed_at": "2026-05-13T13:34:15Z"
-    },
     "resilient/src/lexer_logos.rs": {
       "branch": "res-1820-radix-int-fast-reject",
       "claimed_at": "2026-05-13T13:43:38Z"
     },
-    "resilient/src/string_interp.rs": {
-      "branch": "res-1822-string-interp-expr-presize",
-      "claimed_at": "2026-05-13T13:50:23Z"
-    },
     "resilient/src/lib.rs": {
       "branch": "res-1826-parse-method-presize",
       "claimed_at": "2026-05-13T14:04:02Z"
+    },
+    "resilient/src/format_builtin.rs": {
+      "branch": "res-1832-template-bufs-presize",
+      "claimed_at": "2026-05-13T14:19:16Z"
+    },
+    "resilient/src/string_interp.rs": {
+      "branch": "res-1832-template-bufs-presize",
+      "claimed_at": "2026-05-13T14:19:16Z"
     }
   }
 }

--- a/resilient/src/format_builtin.rs
+++ b/resilient/src/format_builtin.rs
@@ -54,7 +54,9 @@ pub fn parse_template(s: &str) -> Result<Vec<FormatSegment>, String> {
     // matches the typical 1-3-placeholder shape. fmt_validation calls
     // this on every `format(...)` expression at typecheck time.
     let mut out = Vec::with_capacity(s.matches('{').count() * 2 + 1);
-    let mut buf = String::new();
+    // RES-1832: pre-size to 16 — accumulates literal text between
+    // placeholders, typically 5-30 chars per segment.
+    let mut buf = String::with_capacity(16);
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '{' {
@@ -66,7 +68,9 @@ pub fn parse_template(s: &str) -> Result<Vec<FormatSegment>, String> {
             if !buf.is_empty() {
                 out.push(FormatSegment::Literal(std::mem::take(&mut buf)));
             }
-            let mut spec = String::new();
+            // RES-1832: pre-size to 8 — placeholder specs are 0-10
+            // chars (`""`, `":.2f"`, `":0Nd"`, etc.).
+            let mut spec = String::with_capacity(8);
             let mut closed = false;
             while let Some(&c2) = chars.peek() {
                 if c2 == '}' {

--- a/resilient/src/string_interp.rs
+++ b/resilient/src/string_interp.rs
@@ -53,7 +53,10 @@ pub(crate) fn parse_parts(raw: &str) -> Result<Option<Vec<StringPart>>, String> 
     // typical 1-3-placeholder shape and is computed in O(N) via
     // `matches`. Called for every interpolated string literal in source.
     let mut parts: Vec<StringPart> = Vec::with_capacity(raw.matches('{').count() * 2 + 1);
-    let mut literal_buf = String::new();
+    // RES-1832: pre-size to 16 — accumulates literal text between
+    // placeholders. Typical interpolated strings have 5-30 chars per
+    // literal segment.
+    let mut literal_buf = String::with_capacity(16);
     let mut chars = raw.chars().peekable();
 
     while let Some(ch) = chars.next() {
@@ -151,7 +154,10 @@ pub(crate) fn parse_parts(raw: &str) -> Result<Option<Vec<StringPart>>, String> 
 /// directly into the output string or evaluated and converted to its
 /// string representation.
 pub(crate) fn eval_interp(interp: &mut Interpreter, parts: &[StringPart]) -> RResult<Value> {
-    let mut out = String::new();
+    // RES-1832: pre-size to 32 — interpolated string output is the
+    // sum of literal parts (each typically 5-30 chars) plus expr
+    // results. 32 covers the common case.
+    let mut out = String::with_capacity(32);
     for part in parts {
         match part {
             StringPart::Literal(s) => out.push_str(s),


### PR DESCRIPTION
Closes #1832

## Summary
- Four more `String::new()` allocations on parse / runtime hot paths grew from `0`. Pre-size them.

## Changes
- `format_builtin::parse_template` — `buf: String::with_capacity(16)`, `spec: String::with_capacity(8)`.
- `string_interp::parse_parts` — `literal_buf: String::with_capacity(16)`.
- `string_interp::eval_interp` — `out: String::with_capacity(32)`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 3232 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)