### PR TITLE
RES-2120: snapshot_regression — hold baseline read guard, drop HashMap deep clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,5 +1,9 @@
 {
   "claims": {
+    "resilient/src/snapshot_regression.rs": {
+      "branch": "res-2120-snapshot-baseline-borrow-guard",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
       "claimed_at": "2026-05-12T01:23:24Z"

--- a/resilient/src/snapshot_regression.rs
+++ b/resilient/src/snapshot_regression.rs
@@ -98,24 +98,38 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     }
 
     // Compare against baseline and emit regressions.
-    let baseline = SNAPSHOT_BASELINE.read().ok().and_then(|g| g.clone());
-    if let Some(baseline) = baseline {
-        let changed = diff(&baseline, &current);
-        if !changed.is_empty() {
-            eprintln!(
-                "snapshot-regression: {} function(s) have changed behavioral \
-                 fingerprints: [{}]",
-                changed.len(),
-                changed.join(", ")
-            );
-            for name in &changed {
-                if let (Some(old), Some(new)) = (baseline.get(name), current.get(name)) {
+    //
+    // RES-2120: hold the read guard for the diff + diagnostic emission
+    // instead of deep-cloning the entire baseline `HashMap<String, Snapshot>`.
+    // The previous shape called `g.clone()` on the read guard's payload
+    // every typecheck, cloning every `String` key + every `Snapshot`
+    // value just so the diff function could borrow them. The guard is
+    // dropped at the end of the inner block before `install_snapshot_baseline`
+    // takes the write lock. Same pattern as RES-2074 / RES-2112 / RES-2114
+    // / RES-2116.
+    {
+        if let Ok(g) = SNAPSHOT_BASELINE.read() {
+            if let Some(baseline) = g.as_ref() {
+                let changed = diff(baseline, &current);
+                if !changed.is_empty() {
                     eprintln!(
-                        "snapshot-regression:   `{name}`: {} → {}",
-                        old.fingerprint_digest, new.fingerprint_digest
+                        "snapshot-regression: {} function(s) have changed behavioral \
+                         fingerprints: [{}]",
+                        changed.len(),
+                        changed.join(", ")
                     );
+                    for name in &changed {
+                        if let (Some(old), Some(new)) = (baseline.get(name), current.get(name)) {
+                            eprintln!(
+                                "snapshot-regression:   `{name}`: {} → {}",
+                                old.fingerprint_digest, new.fingerprint_digest
+                            );
+                        }
+                    }
                 }
             }
+            // `g` (read guard) drops here before `install_snapshot_baseline`
+            // takes the write lock below.
         }
     }
 


### PR DESCRIPTION
Closes #2120

## Summary

Same fix as RES-2116 (semantic_regression). Hold the baseline read
guard for the diff + diagnostic emission instead of deep-cloning the
baseline `HashMap`. Drop the guard before `install_snapshot_baseline`
takes the write lock.

## Test plan

- [x] `cargo test --lib snapshot_regression` — 6/6 pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)