### PR TITLE
RES-2176: dependent_arrays — drop redundant DependentSpec::item_name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -253,8 +253,8 @@
       "claimed_at": "2026-05-13T11:42:08Z"
     },
     "resilient/src/dependent_arrays.rs": {
-      "branch": "res-1764-attr-collect-presize",
-      "claimed_at": "2026-05-13T11:45:18Z"
+      "branch": "res-2176-dependent-arrays-drop-item-name",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/newtypes.rs": {
       "branch": "res-1764-attr-collect-presize",

--- a/resilient/src/dependent_arrays.rs
+++ b/resilient/src/dependent_arrays.rs
@@ -20,16 +20,22 @@ use crate::Node;
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
+/// RES-2176: dropped the redundant `item_name: String` field. It was
+/// set from the attribute's owning-item name in `collect()`. Readers
+/// used it as either a HashMap key (`install`'s clone) or a name tied
+/// to a found spec (the `check` validation loop's `==` match). The
+/// field stored exactly what the registry key encoded. Same
+/// dead-field pattern as RES-2106 / RES-2110 / RES-2122 / RES-2168 /
+/// RES-2170 / RES-2172 / RES-2174.
 #[derive(Debug, Clone)]
 pub struct DependentSpec {
-    pub item_name: String,
     pub length_var: String,
 }
 
 static SPECS: LazyLock<RwLock<HashMap<String, DependentSpec>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
-pub fn collect() -> Vec<DependentSpec> {
+pub fn collect() -> Vec<(String, DependentSpec)> {
     let attrs = crate::feature_attrs::find_kind("dependent");
     // RES-1764: pre-size to attrs.len() — conditional push (only when
     // the `length` chunk parsed non-empty), so this is an upper bound.
@@ -45,21 +51,20 @@ pub fn collect() -> Vec<DependentSpec> {
             }
         }
         if !length.is_empty() {
-            out.push(DependentSpec {
-                item_name: item,
-                length_var: length,
-            });
+            out.push((item, DependentSpec { length_var: length }));
         }
     }
     out
 }
 
-pub fn install(specs: Vec<DependentSpec>) {
+pub fn install(specs: Vec<(String, DependentSpec)>) {
     if let Ok(mut g) = SPECS.write() {
         g.clear();
-        for s in specs {
-            g.insert(s.item_name.clone(), s);
-        }
+        // RES-2176: move (name, spec) pairs straight from `collect()`
+        // into the map. The previous shape per-spec cloned
+        // `s.item_name` to produce the key, since the field and the
+        // key encoded the same string.
+        g.extend(specs);
     }
 }
 
@@ -88,7 +93,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
             if let Node::Function {
                 name, type_params, ..
             } = &s.node
-                && let Some(spec) = specs.iter().find(|sp| sp.item_name == *name)
+                && let Some((_, spec)) = specs.iter().find(|(item, _)| item == name)
                 && !type_params.contains(&spec.length_var)
             {
                 eprintln!(
@@ -120,7 +125,8 @@ mod tests {
         );
         let s = collect();
         assert_eq!(s.len(), 1);
-        assert_eq!(s[0].length_var, "M+N");
+        assert_eq!(s[0].0, "concat");
+        assert_eq!(s[0].1.length_var, "M+N");
         crate::feature_attrs::reset();
     }
 
@@ -149,7 +155,6 @@ mod tests {
         );
         install(collect());
         let spec = lookup("zip").expect("zip must be found after install");
-        assert_eq!(spec.item_name, "zip");
         assert_eq!(spec.length_var, "N");
         assert!(
             lookup("nonexistent").is_none(),


### PR DESCRIPTION
## Summary

- Removes \`pub item_name: String\` from \`DependentSpec\`.
- \`collect()\` returns \`Vec<(String, DependentSpec)>\`.
- \`install()\` uses \`g.extend(specs)\` — no per-entry clone.
- \`check\`'s validation loop reads the function name from the tuple.

## Why

Two readers (install's key clone + check's `==` match) used the field strictly as a name tied to the HashMap key. Pure overhead per \`#[dependent(...)]\` attribute per \`check()\`. Same dead-field pattern as RES-2106 / RES-2110 / RES-2122 / RES-2168 / RES-2170 / RES-2172 / RES-2174.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib dependent_arrays\` (5 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2176

🤖 Generated with [Claude Code](https://claude.com/claude-code)