### PR TITLE
RES-2132: cfg_attr::node_item_name — return Option<&str> instead of cloning

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,5 +1,9 @@
 {
   "claims": {
+    "resilient/src/cfg_attr.rs": {
+      "branch": "res-2132-cfg-attr-node-item-name-borrow",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     "resilient/src/iterator_protocol.rs": {
       "branch": "res-2126-iterator-protocol-test-lock",
       "claimed_at": "2026-05-19T00:00:00Z"

--- a/resilient/src/cfg_attr.rs
+++ b/resilient/src/cfg_attr.rs
@@ -361,7 +361,7 @@ fn parse_feature_attribute(parser: &mut Parser, name: String) -> Option<crate::N
         && let Some(item_name) = node_item_name(node)
     {
         crate::feature_attrs::record(
-            &item_name,
+            item_name,
             crate::feature_attrs::AttrRecord {
                 name,
                 args: args.trim().to_string(),
@@ -375,15 +375,22 @@ fn parse_feature_attribute(parser: &mut Parser, name: String) -> Option<crate::N
 /// Best-effort: extract the declared name from a top-level node so the
 /// attribute registry can key its entry. Returns `None` for unnamed
 /// statements (let-bindings, expressions).
-fn node_item_name(node: &crate::Node) -> Option<String> {
+///
+/// RES-2132: borrows `&str` directly from the matched `Node` variant
+/// instead of cloning. `feature_attrs::record` takes `item_name: &str`,
+/// so the previous `Option<String>` return type forced an owned
+/// allocation just to immediately re-borrow as `&str` at the call
+/// site. The Node owns the name string for the full parse session,
+/// which outlives this helper, so the borrow is sound.
+fn node_item_name(node: &crate::Node) -> Option<&str> {
     match node {
-        crate::Node::Function { name, .. } => Some(name.clone()),
-        crate::Node::StructDecl { name, .. } => Some(name.clone()),
-        crate::Node::TypeAlias { name, .. } => Some(name.clone()),
-        crate::Node::NewtypeDecl { name, .. } => Some(name.clone()),
-        crate::Node::EnumDecl { name, .. } => Some(name.clone()),
-        crate::Node::TraitDecl { name, .. } => Some(name.clone()),
-        crate::Node::ActorDecl { name, .. } => Some(name.clone()),
+        crate::Node::Function { name, .. } => Some(name.as_str()),
+        crate::Node::StructDecl { name, .. } => Some(name.as_str()),
+        crate::Node::TypeAlias { name, .. } => Some(name.as_str()),
+        crate::Node::NewtypeDecl { name, .. } => Some(name.as_str()),
+        crate::Node::EnumDecl { name, .. } => Some(name.as_str()),
+        crate::Node::TraitDecl { name, .. } => Some(name.as_str()),
+        crate::Node::ActorDecl { name, .. } => Some(name.as_str()),
         _ => None,
     }
 }


### PR DESCRIPTION
Closes #2132

## Summary

`node_item_name` cloned the matched Node's `name` field but the only
caller immediately re-borrowed as `&str`. Switching to `Option<&str>`
drops one `String` allocation per recognized attribute parse on the
parser-side hot path.

## Test plan

- [x] `cargo test --lib cfg_attr` — 13/13 pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)