### PR TITLE
RES-2054: age_bounded_data — borrow target/field as &str + drop unused field key

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -423,6 +423,10 @@
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
       "claimed_at": "2026-05-19T22:27:31Z"
+    },
+    "resilient/src/age_bounded_data.rs": {
+      "branch": "res-2054-age-bounded-borrow",
+      "claimed_at": "2026-05-19T23:26:10Z"
     }
   }
 }

--- a/resilient/src/age_bounded_data.rs
+++ b/resilient/src/age_bounded_data.rs
@@ -30,16 +30,25 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     for_each_function(program, |fname, _params, body| {
         // RES-1750: pre-size per-fn collections to 8 — typical fn
         // body has a handful of field reads / age comparisons.
-        let mut reads_value: Vec<(String, String)> = Vec::with_capacity(8); // (target, field)
-        let mut compares_age: std::collections::HashSet<(String, String)> =
+        //
+        // RES-2054: borrow target/field names as `&str` from the AST
+        // instead of cloning into owned Strings. `visit` exposes
+        // lifetime-tied `&'a Node` references so the collected
+        // entries can borrow into the body for the duration of the
+        // walk. Also drops the unused field slot from `compares_age`
+        // — only the target name is consulted by the freshness gate,
+        // so a `HashSet<&str>` is enough and gives O(1) contains
+        // lookup (vs O(M) iter().any in the old shape).
+        let mut reads_value: Vec<(&str, &str)> = Vec::with_capacity(8); // (target, field)
+        let mut compares_age: std::collections::HashSet<&str> =
             std::collections::HashSet::with_capacity(8);
 
         visit(body, &mut |n| match n {
             Node::FieldAccess { target, field, .. } => {
-                if let Node::Identifier { name: t, .. } = target.as_ref() {
-                    if !field.ends_with("_at") {
-                        reads_value.push((t.clone(), field.clone()));
-                    }
+                if let Node::Identifier { name: t, .. } = target.as_ref()
+                    && !field.ends_with("_at")
+                {
+                    reads_value.push((t.as_str(), field.as_str()));
                 }
             }
             Node::InfixExpression {
@@ -49,23 +58,21 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
                 ..
             } if matches!(*operator, ">" | "<" | ">=" | "<=") => {
                 for side in [left.as_ref(), right.as_ref()] {
-                    if let Node::FieldAccess { target, field, .. } = side {
-                        if field.ends_with("_at") {
-                            if let Node::Identifier { name: t, .. } = target.as_ref() {
-                                compares_age.insert((t.clone(), field.clone()));
-                            }
-                        }
+                    if let Node::FieldAccess { target, field, .. } = side
+                        && field.ends_with("_at")
+                        && let Node::Identifier { name: t, .. } = target.as_ref()
+                    {
+                        compares_age.insert(t.as_str());
                     }
                 }
             }
             _ => {}
         });
 
-        for (target, field) in reads_value {
+        for (target, field) in &reads_value {
             // If we read `target.field` and never compared `target.<anything>_at`,
-            // that's an unguarded read.
-            let saw_age = compares_age.iter().any(|(t, _)| t == &target);
-            if !saw_age {
+            // that's an unguarded read. RES-2054: O(1) contains.
+            if !compares_age.contains(target) {
                 eprintln!(
                     "warning: in '{fname}', value '{target}.{field}' is read with \
                      no comparison on a sibling '*_at' timestamp — data may be stale"


### PR DESCRIPTION
## Summary

`age_bounded_data::check` collected two structures from a per-function body walk, both keyed on `(target, field)` String tuples:

```rust
let mut reads_value: Vec<(String, String)> = ...;
let mut compares_age: HashSet<(String, String)> = ...;
```

Two inefficiencies:

1. Every matching `FieldAccess` and `InfixExpression` pushed `String::clone`d copies of target + field. For a body with N value reads and M age comparisons, that's **2N + 2M heap allocations per function**.

2. The freshness-gate check at the end only consulted `target` (the second tuple element was destructured-and-discarded via `|(t, _)|`). The field slot in `compares_age` was dead weight, and the check was `iter().any(...)` — **O(N × M)** total.

## Changes

- Borrow `target` / `field` as `&str` from the AST. The `visit` walker exposes `&'a Node` lifetime-tied to the body, so collected entries can borrow without cloning.
- Switch `compares_age` to `HashSet<&str>` of target names only.
- Replace the post-walk `iter().any()` with O(1) `contains()`.

Net per call: 2N + 2M fewer String allocations + the freshness check drops from O(N × M) to O(N).

## Pattern

Same borrow-into-AST pattern as RES-1495 / RES-1500 / RES-1503 / RES-1508 / RES-1520 / RES-1522 / RES-1526 / RES-1538 — and same "drop unused tuple key" cleanup as RES-2046 (incremental_verify) and RES-1994 (intent_blocks).

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib age_bounded` — 2/2 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

The diagnostic semantics are unchanged: warning fires iff a value field is read with no sibling `*_at` comparison on the same target.

Closes #2054