### PR TITLE
RES-1958: pre-size assume_axioms output Vec to leading-stmt count

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -383,6 +383,10 @@
     "resilient/src/numeric_units.rs": {
       "branch": "res-1950-numeric-units-static-suffix",
       "claimed_at": "2026-05-19T18:34:18Z"
+    },
+    "resilient/src/assume_axioms.rs": {
+      "branch": "res-1958-assume-axioms-presize",
+      "claimed_at": "2026-05-19T18:52:28Z"
     }
   }
 }

--- a/resilient/src/assume_axioms.rs
+++ b/resilient/src/assume_axioms.rs
@@ -23,11 +23,16 @@ use crate::Node;
 /// Returns conditions in source order. Caller appends them to the
 /// `requires` axiom set when invoking the Z3 prover.
 pub(crate) fn collect_leading_assume_axioms(body: &Node) -> Vec<Node> {
-    let mut out = Vec::new();
     let stmts = match body {
         Node::Block { stmts, .. } => stmts,
-        _ => return out,
+        _ => return Vec::new(),
     };
+    // RES-1958: pre-size to `stmts.len()` — the exact upper bound
+    // (every leading statement could be an `assume`). Called by the
+    // verifier per requires/ensures/recovers_to obligation the
+    // contract folder couldn't discharge, so the 0→4 doubling chain
+    // was paid on a Z3-dispatch hot path.
+    let mut out = Vec::with_capacity(stmts.len());
 
     for stmt in stmts {
         match stmt {


### PR DESCRIPTION
Closes #1958.

## Problem

\`assume_axioms::collect_leading_assume_axioms\` allocated its output Vec with default capacity (0 → 4 → 8 → … doubling chain). The output is bounded above by \`stmts.len()\` — every leading statement could be an \`assume\`, so that's the exact upper bound.

## Solution

Pre-size to \`stmts.len()\` on the Block path. The non-Block early return is moved inline to keep the structure clean.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib assume_axioms\` ✓ (6 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

\`collect_leading_assume_axioms\` is called by the verifier per \`requires\`/\`ensures\`/\`recovers_to\` obligation the contract folder couldn't discharge — i.e. every Z3-dispatched contract proof. For the common shape (1-3 leading \`assume\`s in safety-critical contracts), collapses the 0→4 first grow into a single up-front allocation. Same shape as the recent pre-size series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)