### PR TITLE
RES-2164: epoch_ordering — sequence borrows call names from AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -431,6 +431,10 @@
     "resilient/src/age_bounded_data.rs": {
       "branch": "res-2158-age-bounded-data-borrow",
       "claimed_at": "2026-05-20T03:38:49Z"
+    },
+    "resilient/src/epoch_ordering.rs": {
+      "branch": "res-2164-epoch-ordering-borrow-seq",
+      "claimed_at": "2026-05-20T03:45:57Z"
     }
   }
 }

--- a/resilient/src/epoch_ordering.rs
+++ b/resilient/src/epoch_ordering.rs
@@ -27,12 +27,17 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // identifier. The previous `any_node` pre-scan was redundant —
     // removed.
     for_each_function(program, |fname, _params, body| {
-        let mut sequence: Vec<(String, u32)> = Vec::new();
+        // RES-2164: borrow the call name as `&str` from the body AST.
+        // The sequence vector lives only inside this for_each_function
+        // callback iteration and the consumer just `eprintln!`s the
+        // name — the previous `name.clone()` per epoch-tagged call
+        // was throwaway.
+        let mut sequence: Vec<(&str, u32)> = Vec::new();
         visit(body, &mut |n| {
             if let Node::CallExpression { function, .. } = n {
                 if let Node::Identifier { name, .. } = function.as_ref() {
                     if let Some(e) = epoch_of(name) {
-                        sequence.push((name.clone(), e));
+                        sequence.push((name.as_str(), e));
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- \`sequence\` becomes \`Vec<(&str, u32)>\` instead of \`Vec<(String, u32)>\`.
- Insertion site uses \`name.as_str()\` borrowed through the \`visit<'a>\` callback's per-call lifetime.

## Why

The sequence vector dies at the end of each per-function callback iteration, and the only consumer is \`eprintln!\`. Cloning each \`_epoch<N>\` call name into a per-fn Vec was pure overhead.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2164

🤖 Generated with [Claude Code](https://claude.com/claude-code)