### PR TITLE
RES-2064: toctou_guard — borrow event names/args as &str into per-fn events Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -423,6 +423,10 @@
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
       "claimed_at": "2026-05-19T22:27:31Z"
+    },
+    "resilient/src/toctou_guard.rs": {
+      "branch": "res-2064-toctou-events-borrow",
+      "claimed_at": "2026-05-19T23:45:55Z"
     }
   }
 }

--- a/resilient/src/toctou_guard.rs
+++ b/resilient/src/toctou_guard.rs
@@ -32,42 +32,49 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // `markers.any_call_ident_with_suffix` with the same CHECK_SUFFIXES.
     // The previous `any_node` pre-scan was redundant — removed.
     for_each_function(program, |fname, _params, body| {
-        let mut events: Vec<(bool, String, Option<String>)> = Vec::new();
-        // (is_check, fn_name, first_ident_arg)
+        // RES-2064: borrow event names/args as `&str` from the AST.
+        // The events Vec is scoped to this closure call and drops
+        // at its end; both the fn name (Node::Identifier) and arg
+        // names/values (Node::Identifier / Node::StringLiteral)
+        // are borrowed from the body AST, which outlives the call.
+        // Same borrow-into-AST pattern as RES-2060 / 2062.
+        // Tuple shape `(is_check, fn_name, first_ident_arg)` — all
+        // elements Copy so the pair-detection loop destructures
+        // by-value.
+        let mut events: Vec<(bool, &str, Option<&str>)> = Vec::new();
         visit(body, &mut |n| {
             if let Node::CallExpression {
                 function,
                 arguments,
                 ..
             } = n
+                && let Node::Identifier { name, .. } = function.as_ref()
             {
-                if let Node::Identifier { name, .. } = function.as_ref() {
-                    let arg = arguments.first().and_then(|a| match a {
-                        Node::Identifier { name, .. } => Some(name.clone()),
-                        Node::StringLiteral { value, .. } => Some(value.clone()),
-                        _ => None,
-                    });
-                    if CHECK_SUFFIXES.iter().any(|s| name.ends_with(*s)) {
-                        events.push((true, name.clone(), arg));
-                    } else if USE_SUFFIXES.iter().any(|s| name.ends_with(*s))
-                        && !name.starts_with("atomic_")
-                    {
-                        events.push((false, name.clone(), arg));
-                    }
+                let arg: Option<&str> = arguments.first().and_then(|a| match a {
+                    Node::Identifier { name, .. } => Some(name.as_str()),
+                    Node::StringLiteral { value, .. } => Some(value.as_str()),
+                    _ => None,
+                });
+                if CHECK_SUFFIXES.iter().any(|s| name.ends_with(*s)) {
+                    events.push((true, name.as_str(), arg));
+                } else if USE_SUFFIXES.iter().any(|s| name.ends_with(*s))
+                    && !name.starts_with("atomic_")
+                {
+                    events.push((false, name.as_str(), arg));
                 }
             }
         });
         // Find pairs: a check followed later by a non-atomic use on same arg.
-        for (i, (is_check, cname, carg)) in events.iter().enumerate() {
-            if !*is_check {
+        for (i, &(is_check, cname, carg)) in events.iter().enumerate() {
+            if !is_check {
                 continue;
             }
             let Some(carg) = carg else { continue };
-            for (is_check2, uname, uarg) in events.iter().skip(i + 1) {
-                if *is_check2 {
+            for &(is_check2, uname, uarg) in events.iter().skip(i + 1) {
+                if is_check2 {
                     continue;
                 }
-                if uarg.as_deref() == Some(carg) {
+                if uarg == Some(carg) {
                     eprintln!(
                         "warning: in '{fname}', TOCTOU: '{cname}({carg})' followed \
                          by '{uname}({carg})' — use atomic_{uname} or wrap both \


### PR DESCRIPTION
## Summary

`toctou_guard::check` collected every check/use call site into an `events: Vec<(bool, String, Option<String>)>` for pair detection. Each push allocated up to **two** Strings (fn name + first ident/string arg).

The `events` Vec is scoped to one `for_each_function` closure call and drops at the end. Both the fn name and arg names/values are borrowed from the body AST, which outlives the closure call — so borrowed `&str` keys are sound.

## Changes

- Switch `events` to `Vec<(bool, &str, Option<&str>)>` borrowing into the AST.
- Push `name.as_str()` and `name.as_str()` / `value.as_str()` instead of cloning.
- Pair-detection loop destructures tuples by value (all Copy):

```rust
for (i, &(is_check, cname, carg)) in events.iter().enumerate() {
    if !is_check { continue; }
    let Some(carg) = carg else { continue };
    for &(is_check2, uname, uarg) in events.iter().skip(i + 1) {
        if is_check2 { continue; }
        if uarg == Some(carg) { ... }
    }
}
```

## Impact

For a function with K matching call sites: saves up to 2K String allocations per fn. The pass is gated by the typechecker's marker check (\`any_call_ident_with_suffix\` for CHECK_SUFFIXES) so only files using filesystem-style APIs pay the original cost — but those are exactly the embedded / system-programming workloads where allocation pressure matters.

## Pattern

Same borrow-into-AST pattern as RES-2060 (isr_call_graph) / RES-2062 (reentrancy_guard) / RES-2058 (numeric_units) / RES-2054 (age_bounded_data) and the broader RES-1495..1538 series.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib toctou` — 3/3 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #2064