### PR TITLE
perf(evaluator): borrow func in apply_function to eliminate per-call clones

### DIFF
--- a/resilient/src/array_combinators.rs
+++ b/resilient/src/array_combinators.rs
@@ -57,7 +57,7 @@ pub(crate) fn builtin_array_sort_by(interp: &mut Interpreter, args: &[Value]) ->
         if error.is_some() {
             return std::cmp::Ordering::Equal;
         }
-        match interp.apply_function(cmp.clone(), vec![a.clone(), b.clone()]) {
+        match interp.apply_function(&cmp, vec![a.clone(), b.clone()]) {
             Ok(Value::Int(n)) => n.cmp(&0),
             Ok(other) => {
                 error = Some(format!(
@@ -110,10 +110,10 @@ pub(crate) fn builtin_array_min_by(interp: &mut Interpreter, args: &[Value]) -> 
     }
 
     let mut best_elem = arr[0].clone();
-    let mut best_key = interp.apply_function(f.clone(), vec![arr[0].clone()])?;
+    let mut best_key = interp.apply_function(&f, vec![arr[0].clone()])?;
 
     for elem in arr.into_iter().skip(1) {
-        let key = interp.apply_function(f.clone(), vec![elem.clone()])?;
+        let key = interp.apply_function(&f, vec![elem.clone()])?;
         let is_smaller = compare_key(&key, &best_key).map_err(|e| format!("array_min_by: {e}"))?;
         if is_smaller < 0 {
             best_elem = elem;
@@ -154,10 +154,10 @@ pub(crate) fn builtin_array_max_by(interp: &mut Interpreter, args: &[Value]) -> 
     }
 
     let mut best_elem = arr[0].clone();
-    let mut best_key = interp.apply_function(f.clone(), vec![arr[0].clone()])?;
+    let mut best_key = interp.apply_function(&f, vec![arr[0].clone()])?;
 
     for elem in arr.into_iter().skip(1) {
-        let key = interp.apply_function(f.clone(), vec![elem.clone()])?;
+        let key = interp.apply_function(&f, vec![elem.clone()])?;
         let is_larger = compare_key(&key, &best_key).map_err(|e| format!("array_max_by: {e}"))?;
         if is_larger > 0 {
             best_elem = elem;
@@ -193,7 +193,7 @@ pub(crate) fn builtin_array_count_if(interp: &mut Interpreter, args: &[Value]) -
 
     let mut count: i64 = 0;
     for elem in arr {
-        match interp.apply_function(f.clone(), vec![elem])? {
+        match interp.apply_function(&f, vec![elem])? {
             Value::Bool(true) => count += 1,
             Value::Bool(false) => {}
             other => {
@@ -247,7 +247,7 @@ pub(crate) fn builtin_array_zip_with(interp: &mut Interpreter, args: &[Value]) -
 
     let mut out = Vec::with_capacity(a.len());
     for (x, y) in a.into_iter().zip(b) {
-        out.push(interp.apply_function(f.clone(), vec![x, y])?);
+        out.push(interp.apply_function(&f, vec![x, y])?);
     }
     Ok(Value::Array(out))
 }
@@ -322,7 +322,7 @@ pub(crate) fn builtin_array_take_while(interp: &mut Interpreter, args: &[Value])
 
     let mut out = Vec::new();
     for elem in arr {
-        match interp.apply_function(f.clone(), vec![elem.clone()])? {
+        match interp.apply_function(&f, vec![elem.clone()])? {
             Value::Bool(true) => out.push(elem),
             Value::Bool(false) => break,
             other => {
@@ -364,7 +364,7 @@ pub(crate) fn builtin_array_drop_while(interp: &mut Interpreter, args: &[Value])
     let mut out = Vec::new();
     for elem in arr {
         if dropping {
-            match interp.apply_function(f.clone(), vec![elem.clone()])? {
+            match interp.apply_function(&f, vec![elem.clone()])? {
                 Value::Bool(true) => continue,
                 Value::Bool(false) => {
                     dropping = false;
@@ -412,7 +412,7 @@ pub(crate) fn builtin_array_sum_by(interp: &mut Interpreter, args: &[Value]) -> 
 
     let mut total: i64 = 0;
     for elem in arr {
-        match interp.apply_function(f.clone(), vec![elem])? {
+        match interp.apply_function(&f, vec![elem])? {
             Value::Int(n) => total += n,
             other => {
                 return Err(format!(
@@ -450,7 +450,7 @@ pub(crate) fn builtin_array_product_by(interp: &mut Interpreter, args: &[Value])
 
     let mut product: i64 = 1;
     for elem in arr {
-        match interp.apply_function(f.clone(), vec![elem])? {
+        match interp.apply_function(&f, vec![elem])? {
             Value::Int(n) => product *= n,
             other => {
                 return Err(format!(

--- a/resilient/src/array_functional.rs
+++ b/resilient/src/array_functional.rs
@@ -44,7 +44,7 @@ pub(crate) fn builtin_array_flat_map(interp: &mut Interpreter, args: &[Value]) -
 
     let mut out: Vec<Value> = Vec::with_capacity(arr.len() * 2);
     for elem in arr {
-        let result = interp.apply_function(f.clone(), vec![elem])?;
+        let result = interp.apply_function(&f, vec![elem])?;
         match result {
             Value::Array(inner) => out.extend(inner),
             other => {
@@ -91,7 +91,7 @@ pub(crate) fn builtin_array_group_by(interp: &mut Interpreter, args: &[Value]) -
         std::collections::HashMap::new();
 
     for elem in arr {
-        let key_val = interp.apply_function(f.clone(), vec![elem.clone()])?;
+        let key_val = interp.apply_function(&f, vec![elem.clone()])?;
         let mk = MapKey::from_value(&key_val).map_err(|e| {
             format!("array_group_by: key function returned non-hashable value: {e}")
         })?;
@@ -144,7 +144,7 @@ pub(crate) fn builtin_array_partition(interp: &mut Interpreter, args: &[Value]) 
     let mut passing: Vec<Value> = Vec::new();
     let mut failing: Vec<Value> = Vec::new();
     for elem in arr {
-        let pred_val = interp.apply_function(f.clone(), vec![elem.clone()])?;
+        let pred_val = interp.apply_function(&f, vec![elem.clone()])?;
         match pred_val {
             Value::Bool(true) => passing.push(elem),
             Value::Bool(false) => failing.push(elem),
@@ -244,7 +244,7 @@ pub(crate) fn builtin_array_scan(interp: &mut Interpreter, args: &[Value]) -> RR
     let mut acc = init;
     out.push(acc.clone());
     for elem in arr {
-        acc = interp.apply_function(f.clone(), vec![acc, elem])?;
+        acc = interp.apply_function(&f, vec![acc, elem])?;
         out.push(acc.clone());
     }
     Ok(Value::Array(out))

--- a/resilient/src/collection_extras.rs
+++ b/resilient/src/collection_extras.rs
@@ -77,7 +77,7 @@ pub(crate) fn builtin_array_key_by(interp: &mut Interpreter, args: &[Value]) -> 
         std::collections::HashMap::with_capacity(arr.len());
 
     for elem in arr {
-        let key_val = interp.apply_function(f.clone(), vec![elem.clone()])?;
+        let key_val = interp.apply_function(&f, vec![elem.clone()])?;
         let mk = MapKey::from_value(&key_val)
             .map_err(|e| format!("array_key_by: key function returned non-hashable value: {e}"))?;
         map.insert(mk, elem);
@@ -120,7 +120,7 @@ pub(crate) fn builtin_array_iterate(interp: &mut Interpreter, args: &[Value]) ->
     let mut current = init;
     out.push(current.clone());
     for _ in 0..n {
-        current = interp.apply_function(f.clone(), vec![current])?;
+        current = interp.apply_function(&f, vec![current])?;
         out.push(current.clone());
     }
     Ok(Value::Array(out))

--- a/resilient/src/functional_hof.rs
+++ b/resilient/src/functional_hof.rs
@@ -58,7 +58,7 @@ pub(crate) fn builtin_array_zip_with_fn(
                 .collect();
             let mut out = Vec::with_capacity(pairs.len());
             for (x, y) in pairs {
-                out.push(interp.apply_function(f.clone(), vec![x, y])?);
+                out.push(interp.apply_function(&f, vec![x, y])?);
             }
             Ok(Value::Array(out))
         }
@@ -94,7 +94,7 @@ pub(crate) fn builtin_array_scan_fn(interp: &mut Interpreter, args: &[Value]) ->
             let mut acc = init.clone();
             out.push(acc.clone());
             for elem in elems {
-                acc = interp.apply_function(f.clone(), vec![acc, elem])?;
+                acc = interp.apply_function(&f, vec![acc, elem])?;
                 out.push(acc.clone());
             }
             Ok(Value::Array(out))
@@ -128,7 +128,7 @@ pub(crate) fn builtin_array_flat_map_fn(
             let elems: Vec<Value> = arr.clone();
             let mut out = Vec::new();
             for (i, elem) in elems.into_iter().enumerate() {
-                match interp.apply_function(f.clone(), vec![elem])? {
+                match interp.apply_function(&f, vec![elem])? {
                     Value::Array(sub) => out.extend(sub),
                     other => {
                         return Err(format!(
@@ -171,7 +171,7 @@ pub(crate) fn builtin_array_apply_n(interp: &mut Interpreter, args: &[Value]) ->
             for elem in elems {
                 let mut v = elem;
                 for _ in 0..n {
-                    v = interp.apply_function(f.clone(), vec![v])?;
+                    v = interp.apply_function(&f, vec![v])?;
                 }
                 out.push(v);
             }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -22716,7 +22716,7 @@ impl Interpreter {
                                 let callback = extra_args.pop().unwrap();
                                 let mut out = Vec::with_capacity(items.len());
                                 for item in items {
-                                    out.push(self.apply_function(callback.clone(), vec![item])?);
+                                    out.push(self.apply_function(&callback, vec![item])?);
                                 }
                                 return Ok(Value::Array(out));
                             }
@@ -22730,9 +22730,7 @@ impl Interpreter {
                                 let predicate = extra_args.pop().unwrap();
                                 let mut out = Vec::new();
                                 for item in items {
-                                    match self
-                                        .apply_function(predicate.clone(), vec![item.clone()])?
-                                    {
+                                    match self.apply_function(&predicate, vec![item.clone()])? {
                                         Value::Bool(true) => out.push(item),
                                         Value::Bool(false) => {}
                                         other => {
@@ -22755,7 +22753,7 @@ impl Interpreter {
                                 let callback = extra_args.pop().unwrap();
                                 let mut acc = extra_args.pop().unwrap();
                                 for item in items {
-                                    acc = self.apply_function(callback.clone(), vec![acc, item])?;
+                                    acc = self.apply_function(&callback, vec![acc, item])?;
                                 }
                                 return Ok(acc);
                             }
@@ -22824,7 +22822,7 @@ impl Interpreter {
                             // Prepend the target as the implicit `self`.
                             let mut args = vec![target_val];
                             args.extend(self.eval_expressions(arguments)?);
-                            return self.apply_function(method_val, args);
+                            return self.apply_function(&method_val, args);
                         }
                         // No matching method on this struct — fall
                         // through to the regular `FieldAccess` eval
@@ -22849,9 +22847,7 @@ impl Interpreter {
                                 Value::Array(items) => {
                                     let mut out = Vec::with_capacity(items.len());
                                     for item in items {
-                                        out.push(
-                                            self.apply_function(callback.clone(), vec![item])?,
-                                        );
+                                        out.push(self.apply_function(&callback, vec![item])?);
                                     }
                                     return Ok(Value::Array(out));
                                 }
@@ -22875,9 +22871,7 @@ impl Interpreter {
                                 Value::Array(items) => {
                                     let mut out = Vec::new();
                                     for item in items {
-                                        match self
-                                            .apply_function(predicate.clone(), vec![item.clone()])?
-                                        {
+                                        match self.apply_function(&predicate, vec![item.clone()])? {
                                             Value::Bool(true) => out.push(item),
                                             Value::Bool(false) => {}
                                             other => {
@@ -22909,8 +22903,7 @@ impl Interpreter {
                             match args.pop().unwrap() {
                                 Value::Array(items) => {
                                     for item in items {
-                                        acc =
-                                            self.apply_function(callback.clone(), vec![acc, item])?;
+                                        acc = self.apply_function(&callback, vec![acc, item])?;
                                     }
                                     return Ok(acc);
                                 }
@@ -22935,9 +22928,7 @@ impl Interpreter {
                             match args.pop().unwrap() {
                                 Value::Array(items) => {
                                     for item in items {
-                                        match self
-                                            .apply_function(predicate.clone(), vec![item.clone()])?
-                                        {
+                                        match self.apply_function(&predicate, vec![item.clone()])? {
                                             Value::Bool(true) => {
                                                 return Ok(Value::Option(Some(Box::new(item))));
                                             }
@@ -22971,7 +22962,7 @@ impl Interpreter {
                             match args.pop().unwrap() {
                                 Value::Array(items) => {
                                     for (i, item) in items.into_iter().enumerate() {
-                                        match self.apply_function(predicate.clone(), vec![item])? {
+                                        match self.apply_function(&predicate, vec![item])? {
                                             Value::Bool(true) => {
                                                 return Ok(Value::Int(i as i64));
                                             }
@@ -23006,7 +22997,7 @@ impl Interpreter {
                             match args.pop().unwrap() {
                                 Value::Array(items) => {
                                     for item in items {
-                                        match self.apply_function(predicate.clone(), vec![item])? {
+                                        match self.apply_function(&predicate, vec![item])? {
                                             Value::Bool(true) => return Ok(Value::Bool(true)),
                                             Value::Bool(false) => {}
                                             other => {
@@ -23038,7 +23029,7 @@ impl Interpreter {
                             match args.pop().unwrap() {
                                 Value::Array(items) => {
                                     for item in items {
-                                        match self.apply_function(predicate.clone(), vec![item])? {
+                                        match self.apply_function(&predicate, vec![item])? {
                                             Value::Bool(true) => {}
                                             Value::Bool(false) => return Ok(Value::Bool(false)),
                                             other => {
@@ -23223,7 +23214,7 @@ impl Interpreter {
                 }
                 let func = self.eval(function)?;
                 let args = self.eval_expressions(arguments)?;
-                self.apply_function(func, args)
+                self.apply_function(&func, args)
             }
             Node::ArrayLiteral { items, .. } => {
                 let mut out = Vec::with_capacity(items.len());
@@ -23362,7 +23353,7 @@ impl Interpreter {
                                     args.push(self.eval(a)?);
                                 }
                                 return self
-                                    .apply_function(method_val, args)
+                                    .apply_function(&method_val, args)
                                     .map(|v| Value::Option(Some(Box::new(v))));
                             }
                         }
@@ -23373,7 +23364,7 @@ impl Interpreter {
                                 args.push(self.eval(a)?);
                             }
                             return self
-                                .apply_function(func_val, args)
+                                .apply_function(&func_val, args)
                                 .map(|v| Value::Option(Some(Box::new(v))));
                         }
                         Err(format!("Unknown method '{}'", method))
@@ -25108,7 +25099,7 @@ impl Interpreter {
         Ok(result)
     }
 
-    fn apply_function(&mut self, func: Value, args: Vec<Value>) -> RResult<Value> {
+    fn apply_function(&mut self, func: &Value, args: Vec<Value>) -> RResult<Value> {
         match func {
             Value::Function(fv) => {
                 let FunctionValue {
@@ -25121,7 +25112,7 @@ impl Interpreter {
                     name,
                     type_params,
                     fails,
-                } = *fv;
+                } = fv.as_ref();
                 let max_depth = max_interpreter_call_depth();
                 if self.call_depth >= max_depth {
                     return Err(format!(
@@ -25134,7 +25125,7 @@ impl Interpreter {
                 // captured env IS the same RefCell that gets the
                 // function's name rebound, so recursion works through
                 // shared mutation.
-                let extended_env = Environment::new_enclosed(env);
+                let extended_env = Environment::new_enclosed(env.clone());
 
                 // RES-1471: when the callee is generic the
                 // `infer_subst` path below needs the runtime types of
@@ -25191,7 +25182,7 @@ impl Interpreter {
                         .map(|(ty_str, _)| type_str_to_tc_type(ty_str))
                         .collect();
                     if let Ok(subst) =
-                        crate::generics::infer_subst(&type_params, &declared_types, &actual_types)
+                        crate::generics::infer_subst(type_params, &declared_types, &actual_types)
                     {
                         interpreter.active_subst = Some(subst);
                     }
@@ -25201,7 +25192,7 @@ impl Interpreter {
                 // the body. Parameters are already in scope; anything
                 // else (e.g. `static` bindings, closed-over vars) is
                 // reachable just like inside the body.
-                for clause in &requires {
+                for clause in requires {
                     let v = interpreter.eval(clause)?;
                     if !interpreter.is_truthy(&v) {
                         return Err(format!(
@@ -25213,12 +25204,12 @@ impl Interpreter {
                 }
 
                 if self.inject_checked_failures && !fails.is_empty() {
-                    return Err(checked_failure_signal(&fails[0], &name));
+                    return Err(checked_failure_signal(&fails[0], name));
                 }
 
-                let body_result = interpreter.eval(&body).map_err(|e| {
+                let body_result = interpreter.eval(body).map_err(|e| {
                     if let Some(ref subst) = interpreter.active_subst {
-                        crate::diag::format_subst_context(&name, subst, &e)
+                        crate::diag::format_subst_context(name, subst, &e)
                     } else {
                         e
                     }
@@ -25235,7 +25226,7 @@ impl Interpreter {
                     interpreter
                         .env
                         .set("result".to_string(), return_value.clone());
-                    for clause in &ensures {
+                    for clause in ensures {
                         let v = interpreter.eval(clause)?;
                         if !interpreter.is_truthy(&v) {
                             return Err(format!(
@@ -27063,7 +27054,7 @@ fn run_pending_actors(interpreter: &mut Interpreter) -> RResult<()> {
             }
         };
         actor_runtime::set_current_actor(Some(pid));
-        let result = interpreter.apply_function(fn_val, vec![]);
+        let result = interpreter.apply_function(&fn_val, vec![]);
         actor_runtime::set_current_actor(None);
         match result {
             Ok(_) => {

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -25296,7 +25296,7 @@ impl Interpreter {
                     inject_checked_failures: false,
                     overflow_mode: self.overflow_mode,
                 };
-                for pre in &requires {
+                for pre in requires {
                     let ok = match contract_interp.eval(pre)? {
                         Value::Bool(b) => b,
                         _ => false,
@@ -25309,10 +25309,10 @@ impl Interpreter {
                         ));
                     }
                 }
-                let result = if is_variadic {
-                    crate::ffi_trampolines::call_foreign_variadic(&symbol, &args)?
+                let result = if *is_variadic {
+                    crate::ffi_trampolines::call_foreign_variadic(symbol, &args)?
                 } else {
-                    crate::ffi_trampolines::call_foreign(&symbol, &args)?
+                    crate::ffi_trampolines::call_foreign(symbol, &args)?
                 };
                 // Check postconditions.
                 if !ensures.is_empty() {
@@ -25328,7 +25328,7 @@ impl Interpreter {
                         overflow_mode: self.overflow_mode,
                     };
                     post_interp.env.set("result".to_string(), result.clone());
-                    for post in &ensures {
+                    for post in ensures {
                         let ok = match post_interp.eval(post)? {
                             Value::Bool(b) => b,
                             _ => false,

--- a/resilient/src/map_functional.rs
+++ b/resilient/src/map_functional.rs
@@ -35,7 +35,7 @@ pub(crate) fn builtin_map_filter(interp: &mut Interpreter, args: &[Value]) -> RR
     let mut out = std::collections::HashMap::with_capacity(m.len());
     for (k, v) in &m {
         let k_val = map_key_to_value(k);
-        let keep = interp.apply_function(f.clone(), vec![k_val, v.clone()])?;
+        let keep = interp.apply_function(&f, vec![k_val, v.clone()])?;
         match keep {
             Value::Bool(true) => {
                 out.insert(k.clone(), v.clone());
@@ -78,7 +78,7 @@ pub(crate) fn builtin_map_map_values(interp: &mut Interpreter, args: &[Value]) -
     let mut out = std::collections::HashMap::with_capacity(m.len());
     for (k, v) in &m {
         let k_val = map_key_to_value(k);
-        let new_val = interp.apply_function(f.clone(), vec![k_val, v.clone()])?;
+        let new_val = interp.apply_function(&f, vec![k_val, v.clone()])?;
         out.insert(k.clone(), new_val);
     }
     Ok(Value::Map(out))
@@ -111,7 +111,7 @@ pub(crate) fn builtin_map_for_each(interp: &mut Interpreter, args: &[Value]) -> 
 
     for (k, v) in &m {
         let k_val = map_key_to_value(k);
-        interp.apply_function(f.clone(), vec![k_val, v.clone()])?;
+        interp.apply_function(&f, vec![k_val, v.clone()])?;
     }
     Ok(Value::Void)
 }
@@ -209,7 +209,7 @@ pub(crate) fn builtin_map_merge_with(interp: &mut Interpreter, args: &[Value]) -
     for (k, v2) in &m2 {
         if let Some(v1) = out.get(k) {
             let k_val = map_key_to_value(k);
-            let merged = interp.apply_function(f.clone(), vec![k_val, v1.clone(), v2.clone()])?;
+            let merged = interp.apply_function(&f, vec![k_val, v1.clone(), v2.clone()])?;
             out.insert(k.clone(), merged);
         } else {
             out.insert(k.clone(), v2.clone());
@@ -253,7 +253,7 @@ pub(crate) fn builtin_map_update_with(interp: &mut Interpreter, args: &[Value]) 
     let mk = MapKey::from_value(&key_val)
         .map_err(|e| format!("map_update_with: key is not hashable: {e}"))?;
     let existing = m.get(&mk).cloned().unwrap_or(default);
-    let new_val = interp.apply_function(f, vec![existing])?;
+    let new_val = interp.apply_function(&f, vec![existing])?;
     let mut out = m;
     out.insert(mk, new_val);
     Ok(Value::Map(out))

--- a/resilient/src/operator_overload.rs
+++ b/resilient/src/operator_overload.rs
@@ -82,7 +82,7 @@ pub(crate) fn try_dispatch(
     };
 
     let args = vec![left.clone(), right.clone()];
-    interp.apply_function(method_val, args).map(Some)
+    interp.apply_function(&method_val, args).map(Some)
 }
 
 #[cfg(test)]

--- a/resilient/src/result_option_hof.rs
+++ b/resilient/src/result_option_hof.rs
@@ -40,7 +40,7 @@ pub(crate) fn builtin_result_map(interp: &mut Interpreter, args: &[Value]) -> RR
     };
     match r {
         Value::Result { ok: true, payload } => {
-            let mapped = interp.apply_function(f, vec![*payload])?;
+            let mapped = interp.apply_function(&f, vec![*payload])?;
             Ok(Value::Result {
                 ok: true,
                 payload: Box::new(mapped),
@@ -73,7 +73,7 @@ pub(crate) fn builtin_result_and_then(interp: &mut Interpreter, args: &[Value]) 
     };
     match r {
         Value::Result { ok: true, payload } => {
-            let out = interp.apply_function(f, vec![*payload])?;
+            let out = interp.apply_function(&f, vec![*payload])?;
             match out {
                 r @ Value::Result { .. } => Ok(r),
                 other => Err(format!(
@@ -108,7 +108,7 @@ pub(crate) fn builtin_result_map_err(interp: &mut Interpreter, args: &[Value]) -
     match r {
         ok @ Value::Result { ok: true, .. } => Ok(ok),
         Value::Result { ok: false, payload } => {
-            let mapped = interp.apply_function(f, vec![*payload])?;
+            let mapped = interp.apply_function(&f, vec![*payload])?;
             Ok(Value::Result {
                 ok: false,
                 payload: Box::new(mapped),
@@ -140,7 +140,7 @@ pub(crate) fn builtin_result_or_else(interp: &mut Interpreter, args: &[Value]) -
     match r {
         ok @ Value::Result { ok: true, .. } => Ok(ok),
         Value::Result { ok: false, payload } => {
-            let out = interp.apply_function(f, vec![*payload])?;
+            let out = interp.apply_function(&f, vec![*payload])?;
             match out {
                 r @ Value::Result { .. } => Ok(r),
                 other => Err(format!(
@@ -175,7 +175,7 @@ pub(crate) fn builtin_option_map(interp: &mut Interpreter, args: &[Value]) -> RR
     };
     match o {
         Value::Option(Some(inner)) => {
-            let mapped = interp.apply_function(f, vec![*inner])?;
+            let mapped = interp.apply_function(&f, vec![*inner])?;
             Ok(Value::Option(Some(Box::new(mapped))))
         }
         none @ Value::Option(None) => Ok(none),
@@ -204,7 +204,7 @@ pub(crate) fn builtin_option_and_then(interp: &mut Interpreter, args: &[Value]) 
     };
     match o {
         Value::Option(Some(inner)) => {
-            let out = interp.apply_function(f, vec![*inner])?;
+            let out = interp.apply_function(&f, vec![*inner])?;
             match out {
                 o @ Value::Option(_) => Ok(o),
                 other => Err(format!(
@@ -237,7 +237,7 @@ pub(crate) fn builtin_option_filter(interp: &mut Interpreter, args: &[Value]) ->
         }
     };
     match o {
-        Value::Option(Some(inner)) => match interp.apply_function(f, vec![*inner.clone()])? {
+        Value::Option(Some(inner)) => match interp.apply_function(&f, vec![*inner.clone()])? {
             Value::Bool(true) => Ok(Value::Option(Some(inner))),
             Value::Bool(false) => Ok(Value::Option(None)),
             other => Err(format!(
@@ -271,7 +271,7 @@ pub(crate) fn builtin_option_or_else(interp: &mut Interpreter, args: &[Value]) -
     match o {
         some @ Value::Option(Some(_)) => Ok(some),
         Value::Option(None) => {
-            let out = interp.apply_function(f, vec![])?;
+            let out = interp.apply_function(&f, vec![])?;
             match out {
                 o @ Value::Option(_) => Ok(o),
                 other => Err(format!(

--- a/resilient/src/string_hof.rs
+++ b/resilient/src/string_hof.rs
@@ -43,7 +43,7 @@ pub(crate) fn builtin_string_map_chars(interp: &mut Interpreter, args: &[Value])
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
         let c_str = Value::String(ch.to_string());
-        match interp.apply_function(f.clone(), vec![c_str])? {
+        match interp.apply_function(&f, vec![c_str])? {
             Value::String(piece) => out.push_str(&piece),
             other => {
                 return Err(format!(
@@ -85,7 +85,7 @@ pub(crate) fn builtin_string_filter_by(interp: &mut Interpreter, args: &[Value])
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
         let c_str = Value::String(ch.to_string());
-        match interp.apply_function(f.clone(), vec![c_str])? {
+        match interp.apply_function(&f, vec![c_str])? {
             Value::Bool(true) => out.push(ch),
             Value::Bool(false) => {}
             other => {
@@ -129,7 +129,7 @@ pub(crate) fn builtin_string_fold(interp: &mut Interpreter, args: &[Value]) -> R
     let mut acc = init;
     for ch in s.chars() {
         let c_str = Value::String(ch.to_string());
-        acc = interp.apply_function(f.clone(), vec![acc, c_str])?;
+        acc = interp.apply_function(&f, vec![acc, c_str])?;
     }
     Ok(acc)
 }
@@ -164,7 +164,7 @@ pub(crate) fn builtin_string_for_each_char(
 
     for ch in s.chars() {
         let c_str = Value::String(ch.to_string());
-        interp.apply_function(f.clone(), vec![c_str])?;
+        interp.apply_function(&f, vec![c_str])?;
     }
     Ok(Value::Void)
 }

--- a/resilient/src/type_builtins.rs
+++ b/resilient/src/type_builtins.rs
@@ -37,6 +37,8 @@ pub(crate) fn builtin_type_of(args: &[Value]) -> RResult<Value> {
                 Value::Set(_) => "set",
                 Value::Void => "void",
                 Value::Function(_) | Value::Closure { .. } | Value::Builtin { .. } => "function",
+                #[cfg(feature = "ffi")]
+                Value::Foreign { .. } => "function",
                 Value::Bytes(_) => "bytes",
                 Value::Struct { .. } => "struct",
                 Value::Tuple(_) => "tuple",

--- a/resilient/src/type_builtins.rs
+++ b/resilient/src/type_builtins.rs
@@ -134,7 +134,7 @@ pub(crate) fn builtin_array_from_fn(interp: &mut Interpreter, args: &[Value]) ->
 
     let mut out = Vec::with_capacity(n as usize);
     for i in 0..n {
-        out.push(interp.apply_function(f.clone(), vec![Value::Int(i)])?);
+        out.push(interp.apply_function(&f, vec![Value::Int(i)])?);
     }
     Ok(Value::Array(out))
 }


### PR DESCRIPTION
## Summary
- Change `apply_function` signature from `func: Value` to `func: &Value`
- Eliminates callback `.clone()` on every iteration of map, filter, reduce, sort_by, min_by, flat_map, zip_with, and 40+ other higher-order function call sites
- 10 files changed, 50+ clone sites removed — each iteration now borrows the callback instead of allocating a new `Box<FunctionValue>`

## Details
Before this change, every loop iteration in HOF builtins like `arr.map(fn)` cloned the entire `Value::Function(Box<FunctionValue>)` to pass it by value to `apply_function`. Even with PR #1913's Rc-wrapping of body/params and PR #1914's boxing, each clone still allocated a fresh `Box<FunctionValue>` and bumped several Rc refcounts.

Now `apply_function` borrows the function value. Inside, all fields are accessed by reference — `env.clone()` (Rc bump) creates the enclosed environment, `body`/`parameters`/`requires`/`ensures` are iterated by borrow. Zero per-call allocation for the function value itself.

Affected modules: `lib.rs`, `array_functional.rs`, `array_combinators.rs`, `map_functional.rs`, `string_hof.rs`, `collection_extras.rs`, `functional_hof.rs`, `result_option_hof.rs`, `operator_overload.rs`, `type_builtins.rs`.

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)