### PR TITLE
perf(typechecker): pre-size infer_fn_effects fn_bodies map

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -7921,7 +7921,15 @@ pub fn infer_fn_effects(
     // because `self.stats.fn_effects` is an owned field — the
     // conversion happens once at the end (one `to_string()` per fn,
     // matching what the return type already costs).
-    let mut fn_bodies: std::collections::HashMap<&str, &Node> = std::collections::HashMap::new();
+    //
+    // Pre-size `fn_bodies` to `statements.len()` — upper bound, since
+    // every Function statement contributes one entry. Same shape as
+    // `check_program_purity::pure_fns` (RES-1796) and
+    // `collect_fn_effects::out` (RES-1734) — the two sibling passes
+    // that walk the same statement list to populate the same shape of
+    // map.
+    let mut fn_bodies: std::collections::HashMap<&str, &Node> =
+        std::collections::HashMap::with_capacity(statements.len());
     for stmt in statements {
         if let Node::Function { name, body, .. } = &stmt.node {
             fn_bodies.insert(name.as_str(), body.as_ref());


### PR DESCRIPTION
## Summary

`infer_fn_effects` (RES-192) iterates every top-level statement and collects function bodies into a `HashMap<&str, &Node>` keyed by function name. The map was created with `HashMap::new()`, paying the default 0 → 3 → 7 → 14 → 28 ... bucket-grow cascade for every program with more than a handful of fns.

## What changes

```rust
-let mut fn_bodies: std::collections::HashMap<&str, &Node> = std::collections::HashMap::new();
+let mut fn_bodies: std::collections::HashMap<&str, &Node> =
+    std::collections::HashMap::with_capacity(statements.len());
```

## Why

Both sibling passes that walk the same statement list to populate the same shape of map already pre-size to `statements.len()`:

- `check_program_purity::pure_fns` (RES-1796)
- `collect_fn_effects::out` (RES-1734)

`infer_fn_effects::fn_bodies` is the missing third. `statements.len()` is the tight upper bound — every `Function` statement contributes one entry, every non-Function statement contributes zero.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --locked --all-targets -- -D warnings` clean
- [x] `cargo test --lib effect` — 13 / 13 pass (effect + purity tests)
- [ ] CI: required status checks pass