### PR TITLE
RES-1964: pre-size bounded_blocking per-fn callees + BFS state

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -387,6 +387,10 @@
     "resilient/src/assume_axioms.rs": {
       "branch": "res-1958-assume-axioms-presize",
       "claimed_at": "2026-05-19T18:52:28Z"
+    },
+    "resilient/src/bounded_blocking.rs": {
+      "branch": "res-1964-bounded-blocking-presize",
+      "claimed_at": "2026-05-19T19:03:12Z"
     }
   }
 }

--- a/resilient/src/bounded_blocking.rs
+++ b/resilient/src/bounded_blocking.rs
@@ -74,7 +74,9 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {
             decls.push(name.as_str());
-            let mut cs = Vec::new();
+            // RES-1964: pre-size to 8 — typical fn bodies have 1-10
+            // call sites. Skips the 0→4 first grow.
+            let mut cs = Vec::with_capacity(8);
             let mut bn = 0;
             visit(body, &mut |n| {
                 if let Node::CallExpression { function, .. } = n {
@@ -120,8 +122,12 @@ fn transitive_blocking<'a>(
     bn: &HashMap<&str, usize>,
 ) -> usize {
     let mut total = 0;
-    let mut seen: HashSet<&'a str> = HashSet::new();
-    let mut q: VecDeque<&'a str> = VecDeque::new();
+    // RES-1964: pre-size the BFS visited set and queue to
+    // `callees.len()` — exact upper bound (each fn enqueued at most
+    // once). Saves the 0→4→… doubling chain on every transitive_blocking
+    // root walk.
+    let mut seen: HashSet<&'a str> = HashSet::with_capacity(callees.len());
+    let mut q: VecDeque<&'a str> = VecDeque::with_capacity(callees.len());
     q.push_back(start);
     while let Some(f) = q.pop_front() {
         if !seen.insert(f) {


### PR DESCRIPTION
Closes #1964.

## Problem

\`bounded_blocking::check\` builds a per-function callees Vec and walks the call graph via BFS to compute transitive blocking-call counts. Three sites allocated with default capacity:

- per-fn \`cs: Vec<String>\` — grew through 0→4 doubling.
- BFS \`seen: HashSet<&str>\` visited set and \`q: VecDeque<&str>\` queue in \`transitive_blocking\` — both bounded by \`callees.len()\` (each fn enqueued at most once).

## Solution

- \`cs\`: \`Vec::with_capacity(8)\` — typical body call count.
- \`seen\` + \`q\`: \`with_capacity(callees.len())\` — exact upper bound.

## CI gates

- \`cargo build --manifest-path resilient/Cargo.toml\` ✓
- \`cargo test --manifest-path resilient/Cargo.toml --lib bounded_blocking\` ✓ (2 tests)
- \`cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings\` ✓
- \`cargo fmt --manifest-path resilient/Cargo.toml --check\` ✓

## Impact

Runs on every program with at least one fn matching the \`_bound{N}\` suffix family (RES-1217 gate). Per root, the BFS walks the call graph once, so the seen/q pre-sizes hit per root. Same shape as RES-1944 / RES-1962 call-graph-analysis pre-size series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)