### PR TITLE
RES-2166: incremental_verify nested HashMap kills per-lookup String alloc on Z3 cache

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -21,8 +21,8 @@
       "claimed_at": "2026-05-12T01:09:57Z"
     },
     "resilient/src/incremental_verify.rs": {
-      "branch": "res-1210-incremental-verify-dead-work",
-      "claimed_at": "2026-05-12T01:53:15Z"
+      "branch": "res-2166-incremental-verify-nested-map",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/watchdog_feed.rs": {
       "branch": "res-1218-param-type-fast-reject",

--- a/resilient/src/incremental_verify.rs
+++ b/resilient/src/incremental_verify.rs
@@ -24,9 +24,17 @@ pub enum ProofResult {
     Failed(String),
 }
 
+/// RES-2166: nested HashMap keyed on `fn_name` (outer) and
+/// `contract_digest` (inner). The previous shape was
+/// `HashMap<(String, u64), ProofResult>` which forced every
+/// lookup to allocate a fresh `String` for the tuple key — paid
+/// per Z3 obligation, hits *and* misses alike. The outer map
+/// keys on `String` so we can probe with `&str` via
+/// `Borrow<str>`; lookups walk two hash steps with zero
+/// allocations.
 #[derive(Debug, Clone, Default)]
 pub struct ProofCache {
-    pub entries: HashMap<(String, u64), ProofResult>,
+    pub entries: HashMap<String, HashMap<u64, ProofResult>>,
     pub hits: u64,
     pub misses: u64,
 }
@@ -42,8 +50,13 @@ pub fn reset() {
 pub fn lookup(fn_name: &str, contract_digest: u64) -> Option<ProofResult> {
     if let Ok(mut g) = CACHE.write() {
         let cache = g.get_or_insert_with(ProofCache::default);
-        let key = (fn_name.to_string(), contract_digest);
-        if let Some(r) = cache.entries.get(&key) {
+        // RES-2166: probe the outer map with `&str` (no allocation),
+        // then walk the inner `HashMap<u64, ProofResult>`. The
+        // previous shape allocated a `String` for the tuple key on
+        // every call — paid on every hit AND miss.
+        if let Some(inner) = cache.entries.get(fn_name)
+            && let Some(r) = inner.get(&contract_digest)
+        {
             cache.hits += 1;
             return Some(r.clone());
         }
@@ -55,9 +68,17 @@ pub fn lookup(fn_name: &str, contract_digest: u64) -> Option<ProofResult> {
 pub fn store(fn_name: &str, contract_digest: u64, result: ProofResult) {
     if let Ok(mut g) = CACHE.write() {
         let cache = g.get_or_insert_with(ProofCache::default);
-        cache
-            .entries
-            .insert((fn_name.to_string(), contract_digest), result);
+        // RES-2166: skip the `fn_name.to_string()` alloc on the hot
+        // path when an outer entry already exists. Only the cold
+        // branch (first digest stored for this fn) pays for an owned
+        // `String` key.
+        if let Some(inner) = cache.entries.get_mut(fn_name) {
+            inner.insert(contract_digest, result);
+        } else {
+            let mut inner = HashMap::new();
+            inner.insert(contract_digest, result);
+            cache.entries.insert(fn_name.to_string(), inner);
+        }
     }
 }
 
@@ -113,11 +134,16 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     };
     if let Ok(mut g) = CACHE.write() {
         if let Some(cache) = g.as_mut() {
-            let before = cache.entries.len();
+            // RES-2166: count by inner-map entries (each `(fn_name,
+            // digest)` pair was one entry in the old flat shape).
+            // Retention drops the entire outer entry when the fn is
+            // gone; the inner digests die with it.
+            let before: usize = cache.entries.values().map(|m| m.len()).sum();
             cache
                 .entries
-                .retain(|(fn_name, _), _| live_names.contains(fn_name.as_str()));
-            let evicted = before.saturating_sub(cache.entries.len());
+                .retain(|fn_name, _| live_names.contains(fn_name.as_str()));
+            let after: usize = cache.entries.values().map(|m| m.len()).sum();
+            let evicted = before.saturating_sub(after);
             if evicted > 0 {
                 eprintln!("incremental_verify: evicted {evicted} stale proof-cache entry/ies");
             }


### PR DESCRIPTION
## Summary

- \`ProofCache::entries\` becomes \`HashMap<String, HashMap<u64, ProofResult>>\` (was \`HashMap<(String, u64), ProofResult>\`).
- \`lookup\` does two zero-allocation hash steps via \`cache.entries.get(fn_name)\` + \`inner.get(&digest)\` — the outer \`String\` key probes cleanly with \`&str\` through \`Borrow<str>\`.
- \`store\` allocates an owned \`String\` only on the cold branch (first-digest-for-this-fn); subsequent stores under the same fn reuse the outer entry via \`get_mut\`.
- \`check\`'s retention pass adapted: drop the outer entry when the fn is gone; \`evicted\` recounted by summing inner sizes pre/post.

## Why

The Z3 verifier hits this cache per proof obligation, so allocating a fresh \`String\` for the tuple key was paid on every hit AND miss. There's no \`(String, u64): Borrow<(str, u64)>\` blanket impl — the flat tuple-key shape could not be probed without the alloc. Nesting moves the \`String\` to the outer key (where \`Borrow<str>\` applies) and the \`u64\` to a free inner step.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib incremental_verify\` (5 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)