### PR TITLE
RES-2160: toctou_guard events vector borrows from AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,16 +1,16 @@
 {
   "claims": {
     "resilient/src/distributed_invariants.rs": {
-      "branch": "res-2142-distributed-invariants-borrow-actor",
-      "claimed_at": "2026-05-19T00:00:00Z"
+      "branch": "res-1764-attr-collect-presize",
+      "claimed_at": "2026-05-13T11:45:18Z"
     },
     "resilient/src/array_set_helpers.rs": {
       "branch": "res-2136-array-set-hashset-membership",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/iterator_protocol.rs": {
-      "branch": "res-2126-iterator-protocol-test-lock",
-      "claimed_at": "2026-05-19T00:00:00Z"
+      "branch": "res-1758-more-collect-presize",
+      "claimed_at": "2026-05-13T11:38:11Z"
     },
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
@@ -236,10 +236,6 @@
       "branch": "res-1758-more-collect-presize",
       "claimed_at": "2026-05-13T11:38:11Z"
     },
-    "resilient/src/iterator_protocol.rs": {
-      "branch": "res-1758-more-collect-presize",
-      "claimed_at": "2026-05-13T11:38:11Z"
-    },
     "resilient/src/semver_behavior.rs": {
       "branch": "res-2006-semver-baseline-borrow",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -269,10 +265,6 @@
       "claimed_at": "2026-05-13T11:45:18Z"
     },
     "resilient/src/mmio_regmap.rs": {
-      "branch": "res-1764-attr-collect-presize",
-      "claimed_at": "2026-05-13T11:45:18Z"
-    },
-    "resilient/src/distributed_invariants.rs": {
       "branch": "res-1764-attr-collect-presize",
       "claimed_at": "2026-05-13T11:45:18Z"
     },
@@ -435,6 +427,10 @@
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
       "claimed_at": "2026-05-19T22:27:31Z"
+    },
+    "resilient/src/toctou_guard.rs": {
+      "branch": "res-2160-toctou-guard-borrow-events",
+      "claimed_at": "2026-05-20T03:41:00Z"
     }
   }
 }

--- a/resilient/src/toctou_guard.rs
+++ b/resilient/src/toctou_guard.rs
@@ -32,7 +32,14 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // `markers.any_call_ident_with_suffix` with the same CHECK_SUFFIXES.
     // The previous `any_node` pre-scan was redundant — removed.
     for_each_function(program, |fname, _params, body| {
-        let mut events: Vec<(bool, String, Option<String>)> = Vec::new();
+        // RES-2160: borrow fn_name + first-ident-arg directly from the
+        // body AST. The events vector lives only inside this callback,
+        // and `visit<'a>` already threads the AST lifetime through the
+        // closure call. Previously the loop cloned `name` for every
+        // events push and cloned `name`/`value` from the first argument
+        // — four `String::clone()` per matching CallExpression, all
+        // thrown away at the end of the callback iteration.
+        let mut events: Vec<(bool, &str, Option<&str>)> = Vec::new();
         // (is_check, fn_name, first_ident_arg)
         visit(body, &mut |n| {
             if let Node::CallExpression {
@@ -43,16 +50,16 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
             {
                 if let Node::Identifier { name, .. } = function.as_ref() {
                     let arg = arguments.first().and_then(|a| match a {
-                        Node::Identifier { name, .. } => Some(name.clone()),
-                        Node::StringLiteral { value, .. } => Some(value.clone()),
+                        Node::Identifier { name, .. } => Some(name.as_str()),
+                        Node::StringLiteral { value, .. } => Some(value.as_str()),
                         _ => None,
                     });
                     if CHECK_SUFFIXES.iter().any(|s| name.ends_with(*s)) {
-                        events.push((true, name.clone(), arg));
+                        events.push((true, name.as_str(), arg));
                     } else if USE_SUFFIXES.iter().any(|s| name.ends_with(*s))
                         && !name.starts_with("atomic_")
                     {
-                        events.push((false, name.clone(), arg));
+                        events.push((false, name.as_str(), arg));
                     }
                 }
             }
@@ -67,7 +74,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
                 if *is_check2 {
                     continue;
                 }
-                if uarg.as_deref() == Some(carg) {
+                if *uarg == Some(*carg) {
                     eprintln!(
                         "warning: in '{fname}', TOCTOU: '{cname}({carg})' followed \
                          by '{uname}({carg})' — use atomic_{uname} or wrap both \


### PR DESCRIPTION
## Summary

- \`events\` becomes \`Vec<(bool, &str, Option<&str>)>\` instead of \`Vec<(bool, String, Option<String>)>\`.
- Insertion sites use \`name.as_str()\` / \`value.as_str()\` borrowed through the \`visit<'a>\` callback's per-call lifetime.
- \`uarg.as_deref() == Some(carg)\` simplifies to \`*uarg == Some(*carg)\` (\`&str\` vs \`&str\`).

## Why

The events vector is local to each per-function callback iteration and only consumed via \`eprintln!\` + \`==\`. Four \`String::clone()\` per matching CallExpression was pure overhead.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2160

🤖 Generated with [Claude Code](https://claude.com/claude-code)