### PR TITLE
RES-2006: semver_behavior::check — diff under read guard, drop map clones

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -209,8 +209,8 @@
       "claimed_at": "2026-05-13T11:38:11Z"
     },
     "resilient/src/semver_behavior.rs": {
-      "branch": "res-1758-more-collect-presize",
-      "claimed_at": "2026-05-13T11:38:11Z"
+      "branch": "res-2006-semver-baseline-borrow",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/region_inference.rs": {
       "branch": "res-1972-region-inference-borrow",

--- a/resilient/src/semver_behavior.rs
+++ b/resilient/src/semver_behavior.rs
@@ -122,21 +122,30 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let current_contracts = crate::semantic_regression::extract_contracts(program);
     let current_fps = crate::behavioral_fingerprint::fingerprint_program(program);
 
-    // Compare against baseline if one exists.
-    let baseline = SEMVER_BASELINE.read().ok().and_then(|g| {
-        g.as_ref()
-            .map(|b| (b.contracts.clone(), b.fingerprints.clone()))
-    });
+    // RES-2006: hold the read guard through the two `diff` calls and
+    // only materialize the (small) result Vecs. The previous shape
+    // cloned both baseline maps (`HashMap<String, FunctionContract>`
+    // + `HashMap<String, Fingerprint>`) just to release the lock —
+    // wasted work proportional to baseline size. The diff functions
+    // are pure and short, so holding the guard briefly costs nothing.
+    // Same lock-then-borrow shape as RES-1544 / RES-1547 / RES-1549
+    // / RES-1552 / RES-1558.
+    use crate::semantic_regression::SemanticChange;
+    let diff_data: Option<(Vec<SemanticChange>, Vec<String>)> =
+        if let Ok(g) = SEMVER_BASELINE.read() {
+            g.as_ref().map(|b| {
+                let changes = crate::semantic_regression::diff(&b.contracts, &current_contracts);
+                let regressed =
+                    crate::behavioral_fingerprint::diff_fingerprints(&b.fingerprints, &current_fps);
+                (changes, regressed)
+            })
+        } else {
+            None
+        };
 
-    if let Some((old_contracts, old_fps)) = baseline {
-        // Build ephemeral old/new programs to reuse classify(), or
-        // diff directly from the contract/fingerprint maps.
-        let changes = crate::semantic_regression::diff(&old_contracts, &current_contracts);
-        let regressed = crate::behavioral_fingerprint::diff_fingerprints(&old_fps, &current_fps);
-
-        use crate::semantic_regression::SemanticChange;
+    if let Some((changes, regressed)) = diff_data {
         let mut kind = SemverKind::Patch;
-        let mut reasons: Vec<String> = Vec::new();
+        let mut reasons: Vec<String> = Vec::with_capacity(changes.len() + 1);
 
         if !regressed.is_empty() {
             reasons.push(format!("fingerprint changed for: {}", regressed.join(", ")));


### PR DESCRIPTION
## Summary

\`semver_behavior::check\` previously cloned both baseline maps just to release the read guard:
\`\`\`rust
let baseline = SEMVER_BASELINE.read().ok().and_then(|g| {
    g.as_ref().map(|b| (b.contracts.clone(), b.fingerprints.clone()))
});
\`\`\`

Both maps are keyed on every function name — size scales with program size.

Switch to holding the read guard through the two \`diff\` calls. Only the (small) result Vecs materialize; the (large) baseline maps stay in place. Diff functions are pure and short, so the held-guard duration is just the diff work.

Pre-size \`reasons\` to \`changes.len() + 1\` while there.

Same lock-then-borrow shape as RES-1544 / RES-1547 / RES-1549 / RES-1552 / RES-1558.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (7 semver_behavior tests + full suite — no failures)

Closes #2006

🤖 Generated with [Claude Code](https://claude.com/claude-code)