### PR TITLE
perf(evaluator): replace format! with push_str for string concatenation

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -10592,13 +10592,20 @@ fn format_contract_expr(node: &Node) -> String {
 /// string operand). Returns `None` for values that should NOT be implicitly
 /// coerced (functions, builtins, void, returns). Strings come back as their
 /// raw contents — *without* the surrounding quotes that `Display` adds.
-fn stringify_for_concat(v: &Value) -> Option<String> {
+fn can_stringify_for_concat(v: &Value) -> bool {
+    matches!(
+        v,
+        Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_)
+    )
+}
+
+fn stringify_for_concat_owned(v: Value) -> String {
     match v {
-        Value::String(s) => Some(s.clone()),
-        Value::Int(i) => Some(i.to_string()),
-        Value::Float(f) => Some(f.to_string()),
-        Value::Bool(b) => Some(b.to_string()),
-        _ => None,
+        Value::String(s) => s,
+        Value::Int(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        _ => unreachable!(),
     }
 }
 
@@ -24859,11 +24866,11 @@ impl Interpreter {
         // applies to `+` — other operators keep their strict behavior.
         if operator == "+"
             && (matches!(left, Value::String(_)) || matches!(right, Value::String(_)))
-            && let (Some(ls), Some(rs)) =
-                (stringify_for_concat(&left), stringify_for_concat(&right))
+            && can_stringify_for_concat(&left)
+            && can_stringify_for_concat(&right)
         {
-            let mut s = ls;
-            s.push_str(&rs);
+            let mut s = stringify_for_concat_owned(left);
+            s.push_str(&stringify_for_concat_owned(right));
             return Ok(Value::String(s));
         }
 

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -24862,7 +24862,9 @@ impl Interpreter {
             && let (Some(ls), Some(rs)) =
                 (stringify_for_concat(&left), stringify_for_concat(&right))
         {
-            return Ok(Value::String(format!("{ls}{rs}")));
+            let mut s = ls;
+            s.push_str(&rs);
+            return Ok(Value::String(s));
         }
 
         // Array concat: `[1,2] + [3]` → `[1,2,3]`. Only for `+`.
@@ -25063,7 +25065,11 @@ impl Interpreter {
         // Lexicographic comparison for <, >, <=, >= matches the standard
         // behavior users expect from strings in most languages.
         match operator {
-            "+" => Ok(Value::String(format!("{}{}", left, right))),
+            "+" => {
+                let mut s = left;
+                s.push_str(&right);
+                Ok(Value::String(s))
+            }
             "==" => Ok(Value::Bool(left == right)),
             "!=" => Ok(Value::Bool(left != right)),
             "<" => Ok(Value::Bool(left < right)),


### PR DESCRIPTION
## Summary
- Replace `format!("{}{}", left, right)` with `push_str` for both string-string and mixed-type string concatenation in the evaluator
- `format!` routes through the fmt machinery and always allocates a fresh String; `push_str` reuses the left operand's existing allocation when spare capacity is available
- The `string_concat_200` benchmark exercises the string-string path ~200 times per invocation

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>