### PR TITLE
RES-2152: verifier_liveness other_posts borrows handler name + requires from AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -297,8 +297,8 @@
       "claimed_at": "2026-05-13T11:59:58Z"
     },
     "resilient/src/verifier_liveness.rs": {
-      "branch": "res-1770-verifier-presize",
-      "claimed_at": "2026-05-13T11:59:58Z"
+      "branch": "res-2152-verifier-liveness-borrow-other-posts",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/recovery_checker.rs": {
       "branch": "res-1774-recovery-lint-presize",

--- a/resilient/src/verifier_liveness.rs
+++ b/resilient/src/verifier_liveness.rs
@@ -166,7 +166,14 @@ pub(crate) fn verify_actor_liveness(
         // pushes at most one entry per handler (skipping only the
         // target). Saves the 0→4 doubling chain on actors with many
         // receive handlers.
-        let mut other_posts: Vec<(String, Node, Vec<Node>)> =
+        // RES-2152: `h_name` and `req_h` now borrow directly from the
+        // AST. `post` stays owned because it's a fresh substitution
+        // tree produced by `straight_line_post_public`. The previous
+        // shape paid `h.name.clone()` (String) plus `h.requires.clone()`
+        // (deep Vec<Node> clone — each requires clause is a full AST)
+        // per non-target handler, just to feed a downstream consumer
+        // that only reads through borrowed slices.
+        let mut other_posts: Vec<(&str, Node, &[Node])> =
             Vec::with_capacity(receive_handlers.len());
         let mut bailed = false;
         for h in receive_handlers {
@@ -190,7 +197,7 @@ pub(crate) fn verify_actor_liveness(
                 bailed = true;
                 break;
             };
-            other_posts.push((h.name.clone(), post, h.requires.clone()));
+            other_posts.push((h.name.as_str(), post, h.requires.as_slice()));
         }
         if bailed {
             continue;
@@ -259,7 +266,7 @@ fn try_rank_search(
     post: &Node,
     target_post: &Node,
     target_requires: &[Node],
-    other_posts: &[(String, Node, Vec<Node>)],
+    other_posts: &[(&str, Node, &[Node])],
     timeout_ms: u32,
 ) -> LivenessResult {
     let mut last_reason = String::from("no ranking candidate discharged the obligations");
@@ -299,7 +306,7 @@ fn check_candidate(
     post: &Node,
     target_post: &Node,
     target_requires: &[Node],
-    other_posts: &[(String, Node, Vec<Node>)],
+    other_posts: &[(&str, Node, &[Node])],
     timeout_ms: u32,
 ) -> CandidateVerdict {
     // Constraint — target handler strictly decreases or reaches zero:
@@ -337,7 +344,7 @@ fn check_candidate(
     for (h_name, post_h, req_h) in other_posts {
         let mu_post_h = crate::verifier_actors::substitute_state_public(mu, state_name, post_h);
         let mut ant = mk_true();
-        for r in req_h {
+        for r in *req_h {
             ant = and_node(ant, r.clone());
         }
         let non_increase = infix(mu_post_h, "<=", mu_pre.clone());


### PR DESCRIPTION
## Summary

- \`other_posts\` becomes \`Vec<(&str, Node, &[Node])>\` instead of \`Vec<(String, Node, Vec<Node>)>\`.
- Per-handler entry: \`(h.name.as_str(), post, h.requires.as_slice())\` — no \`h.name.clone()\`, no deep \`h.requires.clone()\`.
- \`post\` stays owned (it's a fresh substitution tree).
- \`try_rank_search\` / \`check_candidate\` signatures updated.
- Inner iteration \`for r in *req_h\` to deref the \`&&[Node]\` yielded by tuple destructuring.

## Why

For an actor with N receive handlers and at least one \`eventually\` clause, the previous shape paid (N-1) × \`Vec<Node>::clone()\` (deep AST clone of each requires clause) plus (N-1) × \`String::clone()\` per liveness check. The downstream consumer only borrows — the clones were never necessary.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2152

🤖 Generated with [Claude Code](https://claude.com/claude-code)