### PR TITLE
RES-2170: probabilistic_contracts — drop redundant ProbContract::fn_name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -205,8 +205,8 @@
       "claimed_at": "2026-05-13T11:24:43Z"
     },
     "resilient/src/probabilistic_contracts.rs": {
-      "branch": "res-1756-program-collect-presize",
-      "claimed_at": "2026-05-13T11:30:51Z"
+      "branch": "res-2170-prob-contracts-drop-fn-name",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/typestate_types.rs": {
       "branch": "res-1756-program-collect-presize",

--- a/resilient/src/probabilistic_contracts.rs
+++ b/resilient/src/probabilistic_contracts.rs
@@ -13,9 +13,15 @@ use crate::Node;
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
+/// RES-2170: dropped the redundant `fn_name: String` field. It was
+/// set from the attribute's owning item name and the only reader was
+/// the `install` loop, which used it as the HashMap key — so the
+/// field stored exactly what the key already encoded. Same dead-field
+/// pattern as RES-2106 (snapshot fn_name), RES-2110 (PhantomSpec
+/// type_name), RES-2122 (Fingerprint function_name), RES-2168
+/// (IntentSpec raw_args).
 #[derive(Debug, Clone)]
 pub struct ProbContract {
-    pub fn_name: String,
     pub clause: String,
     pub probability: f64,
     pub trials: u64,
@@ -25,7 +31,7 @@ pub struct ProbContract {
 static CONTRACTS: LazyLock<RwLock<HashMap<String, ProbContract>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
-pub fn collect() -> Vec<ProbContract> {
+pub fn collect() -> Vec<(String, ProbContract)> {
     let attrs = crate::feature_attrs::find_kind("probabilistic");
     // RES-1756: pre-size to attrs.len() — exactly one push per
     // attribute record, exact bound. Same shape as RES-1754.
@@ -45,23 +51,27 @@ pub fn collect() -> Vec<ProbContract> {
                 }
             }
         }
-        out.push(ProbContract {
-            fn_name: item,
-            clause,
-            probability: p,
-            trials: 0,
-            successes: 0,
-        });
+        out.push((
+            item,
+            ProbContract {
+                clause,
+                probability: p,
+                trials: 0,
+                successes: 0,
+            },
+        ));
     }
     out
 }
 
-pub fn install(contracts: Vec<ProbContract>) {
+pub fn install(contracts: Vec<(String, ProbContract)>) {
     if let Ok(mut g) = CONTRACTS.write() {
         g.clear();
-        for c in contracts {
-            g.insert(c.fn_name.clone(), c);
-        }
+        // RES-2170: move (name, contract) pairs straight from
+        // `collect()` into the map. The previous shape per-contract
+        // cloned `c.fn_name` to produce the key, since the field and
+        // the key encoded the same string.
+        g.extend(contracts);
     }
 }
 


### PR DESCRIPTION
## Summary

- Removes \`pub fn_name: String\` from \`ProbContract\` — the field stored an exact duplicate of the HashMap key.
- \`collect()\` returns \`Vec<(String, ProbContract)>\` so the name and the contract flow as a tuple.
- \`install()\` consumes via \`g.extend(contracts)\` — no per-entry \`String::clone()\` (was \`c.fn_name.clone()\` for the key while moving \`c\` into the value).
- \`record_trial\` / \`empirical_rate\` were already using the key directly — no caller changes.

## Why

The field had one writer (\`collect\`'s init) and one reader (\`install\`'s key clone). It always encoded the same string as the map key. Pure overhead per attribute per \`check()\` invocation. Same dead-field pattern as RES-2106 (snapshot fn_name), RES-2110 (PhantomSpec type_name), RES-2122 (Fingerprint function_name), RES-2168 (IntentSpec raw_args).

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib probabilistic\` (3 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2170

🤖 Generated with [Claude Code](https://claude.com/claude-code)