### PR TITLE
RES-2086: mutual_recursion_scc::transpose — borrow &str instead of cloning V + 2E times

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -237,8 +237,8 @@
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/mutual_recursion_scc.rs": {
-      "branch": "res-1760-callgraph-presize",
-      "claimed_at": "2026-05-13T11:42:08Z"
+      "branch": "res-2086-mutual-recursion-scc-borrow",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/set_result_option.rs": {
       "branch": "res-1760-callgraph-presize",

--- a/resilient/src/mutual_recursion_scc.rs
+++ b/resilient/src/mutual_recursion_scc.rs
@@ -106,25 +106,24 @@ impl CallGraph {
     }
 
     /// Return the transposed graph (edges reversed).
-    fn transpose(&self) -> HashMap<String, HashSet<String>> {
-        // RES-1497: pre-size the transposed map to the source's node
-        // count. The transposed graph has the same set of vertices
-        // (every src is also kept as a key via the
-        // `entry(src.clone()).or_default()` line, and every dest is
-        // a vertex in the source so it's already in `self.graph`).
-        // The default-bucket HashMap rehash chain triggered as we
-        // crossed 4/8/16/... bucket boundaries is avoidable with one
-        // upfront `with_capacity`.
-        let mut transposed: HashMap<String, HashSet<String>> =
-            HashMap::with_capacity(self.graph.len());
+    ///
+    /// RES-2086: keys and edge endpoints borrow `&str` from `self.graph`'s
+    /// owned `String`s. The previous shape cloned each source name once for
+    /// its self-entry plus once per outgoing edge (used as the destination's
+    /// inserted endpoint), and each destination name once per incoming edge
+    /// — `V + 2E` `String` allocations per Kosaraju call. Borrowing through
+    /// `self` keeps the same hash-equality semantics (via `&str: Borrow<str>`)
+    /// while dropping every allocation in this pass.
+    fn transpose(&self) -> HashMap<&str, HashSet<&str>> {
+        let mut transposed: HashMap<&str, HashSet<&str>> = HashMap::with_capacity(self.graph.len());
 
         for (src, dests) in &self.graph {
-            transposed.entry(src.clone()).or_default();
+            transposed.entry(src.as_str()).or_default();
             for dest in dests {
                 transposed
-                    .entry(dest.clone())
+                    .entry(dest.as_str())
                     .or_default()
-                    .insert(src.clone());
+                    .insert(src.as_str());
             }
         }
 
@@ -288,9 +287,14 @@ fn dfs_finish_order<'a>(
 }
 
 /// DFS to collect SCC nodes (second DFS pass of Kosaraju on transposed graph).
+///
+/// RES-2086: `transposed` now holds borrowed `&'a str` keys and endpoints
+/// (see `CallGraph::transpose`), so iteration can yield `&'a str` directly
+/// without re-allocating per visit. The `'a` lifetime ties every borrowed
+/// name back to `CallGraph::graph`, which outlives the whole SCC pass.
 fn dfs_collect<'a>(
     node: &'a str,
-    transposed: &'a HashMap<String, HashSet<String>>,
+    transposed: &HashMap<&'a str, HashSet<&'a str>>,
     visited: &mut HashSet<&'a str>,
     scc: &mut Vec<&'a str>,
 ) {
@@ -298,9 +302,9 @@ fn dfs_collect<'a>(
     scc.push(node);
 
     if let Some(neighbors) = transposed.get(node) {
-        for neighbor in neighbors {
-            if !visited.contains(neighbor.as_str()) {
-                dfs_collect(neighbor.as_str(), transposed, visited, scc);
+        for &neighbor in neighbors {
+            if !visited.contains(neighbor) {
+                dfs_collect(neighbor, transposed, visited, scc);
             }
         }
     }


### PR DESCRIPTION
Closes #2086

## Summary

`CallGraph::transpose` previously allocated `V + 2E` `String`s per
Kosaraju invocation to mirror names already owned by `self.graph`.
This change returns `HashMap<&str, HashSet<&str>>` borrowed from
`&self.graph` and threads the borrowed lifetime through `dfs_collect`.

Public API (`find_sccs() -> Vec<Vec<String>>`) is unchanged; the
borrowing only affects the internal Kosaraju machinery.

## Test plan

- [x] `cargo test --lib mutual_recursion_scc` — 4/4 module tests pass
- [x] `cargo test --lib` — full 4685-test sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)