### PR TITLE
RES-2046: incremental_verify cache — nested HashMap drops per-lookup String allocation

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -9,8 +9,8 @@
       "claimed_at": "2026-05-12T01:09:57Z"
     },
     "resilient/src/incremental_verify.rs": {
-      "branch": "res-1210-incremental-verify-dead-work",
-      "claimed_at": "2026-05-12T01:53:15Z"
+      "branch": "res-2046-incremental-verify-nested-map",
+      "claimed_at": "2026-05-20T01:00:00Z"
     },
     "resilient/src/watchdog_feed.rs": {
       "branch": "res-1218-param-type-fast-reject",

--- a/resilient/src/incremental_verify.rs
+++ b/resilient/src/incremental_verify.rs
@@ -24,9 +24,14 @@ pub enum ProofResult {
     Failed(String),
 }
 
+/// Nested-map shape from RES-2046. The outer key is the fn name, the
+/// inner key is the contract digest. This lets `lookup(&str, u64)`
+/// query the outer map with a borrowed `&str` (via `String: Borrow<str>`)
+/// — dropping the `String` allocation that the previous
+/// `(String, u64)` composite key paid per call.
 #[derive(Debug, Clone, Default)]
 pub struct ProofCache {
-    pub entries: HashMap<(String, u64), ProofResult>,
+    pub entries: HashMap<String, HashMap<u64, ProofResult>>,
     pub hits: u64,
     pub misses: u64,
 }
@@ -39,11 +44,17 @@ pub fn reset() {
     }
 }
 
+/// RES-2046: nested-map lookup. The outer-map `get(fn_name)` accepts
+/// `&str` directly via `String: Borrow<str>`, so the hit path does
+/// no `String` allocation. The previous `(String, u64)` composite-
+/// key shape allocated an owned `String` on every call just to form
+/// the lookup tuple.
 pub fn lookup(fn_name: &str, contract_digest: u64) -> Option<ProofResult> {
     if let Ok(mut g) = CACHE.write() {
         let cache = g.get_or_insert_with(ProofCache::default);
-        let key = (fn_name.to_string(), contract_digest);
-        if let Some(r) = cache.entries.get(&key) {
+        if let Some(per_fn) = cache.entries.get(fn_name)
+            && let Some(r) = per_fn.get(&contract_digest)
+        {
             cache.hits += 1;
             return Some(r.clone());
         }
@@ -57,7 +68,9 @@ pub fn store(fn_name: &str, contract_digest: u64, result: ProofResult) {
         let cache = g.get_or_insert_with(ProofCache::default);
         cache
             .entries
-            .insert((fn_name.to_string(), contract_digest), result);
+            .entry(fn_name.to_string())
+            .or_default()
+            .insert(contract_digest, result);
     }
 }
 
@@ -113,11 +126,16 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     };
     if let Ok(mut g) = CACHE.write() {
         if let Some(cache) = g.as_mut() {
-            let before = cache.entries.len();
+            // RES-2046: count the total inner-entry population before/
+            // after so the eviction message stays meaningful under the
+            // nested-map shape (one outer entry per fn, many inner
+            // entries per contract digest).
+            let before: usize = cache.entries.values().map(|m| m.len()).sum();
             cache
                 .entries
-                .retain(|(fn_name, _), _| live_names.contains(fn_name.as_str()));
-            let evicted = before.saturating_sub(cache.entries.len());
+                .retain(|fn_name, _| live_names.contains(fn_name.as_str()));
+            let after: usize = cache.entries.values().map(|m| m.len()).sum();
+            let evicted = before.saturating_sub(after);
             if evicted > 0 {
                 eprintln!("incremental_verify: evicted {evicted} stale proof-cache entry/ies");
             }


### PR DESCRIPTION
## Summary

`incremental_verify::lookup` is on the Z3 verifier's hot path — called once per function contract during `--features z3` typechecks. Every call allocated a fresh `String` purely to form the `(String, u64)` composite HashMap key:

```rust
let key = (fn_name.to_string(), contract_digest);
if let Some(r) = cache.entries.get(&key) { ... }
```

The owned `String` was dropped immediately after `.get(&key)` — pure overhead on every check, even on cache hits.

This PR switches `entries` from `HashMap<(String, u64), ProofResult>` to `HashMap<String, HashMap<u64, ProofResult>>`. The outer-map `get(fn_name)` accepts `&str` directly via `String: Borrow<str>`, so the hit path does zero allocations:

```rust
if let Some(per_fn) = cache.entries.get(fn_name)
    && let Some(r) = per_fn.get(&contract_digest)
{
    cache.hits += 1;
    return Some(r.clone());
}
```

`store` still allocates a `String` on insert (unavoidable — owned key), but `store` only fires on cache misses (after Z3 has run), while `lookup` fires on every contract check.

`check`'s retention scan now walks the outer map. The eviction message reports the total inner-entry population so it stays meaningful under the nested shape.

## Pattern

Same nested-HashMap pattern established by:
- RES-2008 (#2009) — typestate_types
- RES-2010 (#2011) — hw_state_machine
- RES-2012 (#2013) — default_trait_methods
- RES-2014 (#2015) — associated_constants
- RES-2016 (#2017) — lock_ordering

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib incremental_verify` — 5/5 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Local Z3 build couldn't run (`libz3` not installed on this machine); CI verifies the `--features z3` build separately.

Pre-existing tests cover the relevant behaviour:
- `cache_hit_then_miss` — round-trip lookup/store under both hit and miss
- `check_evicts_stale_entry` — eviction of fn names no longer in AST
- `check_preserves_live_entry` — non-eviction of live fn names
- `failed_proofs_recorded` — non-Discharged ProofResult round-trips

Note: the stale file-claim from `res-1210-incremental-verify-dead-work` (no open PR) was rolled forward to this branch.

Closes #2046