### PR TITLE
perf(deadlock_freedom): pre-size sends + visited HashSets

### DIFF
--- a/resilient/src/deadlock_freedom.rs
+++ b/resilient/src/deadlock_freedom.rs
@@ -47,7 +47,13 @@ pub fn build(program: &Node) -> ActorGraph {
             ..
         } = &s.node
         {
-            let mut sends = HashSet::new();
+            // An actor can only `send` to a known target actor (see
+            // walk_sends's `actors.contains` guard), so the unique
+            // recipients per actor are bounded by the total actor
+            // count. Pre-size to that upper bound to skip the default
+            // bucket-grow cascade for clusters with more than a handful
+            // of actors.
+            let mut sends = HashSet::with_capacity(actor_names.len());
             for h in receive_handlers {
                 walk_sends(&h.body, &actor_names, &mut sends);
             }
@@ -110,7 +116,9 @@ fn walk_sends(node: &Node, actors: &HashSet<&str>, out: &mut HashSet<String>) {
 // borrow chain is sound.
 pub fn detect_cycles<'a>(graph: &'a ActorGraph) -> Vec<Vec<&'a str>> {
     let mut cycles = Vec::new();
-    let mut visited: HashSet<&'a str> = HashSet::new();
+    // `visited` grows to at most one entry per node in the graph; pre-size
+    // to that exact upper bound. Same shape as the `sends` pre-size above.
+    let mut visited: HashSet<&'a str> = HashSet::with_capacity(graph.edges.len());
     for start in graph.edges.keys() {
         let start = start.as_str();
         if visited.contains(start) {


### PR DESCRIPTION
## Summary

Pre-sizes two `HashSet` accumulators in the deadlock-freedom pass that were created via `HashSet::new()` and grown via `insert`.

## What changes

| Site | Container | Upper bound |
|---|---|---|
| `build_actor_graph` line 50 | `sends: HashSet<String>` | `actor_names.len()` |
| `detect_cycles` line 113 | `visited: HashSet<&str>` | `graph.edges.len()` |

`walk_sends` only inserts targets that pass its `actors.contains` guard, so the per-actor recipient set can't grow beyond the total declared actor count. `detect_cycles`'s DFS visits each graph node at most once, so `visited` can't grow beyond the edge-map's key count.

## Why

Skips the default-bucket reallocation cascade for clusters with more than a handful of actors. Same shape as the parser pre-size series (RES-1772, RES-1776, RES-1804) and the lint accumulator pre-size in [#1836](https://github.com/EricSpencer00/Resilient/pull/1836) — established upper bounds substituted for `::new()`.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --locked --all-targets -- -D warnings` clean
- [x] `cargo test --lib deadlock` — 2 / 2 pass (deadlock-specific tests)
- [ ] CI: required status checks pass