### PR TITLE
perf(verifier_loop_invariants): pre-size step_bindings HashMap

### DIFF
--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -274,11 +274,17 @@ fn try_prove_invariant(
 
     // -------- Inductive step --------
     // Drop bindings for names assigned in the body so they're free.
-    let step_bindings: HashMap<String, i64> = bindings
-        .iter()
-        .filter(|(k, _)| !assigned.contains(k.as_str()))
-        .map(|(k, v)| (k.clone(), *v))
-        .collect();
+    // `bindings.len()` is the exact upper bound — `filter` only ever
+    // shrinks the count — and `HashMap::FromIterator` over a filtered
+    // iterator pulls only the lower bound (0) from `size_hint`, so the
+    // collected map starts at capacity 0 and grows. Building it with
+    // an explicit pre-sized loop skips that grow cascade.
+    let mut step_bindings: HashMap<String, i64> = HashMap::with_capacity(bindings.len());
+    for (k, v) in bindings.iter() {
+        if !assigned.contains(k.as_str()) {
+            step_bindings.insert(k.clone(), *v);
+        }
+    }
 
     // Build WP(body, invariant) by reverse substitution.
     let wp = match weakest_precondition(body, invariant) {


### PR DESCRIPTION
## Why

`prove_invariant_with_bindings`'s inductive-step path builds the
free-binding map via filter+map+collect:

```rust
let step_bindings: HashMap<String, i64> = bindings
    .iter()
    .filter(|(k, _)| !assigned.contains(k.as_str()))
    .map(|(k, v)| (k.clone(), *v))
    .collect();
```

`bindings.len()` is the exact upper bound — `filter` only shrinks
the count. But `HashMap::FromIterator` over a filtered iterator
pulls only the lower bound from `size_hint`, which for a `Filter`
is `0`. So the collected map starts at capacity 0 and grows through
the default 0 → 4 → 8 → … rehash cascade once per loop invariant
that survives the base-case check.

## What

Switch to an explicit `HashMap::with_capacity(bindings.len())` +
insert loop:

```rust
let mut step_bindings: HashMap<String, i64> = HashMap::with_capacity(bindings.len());
for (k, v) in bindings.iter() {
    if !assigned.contains(k.as_str()) {
        step_bindings.insert(k.clone(), *v);
    }
}
```

Matches the shape already used at line 131 of the same file for the
function-scope binding snapshot (RES-1798). Per-while-loop hot path
on the Z3 inductive-step verifier.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [ ] CI runs `cargo test --features z3` (no z3 headers locally)

## Risk

None. Same final `HashMap<String, i64>` shape; pre-sized eagerly
instead of grown lazily. No Z3 API surface touched.