### PR TITLE
RES-1938: pre-size combinatorics output Vecs to exact C(n,k) / P(n,k) counts

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -367,6 +367,10 @@
     "resilient/src/array_combinators.rs": {
       "branch": "res-1934-array-combinators-clone-elim",
       "claimed_at": "2026-05-19T17:58:20Z"
+    },
+    "resilient/src/combinatorics.rs": {
+      "branch": "res-1938-combinatorics-presize",
+      "claimed_at": "2026-05-19T18:07:46Z"
     }
   }
 }

--- a/resilient/src/combinatorics.rs
+++ b/resilient/src/combinatorics.rs
@@ -66,7 +66,17 @@ pub(crate) fn builtin_array_combinations(args: &[Value]) -> RResult<Value> {
                     arr.len()
                 ));
             }
-            let mut out = Vec::new();
+            // RES-1938: pre-size `out` to the exact C(n, k) when
+            // computable. Falls back to Vec::new() on overflow — that
+            // case yields gigantic outputs anyway and is dominated by
+            // the per-element work below.
+            let cap = (0..k).try_fold(1usize, |acc, i| {
+                acc.checked_mul(arr.len() - i).map(|m| m / (i + 1))
+            });
+            let mut out = match cap {
+                Some(c) => Vec::with_capacity(c),
+                None => Vec::new(),
+            };
             let mut indices: Vec<usize> = (0..k).collect();
             if k == 0 {
                 out.push(Value::Array(vec![]));
@@ -127,7 +137,14 @@ pub(crate) fn builtin_array_permutations(args: &[Value]) -> RResult<Value> {
                     arr.len()
                 ));
             }
-            let mut out = Vec::new();
+            // RES-1938: pre-size `out` to the exact P(n, k) when
+            // computable. Falls back to Vec::new() on overflow — same
+            // shape as the combinations pre-size above.
+            let cap = (0..k).try_fold(1usize, |acc, i| acc.checked_mul(arr.len() - i));
+            let mut out = match cap {
+                Some(c) => Vec::with_capacity(c),
+                None => Vec::new(),
+            };
             let mut used = vec![false; arr.len()];
             let mut current = Vec::with_capacity(k);
             fn permute(


### PR DESCRIPTION
Closes #1938.

## Problem

\`array_combinations\` and \`array_permutations\` allocated their output Vec with the default 0-bucket capacity and grew through the 0→4→8→16→… doubling chain. For non-trivial inputs the output size grows quickly:

- C(10, 5) = 252
- P(10, 5) = 30240
- C(20, 10) = 184756

The doubling chain triggers ~log2(N) reallocations per call where each realloc copies the entire Vec contents.

## Solution

Compute the exact output size via \`checked_mul\` + integer division at the call site:

- **C(n, k)** = product over i=0..k of (n - i) / (i + 1)
- **P(n, k)** = product over i=0..k of (n - i)

Pre-size \`out\` to that value. Fall back to \`Vec::new()\` if the computation overflows \`usize\` — that case yields a gigantic output anyway and is dominated by the per-element work, so the default-cap path is acceptable there.

Same shape as the recent pre-size series (RES-1762 / RES-1764 / RES-1796 / RES-1800 / RES-1922 / RES-1924).

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib combinatorics\` ✓ (17 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

Common shapes for tournament-bracket generation, exhaustive-search algorithms, and combinatorial test-case enumeration. Collapses the log2(N) doubling-chain reallocations into a single up-front allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)