### PR TITLE
RES-2168: intent_blocks — drop dead IntentSpec::raw_args field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -181,7 +181,7 @@
       "claimed_at": "2026-05-13T12:28:38Z"
     },
     "resilient/src/intent_blocks.rs": {
-      "branch": "res-1994-intent-blocks-drop-fnames",
+      "branch": "res-2168-intent-blocks-drop-raw-args",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/row_polymorphism.rs": {

--- a/resilient/src/intent_blocks.rs
+++ b/resilient/src/intent_blocks.rs
@@ -23,7 +23,6 @@ use std::collections::HashMap;
 #[derive(Debug, Clone)]
 pub struct IntentSpec {
     pub item_name: String,
-    pub raw_args: String,
     pub property: Option<String>,
     pub enforcers: Vec<String>,
 }
@@ -33,9 +32,13 @@ pub fn collect() -> Vec<IntentSpec> {
     // RES-1754: pre-size to attrs.len() — exactly one push per attribute record.
     let mut out = Vec::with_capacity(attrs.len());
     for (item, rec) in attrs {
+        // RES-2168: drop the `raw_args` field — it was set from
+        // `rec.args.clone()` but had zero readers anywhere in the
+        // workspace, so the per-attr String clone was pure overhead.
+        // The parse loop below walks `rec.args.split(',')` directly;
+        // it never touched `spec.raw_args`.
         let mut spec = IntentSpec {
             item_name: item,
-            raw_args: rec.args.clone(),
             property: None,
             enforcers: Vec::new(),
         };


### PR DESCRIPTION
## Summary

- Removes \`IntentSpec::raw_args: String\` (zero readers in the workspace).
- Drops the corresponding \`rec.args.clone()\` initializer in \`collect()\`.

## Why

\`rg \"raw_args\"\` returned only the field declaration and the assignment. The parse loop walks \`rec.args.split(',')\` directly — \`spec.raw_args\` was never touched. The per-attr-record \`String::clone()\` was pure overhead.

Same pattern as the previously-shipped dead-field drops: RES-2106 (snapshot fn_name), RES-2110 (PhantomSpec type_name), RES-2122 (Fingerprint function_name), RES-2130 (CfgNode node).

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2168

🤖 Generated with [Claude Code](https://claude.com/claude-code)