### PR TITLE
RES-2068: verifier_liveness — borrow handler name + requires slice into other_posts

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -285,8 +285,8 @@
       "claimed_at": "2026-05-13T11:59:58Z"
     },
     "resilient/src/verifier_liveness.rs": {
-      "branch": "res-1770-verifier-presize",
-      "claimed_at": "2026-05-13T11:59:58Z"
+      "branch": "res-2068-liveness-borrow-other-posts",
+      "claimed_at": "2026-05-20T05:30:00Z"
     },
     "resilient/src/recovery_checker.rs": {
       "branch": "res-1774-recovery-lint-presize",

--- a/resilient/src/verifier_liveness.rs
+++ b/resilient/src/verifier_liveness.rs
@@ -166,7 +166,14 @@ pub(crate) fn verify_actor_liveness(
         // pushes at most one entry per handler (skipping only the
         // target). Saves the 0→4 doubling chain on actors with many
         // receive handlers.
-        let mut other_posts: Vec<(String, Node, Vec<Node>)> =
+        //
+        // RES-2068: borrow `h.name` and `h.requires` into the AST
+        // instead of cloning. Both consumers (check_candidate's
+        // diagnostic + the inner requires loop) only read these
+        // values — the deep `Vec<Node>` clone was particularly
+        // expensive because Node is recursive. The source slice
+        // `receive_handlers` outlives this whole call.
+        let mut other_posts: Vec<(&str, Node, &[Node])> =
             Vec::with_capacity(receive_handlers.len());
         let mut bailed = false;
         for h in receive_handlers {
@@ -190,7 +197,7 @@ pub(crate) fn verify_actor_liveness(
                 bailed = true;
                 break;
             };
-            other_posts.push((h.name.clone(), post, h.requires.clone()));
+            other_posts.push((h.name.as_str(), post, h.requires.as_slice()));
         }
         if bailed {
             continue;
@@ -259,7 +266,7 @@ fn try_rank_search(
     post: &Node,
     target_post: &Node,
     target_requires: &[Node],
-    other_posts: &[(String, Node, Vec<Node>)],
+    other_posts: &[(&str, Node, &[Node])],
     timeout_ms: u32,
 ) -> LivenessResult {
     let mut last_reason = String::from("no ranking candidate discharged the obligations");
@@ -299,7 +306,7 @@ fn check_candidate(
     post: &Node,
     target_post: &Node,
     target_requires: &[Node],
-    other_posts: &[(String, Node, Vec<Node>)],
+    other_posts: &[(&str, Node, &[Node])],
     timeout_ms: u32,
 ) -> CandidateVerdict {
     // Constraint — target handler strictly decreases or reaches zero:
@@ -337,7 +344,7 @@ fn check_candidate(
     for (h_name, post_h, req_h) in other_posts {
         let mu_post_h = crate::verifier_actors::substitute_state_public(mu, state_name, post_h);
         let mut ant = mk_true();
-        for r in req_h {
+        for r in req_h.iter() {
             ant = and_node(ant, r.clone());
         }
         let non_increase = infix(mu_post_h, "<=", mu_pre.clone());


### PR DESCRIPTION
## Summary

`verify_actor_liveness` built `other_posts: Vec<(String, Node, Vec<Node>)>` for the ranking-function search over non-target handlers:

```rust
other_posts.push((h.name.clone(), post, h.requires.clone()));
```

Two allocations per non-target handler:
- `h.name.clone()` — one String allocation.
- `h.requires.clone()` — clones a `Vec<Node>`. Node is recursive, so each clone is proportional to the requires-clause AST size.

For an actor with K handlers and an eventually clause targeting one: (K-1) String + (K-1) **deep** Vec<Node> clones per eventually clause.

Both consumers in `check_candidate` (the inner `for r in req_h` AND-fold + the diagnostic `h_name` format!) only **read** the data — never take ownership. The source slice `receive_handlers: &[ReceiveHandler]` outlives the entire call.

## Changes

- `other_posts: Vec<(&str, Node, &[Node])>` borrowing into the AST.
- `try_rank_search` + `check_candidate` signatures take `&[(&str, Node, &[Node])]`.
- The inner `for r in req_h` loop uses `req_h.iter()` since `req_h` is now `&&[Node]` from the borrowed-tuple destructure.

The `post: Node` element stays owned because `straight_line_post_public` returns a freshly-substituted Node.

## Impact

Per eventually-clause: (K-1) String + (K-1) deep Vec<Node> clones eliminated. The Vec<Node> clones are the dominant cost since Node is recursive. The pass is `#[cfg(feature = "z3")]` so the speedup is realized in z3 builds, where Z3 verification latency is the primary perf concern.

## Pattern

Same borrow-into-AST pattern as RES-2060 (isr_call_graph), RES-2062 (reentrancy_guard), RES-2064 (toctou_guard), RES-2066 (cluster_verifier).

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib verifier_liveness` — 4/4 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Z3-feature build verified by CI (libz3 not installed locally)

Note: the stale file-claim from `res-1770-verifier-presize` was rolled forward to this branch.

Closes #2068