### PR TITLE
perf(typechecker): borrow Type in literal consistency checks (3 sites)

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -6207,8 +6207,8 @@ impl TypeChecker {
                     }
                 }
                 if key_types.len() > 1 {
-                    let first = key_types[0].clone();
-                    if let Some(other) = key_types.iter().find(|t| **t != first) {
+                    let first = &key_types[0];
+                    if let Some(other) = key_types.iter().skip(1).find(|t| *t != first) {
                         return Err(format!(
                             "map literal contains mixed key types: {} and {} — all keys must have the same type",
                             first, other
@@ -6216,8 +6216,8 @@ impl TypeChecker {
                     }
                 }
                 if val_types.len() > 1 {
-                    let first = val_types[0].clone();
-                    if let Some(other) = val_types.iter().find(|t| **t != first) {
+                    let first = &val_types[0];
+                    if let Some(other) = val_types.iter().skip(1).find(|t| *t != first) {
                         return Err(format!(
                             "map literal contains mixed value types: {} and {} — all values must have the same type",
                             first, other
@@ -6241,8 +6241,8 @@ impl TypeChecker {
                     }
                 }
                 if concrete.len() > 1 {
-                    let first = concrete[0].clone();
-                    if let Some(other) = concrete.iter().find(|t| **t != first) {
+                    let first = &concrete[0];
+                    if let Some(other) = concrete.iter().skip(1).find(|t| *t != first) {
                         return Err(format!(
                             "Set literal contains mixed element types: {} and {}",
                             first, other


### PR DESCRIPTION
## Why

`Node::MapLiteral` and `Node::SetLiteral` walks each cloned the first
`Type` so they could compare against it inside a `find` closure:

```rust
let first = key_types[0].clone();
if let Some(other) = key_types.iter().find(|t| **t != first) { ... }
```

`Type` is an enum, but variants like `Type::Custom(String)` and
`Type::Function { params, return_type, .. }` own heap data — the
clone allocates on every map / set literal walked, only to be
dropped after the comparison.

## What

Three sites in `resilient/src/typechecker.rs`:
- L6210 (map keys)
- L6219 (map values)
- L6244 (set elements)

Each switches from `let first = X[0].clone()` to `let first = &X[0]`
and from `.iter().find(|t| **t != first)` to
`.iter().skip(1).find(|t| *t != first)`. `skip(1)` also drops the
redundant `first vs first` self-comparison the old `find` paid on
the first element (always equal, always skipped — wasted work).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib literal` — 126 / 126 pass

## Risk

None. `&Type == &Type` and `Type == Type` use the same `PartialEq`
impl; the borrow is strictly cheaper. The diagnostic strings on
mismatch are byte-identical (`first` and `other` are still `Display`'d
via the same `Type` impl).