### PR TITLE
RES-1972: region_inference::collect_calls — borrow args, drop deep Node clones

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -205,8 +205,8 @@
       "claimed_at": "2026-05-13T11:38:11Z"
     },
     "resilient/src/region_inference.rs": {
-      "branch": "res-1760-callgraph-presize",
-      "claimed_at": "2026-05-13T11:42:08Z"
+      "branch": "res-1972-region-inference-borrow",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/mutual_recursion_scc.rs": {
       "branch": "res-1760-callgraph-presize",

--- a/resilient/src/region_inference.rs
+++ b/resilient/src/region_inference.rs
@@ -363,7 +363,16 @@ fn build_callee_table(stmts: &[crate::Spanned<crate::Node>]) -> HashMap<String, 
 
 /// Walk a node tree collecting all `Node::CallExpression` nodes whose
 /// function slot is a plain `Node::Identifier`.
-fn collect_calls(node: &crate::Node, calls: &mut Vec<(String, Vec<crate::Node>)>) {
+///
+/// RES-1972: pushed entries borrow into the AST as `(&'a str, &'a [Node])`
+/// instead of cloning `(String, Vec<Node>)`. The consumer
+/// (`check_call_site_region_aliasing`) only reads the borrowed name
+/// for a HashMap lookup and iterates the borrowed slice for the
+/// region-aliasing analysis — it never mutates or moves out of either,
+/// so the previous owning shape was pure overhead. Skipping the
+/// `arguments.clone()` is the dominant win: each per-call-site clone
+/// deep-copies the entire argument-expression subtree.
+fn collect_calls<'a>(node: &'a crate::Node, calls: &mut Vec<(&'a str, &'a [crate::Node])>) {
     match node {
         crate::Node::CallExpression {
             function,
@@ -371,7 +380,7 @@ fn collect_calls(node: &crate::Node, calls: &mut Vec<(String, Vec<crate::Node>)>
             ..
         } => {
             if let crate::Node::Identifier { name, .. } = function.as_ref() {
-                calls.push((name.clone(), arguments.clone()));
+                calls.push((name.as_str(), arguments.as_slice()));
             }
             // Recurse into arguments even if callee isn't an identifier.
             for arg in arguments {
@@ -458,11 +467,15 @@ pub fn check_call_site_region_aliasing(program: &crate::Node, source_path: &str)
             // default `Vec::new()` doubling growth from 0 paid 2-3
             // reallocations per visited fn. Same shape as the
             // RES-1716/1718/1720 pre-size series.
-            let mut calls: Vec<(String, Vec<crate::Node>)> = Vec::with_capacity(8);
+            // RES-1972: entries now borrow into the AST as
+            // `(&str, &[Node])` instead of cloning `(String, Vec<Node>)`
+            // per call site — eliminates the deep `arguments.clone()`
+            // that the consumer never needed.
+            let mut calls: Vec<(&str, &[crate::Node])> = Vec::with_capacity(8);
             collect_calls(body, &mut calls);
 
             for (callee_name, args) in &calls {
-                let Some(info) = callee_table.get(callee_name) else {
+                let Some(info) = callee_table.get(*callee_name) else {
                     continue;
                 };
                 if args.len() != info.param_types.len() {


### PR DESCRIPTION
## Summary
- \`collect_calls\` was cloning \`(name, arguments)\` per call site into \`Vec<(String, Vec<Node>)>\`. The \`arguments.clone()\` **deep-clones the entire argument-expression subtree** (nested calls, infix, literals — all recursively duplicated).
- Consumer (\`check_call_site_region_aliasing\`) only reads \`name\` as a HashMap lookup key and iterates \`args\` looking for \`Node::Identifier\` patterns. Never mutates or moves either field.
- Switch to \`Vec<(&'a str, &'a [Node])>\` borrowed from the AST. Zero per-call-site allocation.

Mirror of the existing borrow-instead-of-clone series (RES-1495..1544).

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (15 region_inference tests + full suite — no failures)
- [x] No behavioural change — same diagnostic output, just zero per-call-site clone

Closes #1972

🤖 Generated with [Claude Code](https://claude.com/claude-code)