### PR TITLE
feat(mcp): publish Resilient MCP server to registry.modelcontextprotocol.io

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,96 @@
+name: mcp-publish
+
+# Publish `server.json` to the official MCP Registry at
+# registry.modelcontextprotocol.io.
+#
+# Triggers:
+#   - `release: published` → after release.yml + release-image.yml finish
+#     producing artifacts for a `v*` tag, this fires automatically.
+#   - `workflow_dispatch` → for manual republishes (e.g., metadata-only
+#     update where the Docker image already exists).
+#
+# Authentication: GitHub OIDC. The registry validates the OIDC token's
+# `repository` claim against the `io.github.<owner>/<name>` namespace,
+# so no PAT is needed. The job requests `id-token: write` to mint the
+# token at runtime.
+#
+# Package ownership: the registry verifies that the OCI image at the
+# `identifier` URL in `server.json` carries a
+# `io.modelcontextprotocol.server.name` LABEL that matches the
+# server name. That label is set in our Dockerfile.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Validate server.json without publishing"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: mcp-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --help | head -5
+
+      - name: Sync server.json version to release tag
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # Strip leading `v` from the tag (e.g. v0.2.0 → 0.2.0).
+          VERSION="${TAG#v}"
+          python3 - <<PY
+          import json, pathlib, os
+          p = pathlib.Path("server.json")
+          data = json.loads(p.read_text())
+          version = os.environ["TAG"].lstrip("v")
+          data["version"] = version
+          # Point at the matching OCI tag that release-image.yml just pushed.
+          for pkg in data.get("packages", []):
+              if pkg.get("registryType") == "oci":
+                  ident = pkg["identifier"]
+                  # ghcr.io/owner/name:OLD_TAG → ghcr.io/owner/name:VERSION
+                  base = ident.rsplit(":", 1)[0]
+                  pkg["identifier"] = f"{base}:{version}"
+          p.write_text(json.dumps(data, indent=2) + "\n")
+          print(f"server.json version bumped to {version}")
+          PY
+
+      - name: Validate server.json
+        run: mcp-publisher validate server.json
+
+      - name: Authenticate with registry (OIDC)
+        if: ${{ !inputs.dry_run }}
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to registry
+        if: ${{ !inputs.dry_run }}
+        run: mcp-publisher publish server.json
+
+      - name: Dry-run summary
+        if: inputs.dry_run
+        run: |
+          echo "::notice::Dry-run complete. server.json validated; no publish performed."

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,12 @@ RUN cargo build \
 # ---------- runtime ----------
 FROM debian:bookworm-slim AS runtime
 
+# MCP registry namespace ownership marker. The Resilient compiler ships
+# an MCP server (`rz --mcp`) and registers under this name on
+# registry.modelcontextprotocol.io. The registry verifies ownership of
+# Docker images by matching this label against the published server name.
+LABEL io.modelcontextprotocol.server.name="io.github.ericspencer00/resilient"
+
 # libz3-4 provides libz3.so.4 at the system-library path the
 # binary linked against. ca-certificates is a defensive add for
 # anyone piping certs through the binary later; small and

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -168,6 +168,19 @@ every function.
 
 ---
 
+## Registry
+
+The Resilient MCP server is published to the [official MCP Registry](https://registry.modelcontextprotocol.io)
+under the namespace `io.github.ericspencer00/resilient`. The registration
+points at the multi-arch Docker image at `ghcr.io/ericspencer00/resilient`
+(both `amd64` and `arm64`), so any MCP client that resolves servers from
+the registry can install Resilient with a single click without needing
+to clone or build from source.
+
+`server.json` at the repo root is the source of truth for the registry
+entry; `.github/workflows/mcp-publish.yml` re-publishes it on every
+`release: published` event, syncing the version + OCI tag to the release.
+
 ## Example session
 
 ```

--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.ericspencer00/resilient",
+  "title": "Resilient",
+  "description": "Resilient compiler-as-MCP — parse, typecheck, run, lint, format, and Z3-verify Resilient programs.",
+  "version": "0.2.0",
+  "websiteUrl": "https://github.com/EricSpencer00/Resilient",
+  "repository": {
+    "url": "https://github.com/EricSpencer00/Resilient",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://ghcr.io",
+      "identifier": "ghcr.io/ericspencer00/resilient:0.2.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "positional",
+          "value": "--mcp"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the artifacts and CI plumbing to register the Resilient compiler's
built-in MCP server (`rz --mcp`) on the official [MCP Registry](https://registry.modelcontextprotocol.io).

- **`server.json`** at the repo root — spec-compliant manifest naming the
  server `io.github.ericspencer00/resilient`, pointing at the multi-arch
  Docker image at `ghcr.io/ericspencer00/resilient:0.2.0`. Verified with
  `mcp-publisher validate` against the live registry.
- **Dockerfile** — adds `LABEL io.modelcontextprotocol.server.name="io.github.ericspencer00/resilient"`
  to the runtime stage. The registry's OCI package-ownership check reads
  this label to prove the image belongs to the claimed namespace.
- **`.github/workflows/mcp-publish.yml`** — new workflow that fires on
  `release: published` (after `release-image.yml` pushes the matching
  `vN.N.N` OCI tag), validates `server.json`, syncs its `version` and
  OCI tag to the release tag, authenticates via GitHub OIDC (no PAT
  needed), and publishes via `mcp-publisher`. Exposes `workflow_dispatch`
  with an optional `dry_run` toggle for manual republishes.
- **`docs/MCP.md`** — documents the registry publication, naming the
  registered identifier and pointing at the workflow + `server.json`
  as the source of truth.

## Why now

PR #1842 landed the MCP server in main; PR #1865 expanded its tool
surface. The server is feature-complete on `main` but not yet
discoverable to MCP clients — registry publication closes that loop.

## How clients will resolve it

```json
{
  "mcpServers": {
    "resilient": {
      "command": "docker",
      "args": ["run", "-i", "--rm", "ghcr.io/ericspencer00/resilient:0.2.0", "--mcp"]
    }
  }
}
```

Once published, MCP clients (Claude Desktop, Cursor, …) that consume
the registry can also auto-resolve it by namespace.

## Test plan

- [x] `mcp-publisher validate server.json` — ✅ valid against the live
  schema
- [x] `cargo build --locked --release` on main HEAD — ✅ clean (1m02s)
- [x] No core-file touches — append-only diff-shape guardrail unaffected
- [ ] CI green (this PR)
- [ ] First publish happens when the next `v*` tag fires `release.yml`
  → `release-image.yml` → `mcp-publish.yml`. Pre-roll the publish via
  `workflow_dispatch` once the image is available.