### PR TITLE
RES-2158: age_bounded_data — per-fn collections borrow target/field from AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,16 +1,16 @@
 {
   "claims": {
     "resilient/src/distributed_invariants.rs": {
-      "branch": "res-2142-distributed-invariants-borrow-actor",
-      "claimed_at": "2026-05-19T00:00:00Z"
+      "branch": "res-1764-attr-collect-presize",
+      "claimed_at": "2026-05-13T11:45:18Z"
     },
     "resilient/src/array_set_helpers.rs": {
       "branch": "res-2136-array-set-hashset-membership",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/iterator_protocol.rs": {
-      "branch": "res-2126-iterator-protocol-test-lock",
-      "claimed_at": "2026-05-19T00:00:00Z"
+      "branch": "res-1758-more-collect-presize",
+      "claimed_at": "2026-05-13T11:38:11Z"
     },
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
@@ -236,10 +236,6 @@
       "branch": "res-1758-more-collect-presize",
       "claimed_at": "2026-05-13T11:38:11Z"
     },
-    "resilient/src/iterator_protocol.rs": {
-      "branch": "res-1758-more-collect-presize",
-      "claimed_at": "2026-05-13T11:38:11Z"
-    },
     "resilient/src/semver_behavior.rs": {
       "branch": "res-2006-semver-baseline-borrow",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -269,10 +265,6 @@
       "claimed_at": "2026-05-13T11:45:18Z"
     },
     "resilient/src/mmio_regmap.rs": {
-      "branch": "res-1764-attr-collect-presize",
-      "claimed_at": "2026-05-13T11:45:18Z"
-    },
-    "resilient/src/distributed_invariants.rs": {
       "branch": "res-1764-attr-collect-presize",
       "claimed_at": "2026-05-13T11:45:18Z"
     },
@@ -435,6 +427,10 @@
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
       "claimed_at": "2026-05-19T22:27:31Z"
+    },
+    "resilient/src/age_bounded_data.rs": {
+      "branch": "res-2158-age-bounded-data-borrow",
+      "claimed_at": "2026-05-20T03:38:49Z"
     }
   }
 }

--- a/resilient/src/age_bounded_data.rs
+++ b/resilient/src/age_bounded_data.rs
@@ -30,15 +30,23 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     for_each_function(program, |fname, _params, body| {
         // RES-1750: pre-size per-fn collections to 8 — typical fn
         // body has a handful of field reads / age comparisons.
-        let mut reads_value: Vec<(String, String)> = Vec::with_capacity(8); // (target, field)
-        let mut compares_age: std::collections::HashSet<(String, String)> =
+        // RES-2158: borrow target + field names directly from the
+        // body AST. The two collections live only for the duration of
+        // this for_each_function callback, so the strings can borrow
+        // through `body`'s lifetime. The previous shape paid
+        // `t.clone() + field.clone()` per matching FieldAccess +
+        // InfixExpression — pure overhead since downstream consumers
+        // (`reads_value` for-loop, `compares_age.iter().any(...)`)
+        // only read.
+        let mut reads_value: Vec<(&str, &str)> = Vec::with_capacity(8); // (target, field)
+        let mut compares_age: std::collections::HashSet<(&str, &str)> =
             std::collections::HashSet::with_capacity(8);
 
         visit(body, &mut |n| match n {
             Node::FieldAccess { target, field, .. } => {
                 if let Node::Identifier { name: t, .. } = target.as_ref() {
                     if !field.ends_with("_at") {
-                        reads_value.push((t.clone(), field.clone()));
+                        reads_value.push((t.as_str(), field.as_str()));
                     }
                 }
             }
@@ -52,7 +60,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
                     if let Node::FieldAccess { target, field, .. } = side {
                         if field.ends_with("_at") {
                             if let Node::Identifier { name: t, .. } = target.as_ref() {
-                                compares_age.insert((t.clone(), field.clone()));
+                                compares_age.insert((t.as_str(), field.as_str()));
                             }
                         }
                     }
@@ -64,7 +72,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         for (target, field) in reads_value {
             // If we read `target.field` and never compared `target.<anything>_at`,
             // that's an unguarded read.
-            let saw_age = compares_age.iter().any(|(t, _)| t == &target);
+            let saw_age = compares_age.iter().any(|(t, _)| *t == target);
             if !saw_age {
                 eprintln!(
                     "warning: in '{fname}', value '{target}.{field}' is read with \


### PR DESCRIPTION
## Summary

- \`reads_value\` becomes \`Vec<(&str, &str)>\`; \`compares_age\` becomes \`HashSet<(&str, &str)>\`.
- Insertion sites use \`t.as_str() / field.as_str()\` borrowed through the \`visit<'a>\` callback's per-call lifetime.
- \`saw_age\` predicate adjusted to \`*t == target\` (\`&str\` vs \`&str\`).

## Why

The two collections are local to each \`for_each_function\` callback iteration and only read downstream. \`t.clone() + field.clone()\` per matching \`Node::FieldAccess\` / \`Node::InfixExpression\` was pure overhead — the strings live behind \`&body\` for the whole callback.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2158

🤖 Generated with [Claude Code](https://claude.com/claude-code)