### PR TITLE
RES-2094: property_tests::check — borrow contracted-fn names from program AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,5 +1,9 @@
 {
   "claims": {
+    "resilient/src/property_tests.rs": {
+      "branch": "res-2094-property-tests-borrow",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
       "claimed_at": "2026-05-12T01:23:24Z"

--- a/resilient/src/property_tests.rs
+++ b/resilient/src/property_tests.rs
@@ -96,7 +96,16 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     }
 
     // Build a set of functions that actually have requires/ensures clauses.
-    let mut functions_with_contracts: std::collections::HashSet<String> =
+    //
+    // RES-2094: borrow `&str` from the program AST instead of cloning each
+    // function name into the set. `functions_with_contracts` lives only for
+    // the duration of this `check` call, and every name it stores is owned
+    // by the `program: &Node` reference for that whole window. The previous
+    // shape allocated one `String` per contract-bearing function — typical
+    // safety-critical programs annotate most functions with `requires`/
+    // `ensures`, so on a 50-fn program that's ~50 wasted allocations per
+    // typecheck. `&str: Borrow<str>` keeps `contains(...)` working.
+    let mut functions_with_contracts: std::collections::HashSet<&str> =
         std::collections::HashSet::new();
     if let Node::Program(stmts) = program {
         for stmt in stmts {
@@ -108,7 +117,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             } = &stmt.node
             {
                 if !requires.is_empty() || !ensures.is_empty() {
-                    functions_with_contracts.insert(name.clone());
+                    functions_with_contracts.insert(name.as_str());
                 }
             }
         }
@@ -116,7 +125,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
 
     let mut warnings: Vec<String> = Vec::new();
     for spec in &specs {
-        if !functions_with_contracts.contains(&spec.fn_name) {
+        if !functions_with_contracts.contains(spec.fn_name.as_str()) {
             warnings.push(format!(
                 "{source_path}:0:0: warning[property_test]: \
                  `#[property_test]` on `{}` has no `requires`/`ensures` \


### PR DESCRIPTION
Closes #2094

## Summary

`property_tests::check` previously cloned each contract-bearing
function name into a local `HashSet<String>` that lived only for the
duration of the call. Switching to `HashSet<&str>` borrowed from
`&Node::Function` drops one transient `String` allocation per
contract-bearing function. `&str: Borrow<str>` preserves `contains(...)`
semantics unchanged.

## Test plan

- [x] `cargo test --lib property_tests` — 5/5 module tests pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)