### PR TITLE
RES-2052: audit_log_required — single body walk tracks both audited-write + audit-call flags

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -77,8 +77,8 @@
       "claimed_at": "2026-05-12T03:27:30Z"
     },
     "resilient/src/audit_log_required.rs": {
-      "branch": "res-1254-audit-log-fast-reject",
-      "claimed_at": "2026-05-12T03:32:45Z"
+      "branch": "res-2052-audit-log-single-walk",
+      "claimed_at": "2026-05-20T02:30:00Z"
     },
     "resilient/src/secret_erasure.rs": {
       "branch": "res-1256-secret-erasure-fast-reject",

--- a/resilient/src/audit_log_required.rs
+++ b/resilient/src/audit_log_required.rs
@@ -18,7 +18,7 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, for_each_function, visit};
+use crate::uniqueness_walk::{for_each_function, visit};
 
 const AUDIT_FNS: &[&str] = &["audit_log", "journal", "record_event", "emit_audit"];
 
@@ -26,28 +26,33 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // RES-1254 / RES-1917: the typechecker gates this call behind
     // `markers.any_field_assigned_with_prefix_or_suffix(&["audited_"],
     // &["_audited"])`, so the program is guaranteed to contain at
-    // least one audited-prefixed/suffixed field assignment. The
-    // previous `any_node` pre-scan was redundant — removed.
+    // least one audited-prefixed/suffixed field assignment.
+    //
+    // RES-2052: single body walk tracks both flags. The previous
+    // shape did one `visit` to find audited writes (no short-circuit)
+    // and then a second `any_node` to find audit calls — two full
+    // AST traversals per function with audited writes. The new form
+    // updates both flags during a single `visit` and decides
+    // afterward whether to emit the warning.
     for_each_function(program, |fname, _params, body| {
         let mut has_audited_write = false;
-        visit(body, &mut |n| {
-            if let Node::FieldAssignment { field, .. } = n {
+        let mut has_audit_call = false;
+        visit(body, &mut |n| match n {
+            Node::FieldAssignment { field, .. } => {
                 if field.starts_with("audited_") || field.ends_with("_audited") {
                     has_audited_write = true;
                 }
             }
+            Node::CallExpression { function, .. } => {
+                if let Node::Identifier { name, .. } = function.as_ref()
+                    && AUDIT_FNS.contains(&name.as_str())
+                {
+                    has_audit_call = true;
+                }
+            }
+            _ => {}
         });
-        if !has_audited_write {
-            return;
-        }
-        let logged = any_node(body, |n| match n {
-            Node::CallExpression { function, .. } => match function.as_ref() {
-                Node::Identifier { name, .. } => AUDIT_FNS.contains(&name.as_str()),
-                _ => false,
-            },
-            _ => false,
-        });
-        if !logged {
+        if has_audited_write && !has_audit_call {
             eprintln!(
                 "warning: function '{fname}' writes to an audited field but never \
                  calls audit_log()/journal()/record_event() — compliance violation"


### PR DESCRIPTION
## Summary

`audit_log_required::check` walked each function body twice when the function had an audited write:

1. `visit(body, ...)` — finds audited field assignments. No short-circuit; walks every node.
2. `any_node(body, ...)` — finds audit-fn calls. Short-circuits, but still walks until first hit.

Two full AST traversals per function with audited writes. The new form folds both checks into a single `visit` that updates both flags during one pass. After the walk, the warning emits iff `has_audited_write && !has_audit_call`.

## Pattern

Same single-pass pattern as RES-1970 (`secret_erasure` — already in flight). Identical motivation: the inputs to both checks fit in one node-visitor closure; doing them in parallel is strictly cheaper than doing them sequentially.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib audit_log` — 3/3 pass (empty, no-trigger, AUDIT_FNS constant)
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

The diagnostic semantics are unchanged — warning fires only when a body has an audited write AND no AUDIT_FNS call. Existing unit tests cover the no-trigger case; the warning emission path is integration-tested elsewhere.

Note: the stale file-claim from `res-1254-audit-log-fast-reject` (no open PR) was rolled forward to this branch.

Closes #2052