### PR TITLE
RES-2040: const_fold + peephole — drop O(n×jumps) jump-relink scan via reverse-map

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -101,8 +101,8 @@
       "claimed_at": "2026-05-12T05:08:27Z"
     },
     "resilient/src/const_fold.rs": {
-      "branch": "res-1341-cache-opt-env-vars",
-      "claimed_at": "2026-05-12T06:52:39Z"
+      "branch": "res-2040-fold-peephole-reverse-map",
+      "claimed_at": "2026-05-19T23:30:00Z"
     },
     "resilient/src/quantifiers.rs": {
       "branch": "res-1376-quantifier-eval-clone",
@@ -423,6 +423,10 @@
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
       "claimed_at": "2026-05-19T22:27:31Z"
+    },
+    "resilient/src/peephole.rs": {
+      "branch": "res-2040-fold-peephole-reverse-map",
+      "claimed_at": "2026-05-19T22:43:00Z"
     }
   }
 }

--- a/resilient/src/const_fold.rs
+++ b/resilient/src/const_fold.rs
@@ -265,19 +265,35 @@ fn fold_pass(chunk: &mut Chunk) -> Result<bool, FoldError> {
         return Ok(false);
     }
 
+    // RES-2040: derive the reverse mapping new_pc → first old_pc in
+    // one O(n) pass. Walking old_pcs ascending and recording the
+    // first writer per new_pc reproduces the semantics of the
+    // previous `find(|&p| old_to_new[p] == new_pc)` scan, which
+    // returned the smallest p satisfying the predicate. The relink
+    // loop below then does an O(1) lookup per jump instead of the
+    // previous O(n) scan — net cost drops from O(n × jumps) to
+    // O(n + jumps) per fold pass.
+    let mut new_to_old: Vec<usize> = vec![usize::MAX; new_code.len()];
+    for (old_pc, &new_pc) in old_to_new.iter().enumerate().take(chunk.code.len()) {
+        if new_pc < new_code.len() && new_to_old[new_pc] == usize::MAX {
+            new_to_old[new_pc] = old_pc;
+        }
+    }
+
     // Re-link jump offsets in the rewritten stream. Identical
-    // mechanic to peephole.rs::optimize: find the originating old
-    // PC for each new jump, look up its original target, map
+    // mechanic to peephole.rs::optimize: look up the originating
+    // old PC via `new_to_old`, fetch its original target, map
     // through old_to_new, and recompute the relative offset.
     for (new_pc, op) in new_code.iter_mut().enumerate() {
         if !is_jump_op(*op) {
             continue;
         }
-        let Some(old_pc) = (0..chunk.code.len()).find(|&p| old_to_new[p] == new_pc) else {
+        let old_pc = new_to_old[new_pc];
+        if old_pc == usize::MAX {
             return Err(FoldError::InternalError(
                 "constant fold: new_pc with no originating old_pc",
             ));
-        };
+        }
         let Some(old_target) = orig_targets[old_pc] else {
             continue;
         };

--- a/resilient/src/peephole.rs
+++ b/resilient/src/peephole.rs
@@ -321,30 +321,38 @@ pub fn optimize(chunk: &mut Chunk) -> Result<(), OptimizeError> {
         return Ok(());
     }
 
+    // RES-2040: derive the reverse mapping new_pc → first old_pc in
+    // one O(n) pass. Walking old_pcs ascending and recording the
+    // first writer per new_pc reproduces the semantics of the
+    // previous `find(|&p| old_to_new[p] == new_pc)` scan (which
+    // returned the smallest p satisfying the predicate). This is
+    // load-bearing: drop-window rules leave old_to_new[head] equal
+    // to the new_pc of the *next* surviving op, and the relink
+    // path expects to see the head's `orig_targets` slot (None for
+    // most rules) — which keeps the emitted offset rather than
+    // recomputing it.
+    let mut new_to_old: Vec<usize> = vec![usize::MAX; new_code.len()];
+    for (old_pc, &new_pc) in old_to_new.iter().enumerate().take(chunk.code.len()) {
+        if new_pc < new_code.len() && new_to_old[new_pc] == usize::MAX {
+            new_to_old[new_pc] = old_pc;
+        }
+    }
+
     // Re-link jump offsets. For each JUMP op in new_code, look up
-    // which old PC it originated from (scan old_to_new), fetch
-    // that old op's original target, map through old_to_new, and
-    // compute the new offset.
-    //
-    // Scanning old_to_new to find the originating old PC per new
-    // op is O(n²) worst-case. For the chunk sizes we see today
-    // (hundreds of ops max) that's irrelevant; a future pass can
-    // carry old_pc alongside each emitted new op if it ever
-    // matters. Keep the simple version here.
+    // which old PC it originated from (now O(1) via new_to_old),
+    // fetch that old op's original target, map through old_to_new,
+    // and compute the new offset.
     for (new_pc, op) in new_code.iter_mut().enumerate() {
         // Only recompute for jump-carrying ops.
         if !is_jump_op(*op) {
             continue;
         }
-        // Find the old PC that maps to this new PC. The
-        // rewriting loop only inserts one new op per old
-        // position (never reorders), so the first old_pc with
-        // `old_to_new[old_pc] == new_pc` is the right one.
-        let Some(old_pc) = (0..chunk.code.len()).find(|&p| old_to_new[p] == new_pc) else {
+        let old_pc = new_to_old[new_pc];
+        if old_pc == usize::MAX {
             return Err(OptimizeError::InternalError(
                 "peephole: new_pc with no originating old_pc",
             ));
-        };
+        }
         let Some(old_target) = orig_targets[old_pc] else {
             continue; // not actually a jump (shouldn't happen)
         };


### PR DESCRIPTION
## Summary

Both `const_fold::fold_pass` and `peephole::optimize` rewrite a chunk to a new `Vec<Op>` and then relink jump offsets. The relink step iterated over each jump in `new_code` and ran a linear scan to find the originating old PC:

```rust
let Some(old_pc) = (0..chunk.code.len()).find(|&p| old_to_new[p] == new_pc) else { ... };
```

O(n) per jump → O(n × jumps) per pass. `peephole.rs` already flagged it: *"a future pass can carry old_pc alongside each emitted new op if it ever matters."* `const_fold` makes it worse by iterating `fold_pass` up to `MAX_PASSES` (64) times to fixpoint — worst case O(n² × 64).

## Changes

Single O(n) derive pass after the rewrite that walks `old_to_new` and records the first old_pc to hit each new_pc into `new_to_old`. The relink step then looks up `new_to_old[new_pc]` in O(1) per jump.

Net cost drops from O(n × jumps) to O(n + jumps) per pass.

## Semantics

The derive pass reproduces the exact behaviour of the previous `find` scan: the **first** (smallest) old_pc with `old_to_new[old_pc] == new_pc` wins. This ordering is load-bearing for `peephole.rs` — drop-window rules (Rules 1, 5, 7-11, 14-17, 22, 23) leave `old_to_new[head]` equal to the new_pc of the *next* surviving op, and the relink path relies on seeing the head's `orig_targets` slot (None for most rules) rather than the copied op's actual jump target. Changing to "last writer wins" would silently break the existing offset-preservation invariant for those rules.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib peephole` — 81/81 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib const_fold` — 43/43 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Pre-existing tests cover the critical paths:
- `rule4_folds_in_full_pass` — Rule 4 (Not; JumpIfFalse → JumpIfTrue) where the rule emits a jump from a window head and the relink must look up the head's `orig_targets`.
- `rule_skipped_when_interior_is_jump_target` — interior-position jump targets that gate the fold.
- `jumps_relink_across_folded_window` (const_fold) — forward + backward jumps across a folded window.
- `idempotent_on_already_folded_chunk` — fixpoint termination.

Note: the stale file-claim from `res-1341-cache-opt-env-vars` (no open PR) was rolled forward to this branch in `agent-scripts/file-claims.json`.

Closes #2040