### PR TITLE
RES-2036: array_combinators — borrow args in 7 remaining higher-order builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -397,8 +397,8 @@
       "claimed_at": "2026-05-19T17:53:14Z"
     },
     "resilient/src/array_combinators.rs": {
-      "branch": "res-1934-array-combinators-clone-elim",
-      "claimed_at": "2026-05-19T17:58:20Z"
+      "branch": "res-2036-array-combinators-borrow-args",
+      "claimed_at": "2026-05-19T22:00:00Z"
     },
     "resilient/src/combinatorics.rs": {
       "branch": "res-1938-combinatorics-presize",

--- a/resilient/src/array_combinators.rs
+++ b/resilient/src/array_combinators.rs
@@ -187,8 +187,9 @@ pub(crate) fn builtin_array_max_by(interp: &mut Interpreter, args: &[Value]) -> 
 /// // evens == 2
 /// ```
 pub(crate) fn builtin_array_count_if(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-2036: borrow `arr` and `f`; clone only per apply_function call.
     let (arr, f) = match args {
-        [Value::Array(a), f] => (a.clone(), f.clone()),
+        [Value::Array(a), f] => (a, f),
         [a, _] => {
             return Err(format!(
                 "array_count_if: first argument must be an Array, got {a}"
@@ -203,8 +204,8 @@ pub(crate) fn builtin_array_count_if(interp: &mut Interpreter, args: &[Value]) -
     };
 
     let mut count: i64 = 0;
-    for elem in arr {
-        match interp.apply_function(&f, vec![elem])? {
+    for elem in arr.iter() {
+        match interp.apply_function(f, vec![elem.clone()])? {
             Value::Bool(true) => count += 1,
             Value::Bool(false) => {}
             other => {
@@ -228,8 +229,11 @@ pub(crate) fn builtin_array_count_if(interp: &mut Interpreter, args: &[Value]) -
 /// // sums == [11, 22, 33]
 /// ```
 pub(crate) fn builtin_array_zip_with(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-2036: borrow both arrays and the function; clone only the
+    // two values passed to apply_function. Saves *two* full-array
+    // clones per call.
     let (a, b, f) = match args {
-        [Value::Array(a), Value::Array(b), f] => (a.clone(), b.clone(), f.clone()),
+        [Value::Array(a), Value::Array(b), f] => (a, b, f),
         [Value::Array(_), b, _] => {
             return Err(format!(
                 "array_zip_with: second argument must be an Array, got {b}"
@@ -257,8 +261,8 @@ pub(crate) fn builtin_array_zip_with(interp: &mut Interpreter, args: &[Value]) -
     }
 
     let mut out = Vec::with_capacity(a.len());
-    for (x, y) in a.into_iter().zip(b) {
-        out.push(interp.apply_function(&f, vec![x, y])?);
+    for (x, y) in a.iter().zip(b.iter()) {
+        out.push(interp.apply_function(f, vec![x.clone(), y.clone()])?);
     }
     Ok(Value::Array(out))
 }
@@ -273,8 +277,9 @@ pub(crate) fn builtin_array_zip_with(interp: &mut Interpreter, args: &[Value]) -
 /// // ws == [[1,2,3], [2,3,4], [3,4,5]]
 /// ```
 pub(crate) fn builtin_array_windows(args: &[Value]) -> RResult<Value> {
+    // RES-2036: borrow `arr`; only per-window `.to_vec()` clones happen.
     let (arr, n) = match args {
-        [Value::Array(a), Value::Int(n)] => (a.clone(), *n),
+        [Value::Array(a), Value::Int(n)] => (a, *n),
         [Value::Array(_), n] => {
             return Err(format!(
                 "array_windows: second argument must be an int, got {n}"
@@ -316,8 +321,10 @@ pub(crate) fn builtin_array_windows(args: &[Value]) -> RResult<Value> {
 /// // prefix == [1, 2, 3]
 /// ```
 pub(crate) fn builtin_array_take_while(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-2036: borrow `arr` and `f`; clone only when pushing to `out`
+    // or passing to apply_function.
     let (arr, f) = match args {
-        [Value::Array(a), f] => (a.clone(), f.clone()),
+        [Value::Array(a), f] => (a, f),
         [a, _] => {
             return Err(format!(
                 "array_take_while: first argument must be an Array, got {a}"
@@ -332,9 +339,9 @@ pub(crate) fn builtin_array_take_while(interp: &mut Interpreter, args: &[Value])
     };
 
     let mut out = Vec::new();
-    for elem in arr {
-        match interp.apply_function(&f, vec![elem.clone()])? {
-            Value::Bool(true) => out.push(elem),
+    for elem in arr.iter() {
+        match interp.apply_function(f, vec![elem.clone()])? {
+            Value::Bool(true) => out.push(elem.clone()),
             Value::Bool(false) => break,
             other => {
                 return Err(format!(
@@ -356,8 +363,10 @@ pub(crate) fn builtin_array_take_while(interp: &mut Interpreter, args: &[Value])
 /// // rest == [3, 4, 1]
 /// ```
 pub(crate) fn builtin_array_drop_while(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-2036: borrow `arr` and `f`; clone individual elements only
+    // when retained (kept after the drop-prefix ends).
     let (arr, f) = match args {
-        [Value::Array(a), f] => (a.clone(), f.clone()),
+        [Value::Array(a), f] => (a, f),
         [a, _] => {
             return Err(format!(
                 "array_drop_while: first argument must be an Array, got {a}"
@@ -373,13 +382,13 @@ pub(crate) fn builtin_array_drop_while(interp: &mut Interpreter, args: &[Value])
 
     let mut dropping = true;
     let mut out = Vec::new();
-    for elem in arr {
+    for elem in arr.iter() {
         if dropping {
-            match interp.apply_function(&f, vec![elem.clone()])? {
+            match interp.apply_function(f, vec![elem.clone()])? {
                 Value::Bool(true) => continue,
                 Value::Bool(false) => {
                     dropping = false;
-                    out.push(elem);
+                    out.push(elem.clone());
                 }
                 other => {
                     return Err(format!(
@@ -388,7 +397,7 @@ pub(crate) fn builtin_array_drop_while(interp: &mut Interpreter, args: &[Value])
                 }
             }
         } else {
-            out.push(elem);
+            out.push(elem.clone());
         }
     }
     Ok(Value::Array(out))
@@ -406,8 +415,9 @@ pub(crate) fn builtin_array_drop_while(interp: &mut Interpreter, args: &[Value])
 /// // total == 3 + 2 + 8 == 13
 /// ```
 pub(crate) fn builtin_array_sum_by(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-2036: borrow `arr` and `f`; clone only per apply_function call.
     let (arr, f) = match args {
-        [Value::Array(a), f] => (a.clone(), f.clone()),
+        [Value::Array(a), f] => (a, f),
         [a, _] => {
             return Err(format!(
                 "array_sum_by: first argument must be an Array, got {a}"
@@ -422,8 +432,8 @@ pub(crate) fn builtin_array_sum_by(interp: &mut Interpreter, args: &[Value]) -> 
     };
 
     let mut total: i64 = 0;
-    for elem in arr {
-        match interp.apply_function(&f, vec![elem])? {
+    for elem in arr.iter() {
+        match interp.apply_function(f, vec![elem.clone()])? {
             Value::Int(n) => total += n,
             other => {
                 return Err(format!(
@@ -444,8 +454,9 @@ pub(crate) fn builtin_array_sum_by(interp: &mut Interpreter, args: &[Value]) -> 
 /// // prod == 2 * 4 * 6 * 8 == 384
 /// ```
 pub(crate) fn builtin_array_product_by(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-2036: borrow `arr` and `f`; clone only per apply_function call.
     let (arr, f) = match args {
-        [Value::Array(a), f] => (a.clone(), f.clone()),
+        [Value::Array(a), f] => (a, f),
         [a, _] => {
             return Err(format!(
                 "array_product_by: first argument must be an Array, got {a}"
@@ -460,8 +471,8 @@ pub(crate) fn builtin_array_product_by(interp: &mut Interpreter, args: &[Value])
     };
 
     let mut product: i64 = 1;
-    for elem in arr {
-        match interp.apply_function(&f, vec![elem])? {
+    for elem in arr.iter() {
+        match interp.apply_function(f, vec![elem.clone()])? {
             Value::Int(n) => product *= n,
             other => {
                 return Err(format!(


### PR DESCRIPTION
## Summary

`array_combinators.rs` has 10 higher-order builtins. RES-1934 (#1928) refactored 3 of them — `array_sort_by`, `array_min_by`, `array_max_by` — to borrow `arr` and `cmp`/`f` from `args` directly instead of cloning ownership upfront. The remaining 7 still paid a full `Vec<Value>` clone of the whole input array (plus a function value clone) on every call.

This PR completes the cleanup for the other 7:

| Builtin | Saved clones per call |
|---|---|
| `array_count_if` | 1 full-array clone, 1 fn clone |
| `array_zip_with` | **2** full-array clones, 1 fn clone |
| `array_windows` | 1 full-array clone |
| `array_take_while` | 1 full-array clone, 1 fn clone |
| `array_drop_while` | 1 full-array clone, 1 fn clone |
| `array_sum_by` | 1 full-array clone, 1 fn clone |
| `array_product_by` | 1 full-array clone, 1 fn clone |

Each now matches `[Value::Array(a), f]` → `(a, f)` where `a: &Vec<Value>` and `f: &Value`, iterates `a.iter()`, and clones only individual elements at the `apply_function` callsite (or when retaining into the output Vec).

## Pattern

This is the same borrow-not-clone pattern RES-1934 already validated on the comparator/key-fn cousins in the same file (`sort_by`/`min_by`/`max_by`). For a 10k-element array, each saved clone avoids 10k Value clones per call — and `zip_with` doubles the savings.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib array_combinators` — 28/28 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Note: the stale file-claim from `res-1934-array-combinators-clone-elim` (which never opened a PR) was rolled forward to this branch in `agent-scripts/file-claims.json`.

Closes #2036