### PR TITLE
RES-2038: quantifier eval — lazy witness iteration for bounded ranges

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -105,8 +105,8 @@
       "claimed_at": "2026-05-12T06:52:39Z"
     },
     "resilient/src/quantifiers.rs": {
-      "branch": "res-1376-quantifier-eval-clone",
-      "claimed_at": "2026-05-12T08:58:44Z"
+      "branch": "res-2038-quantifier-range-lazy",
+      "claimed_at": "2026-05-19T23:00:00Z"
     },
     "resilient/src/unify.rs": {
       "branch": "res-1381-apply-hop-counter",

--- a/resilient/src/quantifiers.rs
+++ b/resilient/src/quantifiers.rs
@@ -154,6 +154,15 @@ pub(crate) fn parse_quantifier(parser: &mut Parser) -> Option<Node> {
 
 /// Runtime evaluation. Iterates the range, binding `var` in a fresh
 /// inner scope, and short-circuits per `kind`.
+///
+/// RES-2038: the `Range { lo, hi }` arm now iterates `lo..hi` lazily
+/// inside the per-witness loop instead of materializing a full
+/// `Vec<Value::Int(_)>` upfront. Short-circuit truly short-circuits
+/// — a `exists i in 0..10000: f(i)` that's true at i=0 no longer
+/// allocates 10000 Values to throw them away. The Iterable arm still
+/// materializes because the underlying Array / Set / Bytes is already
+/// allocated by the evaluator step that produced it; the
+/// `iterable_witnesses` call just takes ownership.
 pub(crate) fn eval_quantifier(
     interp: &mut Interpreter,
     kind: QuantifierKind,
@@ -161,17 +170,24 @@ pub(crate) fn eval_quantifier(
     range: &QuantRange,
     body: &Node,
 ) -> RResult<Value> {
-    let witnesses = collect_witnesses(interp, range)?;
+    // Resolve range / iterable in the *outer* env, before we install
+    // the inner env that binds `var`.
+    let (range_bounds, iterable_vals) = match range {
+        QuantRange::Range { lo, hi } => {
+            let lo_v = expect_int(interp.eval(lo)?, "range lower bound")?;
+            let hi_v = expect_int(interp.eval(hi)?, "range upper bound")?;
+            (Some((lo_v, hi_v)), None)
+        }
+        QuantRange::Iterable(expr) => {
+            let v = interp.eval(expr)?;
+            (None, Some(iterable_witnesses(v)?))
+        }
+    };
+
     // RES-1376: build the enclosed inner from a single clone of the
     // current env, then `mem::replace` the inner into `interp.env`
     // while capturing the original outer for restore. Mirrors the
-    // RES-1320 shape from `TypeChecker::with_quantifier_binding`:
-    // the previous code did one clone for `saved` and another for
-    // `inner.outer`, paying two `Environment::clone`s (Rc bumps) per
-    // quantifier evaluation. The body walk only reads through the
-    // enclosed env (lookups fall through to the outer on miss), so
-    // the moved original is safe to hand back unchanged after the
-    // loop.
+    // RES-1320 shape from `TypeChecker::with_quantifier_binding`.
     let inner_env = crate::Environment::new_enclosed(interp.env.clone());
     let saved_env = std::mem::replace(&mut interp.env, inner_env);
 
@@ -180,59 +196,67 @@ pub(crate) fn eval_quantifier(
         QuantifierKind::Exists => false,
     };
 
-    for witness in witnesses {
-        interp.env.set(var.to_string(), witness);
-        let val = interp.eval(body)?;
-        let b = match val {
-            Value::Bool(b) => b,
-            other => {
-                interp.env = saved_env;
-                return Err(format!(
-                    "{} body must evaluate to Bool, got {}",
-                    kind.keyword(),
-                    other
-                ));
-            }
-        };
-        match kind {
-            QuantifierKind::Forall => {
-                if !b {
-                    result = false;
-                    break;
+    // Single short-circuiting loop over either witness source.
+    let outcome: RResult<()> = (|| {
+        match (range_bounds, iterable_vals) {
+            (Some((lo_v, hi_v)), _) => {
+                for i in lo_v..hi_v {
+                    if !step_quantifier(interp, var, body, kind, Value::Int(i), &mut result)? {
+                        break;
+                    }
                 }
             }
-            QuantifierKind::Exists => {
-                if b {
-                    result = true;
-                    break;
+            (_, Some(vals)) => {
+                for w in vals {
+                    if !step_quantifier(interp, var, body, kind, w, &mut result)? {
+                        break;
+                    }
                 }
             }
+            _ => unreachable!("range_bounds XOR iterable_vals"),
         }
-    }
+        Ok(())
+    })();
 
+    // Always restore the outer env — even on body-type error.
     interp.env = saved_env;
+    outcome?;
     Ok(Value::Bool(result))
 }
 
-fn collect_witnesses(interp: &mut Interpreter, range: &QuantRange) -> RResult<Vec<Value>> {
-    match range {
-        QuantRange::Range { lo, hi } => {
-            let lo_v = expect_int(interp.eval(lo)?, "range lower bound")?;
-            let hi_v = expect_int(interp.eval(hi)?, "range upper bound")?;
-            if hi_v < lo_v {
-                return Ok(Vec::new());
-            }
-            let len = (hi_v - lo_v) as usize;
-            let mut out = Vec::with_capacity(len);
-            for i in lo_v..hi_v {
-                out.push(Value::Int(i));
-            }
-            Ok(out)
+/// RES-2038: shared per-witness step. Returns `Ok(true)` to continue
+/// iterating, `Ok(false)` to short-circuit, `Err(_)` to propagate a
+/// body evaluation / type error.
+fn step_quantifier(
+    interp: &mut Interpreter,
+    var: &str,
+    body: &Node,
+    kind: QuantifierKind,
+    witness: Value,
+    result: &mut bool,
+) -> RResult<bool> {
+    interp.env.set(var.to_string(), witness);
+    let val = interp.eval(body)?;
+    let b = match val {
+        Value::Bool(b) => b,
+        other => {
+            return Err(format!(
+                "{} body must evaluate to Bool, got {}",
+                kind.keyword(),
+                other
+            ));
         }
-        QuantRange::Iterable(expr) => {
-            let v = interp.eval(expr)?;
-            iterable_witnesses(v)
+    };
+    match kind {
+        QuantifierKind::Forall if !b => {
+            *result = false;
+            Ok(false)
         }
+        QuantifierKind::Exists if b => {
+            *result = true;
+            Ok(false)
+        }
+        _ => Ok(true),
     }
 }
 


### PR DESCRIPTION
## Summary

`eval_quantifier` previously called `collect_witnesses` to materialize a full `Vec<Value>` of all witnesses upfront, then iterated and short-circuited per quantifier kind. For `QuantRange::Range { lo, hi }` this meant allocating `hi - lo` `Value::Int` entries even when the quantifier short-circuits on the first witness.

A short-circuiting `exists i in 0..10000: f(i)` that's true at `i=0` no longer allocates 10000 `Value`s to throw them away (~240 KB saved per call for that shape).

## Changes

- The `Range` arm resolves both bounds against the *outer* env first, then iterates `lo..hi` lazily inside the per-witness loop — no upfront `Vec<Value>` allocation.
- The `Iterable` arm still calls `iterable_witnesses` to take ownership of the Array / Set / Bytes that the evaluator already materialized.
- Both arms share a new `step_quantifier` helper that handles the per-witness env update + body eval + short-circuit signal.
- Env restoration is now unified at one site (after the loop) — body-type errors still propagate cleanly without leaking the inner env into the caller.
- The old standalone `collect_witnesses` is removed; its only caller was `eval_quantifier`.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib quantifier` — 13/13 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Existing tests cover the relevant semantics:
- Empty range vacuous-truth (`empty_range_is_vacuous_truth_for_forall`, `empty_range_is_false_for_exists`)
- Short-circuit on first witness (`forall_short_circuits_on_first_false`, `exists_short_circuits_on_first_true`)
- Iterable form (`exists_over_array_iterable`)
- Var doesn't escape (`quantified_variable_does_not_escape`)
- Body type error propagation (`typecheck_rejects_non_bool_body`)

Note: the stale file-claim from `res-1376-quantifier-eval-clone` (no open PR) was rolled forward to this branch.

Closes #2038