### PR TITLE
RES-1976: lsp_server::build_top_level_defs — pre-size out/seen to stmts.len()

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -101,8 +101,8 @@
       "claimed_at": "2026-05-12T11:56:23Z"
     },
     "resilient/src/lsp_server.rs": {
-      "branch": "res-1531-lsp-completion-lazy-clone",
-      "claimed_at": "2026-05-12T14:20:00Z"
+      "branch": "res-1976-lsp-top-defs-presize",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/imports.rs": {
       "branch": "res-1523-imports-canon-move",

--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -387,13 +387,22 @@ pub(crate) fn build_top_level_defs(program: &Node) -> Vec<TopLevelDef> {
         Node::Program(s) => s,
         _ => return Vec::new(),
     };
-    let mut out: Vec<TopLevelDef> = Vec::new();
+    // RES-1976: pre-size `out` and `seen` to `stmts.len()` — the exact
+    // upper bound (at most one entry per top-level statement, since
+    // Function / StructDecl / TypeAlias are the only matching variants
+    // and dedup-via-`seen` only shrinks the count further). Skips the
+    // 0→4→8→16→32 doubling cascade for both Vec and HashSet. Same
+    // exact-upper-bound shape as RES-1742 / RES-1744 / RES-1746 call-
+    // graph pre-size series. `build_top_level_defs` is keystroke-rate
+    // (runs per LSP `textDocument/definition` and `documentSymbol`).
+    let mut out: Vec<TopLevelDef> = Vec::with_capacity(stmts.len());
     // RES-1508: borrow the AST's decl names into the dedup set
     // instead of cloning them. The owned String allocation only
     // happens once at the `out.push(...)` site — previously each
     // decl name allocated twice (once to bind `name`, once to feed
     // `seen.insert`).
-    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut seen: std::collections::HashSet<&str> =
+        std::collections::HashSet::with_capacity(stmts.len());
     for spanned in stmts {
         let name = match &spanned.node {
             Node::Function { name, .. } => name.as_str(),


### PR DESCRIPTION
## Summary
- Pre-size \`out: Vec<TopLevelDef>\` and \`seen: HashSet<&str>\` to \`stmts.len()\` — the exact upper bound (one push per top-level Function / StructDecl / TypeAlias; dedup gate only shrinks further).
- Skips the 0→4→8→16→32 default doubling cascade for both collections.
- Function runs per LSP \`textDocument/definition\` and \`documentSymbol\` request — keystroke-rate path.

Mirror of the RES-1742 / RES-1744 / RES-1746 call-graph pre-size series.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --features lsp clean (6 \`build_top_level_defs\` tests + full lsp suite — no failures)

Closes #1976

🤖 Generated with [Claude Code](https://claude.com/claude-code)