### PR TITLE
RES-2080: type_builtins::array_from_fn — borrow callback instead of cloning

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -423,6 +423,10 @@
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
       "claimed_at": "2026-05-19T22:27:31Z"
+    },
+    "resilient/src/type_builtins.rs": {
+      "branch": "res-2080-array-from-fn-borrow",
+      "claimed_at": "2026-05-20T00:24:38Z"
     }
   }
 }

--- a/resilient/src/type_builtins.rs
+++ b/resilient/src/type_builtins.rs
@@ -115,8 +115,14 @@ pub(crate) fn builtin_result_collect(args: &[Value]) -> RResult<Value> {
 /// // squares == [0, 1, 4, 9, 16]
 /// ```
 pub(crate) fn builtin_array_from_fn(interp: &mut Interpreter, args: &[Value]) -> RResult<Value> {
+    // RES-2080: borrow `f` instead of cloning. `apply_function` takes
+    // `&Value`, so the function never needed to be owned. Same
+    // pattern as RES-2076 (result_option_hof), RES-2078
+    // (collection_extras). The eliminated clone is a deep Value::Function
+    // clone (Box alloc + FunctionValue clone with deep requires/ensures
+    // Vec<Node> clones).
     let (n, f) = match args {
-        [Value::Int(n), f] => (*n, f.clone()),
+        [Value::Int(n), f] => (*n, f),
         [n, _] => {
             return Err(format!(
                 "array_from_fn: first argument must be an int, got {n}"
@@ -136,7 +142,7 @@ pub(crate) fn builtin_array_from_fn(interp: &mut Interpreter, args: &[Value]) ->
 
     let mut out = Vec::with_capacity(n as usize);
     for i in 0..n {
-        out.push(interp.apply_function(&f, vec![Value::Int(i)])?);
+        out.push(interp.apply_function(f, vec![Value::Int(i)])?);
     }
     Ok(Value::Array(out))
 }


### PR DESCRIPTION
## Summary

`builtin_array_from_fn` cloned the callback function on entry:

```rust
let (n, f) = match args {
    [Value::Int(n), f] => (*n, f.clone()),    // <-- deep clone
    ...
};
for i in 0..n {
    out.push(interp.apply_function(&f, vec![Value::Int(i)])?);
}
```

`f.clone()` deep-clones a `Value::Function(Box<FunctionValue>)` — Box alloc + FunctionValue clone including `requires: Vec<Node>` and `ensures: Vec<Node>` (recursive Node clones, proportional to contract AST size).

`apply_function` takes `func: &Value`, so the function never needed to be owned. The clone was pure overhead per call.

## Changes

Match `f` by reference, pass directly to `apply_function`:

```rust
let (n, f) = match args {
    [Value::Int(n), f] => (*n, f),
    ...
};
for i in 0..n {
    out.push(interp.apply_function(f, vec![Value::Int(i)])?);
}
```

## Impact

Per call: one `Value::Function` clone eliminated. For contract-heavy callbacks, proportional to AST size.

## Pattern

Same borrow-not-clone pattern as RES-2076 (result_option_hof) and RES-2078 (collection_extras).

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib type_builtins` — 12/12 pass (covers `array_from_fn_squares`, `array_from_fn_strings`, `array_from_fn_zero_length`, `array_from_fn_negative_n_errors`)
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #2080