### PR TITLE
RES-2012: default_trait_methods — nested HashMap drops per-has_default allocations

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -289,8 +289,8 @@
       "claimed_at": "2026-05-13T12:28:38Z"
     },
     "resilient/src/default_trait_methods.rs": {
-      "branch": "res-1784-attr-collects-3",
-      "claimed_at": "2026-05-13T12:28:38Z"
+      "branch": "res-2012-default-trait-nested-map",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/rate_limit_static.rs": {
       "branch": "res-1962-reentrancy-rate-limit-presize",

--- a/resilient/src/default_trait_methods.rs
+++ b/resilient/src/default_trait_methods.rs
@@ -33,14 +33,23 @@ pub struct DefaultMethod {
     pub method_name: String,
 }
 
-static DEFAULTS: LazyLock<RwLock<HashMap<(String, String), DefaultMethod>>> =
+/// RES-2012: nested map — outer key `trait_name`, inner key
+/// `method_name`. The flat `HashMap<(String, String), V>` shape forced
+/// `has_default` to allocate two transient `String`s per call (stdlib's
+/// `Borrow` impls don't allow `(String, String): Borrow<(&str, &str)>`).
+/// Both nested-map `.get`/`.contains_key` calls accept `&str` via the
+/// existing `String: Borrow<str>` impl. Same fix as RES-2008
+/// (typestate_types) and RES-2010 (hw_state_machine).
+static DEFAULTS: LazyLock<RwLock<HashMap<String, HashMap<String, DefaultMethod>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 pub fn install(items: Vec<DefaultMethod>) {
     if let Ok(mut g) = DEFAULTS.write() {
         g.clear();
         for d in items {
-            g.insert((d.trait_name.clone(), d.method_name.clone()), d);
+            g.entry(d.trait_name.clone())
+                .or_default()
+                .insert(d.method_name.clone(), d);
         }
     }
 }
@@ -49,8 +58,7 @@ pub fn has_default(trait_name: &str, method: &str) -> bool {
     DEFAULTS
         .read()
         .ok()
-        .map(|g| g.contains_key(&(trait_name.to_string(), method.to_string())))
-        .unwrap_or(false)
+        .is_some_and(|g| g.get(trait_name).is_some_and(|m| m.contains_key(method)))
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {


### PR DESCRIPTION
## Summary

Sibling fix to RES-2008 / RES-2010. \`has_default(trait_name, method)\` allocated two transient Strings per call:
\`\`\`rust
g.contains_key(&(trait_name.to_string(), method.to_string()))
\`\`\`

Switch \`DEFAULTS\` from \`HashMap<(String, String), DefaultMethod>\` to nested \`HashMap<String, HashMap<String, DefaultMethod>>\`. Lookup becomes:
\`\`\`rust
g.get(trait_name).is_some_and(|m| m.contains_key(method))
\`\`\`

Both calls use \`String: Borrow<str>\`, accepting \`&str\`. Zero per-call allocations.

\`has_default\` is queried per method-dispatch resolution on programs using trait defaults.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (3 default_trait_methods tests + full suite — no failures)

Closes #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)