### PR TITLE
RES-1952: eliminate redundant clones in file_io::builtin_file_write_chunk and file_seek

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -379,6 +379,10 @@
     "resilient/src/json_builtins.rs": {
       "branch": "res-1946-json-parser-presize",
       "claimed_at": "2026-05-19T18:22:09Z"
+    },
+    "resilient/src/file_io.rs": {
+      "branch": "res-1952-file-io-clone-elim",
+      "claimed_at": "2026-05-19T18:38:57Z"
     }
   }
 }

--- a/resilient/src/file_io.rs
+++ b/resilient/src/file_io.rs
@@ -137,10 +137,14 @@ pub(crate) fn builtin_file_read_chunk(args: &[Value]) -> RResult<Value> {
 /// `file_write_chunk(handle: File, bytes: Bytes) -> Result<Int, String>`.
 /// Writes the entire byte slice; returns the number of bytes written.
 pub(crate) fn builtin_file_write_chunk(args: &[Value]) -> RResult<Value> {
-    let (id, bytes) = match args {
+    // RES-1952: borrow `bytes` from args. The legacy `b.clone()`
+    // allocated a fresh `Vec<u8>` per call (typically 4-64 KiB for
+    // chunked I/O) even though `f.write_all` and `len()` both accept
+    // borrows.
+    let (id, bytes): (i64, &[u8]) = match args {
         [Value::Struct { name, fields }, Value::Bytes(b)] if name == "File" => {
             let id = handle_id_from_fields(fields)?;
-            (id, b.clone())
+            (id, b.as_slice())
         }
         _ => {
             return Err(format!(
@@ -154,7 +158,7 @@ pub(crate) fn builtin_file_write_chunk(args: &[Value]) -> RResult<Value> {
         let f = reg
             .get_mut(&id)
             .ok_or_else(|| std::io::Error::other("closed or unknown file handle"))?;
-        f.write_all(&bytes)?;
+        f.write_all(bytes)?;
         Ok(bytes.len())
     });
     match result {
@@ -173,14 +177,17 @@ pub(crate) fn builtin_file_write_chunk(args: &[Value]) -> RResult<Value> {
 /// Whence is one of `"start"`, `"current"`, `"end"`. Returns the new
 /// cursor position from the start of the file.
 pub(crate) fn builtin_file_seek(args: &[Value]) -> RResult<Value> {
-    let (id, offset, whence) = match args {
+    // RES-1952: borrow `whence` from args — only used for the
+    // immediate `match whence.as_str()` below; cloning the String
+    // was pure overhead.
+    let (id, offset, whence): (i64, i64, &str) = match args {
         [
             Value::Struct { name, fields },
             Value::Int(o),
             Value::String(w),
         ] if name == "File" => {
             let id = handle_id_from_fields(fields)?;
-            (id, *o, w.clone())
+            (id, *o, w.as_str())
         }
         _ => {
             return Err(format!(
@@ -189,7 +196,7 @@ pub(crate) fn builtin_file_seek(args: &[Value]) -> RResult<Value> {
             ));
         }
     };
-    let seek_from = match whence.as_str() {
+    let seek_from = match whence {
         "start" => {
             if offset < 0 {
                 return Err(format!(


### PR DESCRIPTION
Closes #1952.

## Problem

\`file_io::builtin_file_write_chunk\` cloned the input \`Bytes\` (\`Vec<u8>\`) just to pass it to \`f.write_all(&bytes)\` and read \`bytes.len()\`:

\`\`\`rust
let (id, bytes) = match args {
    [Value::Struct { name, fields }, Value::Bytes(b)] if name == "File" => {
        let id = handle_id_from_fields(fields)?;
        (id, b.clone())  // clones the entire byte buffer
    }
    ...
};
\`\`\`

\`args\` is \`&[Value]\`; the pattern match already binds \`b: &Vec<u8>\`. The clone existed only because the closure inside \`REGISTRY.with(...)\` captures \`bytes\` by reference, but the closure already CAN borrow from a buffer that lives in \`args\` (which outlives the closure call).

For chunked writes (the entire purpose of \`file_write_chunk\`) a chunk is typically 4-64 KiB. Cloning the chunk on every write call doubled the I/O-path memory pressure for zero functional benefit.

\`file_seek\` had the same pattern with \`w.clone()\` on the \`whence\` String — small but same shape; only used for an immediate \`match whence.as_str()\`.

## Solution

- \`bytes: &[u8]\` from \`b.as_slice()\`. \`write_all\` and \`len()\` both accept slices.
- \`whence: &str\` from \`w.as_str()\`. The outer \`match whence\` works on \`&str\` directly.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib file_io\` ✓ (9 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

\`file_write_chunk\` is the per-chunk dispatch for streaming I/O (log writes, telemetry batching, network protocol framing). For a 64 KiB chunk size this eliminates one 64 KiB heap allocation per write call. Same shape as RES-1928 / RES-1930 / RES-1932 / RES-1934 / RES-1936 borrow-not-clone series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)