### PR TITLE
perf(verifier_z3): identity-hash PERSISTENT_PROVEN u64 set

### DIFF
--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -543,8 +543,13 @@ pub fn prove_with_axioms_and_timeout(
 // initializer, which is not `const` on stable Rust — `cargo test
 // --features z3` has been red on `main` ever since. Wrap in
 // `LazyLock` so the HashSet is built on first access. RES-1661.
-static PERSISTENT_PROVEN: std::sync::LazyLock<std::sync::RwLock<std::collections::HashSet<u64>>> =
-    std::sync::LazyLock::new(|| std::sync::RwLock::new(std::collections::HashSet::new()));
+// RES: identity hasher (see `IdentityU64Hasher` / `U64HashSet` below)
+// is reused here. Keys are already 64-bit hashes from
+// `hash_node_spanless` — re-hashing with SipHash on every contains /
+// insert wastes ~5-10 cycles per touch with no collision-resistance
+// benefit. Same rationale as the `U64CacheMap` migration in RES-1207.
+static PERSISTENT_PROVEN: std::sync::LazyLock<std::sync::RwLock<U64HashSet>> =
+    std::sync::LazyLock::new(|| std::sync::RwLock::new(U64HashSet::default()));
 
 // RES-1700: AtomicBool fast-reject. Same pattern as RES-1374 for
 // `feature_attrs::find_kind`. Default-mode typechecks (no
@@ -719,6 +724,10 @@ impl std::hash::Hasher for IdentityU64Hasher {
 
 pub(crate) type U64CacheMap<V> =
     std::collections::HashMap<u64, V, std::hash::BuildHasherDefault<IdentityU64Hasher>>;
+
+/// Set companion to [`U64CacheMap`] — same identity-hasher rationale,
+/// just for the verdict-only persistent proven-key store.
+type U64HashSet = std::collections::HashSet<u64, std::hash::BuildHasherDefault<IdentityU64Hasher>>;
 
 thread_local! {
     /// RES-1206: see `prove_with_axioms_and_timeout`. Stays the lifetime


### PR DESCRIPTION
## Summary

Routes `PERSISTENT_PROVEN` (RES-1657 / RES-1661, the process-wide proven-key set) through `IdentityU64Hasher` instead of the default SipHash. Mirrors the `U64CacheMap` migration that already exists for the verdict and counterexample caches — same `u64` keys, same rationale, same hasher.

## What changes

Adds a one-line type alias next to the existing `U64CacheMap`:

```rust
type U64HashSet = std::collections::HashSet<u64, std::hash::BuildHasherDefault<IdentityU64Hasher>>;
```

And routes `PERSISTENT_PROVEN` through it:

```rust
static PERSISTENT_PROVEN: std::sync::LazyLock<std::sync::RwLock<U64HashSet>> =
    std::sync::LazyLock::new(|| std::sync::RwLock::new(U64HashSet::default()));
```

No other changes — `contains` / `insert` / `iter` API is identical.

## Why

The keys are already `u64` hashes produced by `hash_node_spanless`. Re-hashing them through SipHash on every touch costs ~5-10 cycles with no collision-resistance benefit (the upstream hashing pipeline is already collision-aware for compiler-internal proof dedupe). The existing `IdentityU64Hasher` comment (line 696) explicitly calls out this cost for the verdict cache; the persistent set is the only `u64`-keyed container in the file that still pays it.

## Hot-path effect

`persistent_proven_contains` is gated by the RES-1700 `AtomicBool` fast-reject, so default-mode typechecks (no `--persistent-proof-cache` flag) leave the hashing path cold. Users who load a persistent proven-set save the SipHash work on every `contains` lookup — three sites per `prove` (LIA, tautology, BV32) × 100+ obligations per typecheck. Bulk-load (`load_persistent_proven`) and save (`save_persistent_proven`) benefit identically.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --locked --features z3 --all-targets -- -D warnings` clean
- [x] `cargo test --locked --features z3 --lib verifier_z3` — 104 / 104 pass
- [ ] CI: required status checks pass (`build / test with --features z3`)