### PR TITLE
RES-1994: intent_blocks::check — drop redundant fn_names HashSet

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -149,8 +149,8 @@
       "claimed_at": "2026-05-13T11:24:43Z"
     },
     "resilient/src/intent_blocks.rs": {
-      "branch": "res-1754-collect-presize",
-      "claimed_at": "2026-05-13T11:24:43Z"
+      "branch": "res-1994-intent-blocks-drop-fnames",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/row_polymorphism.rs": {
       "branch": "res-1754-collect-presize",

--- a/resilient/src/intent_blocks.rs
+++ b/resilient/src/intent_blocks.rs
@@ -69,10 +69,12 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     };
 
     // RES-1517: collect function names and their contract status in one pass.
-    // `fn_contracts[name]` = true when the function has at least one
-    // `requires` or `ensures` clause.
-    let mut fn_names: std::collections::HashSet<&str> =
-        std::collections::HashSet::with_capacity(stmts.len());
+    // RES-1994: previously kept a parallel `fn_names: HashSet<&str>` whose
+    // key set was identical to `fn_contracts` just for the existence
+    // check below. Drop it — `fn_contracts.get()` returning `None`
+    // already encodes "doesn't exist", and `Some(false)` encodes "no
+    // contracts". One HashMap allocation + N inserts per program
+    // instead of two of each.
     let mut fn_contracts: HashMap<&str, bool> = HashMap::with_capacity(stmts.len());
     for s in stmts {
         if let Node::Function {
@@ -82,7 +84,6 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
             ..
         } = &s.node
         {
-            fn_names.insert(name.as_str());
             fn_contracts.insert(name.as_str(), !requires.is_empty() || !ensures.is_empty());
         }
     }
@@ -91,18 +92,15 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         let prop_label = intent.property.as_deref().unwrap_or(&intent.item_name);
 
         for enforcer in &intent.enforcers {
-            if !fn_names.contains(enforcer.as_str()) {
-                eprintln!(
-                    "warning: intent `{}` (property: \"{}\") names enforcer `{}` \
-                     which doesn't exist in the program",
-                    intent.item_name, prop_label, enforcer
-                );
-            } else {
-                let has_contracts = fn_contracts
-                    .get(enforcer.as_str())
-                    .copied()
-                    .unwrap_or(false);
-                if !has_contracts {
+            match fn_contracts.get(enforcer.as_str()) {
+                None => {
+                    eprintln!(
+                        "warning: intent `{}` (property: \"{}\") names enforcer `{}` \
+                         which doesn't exist in the program",
+                        intent.item_name, prop_label, enforcer
+                    );
+                }
+                Some(false) => {
                     eprintln!(
                         "warning: intent `{}` (property: \"{}\") enforcer `{}` \
                          has no `requires` or `ensures` clauses — the intent \
@@ -110,6 +108,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
                         intent.item_name, prop_label, enforcer
                     );
                 }
+                Some(true) => {}
             }
         }
     }


### PR DESCRIPTION
## Summary

\`intent_blocks::check\` previously maintained two parallel maps:
- \`fn_names: HashSet<&str>\` (used only for existence check)
- \`fn_contracts: HashMap<&str, bool>\` (used for bool lookup)

Both populated from the same loop with the same keys. The HashSet was pure overhead — \`fn_contracts.get()\` returning \`None\` already encodes "doesn't exist", and \`Some(false)\` encodes "no contracts".

Drop the HashSet entirely. Use \`match\` on the \`Option<&bool>\` to fork the two warning paths.

Result: HashMap + N inserts per program instead of HashSet + HashMap + 2N inserts.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (5 intent_blocks tests + full suite — no failures)

Closes #1994

🤖 Generated with [Claude Code](https://claude.com/claude-code)