### PR TITLE
RES-1956: pre-size enum_exhaustiveness collectors (enum_map, matched_variants, nested errors)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -383,6 +383,10 @@
     "resilient/src/numeric_units.rs": {
       "branch": "res-1950-numeric-units-static-suffix",
       "claimed_at": "2026-05-19T18:34:18Z"
+    },
+    "resilient/src/enum_exhaustiveness.rs": {
+      "branch": "res-1956-enum-exhaustiveness-presize",
+      "claimed_at": "2026-05-19T18:48:41Z"
     }
   }
 }

--- a/resilient/src/enum_exhaustiveness.rs
+++ b/resilient/src/enum_exhaustiveness.rs
@@ -41,10 +41,17 @@ pub struct ExhaustivenessError {
 /// nodes in the program (top-level only — nested EnumDecls inside functions
 /// are unusual and handled conservatively by returning no match error).
 fn collect_enum_variants<'a>(program: &'a Node) -> HashMap<&'a str, Vec<&'a str>> {
-    let mut map: HashMap<&'a str, Vec<&'a str>> = HashMap::new();
     let Node::Program(stmts) = program else {
-        return map;
+        return HashMap::new();
     };
+    // RES-1956: pre-size to the actual enum-decl count. One linear
+    // pass to count is essentially free against the loop below;
+    // saves the 0→4→8→… doubling chain for programs with ≥ 4 enums.
+    let enum_count = stmts
+        .iter()
+        .filter(|s| matches!(&s.node, Node::EnumDecl { .. }))
+        .count();
+    let mut map: HashMap<&'a str, Vec<&'a str>> = HashMap::with_capacity(enum_count);
     for s in stmts {
         if let Node::EnumDecl { name, variants, .. } = &s.node {
             map.insert(
@@ -81,8 +88,10 @@ fn check_match(
 
     // Collect all EnumVariant type_names referenced in the arms.
     // If arms mix different enums or non-EnumVariant patterns, skip.
+    // RES-1956: pre-size `matched_variants` to `arms.len()` — exact
+    // upper bound, each arm contributes at most one variant name.
     let mut enum_name_seen: Option<&str> = None;
-    let mut matched_variants: HashSet<&str> = HashSet::new();
+    let mut matched_variants: HashSet<&str> = HashSet::with_capacity(arms.len());
 
     for (pat, _guard, _) in arms {
         match pat {
@@ -157,7 +166,9 @@ fn walk(
     // `errors` by reference, but uniqueness_walk's visitor signature
     // takes `&mut dyn FnMut(&Node)`, so we collect errors into a
     // separate Vec and extend after the visit.
-    let mut nested: Vec<ExhaustivenessError> = Vec::new();
+    // RES-1956: pre-size to 4 — typical match-error counts are low;
+    // skips the default 0→4 first grow.
+    let mut nested: Vec<ExhaustivenessError> = Vec::with_capacity(4);
     crate::uniqueness_walk::visit(node, &mut |n| {
         // Skip Function nodes — they will be handled by the outer walk
         // call in analyze() with the correct context name. Processing them


### PR DESCRIPTION
Closes #1956.

## Problem

Three sites in \`enum_exhaustiveness\` allocated with default capacity:

1. **\`collect_enum_variants\`** built \`map: HashMap<&str, Vec<&str>>\` with \`HashMap::new()\`. For programs declaring multiple enums (parser / state-machine code) this paid the default doubling chain as each enum's variants landed.

2. **\`check_match\`** built \`matched_variants: HashSet<&str>\` with \`HashSet::new()\`. Every match-expression analysis allocated from zero even though \`arms.len()\` is the exact upper bound.

3. **\`walk\`** used \`Vec::new()\` for the per-node \`nested\` errors collector — skipping the default 0→4 first grow is a free win.

## Solution

- \`collect_enum_variants\`: count \`Node::EnumDecl\` top-level statements in one linear pass, then \`HashMap::with_capacity(enum_count)\`.
- \`check_match\`: \`HashSet::with_capacity(arms.len())\`.
- \`walk\`: \`Vec::with_capacity(4)\`.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib enum_exhaustiveness\` ✓ (8 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

Runs on every program with at least one \`EnumDecl\` + \`Match\` expression — the canonical parser / state-machine / sum-type-dispatch workload. Same shape as the recent pre-size series (RES-1762 / RES-1764 / RES-1796 / RES-1800 / RES-1922 / RES-1924 / RES-1938).

🤖 Generated with [Claude Code](https://claude.com/claude-code)