### PR TITLE
fix(runtime): spawn CLI on 16 MB thread to prevent self-host stack overflow

### DIFF
--- a/resilient/src/main.rs
+++ b/resilient/src/main.rs
@@ -8,5 +8,12 @@
 //! library's CLI entry point.
 
 fn main() {
-    resilient::run_cli();
+    const STACK_SIZE: usize = 16 * 1024 * 1024;
+    let builder = std::thread::Builder::new().stack_size(STACK_SIZE);
+    let handler = builder
+        .spawn(resilient::run_cli)
+        .expect("failed to spawn CLI thread");
+    if let Err(e) = handler.join() {
+        std::panic::resume_unwind(e);
+    }
 }


### PR DESCRIPTION
## Summary

- Spawn `run_cli` on a dedicated thread with 16 MB stack size instead of running on the OS main thread (which defaults to 8 MB on macOS)
- The debug binary's recursive `eval` function has large per-frame footprint; the self-host parser (`parser.rz`) exercises deep enough recursion to overflow the default 8 MB main thread stack
- This was blocking the `self_host_success_corpus_matches_rust_tokens_and_ast` test in all debug builds, which in turn blocked every `ready-or-bail.sh` invocation

Closes #1903

## Test plan
- [x] `cargo test --test self_host_parity` — self-host parser test now passes (was stack overflow)
- [x] `cargo test` — all 4818 tests pass (4671 lib + integration tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>