### PR TITLE
RES-2072: lint check — nested HashMap allows drops per-lint String clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -293,8 +293,8 @@
       "claimed_at": "2026-05-13T12:06:03Z"
     },
     "resilient/src/lint.rs": {
-      "branch": "res-1774-recovery-lint-presize",
-      "claimed_at": "2026-05-13T12:06:03Z"
+      "branch": "res-2072-lint-allows-nested-map",
+      "claimed_at": "2026-05-20T06:30:00Z"
     },
     "resilient/src/hw_state_machine.rs": {
       "branch": "res-2010-hw-state-nested-map",

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -1802,16 +1802,27 @@ pub fn check(program: &Node, source: &str) -> Vec<Lint> {
     // guaranteed empty. The `safety_critical && l.code == "L0006"`
     // gate is also a no-op when nothing would otherwise drop the
     // lint — early-out keeps every lint in that case too.
+    //
+    // RES-2072: nested-map lookup drops the per-lint `l.code.clone()`
+    // that the previous `HashSet<(u32, String)>::contains` required
+    // to form a tuple key. `HashSet<String>::contains(&str)` works
+    // via `String: Borrow<str>`, so the new shape is allocation-free
+    // on the hot retain path.
     let allows = collect_allow_comments(source);
     if !allows.is_empty() {
         out.retain(|l| {
             if safety_critical && l.code == "L0006" {
                 return true;
             }
-            if allows.contains(&(l.line, l.code.clone())) {
+            if let Some(codes) = allows.get(&l.line)
+                && codes.contains(l.code.as_str())
+            {
                 return false;
             }
-            if l.code == "L0011" && allows.contains(&(l.line, "L0001".to_string())) {
+            if l.code == "L0011"
+                && let Some(codes) = allows.get(&l.line)
+                && codes.contains("L0001")
+            {
                 return false;
             }
             true
@@ -3244,8 +3255,15 @@ fn recurse_children<F: FnMut(&Node)>(node: &Node, f: &mut F) {
 // K+1. Only `L` codes are recognized; `// resilient: allow foo`
 // is treated as ordinary text.
 
-fn collect_allow_comments(source: &str) -> std::collections::HashSet<(u32, String)> {
-    let mut out = std::collections::HashSet::new();
+// RES-2072: nested-map shape — line → set of allowed codes. The
+// retain loop in `check` then queries with borrowed `&str` against
+// the inner set, dropping the per-lint `l.code.clone()` it
+// previously paid to form a `(u32, String)` tuple-key lookup.
+fn collect_allow_comments(
+    source: &str,
+) -> std::collections::HashMap<u32, std::collections::HashSet<String>> {
+    let mut out: std::collections::HashMap<u32, std::collections::HashSet<String>> =
+        std::collections::HashMap::new();
     for (i, raw) in source.lines().enumerate() {
         let line_no = (i as u32) + 1;
         let Some(pos) = raw.find("// resilient: allow") else {
@@ -3256,7 +3274,7 @@ fn collect_allow_comments(source: &str) -> std::collections::HashSet<(u32, Strin
         for word in tail.split(|c: char| c == ',' || c.is_whitespace()) {
             let w = word.trim();
             if w.starts_with('L') && w.len() == 5 && w.chars().skip(1).all(|c| c.is_ascii_digit()) {
-                out.insert((line_no + 1, w.to_string()));
+                out.entry(line_no + 1).or_default().insert(w.to_string());
             }
         }
     }


### PR DESCRIPTION
## Summary

`lint::check`'s retain loop ran per emitted lint and cloned `l.code` to form a `(u32, String)` tuple-key lookup against `allows: HashSet<(u32, String)>`:

```rust
if allows.contains(&(l.line, l.code.clone())) { return false; }
if l.code == "L0011" && allows.contains(&(l.line, "L0001".to_string())) { return false; }
```

For N emitted lints with any allow comments present: N String clones + 1 `to_string()` per L0011 lint, all as throwaway tuple lookup keys.

## Changes

`allows` switches from `HashSet<(u32, String)>` to `HashMap<u32, HashSet<String>>` (line → set of allowed codes). The retain loop queries via borrowed `&str`:

```rust
if let Some(codes) = allows.get(&l.line)
    && codes.contains(l.code.as_str())
{ return false; }
```

`HashSet<String>::contains(&str)` works via `String: Borrow<str>` — no allocation on the hot retain path.

`collect_allow_comments` returns the nested map; entries are built via `out.entry(line).or_default().insert(code)`.

## Impact

`lint::check` runs on every typecheck (per file edit in the LSP path). For projects that use any `// resilient: allow ...` comments and emit N lints, that's N String clones eliminated per keystroke.

## Pattern

Same nested-HashMap pattern as RES-2008 (typestate_types), RES-2010 (hw_state_machine), RES-2012 (default_trait_methods), RES-2014 (associated_constants), RES-2016 (lock_ordering), RES-2046 (incremental_verify), RES-2056 (traits).

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib lint` — 336/336 pass
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

The L0011 ↔ L0001 alias suppression is unchanged: `L0011` on a line is still suppressed by an `L0001` allow on the same line.

Note: the stale file-claim from `res-1774-recovery-lint-presize` was rolled forward to this branch.

Closes #2072