### PR TITLE
RES-2004: full_modules::detect_cycle — lift stack outside per-root loop

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -117,8 +117,8 @@
       "claimed_at": "2026-05-12T13:18:45Z"
     },
     "resilient/src/full_modules.rs": {
-      "branch": "res-1517-full-modules-dfs-borrow",
-      "claimed_at": "2026-05-12T13:25:00Z"
+      "branch": "res-2004-full-modules-stack-lift",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/crash_only.rs": {
       "branch": "res-1520-crash-only-name-borrow",

--- a/resilient/src/full_modules.rs
+++ b/resilient/src/full_modules.rs
@@ -97,9 +97,15 @@ pub fn detect_cycle(graph: &ModuleGraph) -> Option<Vec<String>> {
     // RES-1786: pre-size both to graph.deps.len() — visited grows
     // exactly to the module count; stack peaks at module-graph depth
     // which is bounded by the same count.
+    // RES-2004: lift `stack` outside the per-root loop. `dfs` is
+    // push/pop balanced, so the stack returns empty after each
+    // unsuccessful return — ready for the next `start` without
+    // re-allocation. Same buffer-reuse shape as RES-1966
+    // (isr_call_graph), RES-1988 (vibe_debt), RES-1990
+    // (resilience_score).
     let mut visited: HashSet<&str> = HashSet::with_capacity(graph.deps.len());
+    let mut stack: Vec<&str> = Vec::with_capacity(graph.deps.len());
     for start in graph.deps.keys() {
-        let mut stack: Vec<&str> = Vec::with_capacity(graph.deps.len());
         if let Some(cycle) = dfs(start.as_str(), graph, &mut stack, &mut visited) {
             return Some(cycle.into_iter().map(str::to_string).collect());
         }


### PR DESCRIPTION
## Summary

\`detect_cycle\` previously allocated a fresh DFS stack \`Vec<&str>\` per starting module in the outer loop. Since \`dfs\` is push/pop balanced, the stack returns to empty after each unsuccessful return — the per-iteration allocation was wasted.

Lift \`stack\` outside the loop. Allocation count drops from \`graph.deps.len()\` to 1.

Same buffer-reuse pattern as RES-1966 (isr_call_graph), RES-1988 (vibe_debt), RES-1990 (resilience_score). \`visited\` was already lifted by RES-1786; \`stack\` was overlooked in the same pass.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (2 full_modules tests + full suite — no failures)

Closes #2004

🤖 Generated with [Claude Code](https://claude.com/claude-code)