### PR TITLE
RES-2066: cluster_verifier collect_self_assignments — O(K²) retain+push → O(K) reverse scan

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -281,8 +281,8 @@
       "claimed_at": "2026-05-13T11:59:58Z"
     },
     "resilient/src/cluster_verifier.rs": {
-      "branch": "res-1770-verifier-presize",
-      "claimed_at": "2026-05-13T11:59:58Z"
+      "branch": "res-2066-cluster-verifier-rev-scan",
+      "claimed_at": "2026-05-20T05:00:00Z"
     },
     "resilient/src/verifier_liveness.rs": {
       "branch": "res-1770-verifier-presize",

--- a/resilient/src/cluster_verifier.rs
+++ b/resilient/src/cluster_verifier.rs
@@ -635,15 +635,20 @@ fn collect_self_assignments(body: &Node) -> Result<Vec<(String, Node)>, String> 
     // RES-1770: pre-size to stmts.len() — every handler body
     // statement must be a `FieldAssignment` (else we error out),
     // and each one contributes exactly one push.
-    let mut out: Vec<(String, Node)> = Vec::with_capacity(stmts.len());
+    //
+    // RES-2066: walk `stmts` once in reverse and keep only the
+    // first occurrence of each field name (rev-first = last-write
+    // source-wise). The previous shape used `retain` + `push` per
+    // statement, which scanned the full `out` vector on every
+    // step — O(K²) for K statements. The new shape is O(K) with
+    // a per-call HashSet that borrows into the AST.
+    //
+    // Pre-pass: validate that every statement is a
+    // `self.<field> = EXPR;` so the error diagnostic still fires
+    // before any work — the rev-scan below assumes well-formed
+    // statements.
     for stmt in stmts {
-        let Node::FieldAssignment {
-            target,
-            field,
-            value,
-            ..
-        } = stmt
-        else {
+        let Node::FieldAssignment { target, .. } = stmt else {
             return Err(format!(
                 "statement `{}` — supported: `self.<field> = EXPR;`",
                 node_kind(stmt)
@@ -658,14 +663,20 @@ fn collect_self_assignments(body: &Node) -> Result<Vec<(String, Node)>, String> 
                 ));
             }
         }
-        // Replace any earlier write to this field so the last
-        // assignment wins, then append so source order is
-        // preserved for the unmodified fields. `retain` +
-        // `push` rather than a map keeps the Vec ordering.
-        out.retain(|(f, _)| f != field);
-        out.push((field.clone(), (**value).clone()));
     }
-    Ok(out)
+
+    let mut seen: std::collections::HashSet<&str> =
+        std::collections::HashSet::with_capacity(stmts.len());
+    let mut rev_out: Vec<(String, Node)> = Vec::with_capacity(stmts.len());
+    for stmt in stmts.iter().rev() {
+        if let Node::FieldAssignment { field, value, .. } = stmt
+            && seen.insert(field.as_str())
+        {
+            rev_out.push((field.clone(), (**value).clone()));
+        }
+    }
+    rev_out.reverse();
+    Ok(rev_out)
 }
 
 /// Human-readable node kind for diagnostics. Matches the terms


### PR DESCRIPTION
## Summary

`cluster_verifier::collect_self_assignments` implemented last-write-wins semantics over handler-body field assignments via `Vec::retain` + `Vec::push`:

```rust
for stmt in stmts {
    // ...
    out.retain(|(f, _)| f != field);     // O(out.len())
    out.push((field.clone(), (**value).clone()));
}
```

For K statements all writing distinct fields, retain is O(K) per push — **O(K²) total** per call. On the Z3 actor-invariant verification critical path (called per always-clause per handler per actor), large handler bodies paid this cost on every Z3 dispatch.

## Changes

1. First-pass validation that every statement is `self.<field> = EXPR;` (preserves the same error diagnostic shape and fires before any output is built).
2. Reverse walk over stmts with a `HashSet<&str>` of fields already seen. The first occurrence in reverse order = the last assignment in source order; push only on first insert.
3. `rev_out.reverse()` restores source order.

Net per call: O(K) instead of O(K²). The HashSet borrows into the AST so no extra String allocations.

## Impact

The pass is `#[cfg(feature = "z3")]` — only realized in z3 builds, but z3 builds are exactly where Z3 verification latency matters. Each Z3 dispatch for an actor's always-clause invokes this. For a handler body with 30 field assignments, the relative cost drops by ~30× (from ~900 scans down to ~30).

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Z3-feature build verified by CI (libz3 not installed locally)

The verifier-actors test suite exercises this path; CI verifies z3-gated tests on every PR.

Note: the stale file-claim from `res-1770-verifier-presize` was rolled forward to this branch.

Closes #2066