### PR TITLE
RES-2144: file_io — borrow bytes/whence in write_chunk and seek

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,5 +1,9 @@
 {
   "claims": {
+    "resilient/src/file_io.rs": {
+      "branch": "res-2144-file-io-borrow-bytes-whence",
+      "claimed_at": "2026-05-19T00:00:00Z"
+    },
     "resilient/src/array_set_helpers.rs": {
       "branch": "res-2136-array-set-hashset-membership",
       "claimed_at": "2026-05-19T00:00:00Z"

--- a/resilient/src/file_io.rs
+++ b/resilient/src/file_io.rs
@@ -137,10 +137,16 @@ pub(crate) fn builtin_file_read_chunk(args: &[Value]) -> RResult<Value> {
 /// `file_write_chunk(handle: File, bytes: Bytes) -> Result<Int, String>`.
 /// Writes the entire byte slice; returns the number of bytes written.
 pub(crate) fn builtin_file_write_chunk(args: &[Value]) -> RResult<Value> {
-    let (id, bytes) = match args {
+    // RES-2144: borrow the byte slice from `args` instead of cloning the
+    // whole `Vec<u8>`. `f.write_all(bytes)` and `bytes.len()` both read
+    // through `&[u8]`; the previous shape allocated and copied every
+    // byte of the input buffer just to discard the clone at the end of
+    // this call. For multi-MB writes that is a measurable allocation +
+    // memcpy off the hot I/O path.
+    let (id, bytes): (i64, &[u8]) = match args {
         [Value::Struct { name, fields }, Value::Bytes(b)] if name == "File" => {
             let id = handle_id_from_fields(fields)?;
-            (id, b.clone())
+            (id, b.as_slice())
         }
         _ => {
             return Err(format!(
@@ -154,7 +160,7 @@ pub(crate) fn builtin_file_write_chunk(args: &[Value]) -> RResult<Value> {
         let f = reg
             .get_mut(&id)
             .ok_or_else(|| std::io::Error::other("closed or unknown file handle"))?;
-        f.write_all(&bytes)?;
+        f.write_all(bytes)?;
         Ok(bytes.len())
     });
     match result {
@@ -173,14 +179,19 @@ pub(crate) fn builtin_file_write_chunk(args: &[Value]) -> RResult<Value> {
 /// Whence is one of `"start"`, `"current"`, `"end"`. Returns the new
 /// cursor position from the start of the file.
 pub(crate) fn builtin_file_seek(args: &[Value]) -> RResult<Value> {
-    let (id, offset, whence) = match args {
+    // RES-2144: borrow `whence` as `&str` from `args` — the only
+    // downstream use is a literal match against `"start"`/`"current"`/
+    // `"end"`, which works on `&str` directly. The previous shape
+    // cloned the input String per `file_seek` call just to throw it
+    // away after the match.
+    let (id, offset, whence): (i64, i64, &str) = match args {
         [
             Value::Struct { name, fields },
             Value::Int(o),
             Value::String(w),
         ] if name == "File" => {
             let id = handle_id_from_fields(fields)?;
-            (id, *o, w.clone())
+            (id, *o, w.as_str())
         }
         _ => {
             return Err(format!(
@@ -189,7 +200,7 @@ pub(crate) fn builtin_file_seek(args: &[Value]) -> RResult<Value> {
             ));
         }
     };
-    let seek_from = match whence.as_str() {
+    let seek_from = match whence {
         "start" => {
             if offset < 0 {
                 return Err(format!(


### PR DESCRIPTION
Closes #2144

## Summary

`file_write_chunk` cloned the whole `Vec<u8>` off args; `file_seek`
cloned the whence String. Both clones were discarded at end of call.
Borrowing into `&[u8]` / `&str` drops one allocation per builtin call.

For multi-MB writes the buffer clone was a measurable allocation +
memcpy off the I/O path.

## Test plan

- [x] `cargo test --lib file_io` — 7/7 pass
- [x] `cargo test --lib` — 4685/4685 sweep green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)