### PR TITLE
RES-1950: numeric_units::unit_of returns &'static str instead of allocating String

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -379,6 +379,10 @@
     "resilient/src/json_builtins.rs": {
       "branch": "res-1946-json-parser-presize",
       "claimed_at": "2026-05-19T18:22:09Z"
+    },
+    "resilient/src/numeric_units.rs": {
+      "branch": "res-1950-numeric-units-static-suffix",
+      "claimed_at": "2026-05-19T18:34:18Z"
     }
   }
 }

--- a/resilient/src/numeric_units.rs
+++ b/resilient/src/numeric_units.rs
@@ -40,7 +40,9 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         // parameter seeds plus a small allowance for body-let
         // bindings with unit suffixes. Same shape as the pre-size
         // series across the per-fn passes.
-        let mut units: std::collections::HashMap<String, String> =
+        // RES-1950: values are `&'static str` from the static
+        // UNIT_SUFFIXES table — no per-binding String allocation.
+        let mut units: std::collections::HashMap<String, &'static str> =
             std::collections::HashMap::with_capacity(params.len() + 8);
         for (_ty, name) in params {
             if let Some(u) = unit_of(name) {
@@ -59,18 +61,20 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn unit_of(name: &str) -> Option<String> {
-    UNIT_SUFFIXES
-        .iter()
-        .find(|s| name.ends_with(*s))
-        .map(|s| (*s).to_string())
+// RES-1950: return the matched static slice directly instead of
+// allocating a fresh String. `UNIT_SUFFIXES` entries are `&'static str`
+// already, so wrapping them in `String::from` was pure overhead —
+// paid once per parameter / let-binding whose name carried a unit
+// suffix.
+fn unit_of(name: &str) -> Option<&'static str> {
+    UNIT_SUFFIXES.iter().find(|s| name.ends_with(*s)).copied()
 }
 
 fn check_expr(
     fname: &str,
     var: &str,
     expr: &Node,
-    units: &std::collections::HashMap<String, String>,
+    units: &std::collections::HashMap<String, &'static str>,
 ) {
     if let Node::InfixExpression {
         operator,
@@ -95,9 +99,14 @@ fn check_expr(
     }
 }
 
-fn ident_unit(node: &Node, units: &std::collections::HashMap<String, String>) -> Option<String> {
+// RES-1950: returns `&'static str` so callers do a Copy instead of
+// a String clone on lookup hit.
+fn ident_unit(
+    node: &Node,
+    units: &std::collections::HashMap<String, &'static str>,
+) -> Option<&'static str> {
     if let Node::Identifier { name, .. } = node {
-        return units.get(name).cloned().or_else(|| unit_of(name));
+        return units.get(name).copied().or_else(|| unit_of(name));
     }
     None
 }


### PR DESCRIPTION
Closes #1950.

## Problem

\`numeric_units::unit_of\` returned \`Option<String>\` even though the unit suffix it was matching came from \`UNIT_SUFFIXES\`, a static \`&[&str]\` slice:

\`\`\`rust
fn unit_of(name: &str) -> Option<String> {
    UNIT_SUFFIXES
        .iter()
        .find(|s| name.ends_with(*s))
        .map(|s| (*s).to_string())  // allocates a fresh String
}
\`\`\`

For every parameter or \`let\`-binding whose name ended in a unit suffix (\`_ms\`, \`_s\`, \`_kg\`, etc.) the pass paid one \`String::from\` allocation just to wrap a static slice. The \`units: HashMap<String, String>\` then stored that owned copy. \`ident_unit\` did \`units.get(name).cloned()\` for the lookup return — another String clone per identifier-unit lookup, forced by the owned-String value type.

## Solution

- \`unit_of(name: &str) -> Option<&'static str>\` via \`.copied()\` on the iterator.
- \`units: HashMap<String, &'static str>\` — keys still owned (from variable name clones), values are now zero-cost static slices.
- \`ident_unit\` returns \`Option<&'static str>\` via \`.copied()\`.

The \`l != r\` comparison still works on \`&str\` either way. \`eprintln!\` interpolations print the same characters.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib numeric_units\` ✓ (3 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

The numeric_units pass runs on every function with a unit-suffixed parameter or let-binding (the entire reason this feature exists). For every such binding the pass previously paid one heap allocation just to wrap a static slice; this change reduces that to zero allocations per binding-discovery. Same shape as RES-1467 / RES-1500 / RES-1520 borrow-not-clone series — applied here to the static-suffix table that's already in static storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)