### PR TITLE
RES-2010: hw_state_machine — nested HashMap drops per-transition allocations

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -281,8 +281,8 @@
       "claimed_at": "2026-05-13T12:06:03Z"
     },
     "resilient/src/hw_state_machine.rs": {
-      "branch": "res-1784-attr-collects-3",
-      "claimed_at": "2026-05-13T12:28:38Z"
+      "branch": "res-2010-hw-state-nested-map",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/stack_contracts.rs": {
       "branch": "res-1784-attr-collects-3",

--- a/resilient/src/hw_state_machine.rs
+++ b/resilient/src/hw_state_machine.rs
@@ -16,7 +16,14 @@ use std::sync::{LazyLock, RwLock};
 pub struct PeripheralSpec {
     pub name: String,
     pub states: Vec<String>,
-    pub transitions: HashMap<(String, String), String>,
+    /// Nested map: `current_state -> (method -> next_state)`.
+    ///
+    /// RES-2010: previously a flat `HashMap<(String, String), String>`.
+    /// The flat shape forced `transition` to allocate two transient
+    /// Strings per call (stdlib's `Borrow` impls don't allow looking
+    /// up a `(String, String)` key by `(&str, &str)`). Same fix as
+    /// RES-2008 for sibling `typestate_types::TypestateSpec`.
+    pub transitions: HashMap<String, HashMap<String, String>>,
     pub initial_state: String,
 }
 
@@ -51,8 +58,12 @@ pub fn collect() -> Vec<PeripheralSpec> {
                         for t in v.split_whitespace() {
                             if let Some((lhs, next)) = t.split_once("->") {
                                 if let Some((s, m)) = lhs.split_once(':') {
+                                    // RES-2010: nested map shape — see comment
+                                    // on `PeripheralSpec::transitions`.
                                     spec.transitions
-                                        .insert((s.to_string(), m.to_string()), next.to_string());
+                                        .entry(s.to_string())
+                                        .or_default()
+                                        .insert(m.to_string(), next.to_string());
                                 }
                             }
                         }
@@ -87,8 +98,13 @@ pub fn transition(peripheral: &str, current: &str, method: &str) -> Result<Strin
     let spec = g
         .get(peripheral)
         .ok_or_else(|| format!("no peripheral spec for `{peripheral}`"))?;
+    // RES-2010: nested-map lookup — `.get(&str)` on each level uses
+    // the existing `String: Borrow<str>` impl. Zero per-call
+    // allocations (the previous flat `(String, String)` key forced
+    // two transient `String::to_string()` allocs per call).
     spec.transitions
-        .get(&(current.to_string(), method.to_string()))
+        .get(current)
+        .and_then(|m| m.get(method))
         .cloned()
         .ok_or_else(|| {
             format!(


### PR DESCRIPTION
## Summary

Sibling fix to RES-2008. \`hw_state_machine::transition\` allocated two transient \`String\`s per call:
\`\`\`rust
spec.transitions
    .get(&(current.to_string(), method.to_string()))
\`\`\`

Switch to nested \`HashMap<String, HashMap<String, String>>\`. Both \`.get(&str)\` calls now use \`String: Borrow<str>\`. Zero per-call allocations.

\`transition\` is called per peripheral-method invocation at runtime — the embedded use case Resilient targets hits this on every state-machine transition.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (3 hw_state_machine tests + full suite — no failures)

Closes #2010

🤖 Generated with [Claude Code](https://claude.com/claude-code)