### PR TITLE
RES-1980: lean_spec::emit_theorem — write! into buffer, drop intermediate allocations

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -189,8 +189,8 @@
       "claimed_at": "2026-05-13T11:30:51Z"
     },
     "resilient/src/lean_spec.rs": {
-      "branch": "res-1756-program-collect-presize",
-      "claimed_at": "2026-05-13T11:30:51Z"
+      "branch": "res-1980-lean-spec-write",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/autopilot.rs": {
       "branch": "res-1758-more-collect-presize",

--- a/resilient/src/lean_spec.rs
+++ b/resilient/src/lean_spec.rs
@@ -48,6 +48,7 @@
 #![allow(clippy::collapsible_if, clippy::doc_lazy_continuation, dead_code)]
 
 use crate::Node;
+use std::fmt::Write as _;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LeanExpr {
@@ -221,18 +222,22 @@ pub fn render_native(expr: &LeanExpr) -> String {
 }
 
 pub fn emit_theorem(f: &LeanFn) -> String {
-    let mut out = String::new();
+    // RES-1980: the four `out.push_str(&format!(...))` sites previously
+    // allocated a fresh `String` per call, copied bytes into `out`, then
+    // dropped the intermediate — four wasted allocations per emit. Switch
+    // to `write!(out, "...", ...)`, which writes formatted bytes directly
+    // into `out`'s backing buffer. Pre-size to 256: covers the import
+    // header (~40 bytes) + def + theorem + simp tactic for a typical
+    // small fn before any growth.
+    let mut out = String::with_capacity(256);
     out.push_str("import Resilient.Semantics\n");
     out.push_str("open Resilient\n\n");
-    out.push_str(&format!(
-        "/-! Auto-generated from Resilient fn `{}` -/\n\n",
+    let _ = writeln!(
+        out,
+        "/-! Auto-generated from Resilient fn `{}` -/\n",
         f.name
-    ));
-    out.push_str(&format!(
-        "def {} : Expr := {}\n\n",
-        f.name,
-        render_expr(&f.body)
-    ));
+    );
+    let _ = writeln!(out, "def {} : Expr := {}\n", f.name, render_expr(&f.body));
 
     let param_pairs: Vec<String> = f
         .params
@@ -247,15 +252,17 @@ pub fn emit_theorem(f: &LeanFn) -> String {
         .map(|(ty, name)| format!("({name} : {})", lean_type_for(ty)))
         .collect();
 
-    out.push_str(&format!(
-        "theorem {}_correct {} :\n",
+    let _ = writeln!(
+        out,
+        "theorem {}_correct {} :",
         f.name,
         param_typed.join(" ")
-    ));
-    out.push_str(&format!(
-        "    eval ({}) {} = some {} := by\n",
+    );
+    let _ = writeln!(
+        out,
+        "    eval ({}) {} = some {} := by",
         env_str, f.name, native_body
-    ));
+    );
     out.push_str("  simp [eval, env_of, ");
     out.push_str(&f.name);
     out.push_str("]\n");


### PR DESCRIPTION
## Summary
- \`emit_theorem\` did \`out.push_str(&format!(...))\` at 4 sites — same antipattern as RES-1978. Each \`format!\` allocated a fresh \`String\`, copied bytes into \`out\`, dropped the intermediate. Four wasted allocations per call.
- Switch to \`writeln!(out, ...)\` — writes formatted bytes directly into \`out\`'s backing buffer.
- Pre-size \`out\` to 256 to skip the 0→4→8→16→32→64→128→256 doubling cascade for typical Lean specs.

Byte-for-byte identical output: \`writeln!\` appends the trailing \`\\n\` that each previous format string carried explicitly.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (12 lean_spec tests + full suite — no failures)

Closes #1980

🤖 Generated with [Claude Code](https://claude.com/claude-code)