### PR TITLE
RES-2062: reentrancy_guard — collect callees borrows into AST (same fix as RES-2060)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -413,8 +413,8 @@
       "claimed_at": "2026-05-19T18:52:28Z"
     },
     "resilient/src/reentrancy_guard.rs": {
-      "branch": "res-1962-reentrancy-rate-limit-presize",
-      "claimed_at": "2026-05-19T18:59:39Z"
+      "branch": "res-2062-reentrancy-callees-borrow",
+      "claimed_at": "2026-05-20T04:30:00Z"
     },
     "resilient/src/isr_call_graph.rs": {
       "branch": "res-1966-isr-bfs-reuse",

--- a/resilient/src/reentrancy_guard.rs
+++ b/resilient/src/reentrancy_guard.rs
@@ -45,27 +45,30 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         return Ok(());
     }
     // RES-1519: borrow each top-level fn name as `&str` from the
-    // AST into the `callees` HashMap and `roots` Vec. The inner
-    // `cs: HashSet<String>` keeps owned Strings because
-    // `uniqueness_walk::visit` uses a HRTB closure that can't bind
-    // the outer AST lifetime — same limitation hit by
-    // RES-1509 / RES-1511. Pair with `reaches_self` borrowing into
-    // the graph for the DFS (mirror of RES-1471 / RES-1474 / RES-1477).
+    // AST into the `callees` HashMap and `roots` Vec.
+    //
+    // RES-2062: also borrow inner call-site names. The earlier
+    // comment cited "HRTB closure can't bind outer 'a" — but
+    // `uniqueness_walk::visit<'a>` is a regular lifetime parameter,
+    // not HRTB (same misread fixed by RES-2060 for isr_call_graph).
+    // The closure can carry `'a` and the inserted &str borrows are
+    // valid for the AST lifetime, which spans the whole check call
+    // including the DFS in `reaches_self`.
     // RES-1742: pre-size the call-graph map to stmts.len() (upper
     // bound — every top-level statement could be a Function). The
     // per-fn callees HashSet starts empty; 8 fits a typical body.
-    let mut callees: HashMap<&str, HashSet<String>> = HashMap::with_capacity(stmts.len());
+    let mut callees: HashMap<&str, HashSet<&str>> = HashMap::with_capacity(stmts.len());
     // RES-1962: pre-size to 4 — typical non-reentrant fn count is low
     // (1-5 fns matching NR_PREFIXES / NR_SUFFIXES per program).
     let mut roots: Vec<&str> = Vec::with_capacity(4);
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {
-            let mut cs = HashSet::with_capacity(8);
+            let mut cs: HashSet<&str> = HashSet::with_capacity(8);
             visit(body, &mut |n| {
-                if let Node::CallExpression { function, .. } = n {
-                    if let Node::Identifier { name, .. } = function.as_ref() {
-                        cs.insert(name.clone());
-                    }
+                if let Node::CallExpression { function, .. } = n
+                    && let Node::Identifier { name, .. } = function.as_ref()
+                {
+                    cs.insert(name.as_str());
                 }
             });
             callees.insert(name.as_str(), cs);
@@ -91,13 +94,16 @@ fn is_nonreentrant(name: &str) -> bool {
         || NR_SUFFIXES.iter().any(|s| name.ends_with(*s))
 }
 
-fn reaches_self<'a>(callees: &'a HashMap<&'a str, HashSet<String>>, start: &str) -> bool {
+fn reaches_self<'a>(callees: &'a HashMap<&'a str, HashSet<&'a str>>, start: &str) -> bool {
     // RES-1962: pre-size the DFS visited set to `callees.len()` —
     // exact upper bound, each callee is visited at most once.
+    // RES-2062: callees' inner set is now `&str`, so the seed can
+    // copy through directly and the inner loop pushes the borrowed
+    // name with no `.as_str()` round-trip.
     let mut seen: HashSet<&'a str> = HashSet::with_capacity(callees.len());
     let mut stack: Vec<&'a str> = callees
         .get(start)
-        .map(|cs| cs.iter().map(String::as_str).collect())
+        .map(|cs| cs.iter().copied().collect())
         .unwrap_or_default();
     while let Some(c) = stack.pop() {
         if c == start {
@@ -107,8 +113,8 @@ fn reaches_self<'a>(callees: &'a HashMap<&'a str, HashSet<String>>, start: &str)
             continue;
         }
         if let Some(cs) = callees.get(c) {
-            for cc in cs {
-                stack.push(cc.as_str());
+            for &cc in cs {
+                stack.push(cc);
             }
         }
     }


### PR DESCRIPTION
## Summary

`reentrancy_guard::check` had the same over-conservative `name.clone()` pattern that RES-2060 fixed in `isr_call_graph::collect_callees`. The inline closure passed to `visit` cloned every call-site name into a `HashSet<String>`:

```rust
visit(body, &mut |n| {
    if let Node::Identifier { name, .. } = function.as_ref() {
        cs.insert(name.clone());     // alloc per call site
    }
});
```

The comment cited "uniqueness_walk::visit uses a HRTB closure that can't bind the outer AST lifetime — same limitation hit by RES-1509 / RES-1511." Same misread as RES-2060: `visit`'s signature is `fn visit<'a>(node: &'a Node, f: &mut impl FnMut(&'a Node))` — a regular `<'a>` parameter, not HRTB. The closure can carry `'a` and the inserted borrows are valid for the AST lifetime, which spans the whole `check` call (including the DFS in `reaches_self`).

## Changes

- `callees: HashMap<&str, HashSet<&str>>` (inner set now borrowed).
- `cs.insert(name.as_str())` at the visit closure.
- `reaches_self` reads `&str` directly from the inner set; the seed `cs.iter().copied()` replaces the `.as_str()` round-trip.

## Impact

Saves one String allocation per call site per function. The reentrancy pass is gated by `has_nonreentrant` so it only fires on programs that declare reentrancy-banned functions — typically embedded firmware or smart-contract-style code — where allocation pressure matters most.

## Pattern

Same fix shape as RES-2060 (isr_call_graph). Same borrow-into-AST pattern as RES-1495..1538.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib reentrancy` — 3/3 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Note: the stale file-claim from `res-1962-reentrancy-rate-limit-presize` (no open PR) was rolled forward to this branch.

Closes #2062