### PR TITLE
RES-2034: array_binary_search — drop intermediate typed Vec materializations

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -161,12 +161,12 @@
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/wcet_contracts.rs": {
-      "branch": "res-2018-attr-move-item",
-      "claimed_at": "2026-05-19T00:00:00Z"
+      "branch": "res-1764-attr-collect-presize",
+      "claimed_at": "2026-05-13T11:45:18Z"
     },
     "resilient/src/stack_contracts.rs": {
-      "branch": "res-2018-attr-move-item",
-      "claimed_at": "2026-05-19T00:00:00Z"
+      "branch": "res-1784-attr-collects-3",
+      "claimed_at": "2026-05-13T12:28:38Z"
     },
     "resilient/src/intent_blocks.rs": {
       "branch": "res-1994-intent-blocks-drop-fnames",
@@ -256,10 +256,6 @@
       "branch": "res-1764-attr-collect-presize",
       "claimed_at": "2026-05-13T11:45:18Z"
     },
-    "resilient/src/wcet_contracts.rs": {
-      "branch": "res-1764-attr-collect-presize",
-      "claimed_at": "2026-05-13T11:45:18Z"
-    },
     "resilient/src/mmio_regmap.rs": {
       "branch": "res-1764-attr-collect-presize",
       "claimed_at": "2026-05-13T11:45:18Z"
@@ -303,10 +299,6 @@
     "resilient/src/hw_state_machine.rs": {
       "branch": "res-2010-hw-state-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
-    },
-    "resilient/src/stack_contracts.rs": {
-      "branch": "res-1784-attr-collects-3",
-      "claimed_at": "2026-05-13T12:28:38Z"
     },
     "resilient/src/default_trait_methods.rs": {
       "branch": "res-1784-attr-collects-3",
@@ -427,6 +419,10 @@
     "resilient/src/isr_call_graph.rs": {
       "branch": "res-1966-isr-bfs-reuse",
       "claimed_at": "2026-05-19T19:06:11Z"
+    },
+    "resilient/src/array_binary_search.rs": {
+      "branch": "res-2034-binary-search-no-intermediate-vec",
+      "claimed_at": "2026-05-19T22:27:31Z"
     }
   }
 }

--- a/resilient/src/array_binary_search.rs
+++ b/resilient/src/array_binary_search.rs
@@ -27,22 +27,27 @@ fn result_int(ok: bool, idx: usize) -> Value {
 /// `array_binary_search(arr, target) -> Result<Int, Int>` — lookup in a
 /// sorted int array. Array elements must all be ints; mixed types are
 /// rejected with a typed error.
+///
+/// RES-2034: pre-walks `items` for type validation, then dispatches
+/// `binary_search_by` directly on the original `&[Value]`. The previous
+/// implementation materialized a throwaway `Vec<i64>` of length N just
+/// to satisfy `binary_search`'s signature.
 pub(crate) fn builtin_array_binary_search(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Array(items), Value::Int(target)] => {
-            let mut nums: Vec<i64> = Vec::with_capacity(items.len());
             for v in items {
-                match v {
-                    Value::Int(n) => nums.push(*n),
-                    other => {
-                        return Err(format!(
-                            "array_binary_search: expected all int elements, got {}",
-                            other
-                        ));
-                    }
+                if !matches!(v, Value::Int(_)) {
+                    return Err(format!(
+                        "array_binary_search: expected all int elements, got {}",
+                        v
+                    ));
                 }
             }
-            match nums.binary_search(target) {
+            let result = items.binary_search_by(|v| match v {
+                Value::Int(n) => n.cmp(target),
+                _ => unreachable!("validated above"),
+            });
+            match result {
                 Ok(idx) => Ok(result_int(true, idx)),
                 Err(idx) => Ok(result_int(false, idx)),
             }
@@ -66,22 +71,26 @@ pub(crate) fn builtin_array_binary_search(args: &[Value]) -> RResult<Value> {
 /// lookup in a sorted float array. Comparison uses `f64::total_cmp` so
 /// the search behaves correctly on NaN / `±0` / signed-NaN inputs,
 /// matching `array_sort_float`'s ordering.
+///
+/// RES-2034: pre-walks `items` for type validation, then dispatches
+/// `binary_search_by` directly on the original `&[Value]` (drops the
+/// previous `Vec<f64>` materialization).
 pub(crate) fn builtin_array_binary_search_float(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Array(items), Value::Float(target)] => {
-            let mut nums: Vec<f64> = Vec::with_capacity(items.len());
             for v in items {
-                match v {
-                    Value::Float(f) => nums.push(*f),
-                    other => {
-                        return Err(format!(
-                            "array_binary_search_float: expected all float elements, got {}",
-                            other
-                        ));
-                    }
+                if !matches!(v, Value::Float(_)) {
+                    return Err(format!(
+                        "array_binary_search_float: expected all float elements, got {}",
+                        v
+                    ));
                 }
             }
-            match nums.binary_search_by(|x| x.total_cmp(target)) {
+            let result = items.binary_search_by(|v| match v {
+                Value::Float(f) => f.total_cmp(target),
+                _ => unreachable!("validated above"),
+            });
+            match result {
                 Ok(idx) => Ok(result_int(true, idx)),
                 Err(idx) => Ok(result_int(false, idx)),
             }
@@ -104,22 +113,27 @@ pub(crate) fn builtin_array_binary_search_float(args: &[Value]) -> RResult<Value
 /// `array_binary_search_string(arr, target) -> Result<Int, Int>` —
 /// lookup in a sorted string array. Comparison is byte-wise on the
 /// UTF-8 representation, matching `array_sort_string`'s ordering.
+///
+/// RES-2034: pre-walks `items` for type validation, then dispatches
+/// `binary_search_by` directly on the original `&[Value]`. The previous
+/// `Vec<&String>` materialization (one pointer per element) is gone.
 pub(crate) fn builtin_array_binary_search_string(args: &[Value]) -> RResult<Value> {
     match args {
         [Value::Array(items), Value::String(target)] => {
-            let mut strings: Vec<&String> = Vec::with_capacity(items.len());
             for v in items {
-                match v {
-                    Value::String(s) => strings.push(s),
-                    other => {
-                        return Err(format!(
-                            "array_binary_search_string: expected all string elements, got {}",
-                            other
-                        ));
-                    }
+                if !matches!(v, Value::String(_)) {
+                    return Err(format!(
+                        "array_binary_search_string: expected all string elements, got {}",
+                        v
+                    ));
                 }
             }
-            match strings.binary_search(&target) {
+            let target_str = target.as_str();
+            let result = items.binary_search_by(|v| match v {
+                Value::String(s) => s.as_str().cmp(target_str),
+                _ => unreachable!("validated above"),
+            });
+            match result {
                 Ok(idx) => Ok(result_int(true, idx)),
                 Err(idx) => Ok(result_int(false, idx)),
             }


### PR DESCRIPTION
## Summary

`array_binary_search.rs` has three builtins (`array_binary_search`, `array_binary_search_float`, `array_binary_search_string`) that each materialize a throwaway typed Vec just to call `slice::binary_search`:

- `array_binary_search` → `Vec<i64>`
- `array_binary_search_float` → `Vec<f64>`
- `array_binary_search_string` → `Vec<&String>`

This PR drops those Vec materializations. Each builtin now:

1. Pre-walks `items` once, returning `Err` on the first bad element (preserves the existing "expected all int/float/string elements, got X" error semantics).
2. Dispatches `items.binary_search_by(|v| match v { ... => cmp, _ => unreachable!() })` directly on the original `&[Value]` slice.

The `unreachable!()` arm is locally sound — the pre-walk has already validated every element before the search starts.

## Pattern

Same single-pass / no-intermediate-Vec pattern established by:
- RES-2026 (#2027) — argmin/argmax (float/string)
- RES-2028 (#2029) — cumulative (cumsum/cumprod/diffs/min_max)
- RES-2030 (#2031) — stats (variance/range/median)
- RES-2032 (#2033) — is_sorted_* (int/float/string)

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib array_binary_search` — 17/17 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Pre-existing tests cover the relevant semantics:
- Element-type rejection at non-first positions (`binary_search_int_rejects_non_int_elements`)
- Target-type rejection (`*_rejects_non_*_target`)
- NaN / total-order / signed-zero (`binary_search_float_handles_total_order`, `binary_search_float_nan_search_in_nan_terminated_array`)
- Empty array → `Err(0)` (`binary_search_int_empty_returns_err_zero`, `binary_search_string_empty`)
- Insertion-index property over a range of misses (`insertion_index_property`)

Closes #2034