### PR TITLE
fix(mcp): match GitHub username case in MCP registry namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,9 @@ FROM debian:bookworm-slim AS runtime
 # an MCP server (`rz --mcp`) and registers under this name on
 # registry.modelcontextprotocol.io. The registry verifies ownership of
 # Docker images by matching this label against the published server name.
-LABEL io.modelcontextprotocol.server.name="io.github.ericspencer00/resilient"
+# Note: case-sensitive — the GitHub OIDC subject carries the original
+# case of the username, so the namespace here must match exactly.
+LABEL io.modelcontextprotocol.server.name="io.github.EricSpencer00/resilient"
 
 # libz3-4 provides libz3.so.4 at the system-library path the
 # binary linked against. ca-certificates is a defensive add for

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.ericspencer00/resilient",
+  "name": "io.github.EricSpencer00/resilient",
   "title": "Resilient",
   "description": "Resilient compiler-as-MCP — parse, typecheck, run, lint, format, and Z3-verify Resilient programs.",
   "version": "0.2.0",


### PR DESCRIPTION
## Why

The first registry publish (after v0.2.0) failed with:

```
You do not have permission to publish this server.
You have permission to publish: io.github.EricSpencer00/*.
Attempting to publish: io.github.ericspencer00/resilient.
```

The MCP registry binds the publisher to the *exact* case of the
GitHub username from the OIDC `repository` claim — `EricSpencer00`,
not `ericspencer00`. The `server.json` and Dockerfile LABEL both
used the lowercased form, so the namespace ownership check rejected
the publish.

## What

Updates both to the mixed-case form:
- `server.json` `name`: `io.github.EricSpencer00/resilient`
- `Dockerfile` LABEL: `io.github.EricSpencer00/resilient`

The OCI image identifier stays lowercase
(`ghcr.io/ericspencer00/resilient:0.2.0`) — GHCR normalizes
repository paths to lowercase regardless of GitHub username case,
so the image URL doesn't change.

## Post-merge

Re-tag v0.2.0 to pick up the Dockerfile LABEL fix, then re-run
`mcp-publish.yml` via `workflow_dispatch`.

## Test plan

- [x] `mcp-publisher validate server.json` — ✅ valid