### PR TITLE
perf(typechecker): remove 11 more redundant any_node pre-scans

### DIFF
--- a/resilient/src/age_bounded_data.rs
+++ b/resilient/src/age_bounded_data.rs
@@ -19,23 +19,14 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, for_each_function, visit};
+use crate::uniqueness_walk::{for_each_function, visit};
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1271: fast-reject. The whole point of this pass is to find
-    // `target.field` reads that aren't gated by a `target.*_at`
-    // comparison. If the program has no `*_at` field anywhere, the
-    // pattern doesn't apply — every read would warn indiscriminately
-    // and the warnings are meaningless for programs that don't use
-    // the age-bounded convention. Pre-scan for any `FieldAccess`
-    // whose field name ends in `_at`; if none, skip the entire pass.
-    let has_age_field = any_node(program, |n| match n {
-        Node::FieldAccess { field, .. } => field.ends_with("_at"),
-        _ => false,
-    });
-    if !has_age_field {
-        return Ok(());
-    }
+    // RES-1271 / RES-1917: the typechecker gates this call behind
+    // `markers.any_field_accessed_with_suffix(&["_at"])`, so the
+    // program is guaranteed to contain at least one `*_at` field
+    // access. The previous `any_node` pre-scan was redundant —
+    // removed.
     for_each_function(program, |fname, _params, body| {
         // RES-1750: pre-size per-fn collections to 8 — typical fn
         // body has a handful of field reads / age comparisons.

--- a/resilient/src/audit_log_required.rs
+++ b/resilient/src/audit_log_required.rs
@@ -23,23 +23,11 @@ use crate::uniqueness_walk::{any_node, for_each_function, visit};
 const AUDIT_FNS: &[&str] = &["audit_log", "journal", "record_event", "emit_audit"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1254: fast-reject. The per-function `visit(body)` walk only
-    // does anything when it finds a `FieldAssignment` whose field name
-    // starts with `audited_` or ends with `_audited`. For programs
-    // that have no such fields (the overwhelming majority of test
-    // inputs and the entire `examples/` tree), every per-function
-    // visit produces nothing. Pre-scan the whole program once via
-    // `any_node` (RES-1238 made this early-terminating) and skip the
-    // pass entirely when no audited field exists.
-    let has_audited_field = any_node(program, |n| match n {
-        Node::FieldAssignment { field, .. } => {
-            field.starts_with("audited_") || field.ends_with("_audited")
-        }
-        _ => false,
-    });
-    if !has_audited_field {
-        return Ok(());
-    }
+    // RES-1254 / RES-1917: the typechecker gates this call behind
+    // `markers.any_field_assigned_with_prefix_or_suffix(&["audited_"],
+    // &["_audited"])`, so the program is guaranteed to contain at
+    // least one audited-prefixed/suffixed field assignment. The
+    // previous `any_node` pre-scan was redundant — removed.
     for_each_function(program, |fname, _params, body| {
         let mut has_audited_write = false;
         visit(body, &mut |n| {

--- a/resilient/src/blame_attribution.rs
+++ b/resilient/src/blame_attribution.rs
@@ -197,13 +197,11 @@ pub fn format_blame_chain(callee: &str, max_depth: usize) -> String {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1291: fast-reject when no calls exist.
-    let has_call =
-        crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::CallExpression { .. }));
-    if !has_call {
-        install(BlameMap::default());
-        return Ok(());
-    }
+    // RES-1291 / RES-1917: the typechecker gates this call behind
+    // `markers.has_call_expression`, so the program is guaranteed to
+    // contain at least one `CallExpression`. The previous `any_node`
+    // pre-scan was redundant — removed. (The typechecker else branch
+    // installs `BlameMap::default()` directly.)
     let map = build(program);
 
     // At compile time, for every function with `requires` clauses, emit a

--- a/resilient/src/epoch_ordering.rs
+++ b/resilient/src/epoch_ordering.rs
@@ -18,27 +18,14 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, for_each_function, visit};
+use crate::uniqueness_walk::{for_each_function, visit};
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1274: fast-reject. The per-function `visit` collects every
-    // call to a function whose identifier matches `_epoch<N>`, then
-    // pairs consecutive calls to detect out-of-order epochs. Programs
-    // with zero `_epoch<N>`-named calls produce an empty `sequence`
-    // and no windows-of-2 pairs, so every per-function walk is dead
-    // work. Pre-scan with the early-terminating `any_node` (RES-1238)
-    // for any `CallExpression` whose identifier matches `epoch_of`,
-    // and skip the per-function loop entirely when none exist.
-    let has_epoch_call = any_node(program, |n| match n {
-        Node::CallExpression { function, .. } => match function.as_ref() {
-            Node::Identifier { name, .. } => epoch_of(name).is_some(),
-            _ => false,
-        },
-        _ => false,
-    });
-    if !has_epoch_call {
-        return Ok(());
-    }
+    // RES-1274 / RES-1917: the typechecker gates this call behind
+    // `markers.any_call_ident_containing(&["_epoch"])`, so the program
+    // is guaranteed to contain at least one `_epoch`-containing call
+    // identifier. The previous `any_node` pre-scan was redundant —
+    // removed.
     for_each_function(program, |fname, _params, body| {
         let mut sequence: Vec<(String, u32)> = Vec::new();
         visit(body, &mut |n| {

--- a/resilient/src/fmt_validation.rs
+++ b/resilient/src/fmt_validation.rs
@@ -138,24 +138,10 @@ fn walk(node: &Node, fn_name: &str, errs: &mut Vec<String>) {
 }
 
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
-    // RES-1284: fast-reject. `analyze` walks every function body
-    // looking for `CallExpression` to the `format` builtin with a
-    // `StringLiteral` first arg. Without any `format` call anywhere
-    // in the program — the overwhelming majority of `cargo test`
-    // inputs and every fixture in `examples/` that doesn't use
-    // `format(...)` — the analyser returns an empty Vec. Pre-scan
-    // once with the early-terminating `any_node` (RES-1238) and skip
-    // the analysis entirely when no `format` call exists.
-    let has_format_call = crate::uniqueness_walk::any_node(program, |n| match n {
-        Node::CallExpression { function, .. } => match function.as_ref() {
-            Node::Identifier { name, .. } => name == "format",
-            _ => false,
-        },
-        _ => false,
-    });
-    if !has_format_call {
-        return Ok(());
-    }
+    // RES-1284 / RES-1917: the typechecker gates this call behind
+    // `markers.call_idents.contains("format")`, so the program is
+    // guaranteed to contain at least one `format` call. The previous
+    // `any_node` pre-scan was redundant — removed.
     let errs = analyze(program);
     if !errs.is_empty() {
         return Err(format!("{}:0:0: error: {}", source_path, errs[0]));

--- a/resilient/src/iterator_protocol.rs
+++ b/resilient/src/iterator_protocol.rs
@@ -37,27 +37,11 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
-    // RES-1291: fast-reject. The for-loop below filters every top-
-    // level statement looking for an `ImplBlock` whose trait_name is
-    // `"Iterator"`. Programs without any Iterator impl produce an
-    // empty set; the loop is dead work for them. Pre-scan with the
-    // early-terminating `any_node` (RES-1238) and short-circuit to
-    // an empty install when no matching ImplBlock exists. We still
-    // install an empty set so a prior program's iterator-impl
-    // registration doesn't leak into this compilation (the
-    // process-global ITERATORS otherwise retains stale entries).
-    let has_iterator_impl = crate::uniqueness_walk::any_node(program, |n| match n {
-        Node::ImplBlock { trait_name, .. } => trait_name.as_deref() == Some("Iterator"),
-        _ => false,
-    });
-    if !has_iterator_impl {
-        install_iterator_impls(HashSet::new());
-        return Ok(());
-    }
-    // RES-1758: pre-size to stmts.len() — every top-level statement
-    // could be a matching ImplBlock and contribute one insert. We
-    // already paid the `any_node` early-reject (RES-1291), so when
-    // we reach here we know at least one Iterator impl exists.
+    // RES-1291 / RES-1917: the typechecker gates this call behind
+    // `markers.has_impl_for_trait("Iterator")`, so the program is
+    // guaranteed to contain at least one Iterator impl. The previous
+    // `any_node` pre-scan was redundant — removed. (The typechecker
+    // else branch installs an empty set directly.)
     let mut iters = HashSet::with_capacity(stmts.len());
     for s in stmts {
         if let Node::ImplBlock {

--- a/resilient/src/lock_ordering.rs
+++ b/resilient/src/lock_ordering.rs
@@ -27,7 +27,7 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, visit};
+use crate::uniqueness_walk::visit;
 use std::collections::{HashMap, HashSet};
 
 const LOCK_FNS: &[&str] = &["lock", "acquire", "mutex_lock"];
@@ -37,29 +37,10 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
-    // RES-1275: fast-reject. `collect_pairs` walks every function
-    // body looking for `lock`/`acquire`/`mutex_lock` calls (or names
-    // prefixed `lock_`/`unlock_`). If the program has no such call
-    // anywhere, the per-function `pair_sites` map is always empty
-    // and the inversion-check loop does nothing — but we still
-    // walked every body. Pre-scan once via `any_node` (RES-1238
-    // early-terminating) and skip the entire pass when no
-    // lock-style call exists.
-    let has_lock_call = any_node(program, |n| match n {
-        Node::CallExpression { function, .. } => match function.as_ref() {
-            Node::Identifier { name, .. } => {
-                LOCK_FNS.contains(&name.as_str())
-                    || UNLOCK_FNS.contains(&name.as_str())
-                    || name.starts_with("lock_")
-                    || name.starts_with("unlock_")
-            }
-            _ => false,
-        },
-        _ => false,
-    });
-    if !has_lock_call {
-        return Ok(());
-    }
+    // RES-1275 / RES-1917: the typechecker gates this call behind
+    // a combined check on `markers.call_idents` for LOCK_FNS/UNLOCK_FNS
+    // names and `lock_`/`unlock_` prefixes. The previous `any_node`
+    // pre-scan was redundant — removed.
     let mut pair_sites: HashMap<(String, String), Vec<String>> = HashMap::new();
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {

--- a/resilient/src/numeric_units.rs
+++ b/resilient/src/numeric_units.rs
@@ -18,7 +18,7 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, for_each_function, visit};
+use crate::uniqueness_walk::{for_each_function, visit};
 
 const UNIT_SUFFIXES: &[&str] = &[
     "_ms", "_s", "_us", "_ns", // time
@@ -31,28 +31,10 @@ const UNIT_SUFFIXES: &[&str] = &[
 ];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1267: fast-reject. The per-function body walk only does
-    // anything when it finds a `LetStatement` whose name matches a
-    // unit suffix (`_ms` / `_s` / `_m` / `_kg` / …). Function params
-    // can also seed the units map. For programs without any
-    // unit-suffixed binding (the overwhelming majority of `cargo
-    // test` inputs and the entire `examples/` tree), every
-    // per-function visit produces nothing.
-    //
-    // Pre-scan the program once via `any_node` (RES-1238 made this
-    // early-terminating) for any `LetStatement` or `Function` param
-    // whose name matches a unit suffix. If none, return `Ok(())`
-    // immediately. The pre-scan also examines `Node::Function`
-    // params because the original closure seeds the units map from
-    // both sources.
-    let has_unit_binding = any_node(program, |n| match n {
-        Node::LetStatement { name, .. } => unit_of(name).is_some(),
-        Node::Function { parameters, .. } => parameters.iter().any(|(_ty, p)| unit_of(p).is_some()),
-        _ => false,
-    });
-    if !has_unit_binding {
-        return Ok(());
-    }
+    // RES-1267 / RES-1917: the typechecker gates this call behind
+    // `markers.any_let_name_with_suffix` and
+    // `markers.any_param_name_with_suffix` with the same UNIT_SUFFIXES.
+    // The previous `any_node` pre-scan was redundant — removed.
     for_each_function(program, |fname, params, body| {
         // RES-1748: pre-size to `params.len() + 8` — covers the
         // parameter seeds plus a small allowance for body-let

--- a/resilient/src/saturation_required.rs
+++ b/resilient/src/saturation_required.rs
@@ -19,26 +19,15 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, for_each_function, visit};
+use crate::uniqueness_walk::{for_each_function, visit};
 
 const SAT_NAME_SUFFIXES: &[&str] = &["_pwm", "_duty", "_brightness", "_pct", "_throttle"];
 const SAT_FNS: &[&str] = &["saturating_add", "saturating_sub", "saturating_mul"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1266: fast-reject. The per-function descent walks every function
-    // body looking for `LetStatement`s whose name ends in a saturation-typed
-    // suffix (`_pwm`, `_duty`, …). The overwhelming majority of programs
-    // (every fixture in `examples/`, every unit test, every integration
-    // test) have no such binding, so every descent produces zero work.
-    // Pre-scan once with the early-terminating `any_node` (RES-1238) and
-    // skip the per-function loop entirely when nothing matches.
-    let has_sat_let = any_node(program, |n| match n {
-        Node::LetStatement { name, .. } => SAT_NAME_SUFFIXES.iter().any(|s| name.ends_with(*s)),
-        _ => false,
-    });
-    if !has_sat_let {
-        return Ok(());
-    }
+    // RES-1266 / RES-1917: the typechecker gates this call behind
+    // `markers.any_let_name_with_suffix` with the same SAT_NAME_SUFFIXES.
+    // The previous `any_node` pre-scan was redundant — removed.
     for_each_function(program, |fname, _params, body| {
         visit(body, &mut |n| {
             if let Node::LetStatement { name, value, .. } = n {

--- a/resilient/src/toctou_guard.rs
+++ b/resilient/src/toctou_guard.rs
@@ -22,30 +22,15 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, for_each_function, visit};
+use crate::uniqueness_walk::{for_each_function, visit};
 
 const CHECK_SUFFIXES: &[&str] = &["_exists", "_is_valid", "_status", "_check"];
 const USE_SUFFIXES: &[&str] = &["_open", "_read", "_write", "_delete", "_unlink", "_chmod"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1266: fast-reject. The TOCTOU detector pairs a `*_exists` /
-    // `*_is_valid` / `*_status` / `*_check` call with a later non-atomic
-    // `*_open` / `*_read` / … on the same argument. Without a *check*
-    // call in the function, there can never be a pair, so the per-function
-    // event collection is dead work for the overwhelming majority of
-    // programs (every fixture in `examples/`, every test). Pre-scan once
-    // for any check-suffixed CallExpression via the early-terminating
-    // `any_node` (RES-1238) and skip the loop entirely when none exist.
-    let has_check_call = any_node(program, |n| match n {
-        Node::CallExpression { function, .. } => match function.as_ref() {
-            Node::Identifier { name, .. } => CHECK_SUFFIXES.iter().any(|s| name.ends_with(*s)),
-            _ => false,
-        },
-        _ => false,
-    });
-    if !has_check_call {
-        return Ok(());
-    }
+    // RES-1266 / RES-1917: the typechecker gates this call behind
+    // `markers.any_call_ident_with_suffix` with the same CHECK_SUFFIXES.
+    // The previous `any_node` pre-scan was redundant — removed.
     for_each_function(program, |fname, _params, body| {
         let mut events: Vec<(bool, String, Option<String>)> = Vec::new();
         // (is_check, fn_name, first_ident_arg)

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -47,27 +47,10 @@ use std::collections::{BTreeSet, HashMap};
 /// only line of defense.
 #[cfg(feature = "z3")]
 pub(crate) fn verify_and_capture(tc: &mut crate::typechecker::TypeChecker, program: &Node) {
-    // RES-1297: fast-reject. The recursive `walk` only does Z3 work
-    // when it finds a `WhileStatement` whose `invariants` field is
-    // non-empty OR whose body contains a `Node::InvariantStatement`.
-    // For programs with no `invariant(P);` clauses anywhere — the
-    // overwhelming majority of `cargo test --features z3` inputs —
-    // the walk descends into every block / fn / for / while only to
-    // find empty invariant lists everywhere.
-    //
-    // Pre-scan via `any_node` (RES-1238 early-terminating) for any
-    // node that signals an invariant: either a `WhileStatement`
-    // with non-empty `invariants`, or a body-statement
-    // `InvariantStatement`. If neither is present, no per-while
-    // work would have anything to do.
-    let has_invariant = crate::uniqueness_walk::any_node(program, |n| match n {
-        Node::WhileStatement { invariants, .. } => !invariants.is_empty(),
-        Node::InvariantStatement { .. } => true,
-        _ => false,
-    });
-    if !has_invariant {
-        return;
-    }
+    // RES-1297 / RES-1917: the typechecker gates this call behind
+    // `markers.has_invariant_statement || markers.has_while_with_invariants`,
+    // so the program is guaranteed to contain at least one invariant.
+    // The previous `any_node` pre-scan was redundant — removed.
     let timeout_ms = tc.verifier_timeout_ms();
     let verbose = tc.verbose_loop_invariants();
     // RES-1798: pre-size to 8 — bindings accumulate Let/Const literal-


### PR DESCRIPTION
## Summary

Continues #1916. Removes 11 redundant `any_node` whole-AST walks from extension passes that are already gated by `pass_gate::Markers` in the typechecker.

Each pass's internal `any_node` fast-reject duplicated the exact condition (or a strict subset) that the typechecker's marker gate already confirmed:

| Pass | Outer gate | Internal check (removed) |
|------|-----------|------------------------|
| `fmt_validation` | `call_idents.contains("format")` | `any_node` for CallExpr with "format" |
| `blame_attribution` | `has_call_expression` | `any_node` for any CallExpr |
| `lock_ordering` | `call_idents` + `any_call_ident_with_prefix` for lock/unlock | `any_node` for LOCK_FNS/UNLOCK_FNS + prefixes |
| `toctou_guard` | `any_call_ident_with_suffix` with CHECK_SUFFIXES | `any_node` for same suffixes |
| `epoch_ordering` | `any_call_ident_containing(&["_epoch"])` | `any_node` for `epoch_of().is_some()` |
| `age_bounded_data` | `any_field_accessed_with_suffix(&["_at"])` | `any_node` for FieldAccess `_at` |
| `audit_log_required` | `any_field_assigned_with_prefix_or_suffix` | `any_node` for same prefix/suffix |
| `saturation_required` | `any_let_name_with_suffix` with SAT_NAME_SUFFIXES | `any_node` for same suffixes |
| `numeric_units` | `any_let_name_with_suffix` + `any_param_name_with_suffix` | `any_node` for same suffixes |
| `verifier_loop_invariants` | `has_invariant_statement \|\| has_while_with_invariants` | `any_node` for same conditions |
| `iterator_protocol` | `has_impl_for_trait("Iterator")` | `any_node` for ImplBlock Iterator |

Net: −199 lines, +53 lines (replacement comments). Each removed walk was a full pre-order DFS of the entire AST that can never return false when reached through the gated path.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test` — 4672+ tests pass

Closes #1917

🤖 Generated with [Claude Code](https://claude.com/claude-code)