### PR TITLE
perf(typechecker): pre-size parts Vec in parse_type_name_inner

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -8260,7 +8260,13 @@ impl TypeChecker {
                 let params = if params_str.trim().is_empty() {
                     Vec::new()
                 } else {
-                    let mut parts: Vec<Type> = Vec::new();
+                    // Upper bound: total comma count + 1. Nested-fn types
+                    // (e.g. `(int) -> (bool, int)`) over-count slightly
+                    // because the inner comma sits at depth > 0, but the
+                    // bytewise scan is still cheaper than the 0 → 4 growth
+                    // chain on `parts` for any params_str with ≥ 4 types.
+                    let cap = params_str.bytes().filter(|b| *b == b',').count() + 1;
+                    let mut parts: Vec<Type> = Vec::with_capacity(cap);
                     let mut depth2 = 0usize;
                     let mut start = 0;
                     for (i, ch) in params_str.char_indices() {


### PR DESCRIPTION
## Why

`parse_type_name_inner`'s function-type branch splits `params_str`
on top-level commas (respecting nested-paren depth) into a
`Vec<Type>`. The Vec started as `Vec::new()`, so any function type
with ≥ 4 parameters paid the default 0 → 4 → 8 realloc cascade.

## What

```rust
let cap = params_str.bytes().filter(|b| *b == b',').count() + 1;
let mut parts: Vec<Type> = Vec::with_capacity(cap);
```

Upper bound: total comma count + 1. Nested fn types like
`(int) -> (bool, int)` over-count slightly (the inner comma sits at
depth > 0 in the parse loop and doesn't push), but the bytewise
scan is O(n) with zero allocations — vastly cheaper than O(log m)
realloc copies of `Vec<Type>` (each `Type` is > 64 bytes once
`Type::Function { params, return_type, .. }` is in the mix).

Hot path during typechecker resolution of any function-typed
binding, callback parameter, or higher-order signature.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib function` — 139 / 139 pass

## Risk

None. Same final `parts` contents; the new shape allocates an
upper-bound capacity instead of growing from 0.