### PR TITLE
perf(lint): pre-size collect_pattern_bindings accumulators

### DIFF
--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -337,7 +337,12 @@ fn collect_pattern_bindings(pattern: &Pattern) -> Vec<&str> {
         // Wildcard and Literal introduce no bindings.
         Pattern::Wildcard | Pattern::Literal(_) => vec![],
         Pattern::Struct { fields, .. } => {
-            let mut names = Vec::new();
+            // Pre-size to fields.len(): each field's sub-pattern most
+            // commonly binds 0–1 names (Identifier / Wildcard), so the
+            // field count is a tight upper bound for the typical case.
+            // Sub-patterns that bind more (nested destructure) trigger
+            // extend's amortised growth from there.
+            let mut names = Vec::with_capacity(fields.len());
             for (_, sub) in fields {
                 names.extend(collect_pattern_bindings(sub.as_ref()));
             }
@@ -354,14 +359,14 @@ fn collect_pattern_bindings(pattern: &Pattern) -> Vec<&str> {
         Pattern::EnumVariant { payload, .. } => match payload {
             crate::EnumPatternPayload::None => vec![],
             crate::EnumPatternPayload::Named(fields) => {
-                let mut names = Vec::new();
+                let mut names = Vec::with_capacity(fields.len());
                 for (_, sub) in fields {
                     names.extend(collect_pattern_bindings(sub.as_ref()));
                 }
                 names
             }
             crate::EnumPatternPayload::Tuple(subs) => {
-                let mut names = Vec::new();
+                let mut names = Vec::with_capacity(subs.len());
                 for sub in subs {
                     names.extend(collect_pattern_bindings(sub));
                 }
@@ -370,7 +375,7 @@ fn collect_pattern_bindings(pattern: &Pattern) -> Vec<&str> {
         },
         // RES-931: tuple-struct destructure — recurse into each field pattern.
         Pattern::TupleStruct { fields, .. } => {
-            let mut names = Vec::new();
+            let mut names = Vec::with_capacity(fields.len());
             for sub in fields {
                 names.extend(collect_pattern_bindings(sub));
             }
@@ -378,7 +383,7 @@ fn collect_pattern_bindings(pattern: &Pattern) -> Vec<&str> {
         }
         // RES-932: anonymous tuple destructure — recurse positionally.
         Pattern::Tuple(items) => {
-            let mut names = Vec::new();
+            let mut names = Vec::with_capacity(items.len());
             for sub in items {
                 names.extend(collect_pattern_bindings(sub));
             }


### PR DESCRIPTION
## Summary

Pre-sizes five `Vec::new()` allocators in `collect_pattern_bindings` (lint.rs:320). The function walks every match pattern in the program for the L0001 unused-binding lint; each container-pattern arm allocates an accumulator that's grown via `.extend()`.

## What changes

```rust
Pattern::Struct        => Vec::with_capacity(fields.len())
Pattern::EnumVariant
  ::Named              => Vec::with_capacity(fields.len())
  ::Tuple              => Vec::with_capacity(subs.len())
Pattern::TupleStruct   => Vec::with_capacity(fields.len())
Pattern::Tuple         => Vec::with_capacity(items.len())
```

## Why

Each container's field/positional count is a tight upper bound for the overwhelmingly common pattern shape: sub-patterns are Identifier / Wildcard / Literal, each binding 0 or 1 names. `Vec::with_capacity(len)` covers those without paying the default-bucket reallocation. Nested-destructure cases (sub-patterns that themselves bind multiple names) fall through to `extend`'s amortised growth from there, so this is a strict win or break-even — never worse.

Mirrors RES-1766's pre-size of `param_types` in the typechecker's FunctionLiteral arm and RES-1726's pre-size of `match_pattern_binding_types`'s enum-variant arms.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --locked --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 3232 / 3232 pass
- [ ] CI: required status checks pass