### PR TITLE
RES-1954: pre-size loop-invariant proof certificate String to skip default doubling

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -309,8 +309,8 @@
       "claimed_at": "2026-05-13T12:47:28Z"
     },
     "resilient/src/verifier_loop_invariants.rs": {
-      "branch": "res-1798-vli-bindings-presize",
-      "claimed_at": "2026-05-13T12:53:30Z"
+      "branch": "res-1954-loop-invariant-cert-presize",
+      "claimed_at": "2026-05-19T18:44:10Z"
     },
     "resilient/src/traits.rs": {
       "branch": "res-1802-traits-presize",

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -300,12 +300,24 @@ fn try_prove_invariant(
     }
 
     // -------- Both proven: capture certificate + emit message --------
-    let mut smt2 = String::new();
+    // RES-1954: pre-size the certificate buffer to the actual base +
+    // step cert lengths plus a small header margin. The legacy
+    // `String::new()` grew through the default 0→4→8→16 doubling
+    // chain even though the final size is known up-front from the
+    // already-materialised `base_cert.smt2` and `step_cert.smt2`
+    // strings. Header / spacing overhead is ~120 bytes.
+    const HEADER_MARGIN: usize = 128;
+    let cap = HEADER_MARGIN
+        + base_cert.as_ref().map(|c| c.smt2.len()).unwrap_or(0)
+        + step_cert.as_ref().map(|c| c.smt2.len()).unwrap_or(0);
+    let mut smt2 = String::with_capacity(cap);
     smt2.push_str("; RES-318 loop-invariant proof certificate\n");
-    smt2.push_str(&format!(
-        "; loop at line {}, col {}\n",
+    use std::fmt::Write as _;
+    let _ = writeln!(
+        &mut smt2,
+        "; loop at line {}, col {}",
         loop_span.start.line, loop_span.start.column
-    ));
+    );
     smt2.push_str("; ----- base case -----\n");
     if let Some(c) = base_cert {
         smt2.push_str(&c.smt2);


### PR DESCRIPTION
Closes #1954.

## Problem

\`verifier_loop_invariants\` built the SMT-LIB2 proof certificate text via:

\`\`\`rust
let mut smt2 = String::new();
smt2.push_str("; RES-318 loop-invariant proof certificate\n");
smt2.push_str(&format!("; loop at line {}, col {}\n", ...));
smt2.push_str("; ----- base case -----\n");
if let Some(c) = base_cert { smt2.push_str(&c.smt2); }
smt2.push_str("; ----- inductive step -----\n");
if let Some(c) = step_cert { smt2.push_str(&c.smt2); }
\`\`\`

The default \`String::new()\` allocated 0 capacity and grew through the doubling chain. The certificate header alone is ~120 bytes; with base + inductive-step certs the full payload is typically 1-4 KB. The doubling chain triggered log₂(N) reallocations as the buffer filled.

Both certs are already-materialised \`String\`s owned by upstream \`prove()\` calls, so their lengths are free to read.

## Solution

Pre-size to \`HEADER_MARGIN (128) + base_cert.smt2.len() + step_cert.smt2.len()\` — the exact upper bound when both certs are present, tighter than default when only one or neither is.

Switched the embedded \`format!\` + \`push_str\` to \`writeln!\` (drops the trailing \`\\n\`) to satisfy clippy's \`write_with_newline\` lint on the --features z3 path.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo build --manifest-path resilient/Cargo.toml --features z3\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --features z3 --lib verifier_loop_invariants\` ✓ (8 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo clippy --manifest-path resilient/Cargo.toml --features z3 --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

Loop-invariant proof certificate generation runs on the *success* path of the verifier — once per successfully-proven invariant. For programs that lean on inductive loop invariants (the typical safety-critical workload Resilient targets), every successful proof emits one of these certs. Collapses log₂(cert_size) reallocations into a single up-front allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)