### PR TITLE
RES-2182: const_fn — drop dead ConstFnSpec struct (no readers)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -439,6 +439,10 @@
     "resilient/src/anti_regression.rs": {
       "branch": "res-2178-anti-regression-drop-item-name",
       "claimed_at": "2026-05-20T04:14:09Z"
+    },
+    "resilient/src/const_fn.rs": {
+      "branch": "res-2182-const-fn-drop-dead-struct",
+      "claimed_at": "2026-05-20T04:19:17Z"
     }
   }
 }

--- a/resilient/src/const_fn.rs
+++ b/resilient/src/const_fn.rs
@@ -18,11 +18,12 @@ use crate::Node;
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
-#[derive(Debug, Clone)]
-pub struct ConstFnSpec {
-    pub fn_name: String,
-}
-
+// RES-2182: dropped `pub struct ConstFnSpec { pub fn_name: String }`.
+// The struct had zero readers anywhere in the workspace — nothing
+// constructed it, destructured it, or referenced its field.
+// `pub fn collect_names()` already returns `Vec<String>` directly from
+// the attribute walker; the dead struct was pure dead code that
+// derived `Debug + Clone` and carried an owned `String` for no reason.
 static CONST_FNS: LazyLock<RwLock<HashMap<String, Node>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 


### PR DESCRIPTION
## Summary

- Removes \`pub struct ConstFnSpec { pub fn_name: String }\` from \`const_fn\`.
- The struct had zero readers in the entire workspace.

## Why

\`rg \"ConstFnSpec\"\` returns only the type definition. \`pub fn collect_names() -> Vec<String>\` already returns the attribute owners directly; the struct was never constructed or destructured. Pure dead code — one fewer pub type to compile, document, and lint.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2182

🤖 Generated with [Claude Code](https://claude.com/claude-code)