### PR TITLE
RES-2082: mutation_testing::summarize — borrow fn_name + kind into &str map

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -365,8 +365,8 @@
       "claimed_at": "2026-05-19T05:02:34Z"
     },
     "resilient/src/mutation_testing.rs": {
-      "branch": "res-1918-mutation-testing-walker-coverage",
-      "claimed_at": "2026-05-19T16:38:37Z"
+      "branch": "res-2082-mutation-testing-summarize-borrow",
+      "claimed_at": "2026-05-20T07:00:00Z"
     },
     "resilient/src/verifier_z3.rs": {
       "branch": "res-1920-collect-cert-idents-single-walk",

--- a/resilient/src/mutation_testing.rs
+++ b/resilient/src/mutation_testing.rs
@@ -339,13 +339,22 @@ fn generate_in(node: &Node, fn_name: &str, out: &mut Vec<Mutation>) {
 }
 
 /// Per-function mutation summary: function name → (total sites, kinds).
-pub fn summarize(mutations: &[Mutation]) -> HashMap<String, (usize, Vec<String>)> {
-    let mut map: HashMap<String, (usize, Vec<String>)> = HashMap::new();
+///
+/// RES-2082: borrows fn_name and kind as `&str` into the mutations
+/// slice. The previous shape's `m.fn_name.clone()` allocated a fresh
+/// String on every `map.entry(...)` call (even when the key already
+/// existed — `HashMap::entry` requires owned keys), plus
+/// `m.kind.clone()` allocated per new kind. The sole caller (`check`
+/// in the same file) only reads names for diagnostic formatting;
+/// no consumer takes ownership.
+pub fn summarize(mutations: &[Mutation]) -> HashMap<&str, (usize, Vec<&str>)> {
+    let mut map: HashMap<&str, (usize, Vec<&str>)> = HashMap::new();
     for m in mutations {
-        let e = map.entry(m.fn_name.clone()).or_default();
+        let e = map.entry(m.fn_name.as_str()).or_default();
         e.0 += 1;
-        if !e.1.contains(&m.kind) {
-            e.1.push(m.kind.clone());
+        let kind_ref = m.kind.as_str();
+        if !e.1.contains(&kind_ref) {
+            e.1.push(kind_ref);
         }
     }
     map
@@ -387,7 +396,9 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         summary.len()
     );
     let mut fns: Vec<_> = summary.iter().collect();
-    fns.sort_by_key(|(n, _)| n.as_str());
+    // RES-2082: keys are now `&str` (borrowed from mutations). The
+    // `&&str` from iter() derefs through to `&str` for sort_by_key.
+    fns.sort_by_key(|(n, _)| *n);
     for (fn_name, (count, kinds)) in &fns {
         let mut kinds_sorted = kinds.clone();
         kinds_sorted.sort();
@@ -402,8 +413,10 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let unconstrained: Vec<(&str, usize)> = fns
         .iter()
         .filter_map(|(name, (count, _))| {
-            if !contracted_fns.contains(name.as_str()) {
-                Some((name.as_str(), *count))
+            // RES-2082: `name: &&&str` — deref to `&str` for the
+            // HashSet<&str> contains lookup and the output tuple.
+            if !contracted_fns.contains(**name) {
+                Some((**name, *count))
             } else {
                 None
             }


### PR DESCRIPTION
## Summary

`mutation_testing::summarize` accumulated per-fn mutation stats into `HashMap<String, (usize, Vec<String>)>`:

```rust
pub fn summarize(mutations: &[Mutation]) -> HashMap<String, (usize, Vec<String>)> {
    let mut map: HashMap<String, (usize, Vec<String>)> = HashMap::new();
    for m in mutations {
        let e = map.entry(m.fn_name.clone()).or_default();    // <-- always allocates
        e.0 += 1;
        if !e.1.contains(&m.kind) {
            e.1.push(m.kind.clone());
        }
    }
    map
}
```

Per mutation:
- `m.fn_name.clone()` allocates a String for the entry API call — even when the key already exists. (`HashMap::entry` requires owned keys; no `entry_ref` on stable yet.)
- `m.kind.clone()` allocates per new kind.

The sole consumer (`check` in the same file) only reads names for diagnostic formatting — no consumer takes ownership. The mutations slice (already owned `Vec<Mutation>`) outlives the entire `check` call, so borrowed `&str` keys are sound.

## Changes

- `summarize` now returns `HashMap<&str, (usize, Vec<&str>)>` borrowing into the mutations slice.
- Consumer's `sort_by_key` uses `*n` (deref `&&str` to `&str`).
- Unconstrained-fns filter uses `**name` to deref `&&&str` (from for-loop pattern over `&fns`) down to `&str` for the `HashSet<&str>::contains` lookup.

## Impact

For N mutations across F functions: ~(N - F) String allocations eliminated for fn_name (most entry calls hit existing keys), plus all per-kind String clones eliminated.

## Pattern

Same borrow-into-AST pattern as RES-2058 (numeric_units), RES-2060 (isr_call_graph), RES-2062 (reentrancy_guard), RES-2064 (toctou_guard), RES-2068 (verifier_liveness), RES-2070 (verifier_loop_invariants).

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml --lib mutation_testing` — 34/34 pass (including `summarize_groups_by_function` and `summarize_groups_top_level_and_impl_methods` which exercise summarize directly)
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib` — 4685/4685 pass, no regressions
- [x] `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Note: the stale file-claim from `res-1918-mutation-testing-walker-coverage` (PR merged) was rolled forward to this branch.

Closes #2082