### PR TITLE
RES-2078: collection_extras — borrow arr/f in array_key_by + array_iterate

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -423,6 +423,10 @@
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
       "claimed_at": "2026-05-19T22:27:31Z"
+    },
+    "resilient/src/collection_extras.rs": {
+      "branch": "res-2078-collection-extras-borrow",
+      "claimed_at": "2026-05-20T00:21:10Z"
     }
   }
 }

--- a/resilient/src/collection_extras.rs
+++ b/resilient/src/collection_extras.rs
@@ -58,8 +58,13 @@ pub(crate) fn builtin_array_frequency_map(args: &[Value]) -> RResult<Value> {
 /// // by_name == {"alice" -> ["alice",30], "bob" -> ["bob",25]}
 /// ```
 pub(crate) fn builtin_array_key_by(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-2078: borrow `arr` and `f` instead of cloning. Same pattern
+    // as RES-1934 / RES-2036 for array_combinators. The previous shape
+    // deep-cloned the whole Vec<Value> + the Value::Function (with
+    // deep requires/ensures clones) per call — both wasted; we only
+    // need owned Values at the per-element insert into the output map.
     let (arr, f) = match args {
-        [Value::Array(a), f] => (a.clone(), f.clone()),
+        [Value::Array(a), f] => (a, f),
         [a, _] => {
             return Err(format!(
                 "array_key_by: first argument must be an Array, got {a}"
@@ -76,11 +81,11 @@ pub(crate) fn builtin_array_key_by(interp: &mut Interpreter, args: &[Value]) -> 
     let mut map: std::collections::HashMap<MapKey, Value> =
         std::collections::HashMap::with_capacity(arr.len());
 
-    for elem in arr {
-        let key_val = interp.apply_function(&f, vec![elem.clone()])?;
+    for elem in arr.iter() {
+        let key_val = interp.apply_function(f, vec![elem.clone()])?;
         let mk = MapKey::from_value(&key_val)
             .map_err(|e| format!("array_key_by: key function returned non-hashable value: {e}"))?;
-        map.insert(mk, elem);
+        map.insert(mk, elem.clone());
     }
 
     Ok(Value::Map(map))
@@ -97,8 +102,12 @@ pub(crate) fn builtin_array_key_by(interp: &mut Interpreter, args: &[Value]) -> 
 /// // powers == [1, 2, 4, 8, 16, 32]
 /// ```
 pub(crate) fn builtin_array_iterate(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-2078: borrow `f` instead of cloning. `apply_function` takes
+    // `&Value` so the function never needed to be owned. `init` is
+    // cloned once (necessary for ownership of the accumulator that
+    // mutates each iteration). Same pattern as RES-2076.
     let (init, n, f) = match args {
-        [init, Value::Int(n), f] => (init.clone(), *n, f.clone()),
+        [init, Value::Int(n), f] => (init.clone(), *n, f),
         [_, n, _] => {
             return Err(format!(
                 "array_iterate: second argument must be an int, got {n}"
@@ -120,7 +129,7 @@ pub(crate) fn builtin_array_iterate(interp: &mut Interpreter, args: &[Value]) ->
     let mut current = init;
     out.push(current.clone());
     for _ in 0..n {
-        current = interp.apply_function(&f, vec![current])?;
+        current = interp.apply_function(f, vec![current])?;
         out.push(current.clone());
     }
     Ok(Value::Array(out))


### PR DESCRIPTION
## Summary

Two builtins in `collection_extras.rs` matched the RES-1934 / RES-2036 `(a.clone(), f.clone())` antipattern.

### `array_key_by`

```rust
let (arr, f) = match args {
    [Value::Array(a), f] => (a.clone(), f.clone()),    // <-- two deep clones
    ...
};
for elem in arr {
    let key_val = interp.apply_function(&f, vec![elem.clone()])?;
    ...
    map.insert(mk, elem);
}
```

Deep-cloned the whole `Vec<Value>` upfront plus the function (`Value::Function` with deep `requires`/`ensures` clones). The loop then iterated the cloned Vec moving elements one at a time — none of that needed to be owned.

### `array_iterate`

```rust
let (init, n, f) = match args {
    [init, Value::Int(n), f] => (init.clone(), *n, f.clone()),    // <-- f.clone()
    ...
};
```

`init` legitimately needs to be owned (accumulator seed). `f.clone()` was unnecessary — `apply_function` takes `&Value`.

## Changes

Both fixes borrow `f` (and `arr` where applicable), iterating via `.iter()` and cloning individual elements only at the `apply_function` callsite + the final `map.insert`. Same RES-1934 / RES-2036 / RES-2076 pattern.

## Impact

Per call:
- **array_key_by**: 1 full `Vec<Value>` deep clone + 1 `Value::Function` clone eliminated.
- **array_iterate**: 1 `Value::Function` clone eliminated.

`Value::Function` clones include a deep clone of the function's `requires` / `ensures` `Vec<Node>` contracts — proportional to the contract AST size.

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib collection_extras` — 11/11 pass (covers `array_key_by`, `array_iterate`, `array_frequency_map`)
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #2078