### PR TITLE
perf(contract_inference): pre-size req/ens/parts Vecs

### DIFF
--- a/resilient/src/contract_inference.rs
+++ b/resilient/src/contract_inference.rs
@@ -57,8 +57,15 @@ pub fn infer_program(program: &Node) -> Vec<InferredContracts> {
             if !requires.is_empty() && !ensures.is_empty() {
                 continue;
             }
-            let mut req = Vec::new();
-            let mut ens = Vec::new();
+            // Per-param inference pushes at most ~4 entries each
+            // (divide-by-zero, len > 0 from indexing, len > 0 from
+            // iteration, non-null from field access); using
+            // `parameters.len()` as the capacity covers the common
+            // case (1-2 contracts inferred per param) and lets
+            // `Vec::extend`'s amortised growth take over for the
+            // rare param that hits multiple branches.
+            let mut req = Vec::with_capacity(parameters.len());
+            let mut ens = Vec::with_capacity(parameters.len());
             for (_, pname) in parameters {
                 if requires.is_empty() {
                     if body_divides_by(body, pname) {
@@ -607,7 +614,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         } else {
             "note[contract_infer]"
         };
-        let mut parts: Vec<String> = Vec::new();
+        let mut parts: Vec<String> = Vec::with_capacity(ic.requires.len() + ic.ensures.len());
         for r in &ic.requires {
             parts.push(format!("requires {r}"));
         }


### PR DESCRIPTION
## Why

`infer_program` builds two per-function `Vec<String>`s (`req`, `ens`)
during inference, and the diagnostic print loop builds a `parts`
`Vec<String>` joining them. All three started as default
`Vec::new()` and grew by `push` even though the upper bound is
trivial to compute:

- `req` / `ens` ≤ ~4 entries per parameter; `parameters.len()`
  covers the common 1-2-per-param case.
- `parts.len() == ic.requires.len() + ic.ensures.len()` exactly
  (the only `push`es are inside `for r in &ic.requires { ... }`
  and `for e in &ic.ensures { ... }`).

## What

Three pre-sizes in `resilient/src/contract_inference.rs`:

- `req = Vec::with_capacity(parameters.len())` (was `Vec::new()`)
- `ens = Vec::with_capacity(parameters.len())` (was `Vec::new()`)
- `parts = Vec::with_capacity(ic.requires.len() + ic.ensures.len())`
  (was `Vec::new()`)

Same shape as RES-1804 / RES-1812 / RES-1836's pre-size series.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib contract_inference` — 22 / 22 pass

## Risk

None. `Vec::with_capacity(n)` is a strict allocation win over
`Vec::new()` followed by `n` pushes — same semantics, fewer
realloc copies.