### PR TITLE
RES-1946: pre-size JSON parser output buffers (string/array/object)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -375,6 +375,10 @@
     "resilient/src/data_utils.rs": {
       "branch": "res-1942-data-utils-presize",
       "claimed_at": "2026-05-19T18:14:43Z"
+    },
+    "resilient/src/json_builtins.rs": {
+      "branch": "res-1946-json-parser-presize",
+      "claimed_at": "2026-05-19T18:22:09Z"
     }
   }
 }

--- a/resilient/src/json_builtins.rs
+++ b/resilient/src/json_builtins.rs
@@ -266,7 +266,33 @@ impl<'a> JsonParser<'a> {
 
     fn parse_string(&mut self) -> RResult<String> {
         self.expect_byte(b'"')?;
-        let mut out = String::new();
+        // RES-1946: scan ahead for the closing unescaped `"` to get an
+        // upper bound on the decoded string length. Escape sequences
+        // can only shorten the output (`\n` → 1 char, `\uXXXX` → ≤ 4
+        // bytes UTF-8 = up to 6 input bytes → 4 output bytes), so the
+        // raw byte delta is a safe pre-size hint. Falls back to 16 if
+        // the input is malformed (no closing quote on this line).
+        let cap = {
+            let mut i = self.pos;
+            let mut bound: Option<usize> = None;
+            while i < self.src.len() {
+                match self.src[i] {
+                    b'"' => {
+                        bound = Some(i - self.pos);
+                        break;
+                    }
+                    b'\\' => {
+                        // Skip the escape char AND the next byte;
+                        // `\uXXXX` is over-counted by 4 but that's
+                        // a tighter upper bound than no scan at all.
+                        i += 2;
+                    }
+                    _ => i += 1,
+                }
+            }
+            bound.unwrap_or(16)
+        };
+        let mut out = String::with_capacity(cap);
         loop {
             let b = self.consume()?;
             match b {
@@ -387,7 +413,10 @@ impl<'a> JsonParser<'a> {
 
     fn parse_array(&mut self) -> RResult<Value> {
         self.expect_byte(b'[')?;
-        let mut items = Vec::new();
+        // RES-1946: typical JSON arrays hold 1-10 items; pre-size to
+        // 4 to skip the default 0→4 first grow. Empty arrays
+        // (immediately followed by `]`) waste 4 slots — negligible.
+        let mut items = Vec::with_capacity(4);
         self.skip_ws();
         if self.peek() == Some(b']') {
             self.pos += 1;
@@ -417,7 +446,10 @@ impl<'a> JsonParser<'a> {
 
     fn parse_object(&mut self) -> RResult<Value> {
         self.expect_byte(b'{')?;
-        let mut map: HashMap<MapKey, Value> = HashMap::new();
+        // RES-1946: typical JSON objects hold 2-10 entries; pre-size
+        // to 4 to skip the default 0-bucket → 4-bucket rehash. Empty
+        // objects waste a small bucket array — negligible.
+        let mut map: HashMap<MapKey, Value> = HashMap::with_capacity(4);
         self.skip_ws();
         if self.peek() == Some(b'}') {
             self.pos += 1;


### PR DESCRIPTION
Closes #1946.

## Problem

The recursive JSON parser in \`json_builtins.rs\` allocated each output container with default capacity, then grew through the 0→4→8→16 doubling chain:

- \`parse_string\`: \`String::new()\` → grows char-by-char
- \`parse_array\`:  \`Vec::new()\`    → grows item-by-item
- \`parse_object\`: \`HashMap::new()\` → grows entry-by-entry

For JSON payloads with non-trivial size (MCP tool I/O, telemetry dumps, config files) every parse paid these reallocs from zero.

## Solution

- **\`parse_string\`**: scan ahead from \`self.pos\` for the next unescaped \`"\` — escape sequences can only **shorten** the decoded output (\`\\n\` → 1 char, \`\\uXXXX\` → ≤ 4 bytes UTF-8), so the raw byte delta is a safe upper-bound pre-size hint. The scan handles \`\\X\` and \`\\"\` correctly by skipping 2 bytes for each backslash. Falls back to 16 if no closing quote is found (malformed input — error path).
- **\`parse_array\` / \`parse_object\`**: pre-size to 4. Lookahead through nested structures would itself cost O(N), so use a small constant that covers the median JSON shape (1-10 items / 2-10 entries) and skips the 0→4 first grow.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib json_builtins\` ✓ (26 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

JSON I/O runs once per MCP tool exchange, per telemetry batch, per config load. The compounding wins are largest for \`parse_string\` (the most common element in real JSON — typical strings hit one well-sized allocation instead of log₂N grow steps) and \`parse_array\` (arrays of 10-100 items pay log₂N reallocs without this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)