### PR TITLE
RES-2114: recursive_types::is_recursive — borrow through guard, drop HashSet deep clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,5 +1,9 @@
 {
   "claims": {
+    "resilient/src/recursive_types.rs": {
+      "branch": "res-2114-recursive-types-borrow-guard",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
       "claimed_at": "2026-05-12T01:23:24Z"

--- a/resilient/src/recursive_types.rs
+++ b/resilient/src/recursive_types.rs
@@ -29,13 +29,16 @@ pub fn install(set: HashSet<String>) {
     }
 }
 
+/// RES-2114: hold the read guard for the contains check instead of deep-
+/// cloning the entire `HashSet<String>`. Same fix as RES-2074 / RES-2112.
+/// The typechecker calls `is_recursive` for every type reference whose
+/// name might be a recursive struct; on a 100-fn program with many
+/// struct refs that's a lot of needless `String` allocations.
 pub fn is_recursive(type_name: &str) -> bool {
-    RECURSIVE_TYPES
-        .read()
-        .ok()
-        .and_then(|g| g.clone())
-        .map(|s| s.contains(type_name))
-        .unwrap_or(false)
+    let Ok(g) = RECURSIVE_TYPES.read() else {
+        return false;
+    };
+    g.as_ref().is_some_and(|s| s.contains(type_name))
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {


### PR DESCRIPTION
Closes #2114

## Summary

Same fix as RES-2112 (async_await) and RES-2074 (ghost_types).
`is_recursive(name)` previously deep-cloned the entire HashSet on
every call. Holding the read guard for the contains check drops the
per-call allocation.

## Test plan

- [x] `cargo test --lib recursive_types` — 5/5 pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)