### PR TITLE
RES-2112: async_await::is_async — borrow through guard, drop HashSet deep clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,5 +1,9 @@
 {
   "claims": {
+    "resilient/src/async_await.rs": {
+      "branch": "res-2112-async-await-borrow-guard",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
       "claimed_at": "2026-05-12T01:23:24Z"

--- a/resilient/src/async_await.rs
+++ b/resilient/src/async_await.rs
@@ -35,13 +35,20 @@ pub fn install(set: HashSet<String>) {
     }
 }
 
+/// RES-2112: hold the read guard for the contains check instead of deep-
+/// cloning the entire `HashSet<String>`. The previous shape called
+/// `g.clone()` on the lock guard's `Option<HashSet<String>>` payload
+/// for every `is_async(name)` call — and the typechecker invokes this
+/// for every call expression in the program. On a program with K
+/// async fns and N call sites, that's `N × K` `String` allocations
+/// burnt just to discover the matching subset. Borrowing through the
+/// guard makes each lookup `O(1)` allocation-free. Same pattern as
+/// RES-2074 (ghost_types).
 pub fn is_async(name: &str) -> bool {
-    ASYNC_FNS
-        .read()
-        .ok()
-        .and_then(|g| g.clone())
-        .map(|s| s.contains(name))
-        .unwrap_or(false)
+    let Ok(g) = ASYNC_FNS.read() else {
+        return false;
+    };
+    g.as_ref().is_some_and(|s| s.contains(name))
 }
 
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {


### PR DESCRIPTION
Closes #2112

## Summary

`is_async(name)` deep-cloned the entire `Option<HashSet<String>>` for
every typechecker call-expression visit. Holding the read guard for
the contains check eliminates that — same pattern as RES-2074
(ghost_types).

For a 100-fn program with 5 async fns × 500 call sites: ~2500
transient `String` allocations dropped per typecheck.

## Test plan

- [x] `cargo test --lib async_await` — 2/2 pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)