### PR TITLE
RES-2020: coverage_warnings — make message field &'static str

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -52,6 +52,10 @@
       "branch": "res-1984-diag-presize-write",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
+    "resilient/src/coverage_warnings.rs": {
+      "branch": "res-2020-coverage-static-msg",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     "resilient/src/ai_threat_model.rs": {
       "branch": "res-1986-block-shape-direct-write",
       "claimed_at": "2026-05-19T00:00:00Z"

--- a/resilient/src/coverage_warnings.rs
+++ b/resilient/src/coverage_warnings.rs
@@ -25,7 +25,13 @@ use crate::Node;
 #[derive(Debug, Clone)]
 pub struct CoverageWarning {
     pub function: String,
-    pub message: String,
+    /// RES-2020: `&'static str` because every push site populates this
+    /// from a string literal. The previous `String` shape forced a
+    /// `.into()` allocation per push for content that already lived in
+    /// the binary's `.rodata` segment. Display via `eprintln!("{}", ...)`
+    /// and `.contains("...")` checks (used by tests) work identically
+    /// on `&str` and `String`.
+    pub message: &'static str,
 }
 
 pub fn analyze(program: &Node) -> Vec<CoverageWarning> {
@@ -52,7 +58,7 @@ fn walk(node: &Node, fn_name: &str, out: &mut Vec<CoverageWarning>) {
             if cons_returns_err {
                 out.push(CoverageWarning {
                     function: fn_name.to_string(),
-                    message: "if-branch returns Err but no test exercises this path".into(),
+                    message: "if-branch returns Err but no test exercises this path",
                 });
             }
             walk(consequence, fn_name, out);
@@ -60,7 +66,7 @@ fn walk(node: &Node, fn_name: &str, out: &mut Vec<CoverageWarning>) {
                 if block_returns_err(alt) {
                     out.push(CoverageWarning {
                         function: fn_name.to_string(),
-                        message: "else-branch returns Err — verify a test exercises it".into(),
+                        message: "else-branch returns Err — verify a test exercises it",
                     });
                 }
                 walk(alt, fn_name, out);
@@ -115,7 +121,7 @@ fn check_unreachable_after_return(stmts: &[Node], fn_name: &str, out: &mut Vec<C
             if !is_trivial_stmt(stmt) {
                 out.push(CoverageWarning {
                     function: fn_name.to_string(),
-                    message: "unreachable code after `return` statement".into(),
+                    message: "unreachable code after `return` statement",
                 });
                 return; // one warning per block is enough
             }
@@ -149,8 +155,7 @@ fn check_all_literal_match_no_wildcard(
         out.push(CoverageWarning {
             function: fn_name.to_string(),
             message: "match covers only literal values with no wildcard arm — \
-                      unhandled values will fall through at runtime"
-                .into(),
+                      unhandled values will fall through at runtime",
         });
     }
 }


### PR DESCRIPTION
## Summary

\`CoverageWarning::message\` was typed \`String\` but every push site populated it from a string literal via \`.into()\`:

\`\`\`rust
message: "if-branch returns Err but no test exercises this path".into(),
\`\`\`

Each \`.into()\` allocates a fresh String per warning for content that already lives in \`.rodata\`.

Change \`message: String\` to \`message: &'static str\`. Drop \`.into()\` at all 4 push sites. \`eprintln!(\"{}\", ...)\` and \`.contains(...)\` (used in tests) work identically on \`&'static str\` and \`String\`.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (7 coverage_warnings tests + full suite — no failures)

Closes #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)