### PR TITLE
RES-1982: snapshot_regression — sort_by cmp + write! + pre-size diff Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -157,8 +157,8 @@
       "claimed_at": "2026-05-13T11:24:43Z"
     },
     "resilient/src/snapshot_regression.rs": {
-      "branch": "res-1754-collect-presize",
-      "claimed_at": "2026-05-13T11:24:43Z"
+      "branch": "res-1982-snapshot-serialize",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/semantic_regression.rs": {
       "branch": "res-1754-collect-presize",

--- a/resilient/src/snapshot_regression.rs
+++ b/resilient/src/snapshot_regression.rs
@@ -13,6 +13,7 @@
 
 use crate::Node;
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::sync::RwLock;
 
 /// Global snapshot baseline — populated on the first check() call;
@@ -48,7 +49,11 @@ pub fn diff(
     stored: &HashMap<String, Snapshot>,
     current: &HashMap<String, Snapshot>,
 ) -> Vec<String> {
-    let mut changed = Vec::new();
+    // RES-1982: pre-size to `current.len()` — exact upper bound (at most
+    // one push per current key when its fingerprint diverges from stored).
+    // Same shape as the RES-1742 / RES-1744 / RES-1746 call-graph pre-size
+    // series.
+    let mut changed: Vec<String> = Vec::with_capacity(current.len());
     for (name, cur) in current {
         if let Some(prev) = stored.get(name) {
             if prev.fingerprint_digest != cur.fingerprint_digest {
@@ -61,14 +66,25 @@ pub fn diff(
 }
 
 pub fn serialize(snapshots: &HashMap<String, Snapshot>) -> String {
-    let mut s = String::from("{\n");
-    let mut entries: Vec<(&String, &Snapshot)> = snapshots.iter().collect();
-    entries.sort_by_key(|(k, _)| (*k).clone());
+    // RES-1982: previously `sort_by_key(|(k, _)| (*k).clone())` cloned
+    // every snapshot name into the sort key (N String clones per call).
+    // `sort_by` with `String::cmp` compares the borrowed strings directly.
+    let mut entries: Vec<(&String, &Snapshot)> = Vec::with_capacity(snapshots.len());
+    entries.extend(snapshots.iter());
+    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    // RES-1982: build the JSON via `write!` directly into `s`. The
+    // previous `s.push_str(&format!(...))` site allocated a fresh
+    // String per entry, copied bytes into `s`, then dropped the
+    // intermediate. Same antipattern as RES-1978 / RES-1980.
+    let mut s = String::with_capacity(2 + entries.len() * 64);
+    s.push_str("{\n");
     for (i, (name, snap)) in entries.iter().enumerate() {
-        s.push_str(&format!(
+        let _ = write!(
+            s,
             r#"  "{}": {{ "digest": {}, "golden_hash": {} }}"#,
             name, snap.fingerprint_digest, snap.golden_output_hash
-        ));
+        );
         if i + 1 < entries.len() {
             s.push(',');
         }


### PR DESCRIPTION
## Summary

Three avoidable allocations in this module:

1. **\`serialize::sort_by_key\` clone**: was \`sort_by_key(|(k, _)| (*k).clone())\` — N String clones per call. Switch to \`sort_by(|(a, _), (b, _)| a.cmp(b))\` — direct borrow comparison, zero clones.

2. **\`serialize::push_str(&format!)\`**: same antipattern as RES-1978 / RES-1980. \`format!\` allocates a fresh String per snapshot entry. Switch to \`write!(s, ...)\` direct write. Pre-size \`s\` to \`2 + entries.len() * 64\` for header + per-snapshot JSON line.

3. **\`diff::changed\`**: pre-size to \`current.len()\` (exact upper bound).

Output is byte-for-byte identical.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (6 snapshot_regression tests + full suite — no failures)

Closes #1982

🤖 Generated with [Claude Code](https://claude.com/claude-code)