### PR TITLE
perf(evaluator): Rc-wrap Value::Function body and parameters

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9832,8 +9832,14 @@ enum Value {
     String(String),
     Bool(bool),
     Function {
-        parameters: Vec<(String, String)>,
-        body: Box<Node>,
+        /// RES-1913: Rc-shared so `env.get()` (which clones the Value)
+        /// bumps a refcount instead of deep-cloning the parameter list.
+        parameters: Rc<Vec<(String, String)>>,
+        /// RES-1913: Rc-shared so every `env.get("fn_name")` avoids
+        /// deep-cloning the entire function body AST. For recursive
+        /// workloads (fib(25) ≈ 243k calls) this eliminates one full
+        /// AST deep-clone per call.
+        body: Rc<Node>,
         env: Environment,
         /// RES-035: pre-conditions propagated into the runtime Value so
         /// apply_function can check them. Empty when absent.
@@ -22246,8 +22252,8 @@ impl Interpreter {
                     requires.clone()
                 };
                 let func = Value::Function {
-                    parameters: parameters.clone(),
-                    body: body.clone(),
+                    parameters: Rc::new(parameters.clone()),
+                    body: Rc::new(body.as_ref().clone()),
                     env: self.env.clone(),
                     requires: runtime_requires,
                     ensures: ensures.clone(),
@@ -23292,8 +23298,8 @@ impl Interpreter {
                 recovers_to,
                 ..
             } => Ok(Value::Function {
-                parameters: parameters.clone(),
-                body: body.clone(),
+                parameters: Rc::new(parameters.clone()),
+                body: Rc::new(body.as_ref().clone()),
                 env: self.env.clone(),
                 requires: requires.clone(),
                 ensures: ensures.clone(),


### PR DESCRIPTION
Closes #1913

## Summary

- Wrap `Value::Function.body` in `Rc<Node>` (was `Box<Node>`) so every
  `env.get("fn_name")` clones a refcount instead of deep-cloning the
  entire function body AST tree.
- Wrap `Value::Function.parameters` in `Rc<Vec<(String, String)>>` (was
  `Vec<(String, String)>`) to avoid cloning the parameter list on every
  function lookup.

For recursive workloads like `fib(25)` (~243k calls), each call
previously deep-cloned the function body — an O(tree-size) operation.
Now it's a refcount bump (O(1)).

The Rc is constructed once at function definition time; all subsequent
clones via `env.get` share the same allocation. Deref coercion means
all existing pattern-match and iteration sites (`.iter()`, `.len()`,
`eval(&body)`) work unchanged.

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>