### PR TITLE
perf(blame_attribution): pre-size roots Vec to chain length

### DIFF
--- a/resilient/src/blame_attribution.rs
+++ b/resilient/src/blame_attribution.rs
@@ -234,7 +234,11 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
                 callers.iter().map(|(n, _)| n.as_str()).collect()
             } else {
                 // Last entries in the chain are deepest; collect unique roots
-                let mut roots: Vec<&str> = Vec::new();
+                // in deepest-first order. `chain.len()` is the exact upper
+                // bound on unique callers (each entry contributes at most
+                // one name); the dedup against `roots.contains` only ever
+                // shrinks the count.
+                let mut roots: Vec<&str> = Vec::with_capacity(chain.len());
                 for (caller, _) in chain.iter().rev() {
                     if !roots.contains(&caller.as_str()) {
                         roots.push(caller.as_str());


### PR DESCRIPTION
## Why

`blame_attribution::check` walks `chain` in reverse to collect unique
deepest-first callers into `roots`, but started from a default
`Vec::new()`:

```rust
let mut roots: Vec<&str> = Vec::new();
for (caller, _) in chain.iter().rev() {
    if !roots.contains(&caller.as_str()) {
        roots.push(caller.as_str());
    }
}
```

`chain.len()` is the exact upper bound — each entry contributes
at most one `roots.push`, and the `contains` dedup only ever
shrinks below that bound.

## What

`Vec::new()` → `Vec::with_capacity(chain.len())` in
`resilient/src/blame_attribution.rs`. Skips the default 0→4→8
doubling cascade on every blame diagnostic produced.

Same shape as RES-1838 (deadlock_freedom visited/sends), RES-1836
(lint pattern bindings), RES-1839 (typechecker fn_bodies).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib blame_attribution` — 6 / 6 pass

## Risk

None. `Vec::with_capacity(n)` with `n` an upper bound is a strict
allocation win over `Vec::new()`.