### PR TITLE
RES-1986: ai_threat_model::collect_block_shapes — direct write, drop Vec<&str> intermediate

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -52,6 +52,10 @@
       "branch": "res-1984-diag-presize-write",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
+    "resilient/src/ai_threat_model.rs": {
+      "branch": "res-1986-block-shape-direct-write",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     ".github/workflows/playground.yml": {
       "branch": "res-1248-playground-rust-cache",
       "claimed_at": "2026-05-12T03:10:39Z"

--- a/resilient/src/ai_threat_model.rs
+++ b/resilient/src/ai_threat_model.rs
@@ -772,11 +772,21 @@ fn detect_copy_paste(node: &Node, ctx: &mut FnContext) {
 fn collect_block_shapes(node: &Node, out: &mut HashMap<String, u32>) {
     if let Node::Block { stmts, .. } = node {
         if stmts.len() >= 3 {
-            let shape = stmts
-                .iter()
-                .map(stmt_shape_tag)
-                .collect::<Vec<_>>()
-                .join("|");
+            // RES-1986: build the shape key directly into a pre-sized
+            // String instead of collecting a `Vec<&'static str>` just
+            // to `.join("|")` it. The previous shape allocated one Vec
+            // + one String per ≥3-stmt block; for programs with many
+            // such blocks (the typical large fn body), the intermediate
+            // Vec is per-block dead weight. Each tag is a single
+            // character so `stmts.len() * 2` covers the tag + separator
+            // pattern exactly.
+            let mut shape = String::with_capacity(stmts.len() * 2);
+            for (i, s) in stmts.iter().enumerate() {
+                if i > 0 {
+                    shape.push('|');
+                }
+                shape.push_str(stmt_shape_tag(s));
+            }
             *out.entry(shape).or_insert(0) += 1;
         }
         for s in stmts {


### PR DESCRIPTION
## Summary
- \`collect_block_shapes\` built the per-block shape-hash key by collecting a \`Vec<&'static str>\` and then \`.join(\"|\")\` — two allocations per block.
- Build the key directly into a pre-sized \`String\` instead, writing each tag + separator into the buffer. One allocation per block.

\`ai_threat_model::check\` is wired into the typechecker dispatch (\`typechecker.rs:5094\`) — this fires for every program, not just \`--ai-threats\`. \`collect_block_shapes\` recurses through every Block / IfStatement / WhileStatement / ForInStatement body in every function.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (9 ai_threat_model tests + full suite — no failures)

Closes #1986

🤖 Generated with [Claude Code](https://claude.com/claude-code)