### PR TITLE
perf(typechecker): borrow Type in array-literal consistency check

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -6173,9 +6173,9 @@ impl TypeChecker {
                     }
                 }
                 if concrete.len() > 1 {
-                    let first_ty = concrete[0].0.clone();
+                    let first_ty = &concrete[0].0;
                     if let Some((other_ty, _)) =
-                        concrete.iter().find(|(t, _)| *t != first_ty).cloned()
+                        concrete.iter().skip(1).find(|(t, _)| t != first_ty)
                     {
                         return Err(format!(
                             "Array literal contains mixed element types: {} and {}. Resilient does not implicitly coerce between types — pick one and convert the others explicitly.",


### PR DESCRIPTION
## Why

`Node::ArrayLiteral`'s mixed-type detection cloned the first element
type and then `.cloned()`'d the matched `find` result just to format
an error message:

```rust
let first_ty = concrete[0].0.clone();
if let Some((other_ty, _)) =
    concrete.iter().find(|(t, _)| *t != first_ty).cloned()
{ ... }
```

Two allocations per array literal (one for `first_ty`, one for the
matched `(other_ty, _)`) — and the matched clone only matters on the
rare mismatch path that produces the diagnostic.

## What

Switch to borrows + `.iter().skip(1)`:

```rust
let first_ty = &concrete[0].0;
if let Some((other_ty, _)) =
    concrete.iter().skip(1).find(|(t, _)| t != first_ty)
{ ... }
```

`Display`-formatting through `&Type` is identical. `skip(1)` also
drops the redundant `first vs first` self-comparison the old `find`
paid on the first element.

Same shape as #1869 which applied this fix to map keys, map values,
and set literals. Array literal was the last of the four homogeneity
checks still cloning.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib array_literal` — 6 / 6 pass

## Risk

None. Strict allocation win; same diagnostic output on mismatch.