### PR TITLE
RES-2108: generics::Substitution::bind — skip alloc on consistent re-bind

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -93,8 +93,8 @@
       "claimed_at": "2026-05-12T04:21:23Z"
     },
     "resilient/src/generics.rs": {
-      "branch": "res-1523-generics-locals-borrow",
-      "claimed_at": "2026-05-12T13:40:00Z"
+      "branch": "res-2108-substitution-bind-skip-redundant",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/feature_attrs.rs": {
       "branch": "res-1303-feature-attrs-kind-index",

--- a/resilient/src/generics.rs
+++ b/resilient/src/generics.rs
@@ -76,13 +76,21 @@ impl Subst {
     /// was already bound to a different type — that's the
     /// "T must be both Int and String" inconsistency the diagnostic
     /// surface targets.
+    ///
+    /// RES-2108: only allocate the owned `String` key on the first
+    /// binding. When `tp_name` is already mapped to the consistent
+    /// `ty`, return `Ok(())` immediately — re-inserting the same
+    /// (key, value) pair re-allocates the `String` key for nothing.
+    /// Generic-heavy code triggers many redundant binds during
+    /// unification, so this is hot.
     pub fn bind(&mut self, tp_name: &str, ty: Type) -> Result<(), String> {
         match self.map.get(tp_name) {
             Some(existing) if existing != &ty => Err(format!(
                 "type parameter `{}` is inferred as both `{}` and `{}` — they must agree",
                 tp_name, existing, ty
             )),
-            _ => {
+            Some(_) => Ok(()),
+            None => {
                 self.map.insert(tp_name.to_string(), ty);
                 Ok(())
             }


### PR DESCRIPTION
Closes #2108

## Summary

`Substitution::bind` previously re-allocated the owned `String` key on
every successful bind — including redundant re-asserts that confirmed
an existing entry. Splitting the consistency-check arm into `Some(_)`
(skip the insert entirely) vs `None` (allocate-and-insert) eliminates
the redundant `to_string()` on the hot unification path.

## Test plan

- [x] `cargo test --lib generics` — 12/12 pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)