### PR TITLE
RES-2050: diag — drop intermediate String allocations in pad/caret/tab expansions

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -49,8 +49,8 @@
       "claimed_at": "2026-05-12T02:48:11Z"
     },
     "resilient/src/diag.rs": {
-      "branch": "res-1984-diag-presize-write",
-      "claimed_at": "2026-05-19T00:00:00Z"
+      "branch": "res-2050-diag-drop-intermediate-strings",
+      "claimed_at": "2026-05-20T02:00:00Z"
     },
     "resilient/src/array_argminmax.rs": {
       "branch": "res-2026-argminmax-single-pass",

--- a/resilient/src/diag.rs
+++ b/resilient/src/diag.rs
@@ -65,26 +65,17 @@ pub fn format_diagnostic(src: &str, span: Span, level: &str, msg: &str) -> Strin
         expanded.chars().count() + 1
     };
     let caret_count = (end_col - start_col).max(1);
-
-    let pad = " ".repeat(start_col - 1);
-    let carets = "^".repeat(caret_count);
+    let pad_count = start_col - 1;
 
     // RES-1984: pre-size to a close-fit estimate (header + line + carets
     // + optional multi-line tail). Skips the 0→4→...→256 doubling
     // cascade. `format_diagnostic` is on every compiler error/warning
     // path so the per-call savings are hot.
+    //
+    // RES-2050: include the pad + caret widths directly in the
+    // capacity calc so the subsequent per-char pushes never reallocate.
     let mut out = String::with_capacity(
-        level.len()
-            + 2
-            + msg.len()
-            + 1
-            + 3
-            + expanded.len()
-            + 1
-            + 3
-            + pad.len()
-            + carets.len()
-            + 32,
+        level.len() + 2 + msg.len() + 1 + 3 + expanded.len() + 1 + 3 + pad_count + caret_count + 32,
     );
     out.push_str(level);
     out.push_str(": ");
@@ -94,8 +85,16 @@ pub fn format_diagnostic(src: &str, span: Span, level: &str, msg: &str) -> Strin
     out.push_str(&expanded);
     out.push('\n');
     out.push_str("   ");
-    out.push_str(&pad);
-    out.push_str(&carets);
+    // RES-2050: write spaces / carets character-by-character into the
+    // pre-sized buffer. `str::repeat` would allocate a fresh String
+    // only to copy it back into `out` immediately — wasted work on
+    // every diagnostic.
+    for _ in 0..pad_count {
+        out.push(' ');
+    }
+    for _ in 0..caret_count {
+        out.push('^');
+    }
     if span.end.line != span.start.line {
         // RES-1984: write! directly into `out` instead of the
         // `push_str(&format!())` antipattern. No intermediate String alloc.
@@ -164,11 +163,17 @@ fn nth_line(src: &str, n: usize) -> Option<&str> {
 /// Expand any `\t` in `line` to `TAB_WIDTH` spaces so the caret
 /// underline lines up visually. Non-tab characters are preserved
 /// byte-for-byte (no UTF-8 normalisation).
+///
+/// RES-2050: tab expansion pushes spaces directly into the output
+/// buffer. The previous `" ".repeat(TAB_WIDTH)` allocated a fresh
+/// String per tab character only to copy it into `out` immediately.
 fn expand_tabs(line: &str) -> String {
     let mut out = String::with_capacity(line.len());
     for c in line.chars() {
         if c == '\t' {
-            out.push_str(&" ".repeat(TAB_WIDTH));
+            for _ in 0..TAB_WIDTH {
+                out.push(' ');
+            }
         } else {
             out.push(c);
         }


### PR DESCRIPTION
## Summary

`diag::format_diagnostic` is on every compiler error / warning path. It already pre-sizes its output buffer (RES-1984), but still allocated two intermediate Strings per call only to copy them into that buffer:

```rust
let pad = " ".repeat(start_col - 1);   // allocation
let carets = "^".repeat(caret_count);   // allocation
...
out.push_str(&pad);
out.push_str(&carets);
```

`str::repeat` always allocates a fresh String before its content is copied into `out` — pure overhead since `out`'s capacity already accounted for pad + carets.

`expand_tabs` had the same antipattern: `" ".repeat(TAB_WIDTH)` allocated one String per tab character before being copied into the output buffer.

Both are now per-char `out.push(' '|'^')` loops into the pre-sized buffer.

## Why this matters

`format_diagnostic` is on three hot paths:
1. CLI typecheck errors / warnings.
2. LSP `publishDiagnostics` — emitted on every edit's typecheck pass.
3. `--ai-threats` and other audit reporters.

The LSP path is per-keystroke; saving 2 allocations per diagnostic, multiplied by N diagnostics per edit, compounds across an editing session.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib diag` — 63/63 pass (covers format_diagnostic + span-error rendering across the typechecker, lean_spec, tla_bridge, try_catch, type_aliases, purity)
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Output bytes are byte-identical to the previous shape — every existing diagnostic-snapshot / line-col test continues to pass.

Note: the stale file-claim from `res-1984-diag-presize-write` was rolled forward to this branch.

Closes #2050