### PR TITLE
RES-1944: pre-size graph_algorithms BFS queues + reverse-adj sub-Vecs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -11,6 +11,10 @@
     "resilient/src/const_fold.rs": {
       "branch": "res-2370-const-fold-relink-on-square",
       "claimed_at": "2026-05-20T15:26:47Z"
+    },
+    "resilient/src/graph_algorithms.rs": {
+      "branch": "res-1944-graph-presize",
+      "claimed_at": "2026-05-19T18:18:16Z"
     }
   }
 }

--- a/resilient/src/graph_algorithms.rs
+++ b/resilient/src/graph_algorithms.rs
@@ -96,7 +96,9 @@ pub(crate) fn builtin_graph_bfs(args: &[Value]) -> RResult<Value> {
 
             let mut visited = vec![false; n];
             let mut order = Vec::with_capacity(n);
-            let mut queue = VecDeque::new();
+            // RES-1944: queue holds at most n nodes (each enqueued at
+            // most once); pre-size to skip the default 0→4→8→… grow.
+            let mut queue = VecDeque::with_capacity(n);
 
             visited[start] = true;
             queue.push_back(start);
@@ -183,7 +185,9 @@ pub(crate) fn builtin_graph_has_path(args: &[Value]) -> RResult<Value> {
             }
 
             let mut visited = vec![false; n];
-            let mut queue = VecDeque::new();
+            // RES-1944: queue holds at most n nodes (each enqueued at
+            // most once); pre-size to skip the default 0→4→8→… grow.
+            let mut queue = VecDeque::with_capacity(n);
             visited[src] = true;
             queue.push_back(src);
 
@@ -280,12 +284,18 @@ pub(crate) fn builtin_graph_connected_components(args: &[Value]) -> RResult<Valu
             let mut component = vec![usize::MAX; n];
             let mut comp_id = 0usize;
 
+            // RES-1944: lift queue out of the per-component loop and
+            // clear() between components. `VecDeque::clear` retains
+            // capacity, so subsequent components reuse the buffer.
+            // Pre-size to n — each component's queue holds at most n
+            // entries (a component cannot exceed the whole graph).
+            let mut queue: VecDeque<usize> = VecDeque::with_capacity(n);
             for start in 0..n {
                 if component[start] != usize::MAX {
                     continue;
                 }
                 // BFS treating edges as undirected
-                let mut queue = VecDeque::new();
+                queue.clear();
                 queue.push_back(start);
                 component[start] = comp_id;
                 while let Some(node) = queue.pop_front() {
@@ -541,7 +551,18 @@ pub(crate) fn builtin_graph_reverse(args: &[Value]) -> RResult<Value> {
         [adj_val] => {
             let adj = extract_adj("graph_reverse", adj_val)?;
             let n = adj.len();
-            let mut rev: Vec<Vec<i64>> = vec![Vec::new(); n];
+            // RES-1944: two-pass — first count in-degrees, then
+            // allocate each inner Vec with its exact capacity. The
+            // single-pass `vec![Vec::new(); n]` shape forced every
+            // reverse-edge insert to grow through the default
+            // 0→4→8→… doubling chain per inner Vec.
+            let mut in_deg = vec![0usize; n];
+            for neighbours in &adj {
+                for &v in neighbours {
+                    in_deg[v] += 1;
+                }
+            }
+            let mut rev: Vec<Vec<i64>> = in_deg.iter().map(|&d| Vec::with_capacity(d)).collect();
             for (u, neighbours) in adj.iter().enumerate() {
                 for &v in neighbours {
                     rev[v].push(u as i64);


### PR DESCRIPTION
Closes #1944.

## Problem

Three \`graph_algorithms\` builtins (\`graph_bfs\`, \`graph_has_path\`, \`graph_connected_components\`) allocated their work queue with \`VecDeque::new()\` — the default 0-capacity grew through the standard 0→4→8→16→… doubling chain as nodes were enqueued. The queue size is bounded above by \`n\` (the graph node count) for BFS-style walks, and the bound is known at the call site.

For \`graph_connected_components\` the queue was allocated **inside** the per-component \`for start in 0..n\` loop, so a graph with k components paid k separate VecDeque allocations.

\`graph_reverse\` allocated \`vec![Vec::new(); n]\` — an outer Vec of n empty inner Vecs. Each inner Vec then grew through the same doubling chain as reversed edges landed. With m total edges, each inner Vec holds ~m/n entries — the per-inner doubling chain across all n Vecs paid ~n × log(m/n) reallocations.

## Solution

- **\`graph_bfs\` / \`graph_has_path\`**: \`VecDeque::with_capacity(n)\` — exact upper bound (each node enqueues at most once).
- **\`graph_connected_components\`**: lift the \`VecDeque\` allocation outside the per-component loop and \`clear()\` between components. \`VecDeque::clear\` retains capacity, so subsequent components reuse the same backing buffer. Pre-size to \`n\` upfront.
- **\`graph_reverse\`**: two-pass — first count in-degrees in one O(n + m) sweep, then allocate each inner \`Vec\` with its exact in-degree capacity. Net: same asymptotic work, single allocation per inner Vec instead of log(in-degree) reallocations.

Same shape as the recent pre-size series.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib graph_algorithms\` ✓ (26 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

Graph algorithms are the hot dispatch path for programs that drive scheduling, dependency resolution, dataflow, or topology-aware optimization. The compounding payoff is most visible in \`graph_connected_components\` (one alloc per component reuse via cleared VecDeque) and \`graph_reverse\` (one alloc per inner Vec instead of log(in-degree) reallocations during edge insert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)