### PR TITLE
perf(const): pre-size const_eval_program resolved map

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -22946,7 +22946,18 @@ impl Interpreter {
     /// `self.consts` (behind an `Rc`) so every sub-interpreter created
     /// for function calls sees the same set of constants.
     fn const_eval_program(&mut self, statements: &[span::Spanned<Node>]) -> RResult<()> {
-        let mut resolved: HashMap<String, Value> = HashMap::new();
+        // Pre-size `resolved` to the actual `Node::Const` count — same
+        // shape as `compile::fn_count` (RES-1461), `pure_fns`
+        // (RES-1796), and `collect_fn_effects::out` (RES-1734): one
+        // linear pre-scan to skip the default 0 → 3 → 7 → 14 → 28 ...
+        // bucket-grow cascade. Non-Const statements contribute zero so
+        // a `statements.len()` over-estimate would over-allocate for
+        // programs with many fns and few consts.
+        let const_count = statements
+            .iter()
+            .filter(|s| matches!(&s.node, Node::Const { .. }))
+            .count();
+        let mut resolved: HashMap<String, Value> = HashMap::with_capacity(const_count);
 
         for stmt in statements {
             let Node::Const { name, value, .. } = &stmt.node else {


### PR DESCRIPTION
## Summary

`const_eval_program` collects every top-level `Node::Const` into a `HashMap<String, Value>` (`resolved`) that's stitched into `self.consts` for sub-interpreters to share. The map was created via `HashMap::new()`, paying the default 0 → 3 → 7 → 14 → 28 ... bucket-grow cascade for programs with more than a handful of consts.

## What changes

```rust
+let const_count = statements
+    .iter()
+    .filter(|s| matches!(&s.node, Node::Const { .. }))
+    .count();
-let mut resolved: HashMap<String, Value> = HashMap::new();
+let mut resolved: HashMap<String, Value> = HashMap::with_capacity(const_count);
```

## Why

Same shape as:
- `compiler::compile::fn_count` + `fn_index` (RES-1461)
- `typechecker::check_program_purity::pure_fns` (RES-1796)
- `typechecker::collect_fn_effects::out` (RES-1734)

A loose `statements.len()` bound would over-allocate for programs with many fns and few consts; one linear pre-scan keeps the bound tight.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --locked --all-targets -- -D warnings` clean
- [x] `cargo test --lib const` — 83 / 83 pass
- [ ] CI: required status checks pass