### PR TITLE
RES-2070: verifier_loop_invariants — borrow assigned-names set into AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -333,8 +333,8 @@
       "claimed_at": "2026-05-13T12:47:28Z"
     },
     "resilient/src/verifier_loop_invariants.rs": {
-      "branch": "res-1954-loop-invariant-cert-presize",
-      "claimed_at": "2026-05-19T18:44:10Z"
+      "branch": "res-2070-loop-inv-assigned-borrow",
+      "claimed_at": "2026-05-20T06:00:00Z"
     },
     "resilient/src/traits.rs": {
       "branch": "res-1802-traits-presize",

--- a/resilient/src/verifier_loop_invariants.rs
+++ b/resilient/src/verifier_loop_invariants.rs
@@ -180,7 +180,12 @@ fn walk(
 
             // Compute the set of names assigned in the body — these
             // become free in the inductive step.
-            let mut assigned: BTreeSet<String> = BTreeSet::new();
+            //
+            // RES-2070: borrow names as `&str` from the body AST.
+            // The set is only consulted via `.contains(&str)` in
+            // try_prove_invariant; owned String keys were pure
+            // overhead since the body outlives the verifier call.
+            let mut assigned: BTreeSet<&str> = BTreeSet::new();
             collect_assigned_names(body, &mut assigned);
 
             for inv in pre_invariants.iter().chain(body_invs.iter().copied()) {
@@ -228,7 +233,7 @@ fn try_prove_invariant(
     condition: &Node,
     body: &Node,
     bindings: &HashMap<String, i64>,
-    assigned: &BTreeSet<String>,
+    assigned: &BTreeSet<&str>,
     loop_span: &Span,
     next_idx: &mut usize,
     timeout_ms: u32,
@@ -361,11 +366,16 @@ fn literal_int(node: &Node) -> Option<i64> {
 /// assignment counts. Unsupported assignment forms (`FieldAssignment`,
 /// `IndexAssignment`) record nothing; the WP step will bail on those
 /// bodies anyway.
+// RES-2070: borrow names as `&'a str` from the body AST. The
+// caller's only use of the set is `assigned.contains(&str)` in the
+// inductive-step `step_bindings` filter — owned String keys were
+// pure overhead. The body AST outlives this whole verifier call,
+// so the `&'a str` borrows are valid.
 #[cfg(feature = "z3")]
-fn collect_assigned_names(node: &Node, out: &mut BTreeSet<String>) {
+fn collect_assigned_names<'a>(node: &'a Node, out: &mut BTreeSet<&'a str>) {
     match node {
         Node::Assignment { name, .. } => {
-            out.insert(name.clone());
+            out.insert(name.as_str());
         }
         Node::Block { stmts, .. } => {
             for s in stmts {


### PR DESCRIPTION
## Summary

`collect_assigned_names` populated a `BTreeSet<String>` of names assigned in a loop body. Each insert allocated:

```rust
out.insert(name.clone());
```

The set's only consumer is `try_prove_invariant`'s step_bindings filter:

```rust
if !assigned.contains(k.as_str()) {
    step_bindings.insert(k.clone(), *v);
}
```

`.contains(&str)` accepts borrowed keys via `String: Borrow<str>` — the owned `String` storage was pure overhead. `body: &Node` outlives the entire verifier call.

## Changes

- `assigned: BTreeSet<&str>` in the WhileStatement walk arm.
- `collect_assigned_names<'a>(node: &'a Node, out: &mut BTreeSet<&'a str>)`.
- `try_prove_invariant` signature takes `assigned: &BTreeSet<&str>`.

The `.contains(k.as_str())` lookup is unchanged in form — only the underlying set storage changed.

## Impact

For each `WhileStatement` with N distinct assigned variables: N String allocations eliminated. The pass is `#[cfg(feature = "z3")]`; loop-invariant verification is on the Z3 critical path so per-loop allocations compound across the verification suite.

## Pattern

Same borrow-into-AST pattern as RES-2060 (isr_call_graph), RES-2062 (reentrancy_guard), RES-2064 (toctou_guard), RES-2068 (verifier_liveness).

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Z3-feature build verified by CI (libz3 not installed locally)

Note: the stale file-claim from `res-1954-loop-invariant-cert-presize` (no open PR) was rolled forward to this branch.

Closes #2070