### PR TITLE
RES-1928: eliminate String + Value clones in string_hof builtins (4 functions)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -351,6 +351,10 @@
     "resilient/src/compiler.rs": {
       "branch": "res-1922-compile-match-presize",
       "claimed_at": "2026-05-19T17:22:52Z"
+    },
+    "resilient/src/string_hof.rs": {
+      "branch": "res-1928-string-hof-clone-elim",
+      "claimed_at": "2026-05-19T17:42:33Z"
     }
   }
 }

--- a/resilient/src/string_hof.rs
+++ b/resilient/src/string_hof.rs
@@ -25,8 +25,13 @@ type RResult<T> = Result<T, String>;
 /// // upper == "HELLO"
 /// ```
 pub(crate) fn builtin_string_map_chars(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-1928: borrow `s` and `f` directly from `args` — `apply_function`
+    // takes `func: &Value`, and the loop body only iterates `s.chars()` /
+    // reads `s.len()`, both of which accept `&str`. The legacy
+    // `s.clone()` / `f.clone()` pair was pure overhead (one String alloc
+    // + one Function Rc bump per call).
     let (s, f) = match args {
-        [Value::String(s), f] => (s.clone(), f.clone()),
+        [Value::String(s), f] => (s.as_str(), f),
         [a, _] => {
             return Err(format!(
                 "string_map_chars: first argument must be a string, got {a}"
@@ -43,7 +48,7 @@ pub(crate) fn builtin_string_map_chars(interp: &mut Interpreter, args: &[Value])
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
         let c_str = Value::String(ch.to_string());
-        match interp.apply_function(&f, vec![c_str])? {
+        match interp.apply_function(f, vec![c_str])? {
             Value::String(piece) => out.push_str(&piece),
             other => {
                 return Err(format!(
@@ -67,8 +72,10 @@ pub(crate) fn builtin_string_map_chars(interp: &mut Interpreter, args: &[Value])
 /// // digits_only == "123"
 /// ```
 pub(crate) fn builtin_string_filter_by(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-1928: borrow `s` and `f` directly from `args`. See
+    // `builtin_string_map_chars` above for rationale.
     let (s, f) = match args {
-        [Value::String(s), f] => (s.clone(), f.clone()),
+        [Value::String(s), f] => (s.as_str(), f),
         [a, _] => {
             return Err(format!(
                 "string_filter_by: first argument must be a string, got {a}"
@@ -85,7 +92,7 @@ pub(crate) fn builtin_string_filter_by(interp: &mut Interpreter, args: &[Value])
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
         let c_str = Value::String(ch.to_string());
-        match interp.apply_function(&f, vec![c_str])? {
+        match interp.apply_function(f, vec![c_str])? {
             Value::Bool(true) => out.push(ch),
             Value::Bool(false) => {}
             other => {
@@ -111,8 +118,11 @@ pub(crate) fn builtin_string_filter_by(interp: &mut Interpreter, args: &[Value])
 /// // count == 1  (one space)
 /// ```
 pub(crate) fn builtin_string_fold(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-1928: `s` and `f` are borrows; `init` still needs `.clone()`
+    // because it seeds the mutable `acc` accumulator that gets rebound
+    // each loop iteration.
     let (s, init, f) = match args {
-        [Value::String(s), init, f] => (s.clone(), init.clone(), f.clone()),
+        [Value::String(s), init, f] => (s.as_str(), init.clone(), f),
         [a, _, _] => {
             return Err(format!(
                 "string_fold: first argument must be a string, got {a}"
@@ -129,7 +139,7 @@ pub(crate) fn builtin_string_fold(interp: &mut Interpreter, args: &[Value]) -> R
     let mut acc = init;
     for ch in s.chars() {
         let c_str = Value::String(ch.to_string());
-        acc = interp.apply_function(&f, vec![acc, c_str])?;
+        acc = interp.apply_function(f, vec![acc, c_str])?;
     }
     Ok(acc)
 }
@@ -147,8 +157,9 @@ pub(crate) fn builtin_string_for_each_char(
     interp: &mut Interpreter,
     args: &[Value],
 ) -> RResult<Value> {
+    // RES-1928: borrow `s` and `f` directly from `args`.
     let (s, f) = match args {
-        [Value::String(s), f] => (s.clone(), f.clone()),
+        [Value::String(s), f] => (s.as_str(), f),
         [a, _] => {
             return Err(format!(
                 "string_for_each_char: first argument must be a string, got {a}"
@@ -164,7 +175,7 @@ pub(crate) fn builtin_string_for_each_char(
 
     for ch in s.chars() {
         let c_str = Value::String(ch.to_string());
-        interp.apply_function(&f, vec![c_str])?;
+        interp.apply_function(f, vec![c_str])?;
     }
     Ok(Value::Void)
 }


### PR DESCRIPTION
Closes #1928.

## Problem

The four \`string_hof\` higher-order builtins (\`string_map_chars\`, \`string_filter_by\`, \`string_fold\`, \`string_for_each_char\`) each opened with a pattern match that cloned the input string and the callback Value:

\`\`\`rust
let (s, f) = match args {
    [Value::String(s), f] => (s.clone(), f.clone()),
    ...
};
\`\`\`

\`args\` is already \`&[Value]\` (a borrow), so the bindings could be used directly. The \`.clone()\` calls allocated a fresh String (heap, scaled with input length) and bumped the \`Value::Function\` Box's refcount per call.

Subsequent code only:
- Iterates \`s.chars()\` (works on \`&str\`)
- Reads \`s.len()\` for \`String::with_capacity\` hinting (works on \`&str\`)
- Passes \`f\` to \`interp.apply_function(&f, ...)\` whose signature is \`apply_function(&mut self, func: &Value, args: Vec<Value>)\` — \`func\` is already taken by reference

No owned \`String\` / owned \`Value\` is needed at any callsite.

## Solution

Bind \`s: &str\` and \`f: &Value\` directly from the pattern match, and pass them through to \`String::with_capacity\` / \`apply_function\` without cloning.

\`string_fold\` keeps its \`init.clone()\` — the mutable \`acc\` accumulator is rebound each loop iteration via \`acc = interp.apply_function(f, vec![acc, c_str])?\`, so the seed value genuinely needs to be owned.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib string_hof\` ✓ (13 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

Every call into one of these builtins drops one String clone (heap allocation proportional to input length) and one Value::Function Rc bump. String HOFs are the natural shape for character-level transforms — common in parsers, lexer post-processing, text sanitization. Same shape as RES-1495 / RES-1500 / RES-1520 / RES-1528 / RES-1915 borrow-not-clone series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)