### PR TITLE
RES-2058: numeric_units — borrow let/param names as &str into per-fn units map

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -405,8 +405,8 @@
       "claimed_at": "2026-05-19T18:22:09Z"
     },
     "resilient/src/numeric_units.rs": {
-      "branch": "res-1950-numeric-units-static-suffix",
-      "claimed_at": "2026-05-19T18:34:18Z"
+      "branch": "res-2058-numeric-units-borrow-keys",
+      "claimed_at": "2026-05-20T03:30:00Z"
     },
     "resilient/src/assume_axioms.rs": {
       "branch": "res-1958-assume-axioms-presize",

--- a/resilient/src/numeric_units.rs
+++ b/resilient/src/numeric_units.rs
@@ -42,17 +42,24 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         // series across the per-fn passes.
         // RES-1950: values are `&'static str` from the static
         // UNIT_SUFFIXES table — no per-binding String allocation.
-        let mut units: std::collections::HashMap<String, &'static str> =
+        //
+        // RES-2058: keys now borrow `&str` directly from the AST
+        // (parameter name in `params`, let-binding name in the body).
+        // The map is dropped at the end of this closure call, so the
+        // borrow lifetime is bounded by the closure's call lifetime —
+        // both `params` and `body` outlive it. Eliminates a `name.clone()`
+        // per inserted entry.
+        let mut units: std::collections::HashMap<&str, &'static str> =
             std::collections::HashMap::with_capacity(params.len() + 8);
         for (_ty, name) in params {
             if let Some(u) = unit_of(name) {
-                units.insert(name.clone(), u);
+                units.insert(name.as_str(), u);
             }
         }
         visit(body, &mut |n| {
             if let Node::LetStatement { name, value, .. } = n {
                 if let Some(u) = unit_of(name) {
-                    units.insert(name.clone(), u);
+                    units.insert(name.as_str(), u);
                 }
                 check_expr(fname, name, value, &units);
             }
@@ -74,7 +81,7 @@ fn check_expr(
     fname: &str,
     var: &str,
     expr: &Node,
-    units: &std::collections::HashMap<String, &'static str>,
+    units: &std::collections::HashMap<&str, &'static str>,
 ) {
     if let Node::InfixExpression {
         operator,
@@ -103,10 +110,10 @@ fn check_expr(
 // a String clone on lookup hit.
 fn ident_unit(
     node: &Node,
-    units: &std::collections::HashMap<String, &'static str>,
+    units: &std::collections::HashMap<&str, &'static str>,
 ) -> Option<&'static str> {
     if let Node::Identifier { name, .. } = node {
-        return units.get(name).copied().or_else(|| unit_of(name));
+        return units.get(name.as_str()).copied().or_else(|| unit_of(name));
     }
     None
 }


### PR DESCRIPTION
## Summary

`numeric_units::check` built a per-function `HashMap<String, &'static str>` mapping binding name → unit suffix. RES-1950 made the values borrowed; the keys still allocated per insert:

```rust
let mut units: HashMap<String, &'static str> = ...;
for (_ty, name) in params {
    if let Some(u) = unit_of(name) {
        units.insert(name.clone(), u);     // alloc
    }
}
visit(body, &mut |n| {
    if let Node::LetStatement { name, value, .. } = n {
        if let Some(u) = unit_of(name) {
            units.insert(name.clone(), u); // alloc per let-binding
        }
        check_expr(fname, name, value, &units);
    }
});
```

The map is scoped to one `for_each_function` closure call and is dropped at the end of that call. The keys never outlive the params + body references the closure receives — borrowed `&str` keys are sound.

This switches `units` to `HashMap<&str, &'static str>` with keys borrowed from the AST. `check_expr` and `ident_unit` signatures follow.

## Impact

Saves one String allocation per parameter with a unit suffix + one per let-binding with a unit suffix, per function. Cumulative for unit-heavy embedded code (sensor / actuator drivers commonly have many `_ms` / `_v` / `_a`-suffixed bindings).

## Pattern

Same borrow-into-AST pattern as RES-1495 / 1500 / 1503 / 1508 / 1520 / 1522 / 1526 / 1538 / 2054 / 2056.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib numeric_units` — 3/3 pass (empty, no-suffix skip, same-unit pass)
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Note: the stale file-claim from `res-1950-numeric-units-static-suffix` (no open PR) was rolled forward to this branch.

Closes #2058