### PR TITLE
perf(typechecker): gate function-only passes and add incremental_verify early exit

### DIFF
--- a/resilient/src/incremental_verify.rs
+++ b/resilient/src/incremental_verify.rs
@@ -61,6 +61,14 @@ pub fn store(fn_name: &str, contract_digest: u64, result: ProofResult) {
     }
 }
 
+pub fn cache_is_empty() -> bool {
+    CACHE
+        .read()
+        .ok()
+        .and_then(|g| g.as_ref().map(|c| c.entries.is_empty()))
+        .unwrap_or(true)
+}
+
 pub fn stats() -> (u64, u64) {
     // RES-1566: borrow through the read guard and read the two `Copy`
     // u64s in place. The previous `g.clone()` shape cloned the entire
@@ -87,6 +95,9 @@ pub fn stats() -> (u64, u64) {
 /// function names from the AST, then drop every cache entry whose
 /// function name is absent from that set.
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+    if cache_is_empty() {
+        return Ok(());
+    }
     let live_names: std::collections::HashSet<&str> = match program {
         Node::Program(stmts) => stmts
             .iter()

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4950,12 +4950,15 @@ impl TypeChecker {
                 // anti_regression so the latter has the call graph.
                 // RES-2645: resilience_score warns for F-grade functions;
                 // vibe_debt warns for fully-vibe-coded functions;
-                // behavioral_fingerprint checks for contract regressions;
                 // contract_inference emits inline contract suggestions.
-                crate::resilience_score::check(program, source_path)?;
-                crate::vibe_debt::check(program, source_path)?;
+                // All three only examine top-level functions — skip them
+                // when the program has none.
+                if !markers.fn_names.is_empty() {
+                    crate::resilience_score::check(program, source_path)?;
+                    crate::vibe_debt::check(program, source_path)?;
+                    crate::contract_inference::check(program, source_path)?;
+                }
                 crate::behavioral_fingerprint::check(program, source_path)?;
-                crate::contract_inference::check(program, source_path)?;
                 // RES-2645: mutation_testing cross-references mutation
                 // sites with contract declarations; warns on unconstrained.
                 crate::mutation_testing::check(program, source_path)?;


### PR DESCRIPTION
## Summary
- Gate `resilience_score::check`, `vibe_debt::check`, and `contract_inference::check` behind `!markers.fn_names.is_empty()` — all three only examine top-level functions, so programs without functions skip three full AST walks
- Add `incremental_verify::cache_is_empty()` read-lock check to short-circuit `check()` when the proof cache is empty (the common case for non-Z3 builds), avoiding a write-lock acquire, `HashSet<&str>` allocation, and full statement iteration
- Continues the pass-gating series from #1900, #1902, #1904

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>