### PR TITLE
RES-2116: semantic_regression — hold baseline read guard, drop HashMap deep clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -189,8 +189,8 @@
       "claimed_at": "2026-05-13T11:24:43Z"
     },
     "resilient/src/semantic_regression.rs": {
-      "branch": "res-1754-collect-presize",
-      "claimed_at": "2026-05-13T11:24:43Z"
+      "branch": "res-2116-semantic-regression-borrow-baseline",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/probabilistic_contracts.rs": {
       "branch": "res-1756-program-collect-presize",

--- a/resilient/src/semantic_regression.rs
+++ b/resilient/src/semantic_regression.rs
@@ -203,39 +203,52 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         );
     }
 
-    // Compare against the installed baseline (if any) and warn on weakenings.
-    let baseline_snap = BASELINE.read().ok().and_then(|g| g.clone());
-    if let Some(baseline) = baseline_snap {
-        let changes = diff(&baseline, &current);
-        for c in &changes {
-            match c {
-                SemanticChange::Weakened {
-                    function,
-                    old_count,
-                    new_count,
-                    kind,
-                } => {
-                    let kind_str = match kind {
-                        ContractKind::Requires => "requires",
-                        ContractKind::Ensures => "ensures",
-                        ContractKind::Fails => "fails",
-                    };
-                    eprintln!(
-                        "semantic-regression: `{function}` {kind_str} weakened \
-                         ({old_count} → {new_count} clause(s))"
-                    );
+    // RES-2116: Compare against the installed baseline (if any) and warn
+    // on weakenings. The previous shape called `g.clone()` on the read
+    // guard's payload — deep-cloning every `FunctionContract` in the
+    // baseline `HashMap` just so `diff(...)` could borrow it. With
+    // potentially dozens of contracted functions per program, that was
+    // a meaningful allocation cost per typecheck. Hold the read guard
+    // for the duration of the diff + diagnostic emission instead, then
+    // drop it explicitly before re-acquiring the lock as a writer in
+    // `install_baseline`.
+    {
+        if let Ok(g) = BASELINE.read() {
+            if let Some(baseline) = g.as_ref() {
+                let changes = diff(baseline, &current);
+                for c in &changes {
+                    match c {
+                        SemanticChange::Weakened {
+                            function,
+                            old_count,
+                            new_count,
+                            kind,
+                        } => {
+                            let kind_str = match kind {
+                                ContractKind::Requires => "requires",
+                                ContractKind::Ensures => "ensures",
+                                ContractKind::Fails => "fails",
+                            };
+                            eprintln!(
+                                "semantic-regression: `{function}` {kind_str} weakened \
+                                 ({old_count} → {new_count} clause(s))"
+                            );
+                        }
+                        SemanticChange::Removed(name) => {
+                            eprintln!(
+                                "semantic-regression: function `{name}` removed — \
+                                 any callers relied on its contracts"
+                            );
+                        }
+                        _ => {}
+                    }
                 }
-                SemanticChange::Removed(name) => {
-                    eprintln!(
-                        "semantic-regression: function `{name}` removed — \
-                         any callers relied on its contracts"
-                    );
+                if has_weakening(&changes) {
+                    eprintln!("semantic-regression: contract weakening detected — review required");
                 }
-                _ => {}
             }
-        }
-        if has_weakening(&changes) {
-            eprintln!("semantic-regression: contract weakening detected — review required");
+            // `g` (read guard) is dropped here before `install_baseline`
+            // takes the write lock below.
         }
     }
 


### PR DESCRIPTION
Closes #2116

## Summary

`check(program)` previously deep-cloned the baseline `HashMap` so
`diff` could borrow it. Holding the read guard for the diff +
diagnostic emission drops the per-typecheck clone. Same pattern as
RES-2074 / RES-2112 / RES-2114.

## Test plan

- [x] `cargo test --lib semantic_regression` — 8/8 pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)