### PR TITLE
RES-1996: refinement_types::check — borrow specs into HashMap value

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -141,8 +141,8 @@
       "claimed_at": "2026-05-13T11:18:18Z"
     },
     "resilient/src/refinement_types.rs": {
-      "branch": "res-1754-collect-presize",
-      "claimed_at": "2026-05-13T11:24:43Z"
+      "branch": "res-1996-refinement-spec-borrow",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/power_contracts.rs": {
       "branch": "res-1754-collect-presize",

--- a/resilient/src/refinement_types.rs
+++ b/resilient/src/refinement_types.rs
@@ -176,14 +176,19 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     if specs.is_empty() {
         return Ok(());
     }
-    // Build a name-indexed map for O(1) annotation lookups before
-    // install() moves the Vec.
-    let spec_map: std::collections::HashMap<String, RefinementSpec> =
-        specs.iter().map(|s| (s.name.clone(), s.clone())).collect();
+    // RES-1996: borrow into `specs` for the lookup map instead of
+    // cloning every `RefinementSpec`. The previous shape allocated
+    // 2N spec materializations per check (clone for spec_map +
+    // move into install). The borrowed view lives only as long as
+    // the predicate-check pass; once that returns, we hand
+    // ownership of `specs` to `install`.
+    let result = {
+        let spec_map: std::collections::HashMap<&str, &RefinementSpec> =
+            specs.iter().map(|s| (s.name.as_str(), s)).collect();
+        check_let_obligations(program, source_path, &spec_map)
+    };
     install(specs);
-    // Compile-time predicate verification: scan for `let x: Refined = CONST`
-    // bindings and reject those whose constant value violates the predicate.
-    check_let_obligations(program, source_path, &spec_map)
+    result
 }
 
 /// Walk the program and emit a compile-time error for any `let` binding
@@ -196,7 +201,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
 fn check_let_obligations(
     program: &Node,
     source_path: &str,
-    specs: &std::collections::HashMap<String, RefinementSpec>,
+    specs: &std::collections::HashMap<&str, &RefinementSpec>,
 ) -> Result<(), String> {
     // Walk only the top-level function bodies — LetStatements inside
     // function bodies are the primary refinement obligation sites.
@@ -212,7 +217,7 @@ fn check_let_obligations(
 fn check_node_obligations(
     node: &Node,
     source_path: &str,
-    specs: &std::collections::HashMap<String, RefinementSpec>,
+    specs: &std::collections::HashMap<&str, &RefinementSpec>,
 ) -> Result<(), String> {
     match node {
         Node::LetStatement {
@@ -320,20 +325,16 @@ mod tests {
 
     // ── compile-time obligation checks ─────────────────────────────────────
 
-    fn make_spec_map(
-        name: &str,
-        predicate: &str,
-    ) -> std::collections::HashMap<String, RefinementSpec> {
-        let mut m = std::collections::HashMap::new();
-        m.insert(
-            name.to_string(),
-            RefinementSpec {
-                name: name.to_string(),
-                base: "int".to_string(),
-                predicate: predicate.to_string(),
-            },
-        );
-        m
+    fn make_specs(name: &str, predicate: &str) -> Vec<RefinementSpec> {
+        vec![RefinementSpec {
+            name: name.to_string(),
+            base: "int".to_string(),
+            predicate: predicate.to_string(),
+        }]
+    }
+
+    fn make_spec_map(specs: &[RefinementSpec]) -> std::collections::HashMap<&str, &RefinementSpec> {
+        specs.iter().map(|s| (s.name.as_str(), s)).collect()
     }
 
     fn make_let(ty_name: &str, int_val: i64) -> Node {
@@ -359,17 +360,19 @@ mod tests {
     #[test]
     fn check_let_obligation_passes_for_valid_value() {
         let _g = crate::feature_attrs::lock_for_test();
-        let specs = make_spec_map("Positive", "self > 0");
+        let specs = make_specs("Positive", "self > 0");
+        let map = make_spec_map(&specs);
         let program = make_let("Positive", 5);
-        assert!(check_let_obligations(&program, "test.rz", &specs).is_ok());
+        assert!(check_let_obligations(&program, "test.rz", &map).is_ok());
     }
 
     #[test]
     fn check_let_obligation_fails_for_invalid_value() {
         let _g = crate::feature_attrs::lock_for_test();
-        let specs = make_spec_map("Positive", "self > 0");
+        let specs = make_specs("Positive", "self > 0");
+        let map = make_spec_map(&specs);
         let program = make_let("Positive", -1);
-        let result = check_let_obligations(&program, "test.rz", &specs);
+        let result = check_let_obligations(&program, "test.rz", &map);
         assert!(result.is_err(), "expected error, got Ok");
         let msg = result.unwrap_err();
         assert!(msg.contains("refinement error"), "unexpected msg: {}", msg);
@@ -379,17 +382,19 @@ mod tests {
     #[test]
     fn check_let_obligation_ignores_unknown_type_annotations() {
         let _g = crate::feature_attrs::lock_for_test();
-        let specs = make_spec_map("Positive", "self > 0");
+        let specs = make_specs("Positive", "self > 0");
+        let map = make_spec_map(&specs);
         // `let x: MyStruct = 0` — MyStruct is not a refinement type, should pass.
         let program = make_let("MyStruct", 0);
-        assert!(check_let_obligations(&program, "test.rz", &specs).is_ok());
+        assert!(check_let_obligations(&program, "test.rz", &map).is_ok());
     }
 
     #[test]
     fn check_empty_program_is_noop() {
         let _g = crate::feature_attrs::lock_for_test();
-        let specs = make_spec_map("Positive", "self > 0");
+        let specs = make_specs("Positive", "self > 0");
+        let map = make_spec_map(&specs);
         let program = Node::Program(vec![]);
-        assert!(check_let_obligations(&program, "test.rz", &specs).is_ok());
+        assert!(check_let_obligations(&program, "test.rz", &map).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Previously \`refinement_types::check\` cloned every \`RefinementSpec\` twice:
\`\`\`rust
let spec_map: HashMap<String, RefinementSpec> =
    specs.iter().map(|s| (s.name.clone(), s.clone())).collect();
install(specs);
\`\`\`

Each \`s.clone()\` deep-clones the entire spec (name + base type + predicate string). For N specs: 2N spec materializations.

Switch to \`HashMap<&str, &RefinementSpec>\` borrowing into \`specs\`. Move \`install(specs)\` to *after* the predicate-check returns — borrow checker enforces correctness via explicit block scope.

Test helpers updated: \`make_specs\` returns owning Vec, \`make_spec_map(&specs)\` builds the borrowed map.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (7 refinement_types tests + full suite — no failures)

Closes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)