### PR TITLE
perf(profile): lto=thin + codegen-units=1 for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,22 @@ opt-level = 1
 
 [profile.test.build-override]
 opt-level = 1
+
+# Release profile tuning for the `rz` compiler binary.
+#
+# `lto = "thin"`: cross-crate inlining across `resilient`, `resilient-runtime`,
+# `resilient-span`, and their transitive deps. Thin LTO trades a modest
+# build-time hit for measurable runtime speedups on the compiler's hot
+# paths (typechecker recursion, expression walks, format-builtin loops),
+# which is the right tradeoff for a binary that ships once per release
+# and runs against every user typecheck thereafter. Already validated as
+# safe by the `playground/` and `resilient-runtime-cortex-m-demo/` crates,
+# which use the same `lto = "thin"` setting (the former for the wasm
+# bundle, the latter as part of `lto = true`).
+#
+# `codegen-units = 1`: lets LLVM see the whole crate at once instead of
+# split-N parallel compilations that fence inlining. Pairs naturally with
+# `lto = "thin"` — splitting the crate would defeat half of the LTO gain.
+[profile.release]
+lto = "thin"
+codegen-units = 1


### PR DESCRIPTION
## Summary

Adds `[profile.release]` to the workspace root so the shipped `rz` compiler binary benefits from cross-crate inlining and single-codegen-unit compilation. Both settings are well-validated within this repo (playground uses `lto = "thin"`; cortex-m-demo uses `lto = true` + `codegen-units = 1`).

## What changes

```toml
[profile.release]
lto = "thin"
codegen-units = 1
```

Applies to the three workspace members (`resilient`, `resilient-runtime`, `resilient-span`). The excluded crates (`playground`, `resilient-runtime-cortex-m-demo`, `fuzz`) each own their own `[profile.release]` block and are unaffected.

## Why

For a compiler that ships once per release cycle and runs against every user typecheck thereafter, trading a small release-build-time hit for steady runtime gains on hot paths (typechecker recursion, expression walks, format-builtin loops, Z3 prover entry) is the right call. Thin LTO gives most cross-crate inlining wins at a fraction of fat-LTO's link cost. `codegen-units = 1` is the natural pair — at the default 16, LLVM fences inlining at split boundaries and defeats half of the LTO gain.

## CI impact

`cargo check` and `cargo test` use the dev/test profiles (already tuned in #1185), so the gated checks (`build / test / clippy`, `build / test with --features z3`, etc.) are not slowed. The release.yml binary build and any future `cargo build --release` runs pick up the new settings.

## Test plan
- [x] `cargo metadata --locked` parses cleanly
- [x] `cargo fmt --all --check` clean
- [x] `cargo check --locked` clean
- [ ] CI: required status checks pass on test/dev profile paths (unchanged)