### PR TITLE
perf(typechecker): remove redundant any_node pre-scans from marker-gated passes

### DIFF
--- a/resilient/src/assume_false_checker.rs
+++ b/resilient/src/assume_false_checker.rs
@@ -5,26 +5,12 @@
 // predicates and warns at the next statement boundary.
 
 use crate::Node;
-use crate::uniqueness_walk::any_node;
 
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
-    // RES-1270: fast-reject. The walker only emits the
-    // "dead-code following assume(false)" warning when it sees a
-    // `Node::Assume { condition: BooleanLiteral { value: false } }`.
-    // The overwhelming majority of programs contain zero `Assume`
-    // nodes (it's a verifier-only construct, ignored by the runtime
-    // and absent from every fixture in `examples/`), so the per-stmt
-    // descent produces nothing. Pre-scan once with the early-
-    // terminating `any_node` (RES-1238) for *any* `Assume`, and skip
-    // the walk entirely when none exist. (We don't pre-filter on
-    // `condition` being `BooleanLiteral { false }` because matching
-    // the exact shape costs a hash-table dispatch per node — the
-    // single bit "has Assume" predicate is enough to short-circuit
-    // the common case, and the inner walk re-checks the shape.)
-    let has_assume = any_node(program, |n| matches!(n, Node::Assume { .. }));
-    if !has_assume {
-        return Ok(());
-    }
+    // RES-1270 / RES-1916: the typechecker gates this call behind
+    // `markers.has_assume`, so the program is guaranteed to contain
+    // at least one `Assume`. The previous `any_node` pre-scan was
+    // redundant — removed.
     let mut checker = AssumeChecker::new(source_path);
     checker.walk(program);
     Ok(())

--- a/resilient/src/bounds_check.rs
+++ b/resilient/src/bounds_check.rs
@@ -149,24 +149,10 @@ pub fn check_array_bounds(program: &Node, source_path: &str) -> Result<(), Strin
     let Node::Program(statements) = program else {
         return Ok(());
     };
-    // RES-1278: fast-reject. `walk_toplevel` only does meaningful work
-    // when it descends into a `Node::IndexExpression` (every other AST
-    // shape is plain recursion). For programs that never index an
-    // array — the overwhelming majority of `cargo test` inputs and
-    // every fixture in `examples/` that isn't array-shaped — the full
-    // descent classifies nothing. Pre-scan once with the early-
-    // terminating `any_node` (RES-1238) and skip the per-stmt walk
-    // entirely when no `IndexExpression` exists. The `reset_stats()`
-    // call above stays — it must run on every invocation so a stale
-    // PROVEN_SITES set from a prior call doesn't cause `is_proven_site`
-    // to report false positives for the current program's bytecode
-    // compilation (safe default: indices not proven → bounds checks
-    // emitted at runtime).
-    let has_index =
-        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::IndexExpression { .. }));
-    if !has_index {
-        return Ok(());
-    }
+    // RES-1278 / RES-1916: the typechecker gates this call behind
+    // `markers.has_index_expression`, so the program is guaranteed to
+    // contain at least one `IndexExpression`. The previous `any_node`
+    // pre-scan was redundant — removed.
     let mut strict_errors: Vec<String> = Vec::new();
     for stmt in statements {
         walk_toplevel(&stmt.node, source_path, &mut strict_errors);

--- a/resilient/src/coverage_warnings.rs
+++ b/resilient/src/coverage_warnings.rs
@@ -167,20 +167,12 @@ fn is_catch_all_arm(p: &crate::Pattern, guard: &Option<Node>) -> bool {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1284: fast-reject. Pre-scan with early-terminating `any_node`.
-    let has_err_call = crate::uniqueness_walk::any_node(program, |n| match n {
-        Node::CallExpression { function, .. } => match function.as_ref() {
-            Node::Identifier { name, .. } => name == "Err",
-            _ => false,
-        },
-        _ => false,
-    });
-    let has_match = crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::Match { .. }));
-    let has_return =
-        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::ReturnStatement { .. }));
-    if !has_err_call && !has_match && !has_return {
-        return Ok(());
-    }
+    // RES-1284 / RES-1916: the typechecker gates this call behind
+    // `markers.call_idents.contains("Err")`, so the program is
+    // guaranteed to contain at least one `Err(…)` call. The three
+    // previous `any_node` pre-scans (Err-call, Match, Return) were
+    // redundant — the first was always true from the outer gate, and
+    // the OR logic meant the fast-reject could never trigger.
     let warnings = analyze(program);
     for w in &warnings {
         eprintln!("warning: coverage in `{}`: {}", w.function, w.message);

--- a/resilient/src/deadlock_freedom.rs
+++ b/resilient/src/deadlock_freedom.rs
@@ -146,21 +146,10 @@ pub fn detect_cycles<'a>(graph: &'a ActorGraph) -> Vec<Vec<&'a str>> {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1291: fast-reject. `build` collects an actor→actors graph
-    // by scanning every top-level statement, filtering ActorDecls,
-    // then walking each ActorDecl's handler bodies for `send` calls.
-    // Programs with zero `Node::ActorDecl` produce an empty graph
-    // (no nodes, no edges) and `detect_cycles` finds nothing. The
-    // overwhelming majority of programs — every fixture in
-    // `examples/` that doesn't model an actor network, every
-    // standalone-function unit test — pay this scan for zero output.
-    // Pre-scan with the early-terminating `any_node` (RES-1238) and
-    // skip both passes when no ActorDecl exists.
-    let has_actor =
-        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::ActorDecl { .. }));
-    if !has_actor {
-        return Ok(());
-    }
+    // RES-1291 / RES-1916: the typechecker gates this call behind
+    // `markers.has_actor_decl`, so the program is guaranteed to
+    // contain at least one `ActorDecl`. The previous `any_node`
+    // pre-scan was redundant — removed.
     let g = build(program);
     let cycles = detect_cycles(&g);
     if cycles.is_empty() {

--- a/resilient/src/linear.rs
+++ b/resilient/src/linear.rs
@@ -70,28 +70,10 @@ pub fn check_linear_usage(program: &Node, source_path: &str) -> Result<(), Strin
     let Node::Program(statements) = program else {
         return Ok(());
     };
-    // RES-1294: fast-reject. The single-use walker inserts a
-    // `LinearBinding` only when it sees a `Function` parameter whose
-    // type starts with `LINEAR_PREFIX` or a `LetStatement` whose
-    // `type_annot` does. Without either anywhere in the program — the
-    // overwhelming majority of `cargo test` inputs and every fixture
-    // in `examples/` outside the linear-types feature tests — the
-    // per-function `bindings` HashMap is always empty, no diagnostic
-    // can fire, and the `Assignment` arm (which only errors when
-    // `bindings.get(name)` returns `Some`) is unreachable. Pre-scan
-    // once with the early-terminating `any_node` (RES-1238) and skip
-    // the per-fn walk when no linear-typed binding exists.
-    let has_linear = crate::uniqueness_walk::any_node(program, |n| match n {
-        Node::Function { parameters, .. } => parameters.iter().any(|(ty, _)| is_linear(ty)),
-        Node::LetStatement {
-            type_annot: Some(ty),
-            ..
-        } => is_linear(ty),
-        _ => false,
-    });
-    if !has_linear {
-        return Ok(());
-    }
+    // RES-1294 / RES-1916: the typechecker gates this call behind
+    // `markers.has_linear_binding`, which checks both Function
+    // parameters and LetStatement type_annots for `is_linear`. The
+    // previous `any_node` pre-scan was redundant — removed.
     for stmt in statements {
         match &stmt.node {
             Node::Function {

--- a/resilient/src/loop_invariants.rs
+++ b/resilient/src/loop_invariants.rs
@@ -61,18 +61,10 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let Node::Program(statements) = program else {
         return Ok(());
     };
-    // RES-1274: fast-reject. `walk` only produces a diagnostic when
-    // it encounters `Node::InvariantStatement` outside a `while`/`for`
-    // body. Programs with no `InvariantStatement` anywhere — the
-    // overwhelming majority, since `invariant` is a verifier-only
-    // construct — have nothing to validate. Pre-scan the program once
-    // with the early-terminating `any_node` (RES-1238) and skip the
-    // per-stmt recursion entirely when no `InvariantStatement` exists.
-    let has_invariant =
-        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::InvariantStatement { .. }));
-    if !has_invariant {
-        return Ok(());
-    }
+    // RES-1274 / RES-1916: the typechecker gates this call behind
+    // `markers.has_invariant_statement`, so the program is guaranteed
+    // to contain at least one `InvariantStatement`. The previous
+    // `any_node` pre-scan was redundant — removed.
     for spanned in statements {
         walk(&spanned.node, /*in_loop=*/ false, source_path)?;
     }

--- a/resilient/src/ranges.rs
+++ b/resilient/src/ranges.rs
@@ -73,19 +73,10 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         Node::Program(stmts) => stmts,
         _ => return Ok(()),
     };
-    // RES-1270: fast-reject. `check_stmt` is a recursive walk over every
-    // top-level statement (and through every block / for / while / fn
-    // body) looking for `Node::Range` to either accept (in `for…in` /
-    // `let` position) or reject (anywhere else). Without a `Node::Range`
-    // anywhere in the program — the case for every fixture in
-    // `examples/` and every unit test that doesn't use range literals
-    // — every recursion produces nothing. Pre-scan once with the
-    // early-terminating `any_node` (RES-1238) and skip the per-stmt
-    // walk entirely when no `Range` exists.
-    let has_range = crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::Range { .. }));
-    if !has_range {
-        return Ok(());
-    }
+    // RES-1270 / RES-1916: the typechecker gates this call behind
+    // `markers.has_range`, so the program is guaranteed to contain
+    // at least one `Range`. The previous `any_node` pre-scan was
+    // redundant — removed.
     for stmt in stmts {
         check_stmt(&stmt.node, source_path)?;
     }

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -9,23 +9,13 @@
 // V1 emits warnings; V2 will escalate to errors under --v2-strict.
 
 use crate::Node;
-use crate::uniqueness_walk::any_node;
 use std::collections::HashSet;
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1270: fast-reject. Both `collect_declarations` and
-    // `check_live_blocks` only produce diagnostics when a `live{}` block
-    // exists somewhere in the program — the recovery-body warnings
-    // (opaque FFI, recursion, capturing closures) fire on nodes
-    // *inside* `Node::LiveBlock`. The overwhelming majority of programs
-    // (every fixture in `examples/`, every test) contain zero
-    // `LiveBlock`s, so the full two-pass descent is dead work. Pre-scan
-    // once with the early-terminating `any_node` (RES-1238) and skip
-    // the walks entirely when none exist.
-    let has_live = any_node(program, |n| matches!(n, Node::LiveBlock { .. }));
-    if !has_live {
-        return Ok(());
-    }
+    // RES-1270 / RES-1916: the typechecker gates this call behind
+    // `markers.has_live_block`, so the program is guaranteed to
+    // contain at least one `LiveBlock`. The previous `any_node`
+    // pre-scan was redundant — removed.
     let mut ctx = Context::new();
     ctx.collect_declarations(program);
     ctx.check_live_blocks(program);

--- a/resilient/src/try_catch.rs
+++ b/resilient/src/try_catch.rs
@@ -173,18 +173,10 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let Node::Program(statements) = program else {
         return Ok(());
     };
-    // RES-1274: fast-reject. The fn_fails table is only consulted by
-    // `walk` when it encounters a `Node::TryCatch`. For programs with
-    // no `TryCatch` anywhere — the overwhelming majority, including
-    // every fixture in `examples/` — both the table-building pass and
-    // the per-function descent produce nothing. Pre-scan the program
-    // once with the early-terminating `any_node` (RES-1238) and skip
-    // both passes when no `TryCatch` exists.
-    let has_try_catch =
-        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::TryCatch { .. }));
-    if !has_try_catch {
-        return Ok(());
-    }
+    // RES-1274 / RES-1916: the typechecker gates this call behind
+    // `markers.has_try_catch`, so the program is guaranteed to contain
+    // at least one `TryCatch`. The previous `any_node` pre-scan was
+    // redundant — removed.
     // RES-1525: borrow fn name + fails slice into fn_fails instead of
     // cloning. Both only live for the check call and the AST outlives it.
     // For N functions this saves N String clones + N Vec<String> clones.


### PR DESCRIPTION
## Summary

- Removes 11 redundant `any_node` AST walks from 9 extension passes that were already gated by `pass_gate::Markers` in the typechecker
- Each pass had an internal `any_node` fast-reject checking for the same node type that the outer marker gate already confirmed exists — the walk was guaranteed to return `true`
- Affected passes: `bounds_check`, `try_catch`, `recovery_checker`, `assume_false_checker`, `loop_invariants`, `ranges`, `deadlock_freedom`, `linear`, `coverage_warnings` (3 redundant walks)

## Test plan

- [x] `cargo test` — 4672 tests pass
- [x] `cargo test --features z3` — 4817 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>