### PR TITLE
fix(ast): add Node::Match to any_node_inner so passes descend into match arms

### DIFF
--- a/resilient/src/uniqueness_walk.rs
+++ b/resilient/src/uniqueness_walk.rs
@@ -213,6 +213,15 @@ fn any_node_inner(node: &Node, pred: &mut impl FnMut(&Node) -> bool) -> bool {
         Node::PrefixExpression { right, .. } => any_node_inner(right, pred),
         Node::ArrayLiteral { items, .. } => items.iter().any(|i| any_node_inner(i, pred)),
         Node::ExpressionStatement { expr, .. } => any_node_inner(expr, pred),
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
+            any_node_inner(scrutinee, pred)
+                || arms.iter().any(|(_, guard, body)| {
+                    guard.as_ref().is_some_and(|g| any_node_inner(g, pred))
+                        || any_node_inner(body, pred)
+                })
+        }
         _ => false,
     }
 }
@@ -301,6 +310,21 @@ mod tests {
             }
         });
         assert!(saw_infix, "visit must reach nested InfixExpression nodes");
+    }
+
+    #[test]
+    fn any_node_descends_into_match_arms() {
+        let src = "fn f(int x) -> int {\n\
+                        return match x {\n\
+                            1 => x + 42,\n\
+                            _ => 0,\n\
+                        };\n\
+                    }\n";
+        let (prog, _) = parse(src);
+        let found = any_node(&prog, |n| {
+            matches!(n, Node::IntegerLiteral { value: 42, .. })
+        });
+        assert!(found, "any_node must descend into match arm bodies");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `any_node_inner` was missing `Node::Match`, causing it to fall through to `_ => false` and skip match scrutinee, guards, and arm bodies
- `walk_children` (used by `visit`) already handled `Match` correctly, so the `Markers` scan and `visit`-based passes were unaffected
- Any pass using `any_node` (e.g. `mutation_testing::check`) silently missed nodes nested inside match arms
- Adds test verifying `any_node` finds an `IntegerLiteral` inside a match arm body

## Test plan
- [x] `cargo test --lib -- uniqueness_walk` — all 8 tests pass including new `any_node_descends_into_match_arms`
- [x] `cargo test` — full suite green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>