### PR TITLE
RES-2056: traits — nested HashMap for explicit_impls + borrow concrete_type

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -337,8 +337,8 @@
       "claimed_at": "2026-05-19T18:44:10Z"
     },
     "resilient/src/traits.rs": {
-      "branch": "res-1802-traits-presize",
-      "claimed_at": "2026-05-13T13:02:04Z"
+      "branch": "res-2056-traits-nested-impl-map",
+      "claimed_at": "2026-05-20T03:00:00Z"
     },
     "resilient/src/verifier_actors.rs": {
       "branch": "res-1808-flatten-body-presize",

--- a/resilient/src/traits.rs
+++ b/resilient/src/traits.rs
@@ -428,8 +428,12 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // top-level ImplBlock for each map.
     let mut type_methods: HashMap<String, HashMap<String, usize>> =
         HashMap::with_capacity(stmts.len());
-    // Set of explicit `impl Trait for Type` declarations.
-    let mut explicit_impls: HashSet<(String, String)> = HashSet::with_capacity(stmts.len());
+    // RES-2056: nested `HashMap<trait_name, HashSet<struct_name>>`
+    // shape — the contains hot path at the bound-satisfaction check
+    // below queries with borrowed `&str`s (via `String: Borrow<str>`)
+    // and never has to construct a `(String, String)` tuple key.
+    // Saves 2 String allocations per generic-call-site bound check.
+    let mut explicit_impls: HashMap<String, HashSet<String>> = HashMap::with_capacity(stmts.len());
 
     for stmt in stmts {
         if let Node::ImplBlock {
@@ -453,7 +457,10 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
                 }
             }
             if let Some(t) = trait_name {
-                explicit_impls.insert((t.clone(), struct_name.clone()));
+                explicit_impls
+                    .entry(t.clone())
+                    .or_default()
+                    .insert(struct_name.clone());
             }
         }
     }
@@ -620,7 +627,7 @@ fn walk_call_sites(
     fns_by_name: &HashMap<&str, &Node>,
     traits: &HashMap<String, (Vec<TraitMethodSig>, Vec<AssociatedTypeDecl>, Span)>,
     type_methods: &HashMap<String, HashMap<String, usize>>,
-    explicit_impls: &HashSet<(String, String)>,
+    explicit_impls: &HashMap<String, HashSet<String>>,
     source_path: &str,
 ) -> Result<(), String> {
     match node {
@@ -805,14 +812,21 @@ fn walk_call_sites(
                         Some(a) => a,
                         None => continue,
                     };
-                    let concrete_type = match arg {
-                        Node::StructLiteral { name, .. } => Some(name.clone()),
+                    // RES-2056: borrow the StructLiteral name as `&str`
+                    // instead of cloning. The lifetime is tied to the
+                    // AST, which outlives this walk.
+                    let concrete_type: Option<&str> = match arg {
+                        Node::StructLiteral { name, .. } => Some(name.as_str()),
                         _ => None,
                     };
                     if let Some(ct) = concrete_type {
                         for bound in bounds {
-                            let satisfied = explicit_impls.contains(&(bound.clone(), ct.clone()))
-                                || trait_satisfied_structurally(bound, &ct, traits, type_methods);
+                            // RES-2056: O(1) nested-map lookups by `&str`,
+                            // no tuple-key allocation.
+                            let satisfied = explicit_impls
+                                .get(bound.as_str())
+                                .is_some_and(|set| set.contains(ct))
+                                || trait_satisfied_structurally(bound, ct, traits, type_methods);
                             if !satisfied {
                                 return Err(format_err(
                                     source_path,


### PR DESCRIPTION
## Summary

`traits::walk_call_sites` checked every generic call site against the explicit-impl set on every type-parameter bound:

```rust
let satisfied = explicit_impls.contains(&(bound.clone(), ct.clone()))
    || trait_satisfied_structurally(bound, &ct, traits, type_methods);
```

Two issues:

1. `explicit_impls` was `HashSet<(String, String)>`; every contains allocated **two transient Strings** just to form the tuple key.

2. `ct` itself was eagerly cloned at the StructLiteral extraction site (`Some(name.clone())`) even though every consumer was happy with a borrowed `&str`.

## Changes

1. Switch `explicit_impls` to `HashMap<String, HashSet<String>>` (trait_name → impl'd struct names). Consult via borrowed `&str` lookups:

```rust
let satisfied = explicit_impls
    .get(bound.as_str())
    .is_some_and(|set| set.contains(ct))
    || trait_satisfied_structurally(bound, ct, traits, type_methods);
```

2. `concrete_type` is now `Option<&str>` borrowing into the AST.

## Impact

Net per bound check: 2 String allocations + 1 (ct) eliminated. For programs with N generic call sites, T type params each, B bounds each: **zero allocations** on the N×T×B contains hot path vs 3×N×T×B in the old shape.

## Pattern

Same nested-HashMap pattern as RES-2008 (typestate_types), RES-2010 (hw_state_machine), RES-2012 (default_trait_methods), RES-2014 (associated_constants), RES-2016 (lock_ordering), RES-2046 (incremental_verify).

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib traits` — 17/17 pass (covers `generic_call_with_satisfied_bound_passes` / `generic_call_with_unsatisfied_bound_errors` / `impl_trait_for_type_records_trait_name` — exactly the contains path)
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Note: the stale file-claim from `res-1802-traits-presize` (no open PR) was rolled forward to this branch.

Closes #2056