### PR TITLE
RES-2076: result_option_hof — borrow callback function in 8 builtins

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -423,6 +423,10 @@
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
       "claimed_at": "2026-05-19T22:27:31Z"
+    },
+    "resilient/src/result_option_hof.rs": {
+      "branch": "res-2076-result-option-hof-borrow-f",
+      "claimed_at": "2026-05-20T00:17:14Z"
     }
   }
 }

--- a/resilient/src/result_option_hof.rs
+++ b/resilient/src/result_option_hof.rs
@@ -25,7 +25,7 @@ type RResult<T> = Result<T, String>;
 /// unchanged. Analogous to `Result::map` in Rust.
 pub(crate) fn builtin_result_map(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
     let (r, f) = match args {
-        [Value::Result { .. }, f] => (args[0].clone(), f.clone()),
+        [Value::Result { .. }, f] => (args[0].clone(), f),
         [a, _] => {
             return Err(format!(
                 "result_map: first argument must be a Result, got {a}"
@@ -40,7 +40,7 @@ pub(crate) fn builtin_result_map(interp: &mut Interpreter, args: &[Value]) -> RR
     };
     match r {
         Value::Result { ok: true, payload } => {
-            let mapped = interp.apply_function(&f, vec![*payload])?;
+            let mapped = interp.apply_function(f, vec![*payload])?;
             Ok(Value::Result {
                 ok: true,
                 payload: Box::new(mapped),
@@ -58,7 +58,7 @@ pub(crate) fn builtin_result_map(interp: &mut Interpreter, args: &[Value]) -> RR
 /// bind / flatMap for `Result`.
 pub(crate) fn builtin_result_and_then(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
     let (r, f) = match args {
-        [Value::Result { .. }, f] => (args[0].clone(), f.clone()),
+        [Value::Result { .. }, f] => (args[0].clone(), f),
         [a, _] => {
             return Err(format!(
                 "result_and_then: first argument must be a Result, got {a}"
@@ -73,7 +73,7 @@ pub(crate) fn builtin_result_and_then(interp: &mut Interpreter, args: &[Value]) 
     };
     match r {
         Value::Result { ok: true, payload } => {
-            let out = interp.apply_function(&f, vec![*payload])?;
+            let out = interp.apply_function(f, vec![*payload])?;
             match out {
                 r @ Value::Result { .. } => Ok(r),
                 other => Err(format!(
@@ -92,7 +92,7 @@ pub(crate) fn builtin_result_and_then(interp: &mut Interpreter, args: &[Value]) 
 /// unchanged.
 pub(crate) fn builtin_result_map_err(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
     let (r, f) = match args {
-        [Value::Result { .. }, f] => (args[0].clone(), f.clone()),
+        [Value::Result { .. }, f] => (args[0].clone(), f),
         [a, _] => {
             return Err(format!(
                 "result_map_err: first argument must be a Result, got {a}"
@@ -108,7 +108,7 @@ pub(crate) fn builtin_result_map_err(interp: &mut Interpreter, args: &[Value]) -
     match r {
         ok @ Value::Result { ok: true, .. } => Ok(ok),
         Value::Result { ok: false, payload } => {
-            let mapped = interp.apply_function(&f, vec![*payload])?;
+            let mapped = interp.apply_function(f, vec![*payload])?;
             Ok(Value::Result {
                 ok: false,
                 payload: Box::new(mapped),
@@ -124,7 +124,7 @@ pub(crate) fn builtin_result_map_err(interp: &mut Interpreter, args: &[Value]) -
 /// `Result`). If `r` is `Ok(v)`, returns it unchanged.
 pub(crate) fn builtin_result_or_else(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
     let (r, f) = match args {
-        [Value::Result { .. }, f] => (args[0].clone(), f.clone()),
+        [Value::Result { .. }, f] => (args[0].clone(), f),
         [a, _] => {
             return Err(format!(
                 "result_or_else: first argument must be a Result, got {a}"
@@ -140,7 +140,7 @@ pub(crate) fn builtin_result_or_else(interp: &mut Interpreter, args: &[Value]) -
     match r {
         ok @ Value::Result { ok: true, .. } => Ok(ok),
         Value::Result { ok: false, payload } => {
-            let out = interp.apply_function(&f, vec![*payload])?;
+            let out = interp.apply_function(f, vec![*payload])?;
             match out {
                 r @ Value::Result { .. } => Ok(r),
                 other => Err(format!(
@@ -160,7 +160,7 @@ pub(crate) fn builtin_result_or_else(interp: &mut Interpreter, args: &[Value]) -
 /// `None`. Analogous to `Option::map` in Rust.
 pub(crate) fn builtin_option_map(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
     let (o, f) = match args {
-        [Value::Option(_), f] => (args[0].clone(), f.clone()),
+        [Value::Option(_), f] => (args[0].clone(), f),
         [a, _] => {
             return Err(format!(
                 "option_map: first argument must be an Option, got {a}"
@@ -175,7 +175,7 @@ pub(crate) fn builtin_option_map(interp: &mut Interpreter, args: &[Value]) -> RR
     };
     match o {
         Value::Option(Some(inner)) => {
-            let mapped = interp.apply_function(&f, vec![*inner])?;
+            let mapped = interp.apply_function(f, vec![*inner])?;
             Ok(Value::Option(Some(Box::new(mapped))))
         }
         none @ Value::Option(None) => Ok(none),
@@ -189,7 +189,7 @@ pub(crate) fn builtin_option_map(interp: &mut Interpreter, args: &[Value]) -> RR
 /// an `Option`). If `o` is `None`, returns `None`. Monadic bind for `Option`.
 pub(crate) fn builtin_option_and_then(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
     let (o, f) = match args {
-        [Value::Option(_), f] => (args[0].clone(), f.clone()),
+        [Value::Option(_), f] => (args[0].clone(), f),
         [a, _] => {
             return Err(format!(
                 "option_and_then: first argument must be an Option, got {a}"
@@ -204,7 +204,7 @@ pub(crate) fn builtin_option_and_then(interp: &mut Interpreter, args: &[Value]) 
     };
     match o {
         Value::Option(Some(inner)) => {
-            let out = interp.apply_function(&f, vec![*inner])?;
+            let out = interp.apply_function(f, vec![*inner])?;
             match out {
                 o @ Value::Option(_) => Ok(o),
                 other => Err(format!(
@@ -223,7 +223,7 @@ pub(crate) fn builtin_option_and_then(interp: &mut Interpreter, args: &[Value]) 
 /// other cases (None, or predicate returned false) returns `None`.
 pub(crate) fn builtin_option_filter(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
     let (o, f) = match args {
-        [Value::Option(_), f] => (args[0].clone(), f.clone()),
+        [Value::Option(_), f] => (args[0].clone(), f),
         [a, _] => {
             return Err(format!(
                 "option_filter: first argument must be an Option, got {a}"
@@ -237,7 +237,7 @@ pub(crate) fn builtin_option_filter(interp: &mut Interpreter, args: &[Value]) ->
         }
     };
     match o {
-        Value::Option(Some(inner)) => match interp.apply_function(&f, vec![*inner.clone()])? {
+        Value::Option(Some(inner)) => match interp.apply_function(f, vec![*inner.clone()])? {
             Value::Bool(true) => Ok(Value::Option(Some(inner))),
             Value::Bool(false) => Ok(Value::Option(None)),
             other => Err(format!(
@@ -255,7 +255,7 @@ pub(crate) fn builtin_option_filter(interp: &mut Interpreter, args: &[Value]) ->
 /// must be an `Option`). If `o` is `Some(v)`, returns it unchanged.
 pub(crate) fn builtin_option_or_else(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
     let (o, f) = match args {
-        [Value::Option(_), f] => (args[0].clone(), f.clone()),
+        [Value::Option(_), f] => (args[0].clone(), f),
         [a, _] => {
             return Err(format!(
                 "option_or_else: first argument must be an Option, got {a}"
@@ -271,7 +271,7 @@ pub(crate) fn builtin_option_or_else(interp: &mut Interpreter, args: &[Value]) -
     match o {
         some @ Value::Option(Some(_)) => Ok(some),
         Value::Option(None) => {
-            let out = interp.apply_function(&f, vec![])?;
+            let out = interp.apply_function(f, vec![])?;
             match out {
                 o @ Value::Option(_) => Ok(o),
                 other => Err(format!(


### PR DESCRIPTION
## Summary

`result_option_hof.rs` exposes 8 higher-order builtins (`result_map`, `result_and_then`, `result_map_err`, `result_or_else`, `option_map`, `option_and_then`, `option_filter`, `option_or_else`). Each started with the same `f.clone()` pattern:

```rust
let (r, f) = match args {
    [Value::Result { .. }, f] => (args[0].clone(), f.clone()),
    ...
};
```

`f.clone()` deep-clones a `Value`. For `Value::Function(Box<FunctionValue>)`, that's a Box alloc plus a deep clone of FunctionValue — which includes `requires: Vec<Node>` and `ensures: Vec<Node>` (recursive Node clones, proportional to contract AST size).

`apply_function` already takes `func: &Value`, so these builtins never needed to own the function. The clone was pure overhead per call.

## Changes

Match `f` by reference in all 8 sites and pass it directly to `apply_function`:

```rust
let (r, f) = match args {
    [Value::Result { .. }, f] => (args[0].clone(), f),
    ...
};
```

`r` still needs to be owned (for the Err / None passthrough that returns `Ok(r)` after pattern destructuring).

## Impact

Per call to any of the 8 builtins: one `Value::Function` clone eliminated (Box alloc + deep clone of requires/ensures Vecs). For contract-heavy functions, the eliminated clone is proportional to the contract AST size.

## Pattern

Same borrow-not-clone pattern as RES-1934 (array_combinators) and RES-2036 (the remaining 7 array combinators).

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib result_option` — 35/35 pass (covers result_map / and_then / map_err / or_else and option_map / and_then / filter / or_else)
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #2076