### PR TITLE
RES-2174: derives — drop redundant DeriveSet::type_name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -431,6 +431,10 @@
     "resilient/src/age_bounded_data.rs": {
       "branch": "res-2158-age-bounded-data-borrow",
       "claimed_at": "2026-05-20T03:38:49Z"
+    },
+    "resilient/src/derives.rs": {
+      "branch": "res-2174-derives-drop-type-name",
+      "claimed_at": "2026-05-20T04:08:32Z"
     }
   }
 }

--- a/resilient/src/derives.rs
+++ b/resilient/src/derives.rs
@@ -23,9 +23,15 @@ use crate::Node;
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
+/// RES-2174: dropped the redundant `type_name: String` field. It was
+/// set from the attribute's owning-item name in `collect()`. Two
+/// readers — `install`'s key clone and `check`'s validation error
+/// message — both used it as a HashMap key / display value tied to
+/// the entry. The field stored exactly what the key encoded. Same
+/// dead-field pattern as RES-2106 / RES-2110 / RES-2122 / RES-2168 /
+/// RES-2170 / RES-2172.
 #[derive(Debug, Clone)]
 pub struct DeriveSet {
-    pub type_name: String,
     pub traits: Vec<String>,
 }
 
@@ -48,7 +54,7 @@ const SUPPORTED: &[&str] = &[
     "Copy",
 ];
 
-pub fn collect() -> Vec<DeriveSet> {
+pub fn collect() -> Vec<(String, DeriveSet)> {
     let attrs = crate::feature_attrs::find_kind("derive");
     // RES-1782: pre-size to attrs.len() — exactly one push per
     // attribute record.
@@ -60,20 +66,19 @@ pub fn collect() -> Vec<DeriveSet> {
             .map(|s| s.trim().trim_matches('"').to_string())
             .filter(|s| !s.is_empty())
             .collect();
-        out.push(DeriveSet {
-            type_name: item,
-            traits,
-        });
+        out.push((item, DeriveSet { traits }));
     }
     out
 }
 
-pub fn install(sets: Vec<DeriveSet>) {
+pub fn install(sets: Vec<(String, DeriveSet)>) {
     if let Ok(mut g) = DERIVES.write() {
         g.clear();
-        for s in sets {
-            g.insert(s.type_name.clone(), s);
-        }
+        // RES-2174: move (name, set) pairs straight from `collect()`
+        // into the map. The previous shape per-set cloned
+        // `s.type_name` to produce the key, since the field and the
+        // key encoded the same string.
+        g.extend(sets);
     }
 }
 
@@ -112,12 +117,12 @@ pub(crate) fn check(_program: &Node, source_path: &str) -> Result<(), String> {
     if sets.is_empty() {
         return Ok(());
     }
-    for s in &sets {
+    for (type_name, s) in &sets {
         for t in &s.traits {
             if !SUPPORTED.contains(&t.as_str()) {
                 return Err(format!(
                     "{}:0:0: error: `#[derive({})]` on `{}` — unknown trait. Supported: {:?}",
-                    source_path, t, s.type_name, SUPPORTED
+                    source_path, t, type_name, SUPPORTED
                 ));
             }
         }


### PR DESCRIPTION
## Summary

- Removes \`pub type_name: String\` from \`DeriveSet\`.
- \`collect()\` returns \`Vec<(String, DeriveSet)>\`.
- \`install()\` uses \`g.extend(sets)\` — no per-entry clone.
- Validation loop in \`check\` destructures tuple for the type-name in error messages.

## Why

The field had two readers (install's key clone + check's format!), both used as a name tied to the HashMap entry. Pure overhead per \`#[derive(...)]\` attribute. Same dead-field pattern as the previously-shipped RES-2106 / RES-2110 / RES-2122 / RES-2168 / RES-2170 / RES-2172.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib derives\` (4 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2174

🤖 Generated with [Claude Code](https://claude.com/claude-code)