### PR TITLE
RES-2126: iterator_protocol — serialize tests via TEST_LOCK (unblocks auto-merge)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,5 +1,9 @@
 {
   "claims": {
+    "resilient/src/iterator_protocol.rs": {
+      "branch": "res-2126-iterator-protocol-test-lock",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
       "claimed_at": "2026-05-12T01:23:24Z"

--- a/resilient/src/iterator_protocol.rs
+++ b/resilient/src/iterator_protocol.rs
@@ -63,9 +63,25 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    /// RES-2126: serialize tests that mutate the process-wide
+    /// `ITERATORS` registry. Without this lock, `cargo test` runs
+    /// `manual_install_registers` and other reader/writer pairs in
+    /// parallel — and another thread can replace the set between
+    /// this test's `install_iterator_impls` and its `is_iterator`
+    /// assertion, flaking the JIT-feature CI gate (observed on
+    /// auto-merge of #2089-2125, which silently blocked the queue).
+    /// Mirrors the `TEST_LOCK` pattern in `feature_attrs`.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_for_test() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     #[test]
     fn manual_install_registers() {
+        let _g = lock_for_test();
         let mut s = HashSet::new();
         s.insert("MyRange".to_string());
         install_iterator_impls(s);
@@ -75,13 +91,17 @@ mod tests {
     }
     #[test]
     fn is_iterator_returns_false_for_unregistered_type() {
+        let _g = lock_for_test();
+        install_iterator_impls(HashSet::new());
         assert!(!is_iterator("UnregisteredType12345"));
     }
 
     #[test]
     fn check_ok_without_attributes() {
-        let _g = crate::feature_attrs::lock_for_test();
+        let _g = lock_for_test();
+        let _fa = crate::feature_attrs::lock_for_test();
         crate::feature_attrs::reset();
+        install_iterator_impls(HashSet::new());
         let src = "fn f(int x) -> int { return x; }\n";
         let (prog, _) = crate::parse(src);
         assert!(check(&prog, "test").is_ok());


### PR DESCRIPTION
Closes #2126

## Summary

**Pipeline unblocker.** `iterator_protocol::tests::manual_install_registers`
races against sibling tests in parallel `cargo test` runs and
intermittently fails the `test (jit)` CI gate. Every queued PR
(#2089-2125) gets stuck at `mergeStateStatus: BEHIND` because the
required check fails.

Adds a `TEST_LOCK: Mutex<()>` to serialize tests touching the global
`ITERATORS` registry. Mirrors the `feature_attrs::TEST_LOCK` pattern
that already exists for the sibling registry.

Verified by 5× consecutive local test runs with zero flakes.

## Test plan

- [x] `cargo test --lib iterator_protocol` — 3/3 pass 5x consecutive
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)