### PR TITLE
RES-2022: struct_exhaustiveness — make message field &'static str

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -52,6 +52,10 @@
       "branch": "res-1984-diag-presize-write",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
+    "resilient/src/struct_exhaustiveness.rs": {
+      "branch": "res-2022-exhaustiveness-static-msg",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     "resilient/src/ai_threat_model.rs": {
       "branch": "res-1986-block-shape-direct-write",
       "claimed_at": "2026-05-19T00:00:00Z"

--- a/resilient/src/struct_exhaustiveness.rs
+++ b/resilient/src/struct_exhaustiveness.rs
@@ -20,7 +20,11 @@ use crate::Node;
 #[derive(Debug, Clone)]
 pub struct ExhaustivenessWarning {
     pub function: String,
-    pub message: String,
+    /// RES-2022: `&'static str` because the sole push site populates
+    /// this from a string literal. The previous `String` shape forced
+    /// a `.into()` allocation per push for content that already lived
+    /// in `.rodata`. Sibling fix to RES-2020 for `coverage_warnings`.
+    pub message: &'static str,
 }
 
 /// Returns true if the sub-pattern inside a struct field binding
@@ -73,8 +77,7 @@ fn walk(node: &Node, fn_name: &str, out: &mut Vec<ExhaustivenessWarning>) {
                 out.push(ExhaustivenessWarning {
                     function: fn_name.to_string(),
                     message: "Non-exhaustive match on struct — add a wildcard arm \
-                              (`_`, an identifier, or `StructName { .. }`)"
-                        .into(),
+                              (`_`, an identifier, or `StructName { .. }`)",
                 });
             }
             for (_, _, body) in arms {


### PR DESCRIPTION
## Summary

Sibling fix to RES-2020 (\`coverage_warnings\`). \`ExhaustivenessWarning::message\` was typed \`String\` but the only push site populated it from a string literal via \`.into()\`. Each \`.into()\` allocated a fresh String for content already in \`.rodata\`.

Change \`message: String\` to \`message: &'static str\`. Drop \`.into()\` at the push site.

## Test plan
- [x] cargo fmt --all clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test --manifest-path resilient/Cargo.toml clean (8 struct_exhaustiveness tests + full suite — no failures)

Closes #2022

🤖 Generated with [Claude Code](https://claude.com/claude-code)