### PR TITLE
RES-1960: epoch_ordering — borrow names as &str + pre-size sequence Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -383,6 +383,10 @@
     "resilient/src/numeric_units.rs": {
       "branch": "res-1950-numeric-units-static-suffix",
       "claimed_at": "2026-05-19T18:34:18Z"
+    },
+    "resilient/src/epoch_ordering.rs": {
+      "branch": "res-1960-epoch-ordering-borrow",
+      "claimed_at": "2026-05-19T18:56:13Z"
     }
   }
 }

--- a/resilient/src/epoch_ordering.rs
+++ b/resilient/src/epoch_ordering.rs
@@ -27,19 +27,22 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // identifier. The previous `any_node` pre-scan was redundant —
     // removed.
     for_each_function(program, |fname, _params, body| {
-        let mut sequence: Vec<(String, u32)> = Vec::new();
+        // RES-1960: borrow `name` as `&str` from the AST (which the
+        // visitor closure already borrows from anyway) — drops the
+        // String clone per epoch-call site. Pre-size to 8 — typical
+        // epoch-call sequences are 2-10.
+        let mut sequence: Vec<(&str, u32)> = Vec::with_capacity(8);
         visit(body, &mut |n| {
-            if let Node::CallExpression { function, .. } = n {
-                if let Node::Identifier { name, .. } = function.as_ref() {
-                    if let Some(e) = epoch_of(name) {
-                        sequence.push((name.clone(), e));
-                    }
-                }
+            if let Node::CallExpression { function, .. } = n
+                && let Node::Identifier { name, .. } = function.as_ref()
+                && let Some(e) = epoch_of(name)
+            {
+                sequence.push((name.as_str(), e));
             }
         });
         for w in sequence.windows(2) {
-            let (a, ea) = &w[0];
-            let (b, eb) = &w[1];
+            let (a, ea) = w[0];
+            let (b, eb) = w[1];
             if ea > eb {
                 eprintln!(
                     "warning: in '{fname}', epoch-ordered call '{a}' (epoch {ea}) \


### PR DESCRIPTION
Closes #1960.

## Problem

\`epoch_ordering::check\` walked each function body and collected \`(name, epoch)\` pairs:

\`\`\`rust
let mut sequence: Vec<(String, u32)> = Vec::new();
visit(body, &mut |n| {
    if let Node::CallExpression { function, .. } = n {
        if let Node::Identifier { name, .. } = function.as_ref() {
            if let Some(e) = epoch_of(name) {
                sequence.push((name.clone(), e));  // String clone per push
            }
        }
    }
});
\`\`\`

Two perf issues:
1. \`name.clone()\` allocated a fresh \`String\` per epoch-call site even though \`name\` is \`&String\` borrowed from the AST (which outlives the closure call). The downstream \`windows(2)\` loop only needs \`&str\` for the warning interpolation.
2. \`Vec::new()\` grew through the default 0→4 doubling.

## Solution

- Change \`sequence\` type to \`Vec<(&str, u32)>\` — borrow from the AST.
- Pre-size to 8 (typical epoch-call sequences are 2-10).
- Collapse the nested \`if\`s into chained \`let-else\` for readability.
- \`w[0]\` / \`w[1]\` are now \`Copy\` (since \`&str\` is Copy), so destructure by value.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib epoch_ordering\` ✓ (3 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

\`epoch_ordering::check\` runs once per function whose program contains \`_epoch\`-suffixed calls — the typestate-style migration ordering pattern (RES-1274 gate). For each such function, this eliminates one String clone per epoch-call site plus the 0→4 first Vec grow. Same shape as RES-1467 / RES-1500 / RES-1520 / RES-1950 borrow-not-clone series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)