### PR TITLE
RES-2138: autopilot::run — HashMap-index vibe/inferred lookups (O(S+V+I))

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,5 +1,9 @@
 {
   "claims": {
+    "resilient/src/autopilot.rs": {
+      "branch": "res-2138-autopilot-index-lookups",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     "resilient/src/iterator_protocol.rs": {
       "branch": "res-2126-iterator-protocol-test-lock",
       "claimed_at": "2026-05-19T00:00:00Z"

--- a/resilient/src/autopilot.rs
+++ b/resilient/src/autopilot.rs
@@ -42,15 +42,33 @@ pub fn run(program: &Node) -> AutopilotReport {
     let vibe = crate::vibe_debt::analyze(program);
     let inferred = crate::contract_inference::infer_program(program);
 
+    // RES-2138: index `vibe` and `inferred` by function name once
+    // upfront. The previous shape ran `.iter().find(...)` per score
+    // entry — `O(S × (V + I))` for `S` scores and `V`/`I` vibe and
+    // inferred entries. For a 100-fn program where typically every
+    // function shows up in all three lists, that's `~30 000` per-call
+    // string-equality comparisons. HashMap lookups drop the loop to
+    // `O(S + V + I)` while still letting the score iteration drive
+    // the result ordering.
+    let vibe_by_name: std::collections::HashMap<&str, &crate::vibe_debt::VibeDebtEntry> = vibe
+        .entries
+        .iter()
+        .map(|v| (v.function_name.as_str(), v))
+        .collect();
+    let inferred_by_name: std::collections::HashMap<
+        &str,
+        &crate::contract_inference::InferredContracts,
+    > = inferred
+        .iter()
+        .map(|i| (i.function_name.as_str(), i))
+        .collect();
+
     // RES-1758: pre-size to scores.len() — exactly one push per
     // score entry, exact bound.
     let mut entries = Vec::with_capacity(scores.len());
     for s in &scores {
-        let v = vibe
-            .entries
-            .iter()
-            .find(|v| v.function_name == s.function_name);
-        let inf = inferred.iter().find(|i| i.function_name == s.function_name);
+        let v = vibe_by_name.get(s.function_name.as_str()).copied();
+        let inf = inferred_by_name.get(s.function_name.as_str()).copied();
         let mut actions = Vec::new();
         if s.contracts_pts < 40 {
             actions.push("add `requires` and `ensures` clauses".to_string());


### PR DESCRIPTION
Closes #2138

## Summary

`autopilot::run` was `O(S × (V + I))` — per score entry, it linearly
scanned `vibe.entries` and `inferred` for a matching function name.
This indexes both into `HashMap<&str, &Entry>` once upfront, dropping
the pass to `O(S + V + I)`.

For a 100-fn program: ~30K string compares → ~200 hash lookups.

## Test plan

- [x] `cargo test --lib autopilot` — 5/5 pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)