### PR TITLE
RES-2042: default_params::rewrite_calls — borrow callee name instead of cloning

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -117,8 +117,8 @@
       "claimed_at": "2026-05-12T09:48:19Z"
     },
     "resilient/src/default_params.rs": {
-      "branch": "res-1475-default-params-skip-no-defaults",
-      "claimed_at": "2026-05-12T11:56:23Z"
+      "branch": "res-2042-default-params-borrow-name",
+      "claimed_at": "2026-05-20T00:00:00Z"
     },
     "resilient/src/lsp_server.rs": {
       "branch": "res-1976-lsp-top-defs-presize",

--- a/resilient/src/default_params.rs
+++ b/resilient/src/default_params.rs
@@ -457,6 +457,12 @@ fn rewrite_calls(node: &mut Node, sigs: &HashMap<String, FnDefaults>) {
         // The hot path: if a call to a known top-level fn is missing
         // trailing arguments and those positions have defaults, fill
         // them in before the interpreter ever sees the call.
+        //
+        // RES-2042: borrow the callee name as `&str` instead of cloning.
+        // `HashMap<String, V>::get` accepts `&str` via `String: Borrow<str>`,
+        // so the lookup works without an owned conversion. The previous
+        // shape cloned `name` on every CallExpression — pure overhead
+        // for programs where no callee has declared defaults.
         Node::CallExpression {
             function,
             arguments,
@@ -466,13 +472,14 @@ fn rewrite_calls(node: &mut Node, sigs: &HashMap<String, FnDefaults>) {
             for a in arguments.iter_mut() {
                 rewrite_calls(a, sigs);
             }
-            let callee_name = if let Node::Identifier { name, .. } = function.as_ref() {
-                Some(name.clone())
+            let callee_name: Option<&str> = if let Node::Identifier { name, .. } = function.as_ref()
+            {
+                Some(name.as_str())
             } else {
                 None
             };
             if let Some(name) = callee_name
-                && let Some(sig) = sigs.get(&name)
+                && let Some(sig) = sigs.get(name)
             {
                 let provided = arguments.len();
                 let total = sig.param_count;


### PR DESCRIPTION
## Summary

The `CallExpression` branch of `default_params::rewrite_calls` unconditionally cloned the callee name on every visit, just to use it as a `HashMap` lookup key:

```rust
let callee_name = if let Node::Identifier { name, .. } = function.as_ref() {
    Some(name.clone())   // unconditional clone
} else {
    None
};
if let Some(name) = callee_name && let Some(sig) = sigs.get(&name) { ... }
```

`HashMap<String, V>::get` accepts `&str` via `String: Borrow<str>`, so the clone was pure overhead. For programs with hundreds of `CallExpression` nodes and few-or-no callees that declare defaults (the common case), that's a hundred allocations + frees per lowering pass for no benefit — the `name` is never moved, stored, or returned.

This PR makes `callee_name` an `Option<&str>` borrowing into the AST, and passes it to `sigs.get(name)` directly.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib default_params` — 9/9 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Existing tests cover the relevant semantics:
- `unknown_callee_call_is_left_unchanged` — callee not in sigs (the common path that used to pay the clone).
- `call_with_all_args_is_unchanged` — known callee, no defaults to fill.
- `missing_arg_with_default_is_filled_in` / `two_missing_defaults_both_filled_in` — the actual rewrite path.

Note: the stale file-claim from `res-1475-default-params-skip-no-defaults` (no open PR) was rolled forward to this branch.

Closes #2042