### PR TITLE
RES-1962: pre-size reentrancy_guard roots/seen + rate_limit_static counts

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -285,8 +285,8 @@
       "claimed_at": "2026-05-13T12:28:38Z"
     },
     "resilient/src/rate_limit_static.rs": {
-      "branch": "res-1788-rate-limit-presize",
-      "claimed_at": "2026-05-13T12:33:38Z"
+      "branch": "res-1962-reentrancy-rate-limit-presize",
+      "claimed_at": "2026-05-19T18:59:39Z"
     },
     "resilient/src/sum_types.rs": {
       "branch": "res-1788-rate-limit-presize",
@@ -387,6 +387,10 @@
     "resilient/src/assume_axioms.rs": {
       "branch": "res-1958-assume-axioms-presize",
       "claimed_at": "2026-05-19T18:52:28Z"
+    },
+    "resilient/src/reentrancy_guard.rs": {
+      "branch": "res-1962-reentrancy-rate-limit-presize",
+      "claimed_at": "2026-05-19T18:59:39Z"
     }
   }
 }

--- a/resilient/src/rate_limit_static.rs
+++ b/resilient/src/rate_limit_static.rs
@@ -57,7 +57,10 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // RES-1788: pre-size decls to stmts.len() (every top-level
     // statement could be a Function, one push each).
     let mut decls: Vec<&str> = Vec::with_capacity(stmts.len());
-    let mut counts: HashMap<String, usize> = HashMap::new();
+    // RES-1962: pre-size to 8 — distinct callee counts in real
+    // programs are typically 5-20, dominated by stdlib + user-fn
+    // names. Skips the 0-bucket initial rehash for the common case.
+    let mut counts: HashMap<String, usize> = HashMap::with_capacity(8);
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {
             decls.push(name.as_str());

--- a/resilient/src/reentrancy_guard.rs
+++ b/resilient/src/reentrancy_guard.rs
@@ -55,7 +55,9 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // bound — every top-level statement could be a Function). The
     // per-fn callees HashSet starts empty; 8 fits a typical body.
     let mut callees: HashMap<&str, HashSet<String>> = HashMap::with_capacity(stmts.len());
-    let mut roots: Vec<&str> = Vec::new();
+    // RES-1962: pre-size to 4 — typical non-reentrant fn count is low
+    // (1-5 fns matching NR_PREFIXES / NR_SUFFIXES per program).
+    let mut roots: Vec<&str> = Vec::with_capacity(4);
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {
             let mut cs = HashSet::with_capacity(8);
@@ -90,7 +92,9 @@ fn is_nonreentrant(name: &str) -> bool {
 }
 
 fn reaches_self<'a>(callees: &'a HashMap<&'a str, HashSet<String>>, start: &str) -> bool {
-    let mut seen: HashSet<&'a str> = HashSet::new();
+    // RES-1962: pre-size the DFS visited set to `callees.len()` —
+    // exact upper bound, each callee is visited at most once.
+    let mut seen: HashSet<&'a str> = HashSet::with_capacity(callees.len());
     let mut stack: Vec<&'a str> = callees
         .get(start)
         .map(|cs| cs.iter().map(String::as_str).collect())


### PR DESCRIPTION
Closes #1962.

## Problem

Three sites in two compiler passes allocated with default capacity:

**\`reentrancy_guard::check\`**
- \`roots: Vec<&str>\` accumulating fns matching NR_PREFIXES / NR_SUFFIXES — grew through 0→4 doubling. Typical non-reentrant count is 1-5 fns per program.
- \`reaches_self\`'s \`seen: HashSet<&str>\` DFS visited set was capped at default 0-bucket; the exact upper bound is \`callees.len()\` (each callee visited at most once).

**\`rate_limit_static::check\`**
- \`counts: HashMap<String, usize>\` accumulating call-site counts per distinct callee — bounded by distinct identifier count, typically 5-20.

## Solution

- \`roots\`: \`Vec::with_capacity(4)\`.
- \`reaches_self.seen\`: \`HashSet::with_capacity(callees.len())\` — exact upper bound.
- \`counts\`: \`HashMap::with_capacity(8)\` — typical distinct callee count.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib reentrancy_guard\` ✓ (3 tests)
- \`cargo test --manifest-path resilient/Cargo.toml --lib rate_limit_static\` ✓ (3 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

Both passes are dispatch-table-driven analyses gated by markers (RES-1271 for reentrancy_guard, RES-1267 for rate_limit_static), so pre-sizing collapses the 0→4 first grow per call. Same shape as the recent pre-size series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)