### PR TITLE
RES-1922: pre-size compile_match_expr after_match_patches Vec to arms.len()

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -347,6 +347,10 @@
     "resilient/src/verifier_z3.rs": {
       "branch": "res-1920-collect-cert-idents-single-walk",
       "claimed_at": "2026-05-19T17:06:58Z"
+    },
+    "resilient/src/compiler.rs": {
+      "branch": "res-1922-compile-match-presize",
+      "claimed_at": "2026-05-19T17:22:52Z"
     }
   }
 }

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -2925,7 +2925,12 @@ fn compile_match_expr(
     *next_local += 1;
     chunk.emit(Op::StoreLocal(scrutinee_slot), line);
 
-    let mut after_match_patches: Vec<usize> = Vec::new();
+    // RES-1922: exact upper bound — every arm pushes one entry below
+    // (its "jump past the whole match" patch). Skips the default
+    // 0→4→8→16 grow chain for matches with ≥ 4 arms (common shape
+    // for enum-exhaustive matches over Result / Option / custom sum
+    // types). Same shape as RES-1800 / RES-1762 / RES-1796 pre-sizes.
+    let mut after_match_patches: Vec<usize> = Vec::with_capacity(arms.len());
 
     for (pattern, guard, body) in arms {
         // Each arm gets its own mutable locals copy so bindings don't


### PR DESCRIPTION
Closes #1922.

## Problem

\`compile_match_expr\` accumulates one entry per arm into a \`Vec<usize>\` (\`after_match_patches\`) that records the bytecode offset of every "jump past the whole match" instruction. The vec was initialised with \`Vec::new()\` and grew through the default 0→4→8→16 doubling chain as the arms loop appended.

For match expressions with ≥ 4 arms — common in enum-exhaustive matches over multi-variant enums like Result, Option, and custom sum types — this triggered a Vec reallocation mid-loop. The exact upper bound is \`arms.len()\` and is already in scope at the allocation site.

## Solution

Replace \`Vec::new()\` with \`Vec::with_capacity(arms.len())\`. Same shape as the recent pre-size series:
- RES-1800 default_params sigs
- RES-1762 cluster_verifier
- RES-1576 / RES-1872 actor refuted Vec
- RES-1796 pure_fns

No behavioral change — the Vec contents are bit-identical to the pre-PR shape.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib compiler\` ✓ (60 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

Removes per-Vec-reallocation cost from match-expression compilation. Hot when programs are dominated by enum-matching code (parsers, state machines, error-handling shapes) — most non-trivial Resilient programs touch this path. The recent any_node + pre-size series has been collapsing these doubling chains across the typechecker / interpreter; this is the same pattern applied to the bytecode compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)