### PR TITLE
RES-1992: behavioral_fingerprint — pre-size diff/regression Vecs, write! msgs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -181,8 +181,8 @@
       "claimed_at": "2026-05-13T11:30:51Z"
     },
     "resilient/src/behavioral_fingerprint.rs": {
-      "branch": "res-1756-program-collect-presize",
-      "claimed_at": "2026-05-13T11:30:51Z"
+      "branch": "res-1992-fingerprint-presize-write",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/contract_inference.rs": {
       "branch": "res-1756-program-collect-presize",

--- a/resilient/src/behavioral_fingerprint.rs
+++ b/resilient/src/behavioral_fingerprint.rs
@@ -30,6 +30,7 @@
 use crate::Node;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
+use std::fmt::Write as _;
 use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Clone)]
@@ -138,7 +139,10 @@ pub fn diff_fingerprints(
     stored: &HashMap<String, Fingerprint>,
     current: &HashMap<String, Fingerprint>,
 ) -> Vec<String> {
-    let mut changed = Vec::new();
+    // RES-1992: pre-size to `current.len()` — exact upper bound (at most
+    // one push per current key when digest diverges). Same pattern as
+    // RES-1982's `snapshot_regression::diff`.
+    let mut changed: Vec<String> = Vec::with_capacity(current.len());
     for (name, cur) in current {
         if let Some(prev) = stored.get(name) {
             if prev.digest != cur.digest {
@@ -177,7 +181,9 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         return Ok(());
     }
     let current = fingerprint_program(program);
-    let mut regressions: Vec<String> = Vec::new();
+    // RES-1992: pre-size to `current.len()` — exact upper bound on
+    // regression count. Same shape as `diff_fingerprints` above.
+    let mut regressions: Vec<String> = Vec::with_capacity(current.len());
     for (name, fp) in &current {
         if let Some(&stored_digest) = stored.get(name.as_str()) {
             if stored_digest != fp.digest {
@@ -189,17 +195,23 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     if regressions.is_empty() {
         return Ok(());
     }
-    let msgs: Vec<String> = regressions
-        .iter()
-        .map(|name| {
-            format!(
-                "{source_path}:0:0: error[fingerprint]: behavioral fingerprint of \
-                 `{name}` changed — contracts or parameter types were modified; \
-                 run `rz fingerprint --update` if the change is intentional"
-            )
-        })
-        .collect();
-    Err(msgs.join("\n"))
+    // RES-1992: previously built the joined message via
+    // `.map(|name| format!(...))` into a `Vec<String>` then `.join("\n")`
+    // — each format! allocated a fresh String, dropped after join. Build
+    // directly into the result String via `write!` instead.
+    let mut msg = String::with_capacity(regressions.len() * 160);
+    for (i, name) in regressions.iter().enumerate() {
+        if i > 0 {
+            msg.push('\n');
+        }
+        let _ = write!(
+            msg,
+            "{source_path}:0:0: error[fingerprint]: behavioral fingerprint of \
+             `{name}` changed — contracts or parameter types were modified; \
+             run `rz fingerprint --update` if the change is intentional"
+        );
+    }
+    Err(msg)
 }
 
 /// Parse `.resilient/fingerprints.lock` — lines of the form:


### PR DESCRIPTION
## Summary
Three avoidable allocations:
1. \`diff_fingerprints::changed\` and \`check::regressions\`: pre-size to \`current.len()\` (exact upper bound — one push per current key when digest diverges).
2. \`check::msgs\`: previously built \`.map(|name| format!(...))\` into a \`Vec<String>\` then \`.join(\"\\n\")\` — each \`format!\` allocated a fresh String dropped after join. Build the joined error directly via \`write!\` into a pre-sized String.

Byte-for-byte identical error output. Same shape as RES-1982 / RES-1984 / RES-1978.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (9 behavioral_fingerprint tests + full suite — no failures)

Closes #1992

🤖 Generated with [Claude Code](https://claude.com/claude-code)