### PR TITLE
RES-2156: typechecker struct-pattern duplicate-field seen-set borrows from AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -285,8 +285,8 @@
       "claimed_at": "2026-05-19T17:31:00Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-1766-typechecker-hot-presize",
-      "claimed_at": "2026-05-13T11:55:37Z"
+      "branch": "res-2156-typechecker-struct-pat-seen-borrow",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/supervisor.rs": {
       "branch": "res-1770-verifier-presize",

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -5184,10 +5184,17 @@ impl TypeChecker {
                 // binding-type push), so the 0→4→8 doubling chain
                 // was paid per struct-pattern-match. Hot path:
                 // every Struct match arm runs this.
-                let mut seen: HashSet<String> = HashSet::with_capacity(fields.len());
+                // RES-2156: borrow `fname` into the `seen` HashSet as
+                // `&str` instead of cloning. The set is local to this
+                // arm (dropped at the end of the for-loop), and
+                // `fname` lives behind `&pat` for the entire scope.
+                // Eliminates one `String::clone()` per struct-pattern
+                // field — a hot path that fires for every struct
+                // match arm in the program.
+                let mut seen: HashSet<&str> = HashSet::with_capacity(fields.len());
                 let mut out = Vec::with_capacity(fields.len());
                 for (fname, sub) in fields {
-                    if !seen.insert(fname.clone()) {
+                    if !seen.insert(fname.as_str()) {
                         return Err(format!(
                             "duplicate field `{}` in struct match pattern",
                             fname


### PR DESCRIPTION
## Summary

- \`match_pattern_binding_types\` \`Pattern::Struct\` arm: \`seen: HashSet<&str>\` instead of \`HashSet<String>\`.
- \`seen.insert(fname.as_str())\` replaces \`seen.insert(fname.clone())\`.

## Why

The set is purely local to the arm — dropped before the function returns. \`fname\` lives behind \`&pat\` for the entire scope, so the per-field \`String::clone()\` was throwaway. The typechecker runs this check on every struct-pattern \`match\` arm.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2156

🤖 Generated with [Claude Code](https://claude.com/claude-code)