### PR TITLE
RES-1948: pre-size array_intersection out Vec to match array_difference

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -375,6 +375,10 @@
     "resilient/src/data_utils.rs": {
       "branch": "res-1942-data-utils-presize",
       "claimed_at": "2026-05-19T18:14:43Z"
+    },
+    "resilient/src/array_set_helpers.rs": {
+      "branch": "res-1948-array-intersection-presize",
+      "claimed_at": "2026-05-19T18:30:11Z"
     }
   }
 }

--- a/resilient/src/array_set_helpers.rs
+++ b/resilient/src/array_set_helpers.rs
@@ -54,7 +54,11 @@ pub(crate) fn builtin_array_difference(args: &[Value]) -> RResult<Value> {
 pub(crate) fn builtin_array_intersection(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Array(a), Value::Array(b)] => {
-            let mut out: Vec<Value> = Vec::new();
+            // RES-1948: match the sister builtin_array_difference's
+            // pre-size — `a.len()` is the exact upper bound (the
+            // intersection contains at most every element of `a`).
+            // Skips the default 0→4→8→… doubling chain.
+            let mut out: Vec<Value> = Vec::with_capacity(a.len());
             for v in a {
                 if member_of("array_intersection", v, b)? {
                     out.push(v.clone());


### PR DESCRIPTION
Closes #1948.

## Problem

\`array_set_helpers::builtin_array_difference\` and \`builtin_array_intersection\` are sister functions with identical control flow — both iterate \`a\`, test \`member_of(v, b)\`, and push matching elements to \`out\`. But they differ in one detail:

\`\`\`rust
// difference:    let mut out = Vec::with_capacity(a.len());
// intersection:  let mut out = Vec::new();
\`\`\`

\`array_intersection\`'s output Vec grew through the default 0→4→8→16 doubling chain even though \`a.len()\` is the exact upper bound — the intersection contains at most every element of \`a\`.

## Solution

Match \`array_difference\`'s pre-size: \`Vec::with_capacity(a.len())\`.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib array_set_helpers\` ✓ (23 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

For programs that compute set-style intersections on non-trivial arrays (de-dup pipelines, allow-list filtering, common-element search), this collapses log₂(|intersection|) reallocations into a single up-front allocation. Same shape as the recent pre-size series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)