### PR TITLE
perf(typechecker): pre-size actor-invariant refuted Vec

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4570,7 +4570,10 @@ impl TypeChecker {
                 } else {
                     Vec::new()
                 };
-                let mut refuted: Vec<String> = Vec::new();
+                // Worst case every obligation is `Refuted` and contributes one
+                // diagnostic; pre-size to skip the default 0→4→8 growth chain
+                // when the file actually has invariant violations to report.
+                let mut refuted: Vec<String> = Vec::with_capacity(obligations.len());
                 for o in obligations {
                     match o.result {
                         crate::verifier_actors::ActorProofResult::Proved => {}


### PR DESCRIPTION
## Why

`check_program`'s actor-invariant obligation loop appended one
diagnostic per `Refuted` obligation into a default `Vec::new()`:

```rust
let obligations = if markers.has_actor_decl { ... } else { Vec::new() };
let mut refuted: Vec<String> = Vec::new();
for o in obligations {
    match o.result {
        ActorProofResult::Refuted { ... } => refuted.push(msg),
        _ => {}
    }
}
```

`obligations.len()` is the exact upper bound (one push per `Refuted`,
≤ one push per obligation).

## What

`Vec::new()` → `Vec::with_capacity(obligations.len())` in
`resilient/src/typechecker.rs`. Skips the default 0→4→8 growth
cascade on every program with refuted actor invariants — the
case where this loop matters at all.

Same shape as RES-1838 (deadlock_freedom), RES-1839 (typechecker
fn_bodies), RES-1840 (const_eval resolved map).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean

## Risk

None. Strict allocation win over `Vec::new()`; same semantics.