### PR TITLE
fix(docker): bump rust 1.85 → 1.90 (unblock release-image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,14 @@
 # `docker run ghcr.io/ericspencer00/resilient:latest --help` (and
 # `rz src/main.rs`) "just work".
 #
-# Deviation from the ticket AC: the builder base is rust:1.85, not
-# rust:1.84. Edition 2024 — used by every crate in this workspace
-# — requires Rust 1.85+. Pinning 1.84 would fail the build. 1.85
-# is the minimum edition-2024 release.
+# Builder base: rust:1.90-bookworm. Edition 2024 (used by every crate
+# in this workspace) requires Rust 1.85+, and one of our transitive
+# deps (`home@0.5.12`) requires 1.88+, so bumping past 1.88 is necessary
+# to avoid `rustc is not supported by the following package` errors.
+# 1.90 is the most recent stable bookworm tag.
 
 # ---------- builder ----------
-FROM rust:1.85-bookworm AS builder
+FROM rust:1.90-bookworm AS builder
 
 # libz3-dev provides the Z3 headers + libz3.so for linking; clang
 # is needed by some sys-crate build scripts (curve25519-dalek's


### PR DESCRIPTION
## Why

`release-image.yml` has been failing on every tag push since `home@0.5.12`
crept in as a transitive dep — including the v0.2.0 push from a few
minutes ago. The Dockerfile pinned `rust:1.85-bookworm`, but the dep
needs ≥ 1.88:

```
error: rustc 1.85.1 is not supported by the following package:
  home@0.5.12 requires rustc 1.88
```

## What

Bumps the builder base in the Dockerfile to `rust:1.90-bookworm` — the
most recent stable bookworm tag, well past the 1.88 floor. No other
workflow is affected (CI / fuzz / playground use
`dtolnay/rust-toolchain@master` with `toolchain: stable`).

## Test plan

- [x] `home@0.5.12 requires rustc 1.88` confirmed in the failing
      [release-image run for v0.2.0](https://github.com/EricSpencer00/Resilient/actions/runs/25950053966)
- [ ] After merge, push a v0.2.0 retag (or workflow_dispatch on
      release-image) to confirm the multi-arch build pushes
      `ghcr.io/ericspencer00/resilient:0.2.0`.

## Follow-up

Once the v0.2.0 image lands, `mcp-publish.yml` (added in #1867) can
publish `server.json` to the MCP Registry.