### PR TITLE
RES-1942: pre-size arange + parse_csv_row output Vecs to exact count

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -371,6 +371,10 @@
     "resilient/src/combinatorics.rs": {
       "branch": "res-1938-combinatorics-presize",
       "claimed_at": "2026-05-19T18:07:46Z"
+    },
+    "resilient/src/data_utils.rs": {
+      "branch": "res-1942-data-utils-presize",
+      "claimed_at": "2026-05-19T18:14:43Z"
     }
   }
 }

--- a/resilient/src/data_utils.rs
+++ b/resilient/src/data_utils.rs
@@ -103,7 +103,19 @@ pub(crate) fn builtin_arange(args: &[Value]) -> RResult<Value> {
                 return Err("arange: step must be nonzero".to_string());
             }
             const MAX_ELEMENTS: usize = 10_000_000;
-            let mut v = Vec::new();
+            // RES-1942: pre-size to the computed step count. Floor at
+            // `MAX_ELEMENTS + 1` so the existing guard still fires for
+            // oversize requests, and clamp NaN / overflow → 0 (fall
+            // back to default-cap Vec). The +1 accommodates the
+            // strict-inequality bound of the loop above for cases
+            // where (stop - start) is an exact multiple of step.
+            let raw = ((stop - start) / step).abs().ceil();
+            let cap = if raw.is_finite() && raw >= 0.0 {
+                (raw as usize).saturating_add(1).min(MAX_ELEMENTS + 1)
+            } else {
+                0
+            };
+            let mut v = Vec::with_capacity(cap);
             let mut x = start;
             while (step > 0.0 && x < stop) || (step < 0.0 && x > stop) {
                 v.push(Value::Float(x));
@@ -168,7 +180,18 @@ fn parse_delimited(s: &str, delim: char) -> Vec<Value> {
 
 /// Parse a single CSV row with optional quoting.
 fn parse_csv_row(line: &str, delim: char) -> Vec<String> {
-    let mut fields = Vec::new();
+    // RES-1942: pre-size `fields` to the upper-bound count of
+    // unescaped delimiters + 1. `,` and `\t` (the only two callers,
+    // via builtin_csv_parse / _tsv) are ASCII single-byte so the
+    // byte-level scan is a safe approximation. Quoted-delimiter
+    // escapes can lower the actual field count, but never raise it,
+    // so this is a safe upper bound.
+    let cap = if (delim as u32) < 0x80 {
+        line.bytes().filter(|&b| b == delim as u8).count() + 1
+    } else {
+        1
+    };
+    let mut fields = Vec::with_capacity(cap);
     let mut current = String::new();
     let mut in_quotes = false;
     let mut chars = line.chars().peekable();


### PR DESCRIPTION
Closes #1942.

## Problem

Two builtins in \`data_utils.rs\` allocated their output Vec with default capacity and grew through the 0→4→8→16 doubling chain:

1. **\`arange(start, stop, step)\`** emits one \`Value::Float\` per step. The final count is computable as \`((stop - start) / step).ceil()\`, capped at the existing \`MAX_ELEMENTS\` (10M) guard.

2. **\`parse_csv_row(line, delim)\`** tokenises one CSV/TSV row. The final field count is bounded above by the unescaped-delimiter count + 1 (quoted-delimiter escapes can lower the actual count but never raise it).

## Solution

- **\`arange\`**: compute the step count, clamp to \`MAX_ELEMENTS + 1\` so the existing oversize guard still fires, use \`saturating_add(1)\` to accommodate the strict-inequality loop bound when \`(stop - start)\` is an exact step multiple, fall back to 0 on NaN / overflow.
- **\`parse_csv_row\`**: count delimiter bytes once (\`,\` and \`\\t\` — the only two callers via \`builtin_csv_parse\` / \`_tsv\` — are ASCII single-byte, so \`line.bytes().filter(...)\` is a safe upper-bound scan). Branch on \`(delim as u32) < 0x80\` so callers that ever pass a non-ASCII delimiter fall back to capacity 1 instead of an incorrect byte-count.

Same shape as the recent pre-size series (RES-1762 / RES-1764 / RES-1796 / RES-1800 / RES-1922 / RES-1924 / RES-1938).

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib data_utils\` ✓ (22 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

\`arange\` is the natural shape for any program that constructs numeric ranges for iteration (math pipelines, MPI/SIMD-style index generation). \`parse_csv_row\` runs once per row on every CSV / TSV parse — a frequent data-ingest path for telemetry dumps, sensor configs, log replay. Collapses log2(N) doubling-chain reallocations into a single up-front allocation per call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)