### PR TITLE
audit: eliminate unwrap() panics and fix edge cases across builtins

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -17879,12 +17879,19 @@ fn builtin_array_min(args: &[Value]) -> RResult<Value> {
             if items.is_empty() {
                 return Err("array_min: empty array has no minimum".to_string());
             }
-            let mut best: Option<i64> = None;
-            for v in items {
+            let first = match &items[0] {
+                Value::Int(n) => *n,
+                other => {
+                    return Err(format!(
+                        "array_min: expected all int elements, got {}",
+                        other
+                    ));
+                }
+            };
+            let mut best = first;
+            for v in &items[1..] {
                 match v {
-                    Value::Int(n) => {
-                        best = Some(best.map_or(*n, |cur| cur.min(*n)));
-                    }
+                    Value::Int(n) => best = best.min(*n),
                     other => {
                         return Err(format!(
                             "array_min: expected all int elements, got {}",
@@ -17893,7 +17900,7 @@ fn builtin_array_min(args: &[Value]) -> RResult<Value> {
                     }
                 }
             }
-            Ok(Value::Int(best.unwrap()))
+            Ok(Value::Int(best))
         }
         [other] => Err(format!("array_min: expected array, got {}", other)),
         _ => Err(format!(
@@ -17911,12 +17918,19 @@ fn builtin_array_max(args: &[Value]) -> RResult<Value> {
             if items.is_empty() {
                 return Err("array_max: empty array has no maximum".to_string());
             }
-            let mut best: Option<i64> = None;
-            for v in items {
+            let first = match &items[0] {
+                Value::Int(n) => *n,
+                other => {
+                    return Err(format!(
+                        "array_max: expected all int elements, got {}",
+                        other
+                    ));
+                }
+            };
+            let mut best = first;
+            for v in &items[1..] {
                 match v {
-                    Value::Int(n) => {
-                        best = Some(best.map_or(*n, |cur| cur.max(*n)));
-                    }
+                    Value::Int(n) => best = best.max(*n),
                     other => {
                         return Err(format!(
                             "array_max: expected all int elements, got {}",
@@ -17925,7 +17939,7 @@ fn builtin_array_max(args: &[Value]) -> RResult<Value> {
                     }
                 }
             }
-            Ok(Value::Int(best.unwrap()))
+            Ok(Value::Int(best))
         }
         [other] => Err(format!("array_max: expected array, got {}", other)),
         _ => Err(format!(
@@ -17945,12 +17959,19 @@ fn builtin_array_max_or(args: &[Value]) -> RResult<Value> {
             if items.is_empty() {
                 return Ok(Value::Int(*default));
             }
-            let mut best: Option<i64> = None;
-            for v in items {
+            let first = match &items[0] {
+                Value::Int(n) => *n,
+                other => {
+                    return Err(format!(
+                        "array_max_or: expected all int elements, got {}",
+                        other
+                    ));
+                }
+            };
+            let mut best = first;
+            for v in &items[1..] {
                 match v {
-                    Value::Int(n) => {
-                        best = Some(best.map_or(*n, |cur| cur.max(*n)));
-                    }
+                    Value::Int(n) => best = best.max(*n),
                     other => {
                         return Err(format!(
                             "array_max_or: expected all int elements, got {}",
@@ -17959,7 +17980,7 @@ fn builtin_array_max_or(args: &[Value]) -> RResult<Value> {
                     }
                 }
             }
-            Ok(Value::Int(best.unwrap()))
+            Ok(Value::Int(best))
         }
         [a, b] => Err(format!(
             "array_max_or: expected (array, int), got ({}, {})",
@@ -17981,12 +18002,19 @@ fn builtin_array_min_or(args: &[Value]) -> RResult<Value> {
             if items.is_empty() {
                 return Ok(Value::Int(*default));
             }
-            let mut best: Option<i64> = None;
-            for v in items {
+            let first = match &items[0] {
+                Value::Int(n) => *n,
+                other => {
+                    return Err(format!(
+                        "array_min_or: expected all int elements, got {}",
+                        other
+                    ));
+                }
+            };
+            let mut best = first;
+            for v in &items[1..] {
                 match v {
-                    Value::Int(n) => {
-                        best = Some(best.map_or(*n, |cur| cur.min(*n)));
-                    }
+                    Value::Int(n) => best = best.min(*n),
                     other => {
                         return Err(format!(
                             "array_min_or: expected all int elements, got {}",
@@ -17995,7 +18023,7 @@ fn builtin_array_min_or(args: &[Value]) -> RResult<Value> {
                     }
                 }
             }
-            Ok(Value::Int(best.unwrap()))
+            Ok(Value::Int(best))
         }
         [a, b] => Err(format!(
             "array_min_or: expected (array, int), got ({}, {})",
@@ -19125,7 +19153,10 @@ fn builtin_format(args: &[Value]) -> RResult<Value> {
             }
             _ => {
                 let rest = &fmt[i..];
-                let ch = rest.chars().next().unwrap();
+                let ch = rest
+                    .chars()
+                    .next()
+                    .ok_or_else(|| "format: internal: byte index past end of string".to_string())?;
                 out.push(ch);
                 i += ch.len_utf8();
             }
@@ -19200,7 +19231,11 @@ fn parse_format_spec(spec_src: &str) -> Result<FormatSpec, String> {
                 spec_src
             ));
         }
-        spec.precision = Some(rest[..pdigit_end].parse::<usize>().unwrap());
+        spec.precision = Some(
+            rest[..pdigit_end]
+                .parse::<usize>()
+                .map_err(|_| format!("format: invalid precision in spec `{}`", spec_src))?,
+        );
         s = &rest[pdigit_end..];
     }
 
@@ -25749,7 +25784,7 @@ fn start_repl() -> RustylineResult<()> {
                     }
                     "clear" => {
                         print!("\x1B[2J\x1B[1;1H"); // ANSI escape code to clear screen
-                        io::stdout().flush().unwrap();
+                        let _ = io::stdout().flush();
                         continue;
                     }
                     "typecheck" => {

--- a/resilient/src/numeric_utils.rs
+++ b/resilient/src/numeric_utils.rs
@@ -147,6 +147,11 @@ pub(crate) fn builtin_round_to(args: &[Value]) -> RResult<Value> {
     if n < 0 {
         return Err(format!("round_to: decimal places must be >= 0, got {n}"));
     }
+    if n > 308 {
+        return Err(format!(
+            "round_to: decimal places must be <= 308 (f64 precision limit), got {n}"
+        ));
+    }
     let factor = 10f64.powi(n as i32);
     Ok(Value::Float((x * factor).round() / factor))
 }

--- a/resilient/src/statistics.rs
+++ b/resilient/src/statistics.rs
@@ -959,6 +959,13 @@ println(stats_percentile([5.0, 1.0, 3.0], 100.0));"#);
         assert!(approx(lines[1], 5.0), "expected 5.0, got {}", lines[1]);
     }
 
+    #[test]
+    fn percentile_nan_input_errors() {
+        // sqrt(-1.0) produces NaN; the percentile function should reject it.
+        let r = run("stats_percentile([1.0, sqrt(-1.0), 3.0], 50.0);");
+        assert!(!r.ok, "expected error for NaN element in percentile");
+    }
+
     // ── zscore ───────────────────────────────────────────────────────────────
 
     #[test]

--- a/resilient/src/statistics.rs
+++ b/resilient/src/statistics.rs
@@ -157,7 +157,10 @@ pub(crate) fn builtin_stats_percentile(args: &[Value]) -> RResult<Value> {
             if xs.is_empty() {
                 return Err("stats_percentile: empty array".to_string());
             }
-            xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            if xs.iter().any(|v| v.is_nan()) {
+                return Err("stats_percentile: array contains NaN".to_string());
+            }
+            xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
             let idx = p / 100.0 * (xs.len() - 1) as f64;
             let lo = idx.floor() as usize;
             let hi = idx.ceil() as usize;
@@ -765,7 +768,7 @@ pub(crate) fn builtin_mat_solve(args: &[Value]) -> RResult<Value> {
                 }
             }
 
-            let x: Vec<f64> = aug.iter().map(|row| *row.last().unwrap()).collect();
+            let x: Vec<f64> = aug.iter().map(|row| row[n]).collect();
             Ok(float_arr(x))
         }
         _ => Err(format!(

--- a/resilient/src/type_builtins.rs
+++ b/resilient/src/type_builtins.rs
@@ -56,7 +56,10 @@ pub(crate) fn builtin_type_of(args: &[Value]) -> RResult<Value> {
             };
             Ok(Value::String(name.to_string()))
         }
-        _ => Err(format!("type_of: expected 1 argument, got {}", args.len())),
+        _ => Err(format!(
+            "type_of: expected 1 argument (x), got {}",
+            args.len()
+        )),
     }
 }
 
@@ -99,7 +102,7 @@ pub(crate) fn builtin_result_collect(args: &[Value]) -> RResult<Value> {
             "result_collect: expected an Array of Results, got {other}"
         )),
         _ => Err(format!(
-            "result_collect: expected 1 argument, got {}",
+            "result_collect: expected 1 argument (arr), got {}",
             args.len()
         )),
     }


### PR DESCRIPTION
## Summary

Codebase audit targeting library panics (CLAUDE.md security rule: every `unwrap()`/`expect()` in library code is a bug) and edge cases in recently-merged builtins.

- **Eliminate 7 `unwrap()` calls in `lib.rs`**: array_min/max/max_or/min_or refactored to direct-value loop (no `Option` accumulator needed); format loop `chars().next()` and precision `parse()` converted to `?`-propagating errors; REPL `flush().unwrap()` downgraded to `let _ = flush()`.
- **Fix panic in `statistics.rs` sort**: `stats_percentile` would panic on NaN inputs via `partial_cmp().unwrap()`. Added explicit NaN guard before sort; added unit test using `sqrt(-1.0)` to produce NaN.
- **Fix `mat_solve` last().unwrap()**: replaced with direct index `row[n]` since the augmented matrix always has exactly `n+1` columns.
- **Error message consistency in `type_builtins.rs`**: `type_of` and `result_collect` were missing parameter names in their arity-error messages, inconsistent with all other builtins in the library.
- **Bounds check in `round_to`**: values above 308 exceed f64's maximum representable precision, producing infinity rather than a useful rounded value.

## Test changes

- Added `statistics::tests::percentile_nan_input_errors` — tests that `stats_percentile` rejects an array containing NaN. Previous fixture used `float_nan()` (not a registered builtin), so the test was passing for the wrong reason.

## Commits

1. `audit: eliminate unwrap() panics in array builtins and format parser`
2. `audit: fix unwrap() in statistics.rs — NaN guard + direct index access`
3. `audit: add NaN-guard test for stats_percentile`
4. `audit: fix error message consistency + round_to precision bound`

https://claude.ai/code/session_017fsCXCqARu4bwgEYaDspBk

---
_Generated by [Claude Code](https://claude.ai/code/session_017fsCXCqARu4bwgEYaDspBk)_