### PR TITLE
RES-2142: distributed_invariants::for_actor — borrow actor name in membership check

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,5 +1,9 @@
 {
   "claims": {
+    "resilient/src/distributed_invariants.rs": {
+      "branch": "res-2142-distributed-invariants-borrow-actor",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     "resilient/src/array_set_helpers.rs": {
       "branch": "res-2136-array-set-hashset-membership",
       "claimed_at": "2026-05-19T00:00:00Z"

--- a/resilient/src/distributed_invariants.rs
+++ b/resilient/src/distributed_invariants.rs
@@ -60,12 +60,18 @@ pub fn install(invs: Vec<DistributedInvariant>) {
 }
 
 pub fn for_actor(actor: &str) -> Vec<DistributedInvariant> {
+    // RES-2142: borrow `actor` into the membership check. The previous
+    // `i.actors.contains(&actor.to_string())` allocated a fresh `String`
+    // per invariant just so `Vec<String>::contains(&String)` had its
+    // expected argument type. `iter().any(|a| a == actor)` compares
+    // `&String` against `&str` via `PartialEq<str> for String` — same
+    // logical predicate, zero allocations on the lookup side.
     INVARIANTS
         .read()
         .ok()
         .map(|g| {
             g.iter()
-                .filter(|i| i.actors.contains(&actor.to_string()))
+                .filter(|i| i.actors.iter().any(|a| a == actor))
                 .cloned()
                 .collect()
         })


### PR DESCRIPTION
Closes #2142

## Summary

`for_actor` used `i.actors.contains(&actor.to_string())` — allocating
a fresh `String` per invariant just to type-match
`Vec<String>::contains`'s argument. Switching to
`iter().any(|a| a == actor)` uses `PartialEq<str> for String` for an
allocation-free comparison.

## Test plan

- [x] `cargo test --lib distributed_invariants` — 3/3 pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)