### PR TITLE
perf(ast): change operator from String to &'static str (#1907)

### DIFF
--- a/resilient/src/age_bounded_data.rs
+++ b/resilient/src/age_bounded_data.rs
@@ -56,7 +56,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
                 left,
                 right,
                 ..
-            } if matches!(operator.as_str(), ">" | "<" | ">=" | "<=") => {
+            } if matches!(*operator, ">" | "<" | ">=" | "<=") => {
                 for side in [left.as_ref(), right.as_ref()] {
                     if let Node::FieldAccess { target, field, .. } = side {
                         if field.ends_with("_at") {

--- a/resilient/src/ai_threat_model.rs
+++ b/resilient/src/ai_threat_model.rs
@@ -198,7 +198,7 @@ fn detect_off_by_one(node: &Node, ctx: &mut FnContext) {
                 operator, right, ..
             } = condition.as_ref()
             {
-                if (operator == "<=" || operator == ">=") && is_len_call(right) {
+                if (*operator == "<=" || *operator == ">=") && is_len_call(right) {
                     ctx.push(
                         ThreatKind::OffByOne,
                         format!(
@@ -354,7 +354,7 @@ fn detect_magic_numbers(node: &Node, ctx: &mut FnContext) {
             right,
             ..
         } => {
-            let arith = matches!(operator.as_str(), "+" | "-" | "*" | "/" | "%" | "<<" | ">>");
+            let arith = matches!(*operator, "+" | "-" | "*" | "/" | "%" | "<<" | ">>");
             if arith {
                 check_magic_operand(left, ctx);
                 check_magic_operand(right, ctx);

--- a/resilient/src/bounds_check.rs
+++ b/resilient/src/bounds_check.rs
@@ -230,7 +230,7 @@ fn walk_node(node: &Node, ctx: &BoundsCtx, source_path: &str, errors: &mut Vec<S
                 right,
                 ..
             } = iterable.as_ref()
-                && operator == ".."
+                && *operator == ".."
             {
                 let ident = |n: &str| Node::Identifier {
                     name: n.to_string(),
@@ -239,14 +239,14 @@ fn walk_node(node: &Node, ctx: &BoundsCtx, source_path: &str, errors: &mut Vec<S
                 // Axiom: lower_bound <= i
                 body_ctx.axioms.push(Node::InfixExpression {
                     left: Box::new((**left).clone()),
-                    operator: "<=".to_string(),
+                    operator: "<=",
                     right: Box::new(ident(name)),
                     span: Span::default(),
                 });
                 // Axiom: i < upper_bound
                 body_ctx.axioms.push(Node::InfixExpression {
                     left: Box::new(ident(name)),
-                    operator: "<".to_string(),
+                    operator: "<",
                     right: Box::new((**right).clone()),
                     span: Span::default(),
                 });
@@ -413,19 +413,19 @@ fn build_bounds_goal(target_name: &str, index: &Node) -> Node {
     };
     let ge = Node::InfixExpression {
         left: Box::new(zero),
-        operator: "<=".to_string(),
+        operator: "<=",
         right: Box::new(index.clone()),
         span: Span::default(),
     };
     let lt = Node::InfixExpression {
         left: Box::new(index.clone()),
-        operator: "<".to_string(),
+        operator: "<",
         right: Box::new(len_call),
         span: Span::default(),
     };
     Node::InfixExpression {
         left: Box::new(ge),
-        operator: "&&".to_string(),
+        operator: "&&",
         right: Box::new(lt),
         span: Span::default(),
     }

--- a/resilient/src/cluster_verifier.rs
+++ b/resilient/src/cluster_verifier.rs
@@ -384,11 +384,11 @@ fn verify_handler_against_invariant(
     // inside the supported grammar.
     let implication = Node::InfixExpression {
         left: Box::new(Node::PrefixExpression {
-            operator: "!".to_string(),
+            operator: "!",
             right: Box::new(pre_invariant.clone()),
             span: Span::default(),
         }),
-        operator: "||".to_string(),
+        operator: "||",
         right: Box::new(post_invariant.clone()),
         span: Span::default(),
     };
@@ -519,7 +519,7 @@ fn rewrite_field_refs(node: &Node, scope_as_self: Option<&str>) -> Option<Node> 
             right,
             span,
         } => Some(Node::PrefixExpression {
-            operator: operator.clone(),
+            operator: *operator,
             right: Box::new(rewrite_field_refs(right, scope_as_self)?),
             span: *span,
         }),
@@ -530,7 +530,7 @@ fn rewrite_field_refs(node: &Node, scope_as_self: Option<&str>) -> Option<Node> 
             span,
         } => Some(Node::InfixExpression {
             left: Box::new(rewrite_field_refs(left, scope_as_self)?),
-            operator: operator.clone(),
+            operator: *operator,
             right: Box::new(rewrite_field_refs(right, scope_as_self)?),
             span: *span,
         }),
@@ -581,7 +581,7 @@ fn rewrite_invariant_post(
             right,
             span,
         } => Some(Node::PrefixExpression {
-            operator: operator.clone(),
+            operator: *operator,
             right: Box::new(rewrite_invariant_post(
                 right,
                 owning_member,
@@ -602,7 +602,7 @@ fn rewrite_invariant_post(
                 members,
                 post_rewrites,
             )?),
-            operator: operator.clone(),
+            operator: *operator,
             right: Box::new(rewrite_invariant_post(
                 right,
                 owning_member,

--- a/resilient/src/cluster_verifier.rs
+++ b/resilient/src/cluster_verifier.rs
@@ -265,7 +265,7 @@ fn is_supported_invariant(node: &Node) -> bool {
         Node::FieldAccess { target, .. } => matches!(target.as_ref(), Node::Identifier { .. }),
         Node::PrefixExpression {
             right, operator, ..
-        } => matches!(operator.as_str(), "!" | "-") && is_supported_invariant(right),
+        } => matches!(*operator, "!" | "-") && is_supported_invariant(right),
         Node::InfixExpression {
             left,
             right,
@@ -273,7 +273,7 @@ fn is_supported_invariant(node: &Node) -> bool {
             ..
         } => {
             matches!(
-                operator.as_str(),
+                *operator,
                 "+" | "-" | "*" | "/" | "%" | "==" | "!=" | "<" | ">" | "<=" | ">=" | "&&" | "||"
             ) && is_supported_invariant(left)
                 && is_supported_invariant(right)
@@ -519,7 +519,7 @@ fn rewrite_field_refs(node: &Node, scope_as_self: Option<&str>) -> Option<Node> 
             right,
             span,
         } => Some(Node::PrefixExpression {
-            operator: *operator,
+            operator,
             right: Box::new(rewrite_field_refs(right, scope_as_self)?),
             span: *span,
         }),
@@ -530,7 +530,7 @@ fn rewrite_field_refs(node: &Node, scope_as_self: Option<&str>) -> Option<Node> 
             span,
         } => Some(Node::InfixExpression {
             left: Box::new(rewrite_field_refs(left, scope_as_self)?),
-            operator: *operator,
+            operator,
             right: Box::new(rewrite_field_refs(right, scope_as_self)?),
             span: *span,
         }),
@@ -581,7 +581,7 @@ fn rewrite_invariant_post(
             right,
             span,
         } => Some(Node::PrefixExpression {
-            operator: *operator,
+            operator,
             right: Box::new(rewrite_invariant_post(
                 right,
                 owning_member,
@@ -602,7 +602,7 @@ fn rewrite_invariant_post(
                 members,
                 post_rewrites,
             )?),
-            operator: *operator,
+            operator,
             right: Box::new(rewrite_invariant_post(
                 right,
                 owning_member,

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1857,7 +1857,7 @@ fn compile_expr(
         }
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "-" => {
+        } if *operator == "-" => {
             compile_expr(
                 right,
                 chunk,
@@ -1875,7 +1875,7 @@ fn compile_expr(
         // RES-083: logical negation.
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "!" => {
+        } if *operator == "!" => {
             compile_expr(
                 right,
                 chunk,
@@ -1896,7 +1896,7 @@ fn compile_expr(
             operator,
             right,
             ..
-        } if operator == "&&" => {
+        } if *operator == "&&" => {
             compile_expr(
                 left,
                 chunk,
@@ -1936,7 +1936,7 @@ fn compile_expr(
             operator,
             right,
             ..
-        } if operator == "||" => {
+        } if *operator == "||" => {
             compile_expr(
                 left,
                 chunk,
@@ -2001,7 +2001,7 @@ fn compile_expr(
                 next_fn_idx,
                 line,
             )?;
-            let op = match operator.as_str() {
+            let op = match *operator {
                 "+" => Op::Add,
                 "-" => Op::Sub,
                 "*" => Op::Mul,

--- a/resilient/src/const_fn.rs
+++ b/resilient/src/const_fn.rs
@@ -62,7 +62,7 @@ fn eval_depth(body: &Node, env: &HashMap<String, ConstValue>, depth: u32) -> Opt
             operator, right, ..
         } => {
             let v = eval_depth(right, env, depth + 1)?;
-            match (operator.as_str(), v) {
+            match (*operator, v) {
                 ("-", ConstValue::Int(n)) => Some(ConstValue::Int(-n)),
                 ("!", ConstValue::Bool(b)) => Some(ConstValue::Bool(!b)),
                 _ => None,
@@ -76,7 +76,7 @@ fn eval_depth(body: &Node, env: &HashMap<String, ConstValue>, depth: u32) -> Opt
             ..
         } => {
             // Short-circuit `&&` and `||` before evaluating both sides.
-            match operator.as_str() {
+            match *operator {
                 "&&" => {
                     let lv = eval_depth(left, env, depth + 1)?;
                     if let ConstValue::Bool(false) = lv {
@@ -103,7 +103,7 @@ fn eval_depth(body: &Node, env: &HashMap<String, ConstValue>, depth: u32) -> Opt
             }
             let l = eval_depth(left, env, depth + 1)?;
             let r = eval_depth(right, env, depth + 1)?;
-            match (l, r, operator.as_str()) {
+            match (l, r, *operator) {
                 (ConstValue::Int(a), ConstValue::Int(b), "+") => {
                     Some(ConstValue::Int(a.wrapping_add(b)))
                 }
@@ -254,10 +254,10 @@ mod tests {
         }
     }
 
-    fn infix(left: Node, op: &str, right: Node) -> Node {
+    fn infix(left: Node, op: &'static str, right: Node) -> Node {
         Node::InfixExpression {
             left: Box::new(left),
-            operator: op.into(),
+            operator: op,
             right: Box::new(right),
             span: crate::Span::default(),
         }
@@ -344,7 +344,7 @@ mod tests {
     fn evaluates_prefix_negation() {
         let env = HashMap::new();
         let neg = Node::PrefixExpression {
-            operator: "-".into(),
+            operator: "-",
             right: Box::new(int_lit(5)),
             span: crate::Span::default(),
         };
@@ -355,7 +355,7 @@ mod tests {
     fn evaluates_prefix_not() {
         let env = HashMap::new();
         let not = Node::PrefixExpression {
-            operator: "!".into(),
+            operator: "!",
             right: Box::new(bool_lit(true)),
             span: crate::Span::default(),
         };
@@ -453,7 +453,7 @@ mod tests {
         };
         let expr = Node::InfixExpression {
             left: Box::new(bool_lit(false)),
-            operator: "&&".into(),
+            operator: "&&",
             right: Box::new(unevaluable),
             span: crate::Span::default(),
         };
@@ -470,7 +470,7 @@ mod tests {
         };
         let expr = Node::InfixExpression {
             left: Box::new(bool_lit(true)),
-            operator: "||".into(),
+            operator: "||",
             right: Box::new(unevaluable),
             span: crate::Span::default(),
         };

--- a/resilient/src/contract_inference.rs
+++ b/resilient/src/contract_inference.rs
@@ -133,7 +133,7 @@ fn body_divides_by(node: &Node, param: &str) -> bool {
             right,
             ..
         } => {
-            if (operator == "/" || operator == "%")
+            if (*operator == "/" || *operator == "%")
                 && matches!(right.as_ref(), Node::Identifier { name, .. } if name == param)
             {
                 return true;
@@ -280,7 +280,7 @@ fn is_upper_bound_for(node: &Node, param: &str) -> bool {
         operator, right, ..
     } = node
     {
-        if (operator == "<" || operator == "<=")
+        if (*operator == "<" || *operator == "<=")
             && matches!(right.as_ref(), Node::Identifier { name, .. } if name == param)
         {
             return true;
@@ -297,7 +297,7 @@ fn body_uses_as_shift_amount(node: &Node, param: &str) -> bool {
             operator, right, ..
         } = n
         {
-            (operator == "<<" || operator == ">>")
+            (*operator == "<<" || *operator == ">>")
                 && matches!(right.as_ref(), Node::Identifier { name, .. } if name == param)
         } else {
             false
@@ -321,7 +321,7 @@ fn body_compares_to_negative(node: &Node, param: &str) -> bool {
             ..
         } = n
         {
-            let is_relational = matches!(operator.as_str(), "<" | "<=" | ">" | ">=");
+            let is_relational = matches!(*operator, "<" | "<=" | ">" | ">=");
             if !is_relational {
                 return false;
             }
@@ -330,7 +330,7 @@ fn body_compares_to_negative(node: &Node, param: &str) -> bool {
                 matches!(left.as_ref(), Node::Identifier { name, .. } if name == param);
             let right_is_neg_literal = matches!(right.as_ref(),
                 Node::PrefixExpression { operator: op, right: r, .. }
-                    if op == "-" && matches!(r.as_ref(), Node::IntegerLiteral { value, .. } if *value > 0)
+                    if *op == "-" && matches!(r.as_ref(), Node::IntegerLiteral { value, .. } if *value > 0)
             );
             if left_is_param && right_is_neg_literal {
                 return true;
@@ -339,7 +339,7 @@ fn body_compares_to_negative(node: &Node, param: &str) -> bool {
                 matches!(right.as_ref(), Node::Identifier { name, .. } if name == param);
             let left_is_neg_literal = matches!(left.as_ref(),
                 Node::PrefixExpression { operator: op, right: r, .. }
-                    if op == "-" && matches!(r.as_ref(), Node::IntegerLiteral { value, .. } if *value > 0)
+                    if *op == "-" && matches!(r.as_ref(), Node::IntegerLiteral { value, .. } if *value > 0)
             );
             right_is_param && left_is_neg_literal
         } else {
@@ -390,7 +390,7 @@ fn format_simple_expr(node: &Node) -> String {
         }
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "-" => {
+        } if *operator == "-" => {
             let inner = format_simple_expr(right);
             if inner == "<complex>" {
                 "<complex>".to_string()
@@ -536,7 +536,7 @@ fn expr_is_strictly_positive(node: &Node) -> bool {
             operator,
             right,
             ..
-        } => match operator.as_str() {
+        } => match *operator {
             "+" => {
                 expr_is_non_negative(left) && expr_is_strictly_positive(right)
                     || expr_is_strictly_positive(left) && expr_is_non_negative(right)
@@ -559,10 +559,9 @@ fn expr_is_non_negative(node: &Node) -> bool {
             operator,
             right,
             ..
-        } => match operator.as_str() {
-            "+" | "*" => expr_is_non_negative(left) && expr_is_non_negative(right),
-            _ => false,
-        },
+        } if matches!(*operator, "+" | "*") => {
+            expr_is_non_negative(left) && expr_is_non_negative(right)
+        }
         _ => false,
     }
 }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -725,7 +725,7 @@ mod tests {
                 name: "x".into(),
                 value: Box::new(Node::InfixExpression {
                     left: Box::new(ident("x")),
-                    operator: "+".into(),
+                    operator: "+",
                     right: Box::new(int_lit(1)),
                     span: Span::default(),
                 }),
@@ -746,7 +746,7 @@ mod tests {
                 stmts: vec![Node::ReturnStatement {
                     value: Some(Box::new(Node::InfixExpression {
                         left: Box::new(ident("x")),
-                        operator: "+".into(),
+                        operator: "+",
                         right: Box::new(ident("n")),
                         span: Span::default(),
                     })),
@@ -794,11 +794,11 @@ mod tests {
                     value: Some(Box::new(Node::InfixExpression {
                         left: Box::new(Node::InfixExpression {
                             left: Box::new(ident("x")),
-                            operator: "+".into(),
+                            operator: "+",
                             right: Box::new(ident("a")),
                             span: Span::default(),
                         }),
-                        operator: "+".into(),
+                        operator: "+",
                         right: Box::new(ident("b")),
                         span: Span::default(),
                     })),
@@ -826,7 +826,7 @@ mod tests {
                     name: "sum".into(),
                     value: Box::new(Node::InfixExpression {
                         left: Box::new(ident("sum")),
-                        operator: "+".into(),
+                        operator: "+",
                         right: Box::new(ident("x")),
                         span: Span::default(),
                     }),
@@ -851,7 +851,7 @@ mod tests {
                 None,
                 Node::InfixExpression {
                     left: Box::new(ident("y")),
-                    operator: "+".into(),
+                    operator: "+",
                     right: Box::new(ident("outer")),
                     span: Span::default(),
                 },
@@ -885,11 +885,11 @@ mod tests {
                     value: Some(Box::new(Node::InfixExpression {
                         left: Box::new(Node::InfixExpression {
                             left: Box::new(ident("a")),
-                            operator: "+".into(),
+                            operator: "+",
                             right: Box::new(ident("b")),
                             span: Span::default(),
                         }),
-                        operator: "+".into(),
+                        operator: "+",
                         right: Box::new(ident("c")),
                         span: Span::default(),
                     })),
@@ -940,7 +940,7 @@ mod tests {
             name: "sum".into(),
             value: Box::new(Node::InfixExpression {
                 left: Box::new(ident("sum")),
-                operator: "+".into(),
+                operator: "+",
                 right: Box::new(int_lit(1)),
                 span: Span::default(),
             }),
@@ -1019,22 +1019,22 @@ mod tests {
         let a = Node::InfixExpression {
             left: Box::new(Node::InfixExpression {
                 left: Box::new(ident("gamma")),
-                operator: "+".into(),
+                operator: "+",
                 right: Box::new(ident("alpha")),
                 span: Span::default(),
             }),
-            operator: "+".into(),
+            operator: "+",
             right: Box::new(ident("beta")),
             span: Span::default(),
         };
         let b = Node::InfixExpression {
             left: Box::new(Node::InfixExpression {
                 left: Box::new(ident("alpha")),
-                operator: "+".into(),
+                operator: "+",
                 right: Box::new(ident("beta")),
                 span: Span::default(),
             }),
-            operator: "+".into(),
+            operator: "+",
             right: Box::new(ident("gamma")),
             span: Span::default(),
         };
@@ -1068,7 +1068,7 @@ mod tests {
             }),
             invariants: vec![Node::InfixExpression {
                 left: Box::new(ident("p")),
-                operator: ">=".into(),
+                operator: ">=",
                 right: Box::new(int_lit(0)),
                 span: Span::default(),
             }],

--- a/resilient/src/generics.rs
+++ b/resilient/src/generics.rs
@@ -294,7 +294,7 @@ fn check_body_for_constraints(
             // generic-typed local AND the other operand is a concrete
             // numeric literal — that's the canonical body-consistency
             // violation.
-            let arith = matches!(operator.as_str(), "+" | "-" | "*" | "/" | "%");
+            let arith = matches!(*operator, "+" | "-" | "*" | "/" | "%");
             if arith {
                 let left_is_generic = identifier_in_set(left, generic_locals);
                 let right_is_generic = identifier_in_set(right, generic_locals);

--- a/resilient/src/jit_backend.rs
+++ b/resilient/src/jit_backend.rs
@@ -2638,7 +2638,7 @@ fn lower_expr(
             right,
             ..
         } => {
-            let op_str = operator.as_str();
+            let op_str = *operator;
             // Validate first so we can short-circuit Unsupported
             // before recursing into the operands.
             if !matches!(

--- a/resilient/src/jit_backend.rs
+++ b/resilient/src/jit_backend.rs
@@ -3737,7 +3737,7 @@ mod tests {
                         name: "n".to_string(),
                         span: Span::default(),
                     }),
-                    operator: "*".to_string(),
+                    operator: "*",
                     right: Box::new(Node::IntegerLiteral {
                         value: 2,
                         span: Span::default(),
@@ -3807,7 +3807,7 @@ mod tests {
         for _ in 0..10 {
             body = Node::InfixExpression {
                 left: Box::new(body),
-                operator: "+".to_string(),
+                operator: "+",
                 right: Box::new(Node::IntegerLiteral {
                     value: 1,
                     span: Span::default(),

--- a/resilient/src/lean_spec.rs
+++ b/resilient/src/lean_spec.rs
@@ -139,7 +139,7 @@ fn lower_expr(node: &Node) -> Result<LeanExpr, LowerError> {
             operator, right, ..
         } => {
             let inner = lower_expr(right)?;
-            match operator.as_str() {
+            match *operator {
                 "-" => Ok(LeanExpr::Neg(Box::new(inner))),
                 "!" => Ok(LeanExpr::Not(Box::new(inner))),
                 op => Err(LowerError::UnsupportedOperator(op.to_string())),
@@ -153,7 +153,7 @@ fn lower_expr(node: &Node) -> Result<LeanExpr, LowerError> {
         } => {
             let l = Box::new(lower_expr(left)?);
             let r = Box::new(lower_expr(right)?);
-            match operator.as_str() {
+            match *operator {
                 "+" => Ok(LeanExpr::Add(l, r)),
                 "-" => Ok(LeanExpr::Sub(l, r)),
                 "*" => Ok(LeanExpr::Mul(l, r)),

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -2353,7 +2353,7 @@ enum Node {
         span: span::Span,
     },
     PrefixExpression {
-        operator: String,
+        operator: &'static str,
         right: Box<Node>,
         /// RES-084: source span of the operator token. Consumed in
         /// follow-ups (e.g. typechecker arithmetic-mismatch errors).
@@ -2362,7 +2362,7 @@ enum Node {
     },
     InfixExpression {
         left: Box<Node>,
-        operator: String,
+        operator: &'static str,
         right: Box<Node>,
         /// RES-084: span of the operator token (NOT the full
         /// `lhs op rhs` range — that's a future refinement).
@@ -3425,7 +3425,7 @@ impl Parser {
     /// RES-917: build the desugared assignment node for
     /// `LHS OP= RHS`. The LHS is cloned for the read-side of the
     /// generated `InfixExpression`.
-    fn build_compound_lvalue_assignment(&mut self, lhs: Node, op: &str, rhs: Node) -> Node {
+    fn build_compound_lvalue_assignment(&mut self, lhs: Node, op: &'static str, rhs: Node) -> Node {
         let stmt_span = match &lhs {
             Node::IndexExpression { span, .. } => *span,
             Node::FieldAccess { span, .. } => *span,
@@ -3444,7 +3444,7 @@ impl Parser {
                 };
                 let combined = Node::InfixExpression {
                     left: Box::new(read),
-                    operator: op.to_string(),
+                    operator: op,
                     right: Box::new(rhs),
                     span: stmt_span,
                 };
@@ -3467,7 +3467,7 @@ impl Parser {
                 };
                 let combined = Node::InfixExpression {
                     left: Box::new(read),
-                    operator: op.to_string(),
+                    operator: op,
                     right: Box::new(rhs),
                     span: stmt_span,
                 };
@@ -3525,7 +3525,7 @@ impl Parser {
         };
         let ident_span = self.span_at_current();
         self.next_token(); // move onto the OP= token
-        let op_str = match &self.current_token {
+        let op_str: &'static str = match &self.current_token {
             Token::PlusAssign => "+",
             Token::MinusAssign => "-",
             Token::StarAssign => "*",
@@ -3537,8 +3537,7 @@ impl Parser {
             Token::ShlAssign => "<<",
             Token::ShrAssign => ">>",
             other => unreachable!("compound-assign with non-OP= token: {:?}", other),
-        }
-        .to_string();
+        };
         self.next_token(); // skip the OP= token to first token of RHS
         let rhs = self.parse_expression(0).unwrap_or(Node::IntegerLiteral {
             value: 0,
@@ -7728,7 +7727,7 @@ impl Parser {
                 // `-1 + 2` stays `(-1) + 2`.
                 let right = self.parse_expression(10)?;
                 Some(Node::PrefixExpression {
-                    operator: op.to_string(),
+                    operator: op,
                     right: Box::new(right),
                     span: op_span,
                 })
@@ -7862,7 +7861,7 @@ impl Parser {
                     });
                     Some(Node::InfixExpression {
                         left: Box::new(current_left),
-                        operator: "??".to_string(),
+                        operator: "??",
                         right: Box::new(rhs),
                         span: op_span,
                     })
@@ -7998,28 +7997,26 @@ impl Parser {
     }
 
     fn parse_infix_expression(&mut self, left: Node) -> Option<Node> {
-        let operator = match &self.current_token {
-            Token::Plus => "+".to_string(),
-            Token::Minus => "-".to_string(),
-            Token::Multiply => "*".to_string(),
-            Token::Divide => "/".to_string(),
-            Token::Modulo => "%".to_string(),
-            Token::And => "&&".to_string(),
-            Token::Or => "||".to_string(),
-            Token::BitAnd => "&".to_string(),
-            Token::BitOr => "|".to_string(),
-            Token::BitXor => "^".to_string(),
-            Token::ShiftLeft => "<<".to_string(),
-            Token::ShiftRight => ">>".to_string(),
-            Token::Equal => "==".to_string(),
-            Token::NotEqual => "!=".to_string(),
-            Token::Less => "<".to_string(),
-            Token::Greater => ">".to_string(),
-            Token::LessEqual => "<=".to_string(),
-            Token::GreaterEqual => ">=".to_string(),
+        let operator: &'static str = match &self.current_token {
+            Token::Plus => "+",
+            Token::Minus => "-",
+            Token::Multiply => "*",
+            Token::Divide => "/",
+            Token::Modulo => "%",
+            Token::And => "&&",
+            Token::Or => "||",
+            Token::BitAnd => "&",
+            Token::BitOr => "|",
+            Token::BitXor => "^",
+            Token::ShiftLeft => "<<",
+            Token::ShiftRight => ">>",
+            Token::Equal => "==",
+            Token::NotEqual => "!=",
+            Token::Less => "<",
+            Token::Greater => ">",
+            Token::LessEqual => "<=",
+            Token::GreaterEqual => ">=",
             _ => {
-                // Unreachable in practice (the caller only dispatches
-                // known operator tokens), but better to report than panic.
                 let tok = self.current_token.clone();
                 self.record_error(format!("Internal: unexpected operator token {:?}", tok));
                 return None;
@@ -22576,7 +22573,7 @@ impl Interpreter {
                 // fall through to `eval_infix_expression` so the
                 // existing "Logical '&&' requires bool operands" error
                 // still fires.
-                if operator == "&&" {
+                if *operator == "&&" {
                     let left_val = self.eval(left)?;
                     if let Value::Bool(false) = left_val {
                         return Ok(Value::Bool(false));
@@ -22584,7 +22581,7 @@ impl Interpreter {
                     let right_val = self.eval(right)?;
                     return self.eval_infix_expression(operator, left_val, right_val);
                 }
-                if operator == "||" {
+                if *operator == "||" {
                     let left_val = self.eval(left)?;
                     if let Value::Bool(true) = left_val {
                         return Ok(Value::Bool(true));
@@ -24034,7 +24031,7 @@ impl Interpreter {
                 operator, right, ..
             } => {
                 let rv = Self::eval_const_expr(right, resolved, evaluating)?;
-                match (operator.as_str(), rv) {
+                match (*operator, rv) {
                     ("-", Value::Int(i)) => Ok(Value::Int(-i)),
                     ("-", Value::Float(f)) => Ok(Value::Float(-f)),
                     ("!", Value::Bool(b)) => Ok(Value::Bool(!b)),
@@ -24052,7 +24049,7 @@ impl Interpreter {
             } => {
                 let lv = Self::eval_const_expr(left, resolved, evaluating)?;
                 let rv = Self::eval_const_expr(right, resolved, evaluating)?;
-                match (operator.as_str(), lv, rv) {
+                match (*operator, lv, rv) {
                     ("+", Value::Int(a), Value::Int(b)) => Ok(Value::Int(a + b)),
                     ("-", Value::Int(a), Value::Int(b)) => Ok(Value::Int(a - b)),
                     ("*", Value::Int(a), Value::Int(b)) => Ok(Value::Int(a * b)),
@@ -24791,7 +24788,7 @@ impl Interpreter {
             right,
             ..
         } = condition
-            && matches!(operator.as_str(), "==" | "!=" | "<" | ">" | "<=" | ">=")
+            && matches!(*operator, "==" | "!=" | "<" | ">" | "<=" | ">=")
             && let (Ok(lv), Ok(rv)) = (self.eval(left), self.eval(right))
         {
             return format!("condition {} {} {} was {}", lv, operator, rv, final_value);
@@ -53410,7 +53407,7 @@ mod tests {
         let Node::InfixExpression { operator, span, .. } = expr.as_ref() else {
             panic!("expected InfixExpression, got {:?}", expr);
         };
-        assert_eq!(operator, "+");
+        assert_eq!(*operator, "+");
         assert!(span.start.line >= 1, "infix span: {:?}", span);
     }
 
@@ -53429,7 +53426,7 @@ mod tests {
         let Node::PrefixExpression { operator, span, .. } = expr.as_ref() else {
             panic!()
         };
-        assert_eq!(operator, "!");
+        assert_eq!(*operator, "!");
         assert!(span.start.line >= 1);
         // stmt 2 is the call f()
         let Node::ExpressionStatement { expr, .. } = &stmts[2].node else {

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -1278,54 +1278,54 @@ fn scan_node(node: &Node, t: &mut LintTriggers) {
             ..
         } => {
             t.has_infix = true;
-            if operator == "/" || operator == "%" {
+            if *operator == "/" || *operator == "%" {
                 t.has_division = true;
             }
             // L0040: arithmetic operator — combined with has_integer_literal
             // to gate the magic-number pass.
-            if matches!(operator.as_str(), "+" | "-" | "*" | "/" | "%") {
+            if matches!(*operator, "+" | "-" | "*" | "/" | "%") {
                 t.has_arith_int_literal = true;
             }
             // L0044: shift with a literal RHS.
-            if matches!(operator.as_str(), "<<" | ">>")
+            if matches!(*operator, "<<" | ">>")
                 && matches!(right.as_ref(), Node::IntegerLiteral { .. })
             {
                 t.has_literal_shift = true;
             }
             // L0048: any Bxor (^) infix expression.
-            if operator == "^" {
+            if *operator == "^" {
                 t.has_xor_infix = true;
             }
             // L0051: `==` or `!=` between two string literals.
-            if matches!(operator.as_str(), "==" | "!=")
+            if matches!(*operator, "==" | "!=")
                 && matches!(left.as_ref(), Node::StringLiteral { .. })
                 && matches!(right.as_ref(), Node::StringLiteral { .. })
             {
                 t.has_string_literal_cmp = true;
             }
             // L0055: `!=` where one operand is a boolean literal.
-            if operator == "!="
+            if *operator == "!="
                 && (matches!(left.as_ref(), Node::BooleanLiteral { .. })
                     || matches!(right.as_ref(), Node::BooleanLiteral { .. }))
             {
                 t.has_bool_neq_cmp = true;
             }
             // L0057-L0061: arithmetic identity operands (0 or 1 as literal).
-            if matches!(operator.as_str(), "+" | "-" | "*" | "/" | "<<" | ">>")
+            if matches!(*operator, "+" | "-" | "*" | "/" | "<<" | ">>")
                 && (matches!(left.as_ref(), Node::IntegerLiteral { value: 0 | 1, .. })
                     || matches!(right.as_ref(), Node::IntegerLiteral { value: 0 | 1, .. }))
             {
                 t.has_arith_identity = true;
             }
             // L0067-L0070: `&&` / `||` where one operand is a boolean literal.
-            if matches!(operator.as_str(), "&&" | "||")
+            if matches!(*operator, "&&" | "||")
                 && (matches!(left.as_ref(), Node::BooleanLiteral { .. })
                     || matches!(right.as_ref(), Node::BooleanLiteral { .. }))
             {
                 t.has_bool_logic_with_literal = true;
             }
             // L0086: `==` / `!=` with an empty string literal operand.
-            if matches!(operator.as_str(), "==" | "!=")
+            if matches!(*operator, "==" | "!=")
                 && (matches!(left.as_ref(), Node::StringLiteral { value, .. } if value.is_empty())
                     || matches!(right.as_ref(), Node::StringLiteral { value, .. } if value.is_empty()))
             {
@@ -1337,7 +1337,7 @@ fn scan_node(node: &Node, t: &mut LintTriggers) {
         } => {
             t.has_prefix_expr = true;
             // L0052: `!` applied directly to a bool literal.
-            if operator == "!" && matches!(right.as_ref(), Node::BooleanLiteral { .. }) {
+            if *operator == "!" && matches!(right.as_ref(), Node::BooleanLiteral { .. }) {
                 t.has_negated_bool_literal = true;
             }
         }
@@ -1478,7 +1478,7 @@ fn scan_node(node: &Node, t: &mut LintTriggers) {
         Node::FloatLiteral { .. } => t.has_float_literal = true,
         Node::ExpressionStatement { expr, .. } => {
             if matches!(expr.as_ref(), Node::InfixExpression { operator, .. }
-                if matches!(operator.as_str(), "==" | "!=" | "<" | "<=" | ">" | ">="))
+                if matches!(*operator, "==" | "!=" | "<" | "<=" | ">" | ">="))
             {
                 t.has_expr_stmt_cmp = true;
             }
@@ -2622,12 +2622,12 @@ fn walk_self_comparisons(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && (operator == "==" || operator == "!=")
+        && (*operator == "==" || *operator == "!=")
         && let (Node::Identifier { name: ln, .. }, Node::Identifier { name: rn, .. }) =
             (left.as_ref(), right.as_ref())
         && ln == rn
     {
-        let always = if operator == "==" {
+        let always = if *operator == "==" {
             "always true"
         } else {
             "always false"
@@ -2667,7 +2667,7 @@ fn walk_and_or(node: &Node, out: &mut Vec<Lint>) {
         span,
     } = node
     {
-        let opposite = match operator.as_str() {
+        let opposite = match *operator {
             "&&" => Some("||"),
             "||" => Some("&&"),
             _ => None,
@@ -2691,7 +2691,7 @@ fn walk_and_or(node: &Node, out: &mut Vec<Lint>) {
 }
 
 fn has_top_level_op(node: &Node, op: &str) -> bool {
-    matches!(node, Node::InfixExpression { operator, .. } if operator == op)
+    matches!(node, Node::InfixExpression { operator, .. } if *operator == op)
 }
 
 /// RES-198: best-effort span extraction. Mirrors the helper in
@@ -2991,7 +2991,7 @@ fn walk_divisions(node: &Node, requires: &[Node], out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && (operator == "/" || operator == "%")
+        && (*operator == "/" || *operator == "%")
     {
         match right.as_ref() {
             Node::IntegerLiteral { value: 0, .. } => {
@@ -3045,7 +3045,7 @@ fn l0009_z3_check(
     // Construct the synthetic obligation `<right> != 0`.
     let obligation = Node::InfixExpression {
         left: Box::new(right.clone()),
-        operator: "!=".to_string(),
+        operator: "!=",
         right: Box::new(Node::IntegerLiteral {
             value: 0,
             span: crate::span::Span::default(),
@@ -3902,7 +3902,7 @@ fn try_const_int(node: &Node) -> Option<i64> {
         Node::IntegerLiteral { value, .. } => Some(*value),
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "-" => try_const_int(right).and_then(i64::checked_neg),
+        } if *operator == "-" => try_const_int(right).and_then(i64::checked_neg),
         Node::InfixExpression {
             operator,
             left,
@@ -3911,7 +3911,7 @@ fn try_const_int(node: &Node) -> Option<i64> {
         } => {
             let l = try_const_int(left)?;
             let r = try_const_int(right)?;
-            match operator.as_str() {
+            match *operator {
                 "+" => l.checked_add(r),
                 "-" => l.checked_sub(r),
                 "*" => l.checked_mul(r),
@@ -3944,7 +3944,7 @@ fn walk_l0015(node: &Node, out: &mut Vec<Lint>) {
         span,
     } = node
     {
-        let op = operator.as_str();
+        let op = *operator;
         if matches!(op, "+" | "-" | "*" | "/" | "%") {
             let l_val = try_const_int(left);
             let r_val = try_const_int(right);
@@ -3996,13 +3996,13 @@ fn try_const_bool(node: &Node) -> Option<bool> {
         Node::BooleanLiteral { value, .. } => Some(*value),
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "!" => try_const_bool(right).map(|v| !v),
+        } if *operator == "!" => try_const_bool(right).map(|v| !v),
         Node::InfixExpression {
             operator,
             left,
             right,
             ..
-        } => match operator.as_str() {
+        } => match *operator {
             "==" => {
                 let (l, r) = (try_const_int(left)?, try_const_int(right)?);
                 Some(l == r)
@@ -4502,7 +4502,7 @@ fn walk_l0021(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && (operator == "&&" || operator == "||")
+        && (*operator == "&&" || *operator == "||")
         && nodes_structurally_equal(left, right)
     {
         out.push(Lint {
@@ -4629,7 +4629,7 @@ fn walk_l0023(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && operator == "=="
+        && *operator == "=="
     {
         let (bool_val, other_side) = if let Node::BooleanLiteral { value, .. } = left.as_ref() {
             (Some(*value), right.as_ref())
@@ -4914,7 +4914,7 @@ fn walk_l0028(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && operator == "!"
+        && *operator == "!"
         && let Node::BooleanLiteral { value, .. } = right.as_ref()
     {
         let result = if *value { "false" } else { "true" };
@@ -4948,7 +4948,7 @@ fn run_l0029_comparison_result_discarded(program: &Node, out: &mut Vec<Lint>) {
 fn walk_l0029(node: &Node, out: &mut Vec<Lint>) {
     if let Node::ExpressionStatement { expr, span } = node
         && let Node::InfixExpression { operator, .. } = expr.as_ref()
-        && matches!(operator.as_str(), "==" | "!=" | "<" | "<=" | ">" | ">=")
+        && matches!(*operator, "==" | "!=" | "<" | "<=" | ">" | ">=")
     {
         out.push(Lint {
             code: "L0029".into(),
@@ -4988,7 +4988,7 @@ fn walk_l0030(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && (operator == "==" || operator == "!=")
+        && (*operator == "==" || *operator == "!=")
     {
         let left_is_float = matches!(left.as_ref(), Node::FloatLiteral { .. });
         let right_is_float = matches!(right.as_ref(), Node::FloatLiteral { .. });
@@ -5026,11 +5026,11 @@ fn walk_l0031(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && operator == "!"
+        && *operator == "!"
         && let Node::PrefixExpression {
             operator: inner_op, ..
         } = right.as_ref()
-        && inner_op == "!"
+        && *inner_op == "!"
     {
         out.push(Lint {
             code: "L0031".into(),
@@ -5093,7 +5093,7 @@ fn walk_l0033(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && operator == "%"
+        && *operator == "%"
         && matches!(right.as_ref(), Node::IntegerLiteral { value: 1, .. })
     {
         out.push(Lint {
@@ -5137,7 +5137,7 @@ fn walk_l0034_loop(node: &Node, in_loop: bool, out: &mut Vec<Lint>) {
             operator,
             right,
             span,
-        } if in_loop && operator == "+" => {
+        } if in_loop && *operator == "+" => {
             let left_is_str = matches!(left.as_ref(), Node::StringLiteral { .. });
             let right_is_str = matches!(right.as_ref(), Node::StringLiteral { .. });
             if left_is_str || right_is_str {
@@ -5254,7 +5254,7 @@ fn is_negative_int_literal(node: &Node) -> bool {
         Node::IntegerLiteral { value, .. } => *value < 0,
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "-" => {
+        } if *operator == "-" => {
             matches!(right.as_ref(), Node::IntegerLiteral { value, .. } if *value > 0)
         }
         _ => false,
@@ -5268,7 +5268,7 @@ fn walk_l0036(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && matches!(operator.as_str(), "<" | "<=" | "==" | "!=" | ">" | ">=")
+        && matches!(*operator, "<" | "<=" | "==" | "!=" | ">" | ">=")
     {
         let matched = (is_len_call(left) && is_negative_int_literal(right))
             || (is_len_call(right) && is_negative_int_literal(left));
@@ -5533,7 +5533,7 @@ fn walk_l0040_arith(node: &Node, out: &mut Vec<Lint>) {
         right,
         ..
     } = node
-        && matches!(operator.as_str(), "+" | "-" | "*" | "/" | "%")
+        && matches!(*operator, "+" | "-" | "*" | "/" | "%")
     {
         // Check left operand.
         if let Node::IntegerLiteral { value, span } = left.as_ref()
@@ -5742,7 +5742,7 @@ fn walk_l0044(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && matches!(operator.as_str(), "<<" | ">>")
+        && matches!(*operator, "<<" | ">>")
         && let Node::IntegerLiteral { value, .. } = right.as_ref()
         && !(0..64).contains(value)
     {
@@ -5881,7 +5881,7 @@ fn walk_l0048(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && operator == "^"
+        && *operator == "^"
         && let Node::Identifier { name: lname, .. } = left.as_ref()
         && let Node::Identifier { name: rname, .. } = right.as_ref()
         && lname == rname
@@ -6003,11 +6003,15 @@ fn walk_l0051(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && matches!(operator.as_str(), "==" | "!=")
+        && matches!(*operator, "==" | "!=")
         && let Node::StringLiteral { value: lv, .. } = left.as_ref()
         && let Node::StringLiteral { value: rv, .. } = right.as_ref()
     {
-        let result = if operator == "==" { lv == rv } else { lv != rv };
+        let result = if *operator == "==" {
+            lv == rv
+        } else {
+            lv != rv
+        };
         out.push(Lint {
             code: "L0051".into(),
             severity: Severity::Warning,
@@ -6036,7 +6040,7 @@ fn walk_l0052(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && operator == "!"
+        && *operator == "!"
         && let Node::BooleanLiteral { value, .. } = right.as_ref()
     {
         let simplified = if *value { "false" } else { "true" };
@@ -6076,7 +6080,7 @@ fn walk_l0053(node: &Node, out: &mut Vec<Lint>) {
             Node::IntegerLiteral { value, .. } => Some(*value),
             Node::PrefixExpression {
                 operator, right, ..
-            } if operator == "-" => {
+            } if *operator == "-" => {
                 if let Node::IntegerLiteral { value, .. } = right.as_ref() {
                     Some(-(*value))
                 } else {
@@ -6122,7 +6126,7 @@ fn walk_l0055(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && operator == "!="
+        && *operator == "!="
     {
         let bool_val = if let Node::BooleanLiteral { value, .. } = left.as_ref() {
             Some(*value)
@@ -6167,7 +6171,7 @@ fn walk_l0057(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && operator == "+"
+        && *operator == "+"
         && (matches!(left.as_ref(), Node::IntegerLiteral { value: 0, .. })
             || matches!(right.as_ref(), Node::IntegerLiteral { value: 0, .. }))
     {
@@ -6197,7 +6201,7 @@ fn walk_l0058(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && operator == "-"
+        && *operator == "-"
         && matches!(right.as_ref(), Node::IntegerLiteral { value: 0, .. })
     {
         out.push(Lint {
@@ -6226,7 +6230,7 @@ fn walk_l0059(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && operator == "*"
+        && *operator == "*"
         && (matches!(left.as_ref(), Node::IntegerLiteral { value: 1, .. })
             || matches!(right.as_ref(), Node::IntegerLiteral { value: 1, .. }))
     {
@@ -6256,7 +6260,7 @@ fn walk_l0060(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && operator == "/"
+        && *operator == "/"
         && matches!(right.as_ref(), Node::IntegerLiteral { value: 1, .. })
     {
         out.push(Lint {
@@ -6285,7 +6289,7 @@ fn walk_l0061(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && (operator == "<<" || operator == ">>")
+        && (*operator == "<<" || *operator == ">>")
         && matches!(right.as_ref(), Node::IntegerLiteral { value: 0, .. })
     {
         out.push(Lint {
@@ -6315,12 +6319,12 @@ fn walk_l0062(node: &Node, out: &mut Vec<Lint>) {
         right,
         span,
     } = node
-        && matches!(operator.as_str(), "<" | ">" | "<=" | ">=")
+        && matches!(*operator, "<" | ">" | "<=" | ">=")
         && let Node::Identifier { name: lname, .. } = left.as_ref()
         && let Node::Identifier { name: rname, .. } = right.as_ref()
         && lname == rname
     {
-        let result = if operator == "<" || operator == ">" {
+        let result = if *operator == "<" || *operator == ">" {
             "always false"
         } else {
             "always true"
@@ -6808,7 +6812,7 @@ fn walk_l0067(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && operator == "&&"
+        && *operator == "&&"
         && (matches!(left.as_ref(), Node::BooleanLiteral { value: true, .. })
             || matches!(right.as_ref(), Node::BooleanLiteral { value: true, .. }))
     {
@@ -6838,7 +6842,7 @@ fn walk_l0068(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && operator == "&&"
+        && *operator == "&&"
         && (matches!(left.as_ref(), Node::BooleanLiteral { value: false, .. })
             || matches!(right.as_ref(), Node::BooleanLiteral { value: false, .. }))
     {
@@ -6867,7 +6871,7 @@ fn walk_l0069(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && operator == "||"
+        && *operator == "||"
         && (matches!(left.as_ref(), Node::BooleanLiteral { value: true, .. })
             || matches!(right.as_ref(), Node::BooleanLiteral { value: true, .. }))
     {
@@ -6898,7 +6902,7 @@ fn walk_l0070(node: &Node, out: &mut Vec<Lint>) {
         span,
         ..
     } = node
-        && operator == "||"
+        && *operator == "||"
         && (matches!(left.as_ref(), Node::BooleanLiteral { value: false, .. })
             || matches!(right.as_ref(), Node::BooleanLiteral { value: false, .. }))
     {
@@ -7288,14 +7292,13 @@ fn run_l0086_empty_string_comparison(program: &Node, out: &mut Vec<Lint>) {
             span,
         } = node
         {
-            if !matches!(operator.as_str(), "==" | "!=") {
+            if !matches!(*operator, "==" | "!=") {
                 return;
             }
             let is_empty_str =
                 |n: &Node| matches!(n, Node::StringLiteral { value, .. } if value.is_empty());
             if is_empty_str(left) || is_empty_str(right) {
-                let op = operator.clone();
-                let suggestion = if op == "==" {
+                let suggestion = if *operator == "==" {
                     "is_empty(s)"
                 } else {
                     "!is_empty(s)"
@@ -7303,7 +7306,7 @@ fn run_l0086_empty_string_comparison(program: &Node, out: &mut Vec<Lint>) {
                 out.push(Lint {
                     code: "L0086".into(),
                     message: format!(
-                        "comparing to empty string literal with `{op}`; \
+                        "comparing to empty string literal with `{operator}`; \
                          prefer `{suggestion}` for clarity"
                     ),
                     line: span.start.line as u32,

--- a/resilient/src/monomorph.rs
+++ b/resilient/src/monomorph.rs
@@ -467,7 +467,7 @@ fn rewrite_node(
             span,
         } => Node::InfixExpression {
             left: Box::new(rewrite_node(left, generic_fns, instantiations)),
-            operator: operator.clone(),
+            operator,
             right: Box::new(rewrite_node(right, generic_fns, instantiations)),
             span: *span,
         },
@@ -476,7 +476,7 @@ fn rewrite_node(
             right,
             span,
         } => Node::PrefixExpression {
-            operator: operator.clone(),
+            operator,
             right: Box::new(rewrite_node(right, generic_fns, instantiations)),
             span: *span,
         },

--- a/resilient/src/monotonic_field.rs
+++ b/resilient/src/monotonic_field.rs
@@ -82,7 +82,7 @@ fn value_is_monotonic(value: &Node, target: &Node, field: &str) -> bool {
             right,
             ..
         } => {
-            if operator == "+" {
+            if *operator == "+" {
                 touches_self_field(left, target, field) || touches_self_field(right, target, field)
             } else {
                 false

--- a/resilient/src/mutation_testing.rs
+++ b/resilient/src/mutation_testing.rs
@@ -60,7 +60,7 @@ fn generate_in(node: &Node, fn_name: &str, out: &mut Vec<Mutation>) {
             right,
             ..
         } => {
-            match operator.as_str() {
+            match *operator {
                 // arithmetic
                 "+" => push(out, fn_name, "arithmetic", "swap `+` -> `-`"),
                 "-" => push(out, fn_name, "arithmetic", "swap `-` -> `+`"),
@@ -93,7 +93,7 @@ fn generate_in(node: &Node, fn_name: &str, out: &mut Vec<Mutation>) {
         Node::PrefixExpression {
             operator, right, ..
         } => {
-            if operator == "-" {
+            if *operator == "-" {
                 push(
                     out,
                     fn_name,

--- a/resilient/src/numeric_units.rs
+++ b/resilient/src/numeric_units.rs
@@ -97,7 +97,7 @@ fn check_expr(
         ..
     } = expr
     {
-        if !matches!(operator.as_str(), "+" | "-") {
+        if !matches!(*operator, "+" | "-") {
             return;
         }
         let lu = ident_unit(left, units);

--- a/resilient/src/recovers_to_bmc.rs
+++ b/resilient/src/recovers_to_bmc.rs
@@ -321,7 +321,7 @@ pub(crate) fn node_to_smtlib2(node: &Node) -> String {
         } => {
             let l = node_to_smtlib2(left);
             let r = node_to_smtlib2(right);
-            let op = match operator.as_str() {
+            let op = match *operator {
                 "+" => "+",
                 "-" => "-",
                 "*" => "*",
@@ -343,7 +343,7 @@ pub(crate) fn node_to_smtlib2(node: &Node) -> String {
             operator, right, ..
         } => {
             let r = node_to_smtlib2(right);
-            match operator.as_str() {
+            match *operator {
                 "!" => format!("(not {r})"),
                 "-" => format!("(- {r})"),
                 _ => "true".to_string(),
@@ -635,7 +635,7 @@ mod tests {
                 name: "reading".to_string(),
                 span: Span::default(),
             }),
-            operator: ">".to_string(),
+            operator: ">",
             right: Box::new(Node::IntegerLiteral {
                 value: 100,
                 span: Span::default(),
@@ -653,7 +653,7 @@ mod tests {
                 name: "a".to_string(),
                 span: Span::default(),
             }),
-            operator: "!=".to_string(),
+            operator: "!=",
             right: Box::new(Node::Identifier {
                 name: "b".to_string(),
                 span: Span::default(),
@@ -666,7 +666,7 @@ mod tests {
     #[test]
     fn smtlib2_prefix_not() {
         let node = Node::PrefixExpression {
-            operator: "!".to_string(),
+            operator: "!",
             right: Box::new(Node::BooleanLiteral {
                 value: true,
                 span: Span::default(),
@@ -684,7 +684,7 @@ mod tests {
                 name: "reading".to_string(),
                 span: Span::default(),
             }),
-            operator: ">".to_string(),
+            operator: ">",
             right: Box::new(Node::IntegerLiteral {
                 value: 100,
                 span: Span::default(),
@@ -722,7 +722,7 @@ mod tests {
                 name: "reading".to_string(),
                 span: Span::default(),
             }),
-            operator: ">=".to_string(),
+            operator: ">=",
             right: Box::new(Node::IntegerLiteral {
                 value: 0,
                 span: Span::default(),
@@ -734,7 +734,7 @@ mod tests {
                 name: "reading".to_string(),
                 span: Span::default(),
             }),
-            operator: ">".to_string(),
+            operator: ">",
             right: Box::new(Node::IntegerLiteral {
                 value: 100,
                 span: Span::default(),

--- a/resilient/src/saturation_required.rs
+++ b/resilient/src/saturation_required.rs
@@ -61,7 +61,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
 
 fn uses_unchecked_arith(node: &Node) -> bool {
     if let Node::InfixExpression { operator, .. } = node {
-        return matches!(operator.as_str(), "+" | "-" | "*");
+        return matches!(*operator, "+" | "-" | "*");
     }
     false
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -515,13 +515,13 @@ fn fold_const_bool(n: &Node, bindings: &HashMap<String, i64>) -> Option<bool> {
         Node::BooleanLiteral { value: b, .. } => Some(*b),
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "!" => fold_const_bool(right, bindings).map(|b| !b),
+        } if *operator == "!" => fold_const_bool(right, bindings).map(|b| !b),
         Node::InfixExpression {
             left,
             operator,
             right,
             ..
-        } => match operator.as_str() {
+        } => match *operator {
             // RES-1353: short-circuit `&&` / `||` before recursing
             // on the right operand. The old pattern-match form
             // (`match (fold(left), fold(right)) { … }`) eagerly
@@ -561,7 +561,7 @@ fn fold_const_bool(n: &Node, bindings: &HashMap<String, i64>) -> Option<bool> {
             "==" | "!=" | "<" | ">" | "<=" | ">=" => {
                 let l = fold_const_i64(left, bindings)?;
                 let r = fold_const_i64(right, bindings)?;
-                Some(match operator.as_str() {
+                Some(match *operator {
                     "==" => l == r,
                     "!=" => l != r,
                     "<" => l < r,
@@ -591,7 +591,7 @@ fn extract_eq_assumption(cond: &Node) -> Option<(String, i64)> {
         right,
         ..
     } = cond
-        && operator == "=="
+        && *operator == "=="
     {
         let no_b: HashMap<String, i64> = HashMap::new();
         match (left.as_ref(), right.as_ref()) {
@@ -615,7 +615,7 @@ fn fold_const_i64(n: &Node, bindings: &HashMap<String, i64>) -> Option<i64> {
         Node::Identifier { name, .. } => bindings.get(name).copied(),
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "-" => fold_const_i64(right, bindings).map(|v| -v),
+        } if *operator == "-" => fold_const_i64(right, bindings).map(|v| -v),
         Node::InfixExpression {
             left,
             operator,
@@ -624,7 +624,7 @@ fn fold_const_i64(n: &Node, bindings: &HashMap<String, i64>) -> Option<i64> {
         } => {
             let l = fold_const_i64(left, bindings)?;
             let r = fold_const_i64(right, bindings)?;
-            match operator.as_str() {
+            match *operator {
                 "+" => l.checked_add(r),
                 "-" => l.checked_sub(r),
                 "*" => l.checked_mul(r),
@@ -7600,7 +7600,7 @@ impl TypeChecker {
                 }
                 let right_type = self.check_node(right)?;
 
-                match operator.as_str() {
+                match *operator {
                     "!" => {
                         if right_type != Type::Bool && right_type != Type::Any {
                             return Err(format!("Cannot apply '!' to {}", right_type));
@@ -7638,7 +7638,7 @@ impl TypeChecker {
                 // operator arm.
                 let is_bool = |t: &Type| matches!(t, Type::Bool | Type::Any);
 
-                match operator.as_str() {
+                match *operator {
                     "+" => {
                         // String-plus-primitive coercion (RES-008): if
                         // either side is a string, the result is a string.
@@ -7661,13 +7661,13 @@ impl TypeChecker {
                     "-" | "*" | "/" | "%" => {
                         // RES-130: same policy as `+` — no mixed int / float.
                         // RES-413: static division / modulo by zero detection.
-                        if matches!(operator.as_str(), "/" | "%")
+                        if matches!(*operator, "/" | "%")
                             && let Some(divisor) = fold_const_i64(right, &self.const_bindings)
                             && divisor == 0
                         {
                             return Err(format!(
                                 "integer {} by zero — denominator is a compile-time constant 0",
-                                if operator == "/" {
+                                if *operator == "/" {
                                     "division"
                                 } else {
                                     "modulo"

--- a/resilient/src/verifier_actors.rs
+++ b/resilient/src/verifier_actors.rs
@@ -181,7 +181,7 @@ fn substitute_state(expr: &Node, state_name: &str, value: &Node) -> Node {
             span,
         } => Node::InfixExpression {
             left: Box::new(substitute_state(left, state_name, value)),
-            operator: operator.clone(),
+            operator,
             right: Box::new(substitute_state(right, state_name, value)),
             span: *span,
         },
@@ -190,7 +190,7 @@ fn substitute_state(expr: &Node, state_name: &str, value: &Node) -> Node {
             right,
             span,
         } => Node::PrefixExpression {
-            operator: operator.clone(),
+            operator,
             right: Box::new(substitute_state(right, state_name, value)),
             span: *span,
         },
@@ -313,7 +313,7 @@ fn flatten_body(body: &Node) -> Option<Vec<&Node>> {
 fn and_node(a: Node, b: Node) -> Node {
     Node::InfixExpression {
         left: Box::new(a),
-        operator: "&&".to_string(),
+        operator: "&&",
         right: Box::new(b),
         span: Span::default(),
     }
@@ -323,11 +323,11 @@ fn and_node(a: Node, b: Node) -> Node {
 fn implies_node(a: Node, b: Node) -> Node {
     Node::InfixExpression {
         left: Box::new(Node::PrefixExpression {
-            operator: "!".to_string(),
+            operator: "!",
             right: Box::new(a),
             span: Span::default(),
         }),
-        operator: "||".to_string(),
+        operator: "||",
         right: Box::new(b),
         span: Span::default(),
     }
@@ -453,10 +453,10 @@ mod tests {
         }
     }
 
-    fn infix(left: Node, op: &str, right: Node) -> Node {
+    fn infix(left: Node, op: &'static str, right: Node) -> Node {
         Node::InfixExpression {
             left: Box::new(left),
-            operator: op.to_string(),
+            operator: op,
             right: Box::new(right),
             span: Span::default(),
         }

--- a/resilient/src/verifier_liveness.rs
+++ b/resilient/src/verifier_liveness.rs
@@ -230,21 +230,21 @@ fn candidates(state_name: &str) -> Vec<Node> {
         state.clone(),
         // μ = -state
         Node::PrefixExpression {
-            operator: "-".to_string(),
+            operator: "-",
             right: Box::new(state.clone()),
             span: Span::default(),
         },
         // μ = state - 1
         Node::InfixExpression {
             left: Box::new(state.clone()),
-            operator: "-".to_string(),
+            operator: "-",
             right: Box::new(int_lit(1)),
             span: Span::default(),
         },
         // μ = 1 - state
         Node::InfixExpression {
             left: Box::new(int_lit(1)),
-            operator: "-".to_string(),
+            operator: "-",
             right: Box::new(state),
             span: Span::default(),
         },
@@ -428,10 +428,10 @@ fn mk_true() -> Node {
     }
 }
 
-fn infix(left: Node, op: &str, right: Node) -> Node {
+fn infix(left: Node, op: &'static str, right: Node) -> Node {
     Node::InfixExpression {
         left: Box::new(left),
-        operator: op.to_string(),
+        operator: op,
         right: Box::new(right),
         span: Span::default(),
     }
@@ -440,7 +440,7 @@ fn infix(left: Node, op: &str, right: Node) -> Node {
 fn and_node(a: Node, b: Node) -> Node {
     Node::InfixExpression {
         left: Box::new(a),
-        operator: "&&".to_string(),
+        operator: "&&",
         right: Box::new(b),
         span: Span::default(),
     }
@@ -449,7 +449,7 @@ fn and_node(a: Node, b: Node) -> Node {
 fn or_node(a: Node, b: Node) -> Node {
     Node::InfixExpression {
         left: Box::new(a),
-        operator: "||".to_string(),
+        operator: "||",
         right: Box::new(b),
         span: Span::default(),
     }
@@ -458,11 +458,11 @@ fn or_node(a: Node, b: Node) -> Node {
 fn implies_node(a: Node, b: Node) -> Node {
     Node::InfixExpression {
         left: Box::new(Node::PrefixExpression {
-            operator: "!".to_string(),
+            operator: "!",
             right: Box::new(a),
             span: Span::default(),
         }),
-        operator: "||".to_string(),
+        operator: "||",
         right: Box::new(b),
         span: Span::default(),
     }

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -435,7 +435,7 @@ fn substitute(node: &Node, name: &str, replacement: &Node) -> Node {
             span,
         } => Node::InfixExpression {
             left: Box::new(substitute(left, name, replacement)),
-            operator: operator.clone(),
+            operator: *operator,
             right: Box::new(substitute(right, name, replacement)),
             span: *span,
         },
@@ -444,7 +444,7 @@ fn substitute(node: &Node, name: &str, replacement: &Node) -> Node {
             right,
             span,
         } => Node::PrefixExpression {
-            operator: operator.clone(),
+            operator: *operator,
             right: Box::new(substitute(right, name, replacement)),
             span: *span,
         },
@@ -458,18 +458,18 @@ fn substitute(node: &Node, name: &str, replacement: &Node) -> Node {
 fn build_implication(p: &Node, cond: &Node, q: &Node) -> Node {
     let p_and_cond = Node::InfixExpression {
         left: Box::new(p.clone()),
-        operator: "&&".to_string(),
+        operator: "&&",
         right: Box::new(cond.clone()),
         span: Span::default(),
     };
     let neg_p_and_cond = Node::PrefixExpression {
-        operator: "!".to_string(),
+        operator: "!",
         right: Box::new(p_and_cond),
         span: Span::default(),
     };
     Node::InfixExpression {
         left: Box::new(neg_p_and_cond),
-        operator: "||".to_string(),
+        operator: "||",
         right: Box::new(q.clone()),
         span: Span::default(),
     }

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -352,7 +352,7 @@ fn literal_int(node: &Node) -> Option<i64> {
     } else if let Node::PrefixExpression {
         operator, right, ..
     } = node
-        && operator == "-"
+        && *operator == "-"
         && let Node::IntegerLiteral { value, .. } = right.as_ref()
     {
         Some(-*value)
@@ -435,7 +435,7 @@ fn substitute(node: &Node, name: &str, replacement: &Node) -> Node {
             span,
         } => Node::InfixExpression {
             left: Box::new(substitute(left, name, replacement)),
-            operator: *operator,
+            operator,
             right: Box::new(substitute(right, name, replacement)),
             span: *span,
         },
@@ -444,7 +444,7 @@ fn substitute(node: &Node, name: &str, replacement: &Node) -> Node {
             right,
             span,
         } => Node::PrefixExpression {
-            operator: *operator,
+            operator,
             right: Box::new(substitute(right, name, replacement)),
             span: *span,
         },

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -103,7 +103,7 @@ fn try_const_int(expr: &Node) -> Option<i64> {
         Node::IntegerLiteral { value, .. } => Some(*value),
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "-" => try_const_int(right).and_then(i64::checked_neg),
+        } if *operator == "-" => try_const_int(right).and_then(i64::checked_neg),
         Node::InfixExpression {
             left,
             operator,
@@ -192,7 +192,7 @@ fn try_const_eval_bool(expr: &Node) -> Option<bool> {
         Node::BooleanLiteral { value, .. } => Some(*value),
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "!" => try_const_eval_bool(right).map(|v| !v),
+        } if *operator == "!" => try_const_eval_bool(right).map(|v| !v),
         Node::InfixExpression {
             left,
             operator,
@@ -251,7 +251,11 @@ fn try_const_eval_bool(expr: &Node) -> Option<bool> {
                 && let (Some(la), Some(rb)) =
                     (try_const_eval_bool(left), try_const_eval_bool(right))
             {
-                return Some(if operator == "==" { la == rb } else { la != rb });
+                return Some(if *operator == "==" {
+                    la == rb
+                } else {
+                    la != rb
+                });
             }
             // Boolean combinators — recurse to fold known sides,
             // short-circuiting before the other side has to fold.
@@ -1931,7 +1935,7 @@ fn translate_bool_bv<'c>(
         Node::BooleanLiteral { value: b, .. } => Some(Bool::from_bool(ctx, *b)),
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "!" => translate_bool_bv(ctx, right, bindings).map(|b| b.not()),
+        } if *operator == "!" => translate_bool_bv(ctx, right, bindings).map(|b| b.not()),
         Node::InfixExpression {
             left,
             operator,
@@ -1982,7 +1986,7 @@ fn translate_bv<'c>(
         },
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "-" => translate_bv(ctx, right, bindings).map(|v| v.bvneg()),
+        } if *operator == "-" => translate_bv(ctx, right, bindings).map(|v| v.bvneg()),
         Node::InfixExpression {
             left,
             operator,
@@ -2110,10 +2114,10 @@ fn collect_cert_idents<'a>(
             arguments,
             ..
         } => {
-            if is_len_call(function, arguments) {
-                if let Node::Identifier { name, .. } = &arguments[0] {
-                    len_args.insert(name.as_str());
-                }
+            if is_len_call(function, arguments)
+                && let Node::Identifier { name, .. } = &arguments[0]
+            {
+                len_args.insert(name.as_str());
             }
             // int_idents: original collect_int_identifiers ignores
             // CallExpression entirely, so we must NOT recurse for
@@ -2231,7 +2235,7 @@ fn translate_bool<'c>(
         } => crate::quantifiers::z3_encode(ctx, *kind, var, range, body, bindings),
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "!" => translate_bool(ctx, right, bindings).map(|b| b.not()),
+        } if *operator == "!" => translate_bool(ctx, right, bindings).map(|b| b.not()),
         Node::InfixExpression {
             left,
             operator,
@@ -2284,7 +2288,7 @@ fn translate_int<'c>(
         },
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "-" => translate_int(ctx, right, bindings).map(|v| v.unary_minus()),
+        } if *operator == "-" => translate_int(ctx, right, bindings).map(|v| v.unary_minus()),
         Node::InfixExpression {
             left,
             operator,
@@ -2690,7 +2694,9 @@ fn translate_state_rhs<'c>(
         Node::Identifier { .. } => None,
         Node::PrefixExpression {
             operator, right, ..
-        } if operator == "-" => translate_state_rhs(ctx, right, pre_state).map(|v| v.unary_minus()),
+        } if *operator == "-" => {
+            translate_state_rhs(ctx, right, pre_state).map(|v| v.unary_minus())
+        }
         Node::InfixExpression {
             left,
             operator,

--- a/resilient/src/verifier_z3.rs
+++ b/resilient/src/verifier_z3.rs
@@ -112,7 +112,7 @@ fn try_const_int(expr: &Node) -> Option<i64> {
         } => {
             let l = try_const_int(left)?;
             let r = try_const_int(right)?;
-            match operator.as_str() {
+            match *operator {
                 "+" => l.checked_add(r),
                 "-" => l.checked_sub(r),
                 "*" => l.checked_mul(r),
@@ -205,7 +205,7 @@ fn try_const_eval_bool(expr: &Node) -> Option<bool> {
             // through. Subsumes the original RES-1665 raw-literal
             // arm — a bare `IntegerLiteral` is a one-step fold.
             if let (Some(a), Some(b)) = (try_const_int(left), try_const_int(right)) {
-                return match operator.as_str() {
+                return match *operator {
                     "==" => Some(a == b),
                     "!=" => Some(a != b),
                     "<" => Some(a < b),
@@ -227,7 +227,7 @@ fn try_const_eval_bool(expr: &Node) -> Option<bool> {
                 (left.as_ref(), right.as_ref())
                 && a == b
             {
-                return match operator.as_str() {
+                return match *operator {
                     "==" | "<=" | ">=" => Some(true),
                     "!=" | "<" | ">" => Some(false),
                     _ => None,
@@ -247,7 +247,7 @@ fn try_const_eval_bool(expr: &Node) -> Option<bool> {
             // Other operators (`&&`, `||`, `<`, ...) fall through to
             // the bool-combinator arm below — `BoolLit(true) && BoolLit(true)`
             // must still fold via the `&&` combinator path.
-            if matches!(operator.as_str(), "==" | "!=")
+            if matches!(*operator, "==" | "!=")
                 && let (Some(la), Some(rb)) =
                     (try_const_eval_bool(left), try_const_eval_bool(right))
             {
@@ -255,7 +255,7 @@ fn try_const_eval_bool(expr: &Node) -> Option<bool> {
             }
             // Boolean combinators — recurse to fold known sides,
             // short-circuiting before the other side has to fold.
-            match operator.as_str() {
+            match *operator {
                 "&&" => {
                     let l = try_const_eval_bool(left);
                     if l == Some(false) {
@@ -301,7 +301,7 @@ pub fn has_bitwise_ops(node: &Node) -> bool {
             right,
             ..
         } => {
-            matches!(operator.as_str(), "&" | "|" | "^" | "<<" | ">>")
+            matches!(*operator, "&" | "|" | "^" | "<<" | ">>")
                 || has_bitwise_ops(left)
                 || has_bitwise_ops(right)
         }
@@ -1842,7 +1842,7 @@ pub fn prove_alias_disjoint(param_a: &str, param_b: &str, requires: &[Node]) -> 
             name: param_a.to_string(),
             span: crate::span::Span::default(),
         }),
-        operator: "!=".to_string(),
+        operator: "!=",
         right: Box::new(Node::Identifier {
             name: param_b.to_string(),
             span: crate::span::Span::default(),
@@ -1937,7 +1937,7 @@ fn translate_bool_bv<'c>(
             operator,
             right,
             ..
-        } => match operator.as_str() {
+        } => match *operator {
             "&&" => {
                 let l = translate_bool_bv(ctx, left, bindings)?;
                 let r = translate_bool_bv(ctx, right, bindings)?;
@@ -1951,7 +1951,7 @@ fn translate_bool_bv<'c>(
             "==" | "!=" | "<" | ">" | "<=" | ">=" => {
                 let l = translate_bv(ctx, left, bindings)?;
                 let r = translate_bv(ctx, right, bindings)?;
-                let cmp = match operator.as_str() {
+                let cmp = match *operator {
                     "==" => l._eq(&r),
                     "!=" => l._eq(&r).not(),
                     "<" => l.bvslt(&r),
@@ -1991,7 +1991,7 @@ fn translate_bv<'c>(
         } => {
             let l = translate_bv(ctx, left, bindings)?;
             let r = translate_bv(ctx, right, bindings)?;
-            Some(match operator.as_str() {
+            Some(match *operator {
                 "+" => l.bvadd(&r),
                 "-" => l.bvsub(&r),
                 "*" => l.bvmul(&r),
@@ -2237,7 +2237,7 @@ fn translate_bool<'c>(
             operator,
             right,
             ..
-        } => match operator.as_str() {
+        } => match *operator {
             "&&" => {
                 let l = translate_bool(ctx, left, bindings)?;
                 let r = translate_bool(ctx, right, bindings)?;
@@ -2251,7 +2251,7 @@ fn translate_bool<'c>(
             "==" | "!=" | "<" | ">" | "<=" | ">=" => {
                 let l = translate_int(ctx, left, bindings)?;
                 let r = translate_int(ctx, right, bindings)?;
-                let cmp = match operator.as_str() {
+                let cmp = match *operator {
                     "==" => l._eq(&r),
                     "!=" => l._eq(&r).not(),
                     "<" => l.lt(&r),
@@ -2293,7 +2293,7 @@ fn translate_int<'c>(
         } => {
             let l = translate_int(ctx, left, bindings)?;
             let r = translate_int(ctx, right, bindings)?;
-            Some(match operator.as_str() {
+            Some(match *operator {
                 "+" => Int::add(ctx, &[&l, &r]),
                 "-" => Int::sub(ctx, &[&l, &r]),
                 "*" => Int::mul(ctx, &[&l, &r]),
@@ -2699,7 +2699,7 @@ fn translate_state_rhs<'c>(
         } => {
             let l = translate_state_rhs(ctx, left, pre_state)?;
             let r = translate_state_rhs(ctx, right, pre_state)?;
-            Some(match operator.as_str() {
+            Some(match *operator {
                 "+" => Int::add(ctx, &[&l, &r]),
                 "-" => Int::sub(ctx, &[&l, &r]),
                 "*" => Int::mul(ctx, &[&l, &r]),
@@ -2730,7 +2730,7 @@ mod tests {
                 value: 7,
                 span: crate::span::Span::default(),
             }),
-            operator: ">".to_string(),
+            operator: ">",
             right: Box::new(Node::IntegerLiteral {
                 value: 3,
                 span: crate::span::Span::default(),
@@ -2756,7 +2756,7 @@ mod tests {
                 value: 5,
                 span: crate::span::Span::default(),
             }),
-            operator: ">".to_string(),
+            operator: ">",
             right: Box::new(Node::IntegerLiteral {
                 value: 3,
                 span: crate::span::Span::default(),
@@ -2791,7 +2791,7 @@ mod tests {
                 value: 0,
                 span: crate::span::Span::default(),
             }),
-            operator: "!=".to_string(),
+            operator: "!=",
             right: Box::new(Node::IntegerLiteral {
                 value: 0,
                 span: crate::span::Span::default(),
@@ -2818,7 +2818,7 @@ mod tests {
                 value: 5,
                 span: crate::span::Span::default(),
             }),
-            operator: "!=".to_string(),
+            operator: "!=",
             right: Box::new(Node::IntegerLiteral {
                 value: 0,
                 span: crate::span::Span::default(),
@@ -2830,7 +2830,7 @@ mod tests {
                 value: 0,
                 span: crate::span::Span::default(),
             }),
-            operator: "!=".to_string(),
+            operator: "!=",
             right: Box::new(Node::IntegerLiteral {
                 value: 0,
                 span: crate::span::Span::default(),
@@ -2852,7 +2852,7 @@ mod tests {
                 value: 5,
                 span: crate::span::Span::default(),
             }),
-            operator: "!=".to_string(),
+            operator: "!=",
             right: Box::new(Node::IntegerLiteral {
                 value: 0,
                 span: crate::span::Span::default(),
@@ -2871,7 +2871,7 @@ mod tests {
                 value: 0,
                 span: crate::span::Span::default(),
             }),
-            operator: "!=".to_string(),
+            operator: "!=",
             right: Box::new(Node::IntegerLiteral {
                 value: 0,
                 span: crate::span::Span::default(),
@@ -2892,14 +2892,14 @@ mod tests {
                     name: "x".to_string(),
                     span: crate::span::Span::default(),
                 }),
-                operator: "+".to_string(),
+                operator: "+",
                 right: Box::new(Node::IntegerLiteral {
                     value: 0,
                     span: crate::span::Span::default(),
                 }),
                 span: crate::span::Span::default(),
             }),
-            operator: "==".to_string(),
+            operator: "==",
             right: Box::new(Node::Identifier {
                 name: "x".to_string(),
                 span: crate::span::Span::default(),
@@ -2926,20 +2926,20 @@ mod tests {
                     name: "x".to_string(),
                     span: crate::span::Span::default(),
                 }),
-                operator: ">".to_string(),
+                operator: ">",
                 right: Box::new(Node::IntegerLiteral {
                     value: 0,
                     span: crate::span::Span::default(),
                 }),
                 span: crate::span::Span::default(),
             }),
-            operator: "||".to_string(),
+            operator: "||",
             right: Box::new(Node::InfixExpression {
                 left: Box::new(Node::Identifier {
                     name: "x".to_string(),
                     span: crate::span::Span::default(),
                 }),
-                operator: "<=".to_string(),
+                operator: "<=",
                 right: Box::new(Node::IntegerLiteral {
                     value: 0,
                     span: crate::span::Span::default(),
@@ -2963,14 +2963,14 @@ mod tests {
                     name: "x".to_string(),
                     span: crate::span::Span::default(),
                 }),
-                operator: "+".to_string(),
+                operator: "+",
                 right: Box::new(Node::IntegerLiteral {
                     value: 0,
                     span: crate::span::Span::default(),
                 }),
                 span: crate::span::Span::default(),
             }),
-            operator: "==".to_string(),
+            operator: "==",
             right: Box::new(Node::Identifier {
                 name: "x".to_string(),
                 span: crate::span::Span::default(),
@@ -3014,7 +3014,7 @@ mod tests {
                 name: "n".to_string(),
                 span: crate::span::Span::default(),
             }),
-            operator: ">".to_string(),
+            operator: ">",
             right: Box::new(Node::IntegerLiteral {
                 value: 0,
                 span: crate::span::Span::default(),
@@ -3041,7 +3041,7 @@ mod tests {
                 name: "x".to_string(),
                 span: crate::span::Span::default(),
             }),
-            operator: ">".to_string(),
+            operator: ">",
             right: Box::new(Node::IntegerLiteral {
                 value: 0,
                 span: crate::span::Span::default(),
@@ -3062,7 +3062,7 @@ mod tests {
                 name: "x".to_string(),
                 span: crate::span::Span::default(),
             }),
-            operator: ">".to_string(),
+            operator: ">",
             right: Box::new(Node::IntegerLiteral {
                 value: 0,
                 span: crate::span::Span::default(),
@@ -3091,10 +3091,10 @@ mod tests {
     }
 
     /// Build `left OP right` with a default span.
-    fn infix(left: Node, op: &str, right: Node) -> Node {
+    fn infix(left: Node, op: &'static str, right: Node) -> Node {
         Node::InfixExpression {
             left: Box::new(left),
-            operator: op.to_string(),
+            operator: op,
             right: Box::new(right),
             span: crate::span::Span::default(),
         }
@@ -4080,7 +4080,7 @@ mod tests {
 
     fn not_node(inner: Node) -> Node {
         Node::PrefixExpression {
-            operator: "!".to_string(),
+            operator: "!",
             right: Box::new(inner),
             span: crate::span::Span::default(),
         }
@@ -4358,7 +4358,7 @@ mod tests {
     #[test]
     fn const_int_folds_unary_minus() {
         let neg5 = Node::PrefixExpression {
-            operator: "-".to_string(),
+            operator: "-",
             right: Box::new(int(5)),
             span: crate::span::Span::default(),
         };


### PR DESCRIPTION
## Summary

- Changed `Node::InfixExpression.operator` and `Node::PrefixExpression.operator` from `String` to `&'static str`
- Eliminates ~60 heap allocations across the codebase — every operator is always a string literal (`"+"`, `"=="`, `"&&"`, etc.) that was previously `.to_string()`'d
- All `operator.as_str()` calls (dozens in typechecker, verifier_z3, evaluator) become no-ops — `&str` is already `&str`
- 24 files changed, net -1 line

## Files changed

Parser (lib.rs), typechecker, evaluator, compiler, verifier_z3, verifier_actors, verifier_liveness, verifier_loop_invariants, recovers_to_bmc, bounds_check, cluster_verifier, contract_inference, const_fn, free_vars, generics, jit_backend, lean_spec, lint, monomorph, monotonic_field, mutation_testing, numeric_units, saturation_required, age_bounded_data

## Test plan

- [x] `cargo test` — 4671 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #1907

🤖 Generated with [Claude Code](https://claude.com/claude-code)