### PR TITLE
RES-2014: associated_constants — nested HashMap drops per-lookup allocations

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -292,6 +292,10 @@
       "branch": "res-1784-attr-collects-3",
       "claimed_at": "2026-05-13T12:28:38Z"
     },
+    "resilient/src/associated_constants.rs": {
+      "branch": "res-2014-assoc-const-nested-map",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     "resilient/src/rate_limit_static.rs": {
       "branch": "res-1962-reentrancy-rate-limit-presize",
       "claimed_at": "2026-05-19T18:59:39Z"

--- a/resilient/src/associated_constants.rs
+++ b/resilient/src/associated_constants.rs
@@ -28,7 +28,15 @@ pub struct AssocConstant {
     pub value: String,
 }
 
-static ASSOC: LazyLock<RwLock<HashMap<(String, String), AssocConstant>>> =
+/// RES-2014: nested map — outer key `type_name`, inner key `const_name`.
+/// The flat `HashMap<(String, String), V>` shape forced `lookup` to
+/// allocate two transient `String`s per call (stdlib's `Borrow`
+/// impls don't allow `(String, String): Borrow<(&str, &str)>`).
+/// Both nested-map `.get` calls accept `&str` via the existing
+/// `String: Borrow<str>` impl. Same fix as RES-2008 / RES-2010 /
+/// RES-2012 — completes the (String, String) HashMap key conversion
+/// across all four registries in the codebase.
+static ASSOC: LazyLock<RwLock<HashMap<String, HashMap<String, AssocConstant>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 pub fn collect() -> Vec<AssocConstant> {
@@ -69,14 +77,21 @@ pub fn install(items: Vec<AssocConstant>) {
     if let Ok(mut g) = ASSOC.write() {
         g.clear();
         for a in items {
-            g.insert((a.type_name.clone(), a.const_name.clone()), a);
+            g.entry(a.type_name.clone())
+                .or_default()
+                .insert(a.const_name.clone(), a);
         }
     }
 }
 
 pub fn lookup(type_name: &str, const_name: &str) -> Option<String> {
+    // RES-2014: nested-map lookup — `.get(&str)` on each level uses
+    // the existing `String: Borrow<str>` impl. Zero per-call
+    // allocations (the previous flat `(String, String)` key forced
+    // two transient `String::to_string()` allocs per call).
     ASSOC.read().ok().and_then(|g| {
-        g.get(&(type_name.to_string(), const_name.to_string()))
+        g.get(type_name)
+            .and_then(|m| m.get(const_name))
             .map(|a| a.value.clone())
     })
 }


### PR DESCRIPTION
## Summary

Sibling fix to RES-2008 / RES-2010 / RES-2012 — completes the \`(String, String)\` HashMap key conversion across all four registries in the codebase.

\`lookup(type_name, const_name)\` allocated two transient Strings per call:
\`\`\`rust
g.get(&(type_name.to_string(), const_name.to_string()))
\`\`\`

Switch \`ASSOC\` to nested \`HashMap<String, HashMap<String, AssocConstant>>\`. Lookup becomes:
\`\`\`rust
g.get(type_name).and_then(|m| m.get(const_name)).map(|a| a.value.clone())
\`\`\`

Both \`.get\` calls use \`String: Borrow<str>\`, accepting \`&str\`. Zero per-call allocations.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (4 associated_constants tests including \`multiple_constants_on_same_type\` + full suite — no failures)

Closes #2014

🤖 Generated with [Claude Code](https://claude.com/claude-code)