### PR TITLE
RES-2162: numeric_units — units HashMap keys borrow from AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -409,8 +409,8 @@
       "claimed_at": "2026-05-19T18:22:09Z"
     },
     "resilient/src/numeric_units.rs": {
-      "branch": "res-1950-numeric-units-static-suffix",
-      "claimed_at": "2026-05-19T18:34:18Z"
+      "branch": "res-2162-numeric-units-borrow-keys",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/assume_axioms.rs": {
       "branch": "res-1958-assume-axioms-presize",

--- a/resilient/src/numeric_units.rs
+++ b/resilient/src/numeric_units.rs
@@ -42,17 +42,23 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         // series across the per-fn passes.
         // RES-1950: values are `&'static str` from the static
         // UNIT_SUFFIXES table — no per-binding String allocation.
-        let mut units: std::collections::HashMap<String, &'static str> =
+        // RES-2162: keys now borrow `&str` from the AST (params +
+        // body) instead of cloning per insert. The map dies at the
+        // end of this for_each_function callback iteration; every
+        // entry lives behind `&params` / `&body` for the entire
+        // scope. Eliminates one `String::clone()` per param + per
+        // matching let-binding.
+        let mut units: std::collections::HashMap<&str, &'static str> =
             std::collections::HashMap::with_capacity(params.len() + 8);
         for (_ty, name) in params {
             if let Some(u) = unit_of(name) {
-                units.insert(name.clone(), u);
+                units.insert(name.as_str(), u);
             }
         }
         visit(body, &mut |n| {
             if let Node::LetStatement { name, value, .. } = n {
                 if let Some(u) = unit_of(name) {
-                    units.insert(name.clone(), u);
+                    units.insert(name.as_str(), u);
                 }
                 check_expr(fname, name, value, &units);
             }
@@ -74,7 +80,7 @@ fn check_expr(
     fname: &str,
     var: &str,
     expr: &Node,
-    units: &std::collections::HashMap<String, &'static str>,
+    units: &std::collections::HashMap<&str, &'static str>,
 ) {
     if let Node::InfixExpression {
         operator,
@@ -103,10 +109,10 @@ fn check_expr(
 // a String clone on lookup hit.
 fn ident_unit(
     node: &Node,
-    units: &std::collections::HashMap<String, &'static str>,
+    units: &std::collections::HashMap<&str, &'static str>,
 ) -> Option<&'static str> {
     if let Node::Identifier { name, .. } = node {
-        return units.get(name).copied().or_else(|| unit_of(name));
+        return units.get(name.as_str()).copied().or_else(|| unit_of(name));
     }
     None
 }


### PR DESCRIPTION
## Summary

- \`units\` becomes \`HashMap<&str, &'static str>\` keyed by \`name.as_str()\` from params + body.
- \`check_expr\` / \`ident_unit\` signatures updated to \`&HashMap<&str, _>\`.
- Lookup \`units.get(name)\` → \`units.get(name.as_str())\`.

## Why

The map lives only for one \`for_each_function\` callback iteration. Both \`params\` and \`body\` are borrowed into the callback scope — keys can borrow through them. Combined with RES-1950 (value side), the map is now allocation-free per function.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2162

🤖 Generated with [Claude Code](https://claude.com/claude-code)