### PR TITLE
RES-2186: property_tests — drop dead run_property + redundant PropertySpec::fn_name

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -443,6 +443,10 @@
     "resilient/src/const_fn.rs": {
       "branch": "res-2182-const-fn-drop-dead-struct",
       "claimed_at": "2026-05-20T04:19:17Z"
+    },
+    "resilient/src/property_tests.rs": {
+      "branch": "res-2186-property-tests-cleanup",
+      "claimed_at": "2026-05-20T04:27:32Z"
     }
   }
 }

--- a/resilient/src/property_tests.rs
+++ b/resilient/src/property_tests.rs
@@ -15,20 +15,19 @@
 
 use crate::Node;
 
+/// RES-2186: dropped the redundant `fn_name: String` field on
+/// `PropertySpec`. The two readers (`check`'s contract-presence
+/// lookup + warning format) both used it as a name tied to the
+/// attribute owner; the field stored exactly what the attribute key
+/// encoded. Pipeline now carries `(String, PropertySpec)` pairs from
+/// `collect()` to `check()`. Same dead-field pattern as RES-2106 / …
+/// / RES-2184.
 #[derive(Debug, Clone)]
 pub struct PropertySpec {
-    pub fn_name: String,
     pub samples: u32,
 }
 
-#[derive(Debug, Clone)]
-pub struct PropertyResult {
-    pub fn_name: String,
-    pub samples_run: u32,
-    pub failures: Vec<String>,
-}
-
-pub fn collect() -> Vec<PropertySpec> {
+pub fn collect() -> Vec<(String, PropertySpec)> {
     let attrs = crate::feature_attrs::find_kind("property_test");
     // RES-1762: pre-size to attrs.len() — exactly one push per
     // attribute record, exact bound. Same shape as RES-1754 / 1756.
@@ -45,10 +44,7 @@ pub fn collect() -> Vec<PropertySpec> {
                 }
             }
         }
-        out.push(PropertySpec {
-            fn_name: item,
-            samples,
-        });
+        out.push((item, PropertySpec { samples }));
     }
     out
 }
@@ -75,13 +71,11 @@ impl PropRng {
     }
 }
 
-pub fn run_property(spec: &PropertySpec) -> PropertyResult {
-    PropertyResult {
-        fn_name: spec.fn_name.clone(),
-        samples_run: spec.samples,
-        failures: Vec::new(),
-    }
-}
+// RES-2186: dropped `pub fn run_property(spec) -> PropertyResult`
+// and the entire `PropertyResult` struct. The function had no
+// callers anywhere in the workspace (the orchestrator that was
+// supposed to consume it is still a follow-up per the module doc),
+// and its return type was only constructed inside the dead fn.
 
 /// Validate `#[property_test]` annotations and verify their functions
 /// have contracts (`requires`/`ensures`) to actually test.
@@ -115,18 +109,18 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     }
 
     let mut warnings: Vec<String> = Vec::new();
-    for spec in &specs {
-        if !functions_with_contracts.contains(&spec.fn_name) {
+    for (fn_name, spec) in &specs {
+        if !functions_with_contracts.contains(fn_name.as_str()) {
             warnings.push(format!(
                 "{source_path}:0:0: warning[property_test]: \
                  `#[property_test]` on `{}` has no `requires`/`ensures` \
                  contracts — no properties will be checked",
-                spec.fn_name
+                fn_name
             ));
         } else {
             eprintln!(
                 "property_test: `{}` registered for {} sample(s)",
-                spec.fn_name, spec.samples
+                fn_name, spec.samples
             );
         }
     }
@@ -155,7 +149,8 @@ mod tests {
         );
         let specs = collect();
         assert_eq!(specs.len(), 1);
-        assert_eq!(specs[0].samples, 500);
+        assert_eq!(specs[0].0, "add_commutes");
+        assert_eq!(specs[0].1.samples, 500);
         crate::feature_attrs::reset();
     }
 


### PR DESCRIPTION
## Summary

Two cleanups in one file:

1. Delete \`pub fn run_property(spec) -> PropertyResult\` (zero callers in the workspace) and \`pub struct PropertyResult\` (only constructed inside the dead fn).
2. Drop \`PropertySpec::fn_name\`. \`collect()\` returns \`Vec<(String, PropertySpec)>\`; \`check\` destructures \`(fn_name, spec)\` and uses \`fn_name.as_str()\` for the contract-set lookup.

## Why

\`run_property\` and \`PropertyResult\` were stubs waiting for an orchestrator that's still a follow-up — pure dead code today. \`PropertySpec::fn_name\` stored exactly what the attribute key encoded, with only two readers (contract-presence check + warning format) — both used it as a name tied to the attribute owner.

Same dead-field cleanup pattern as the RES-2106 / … / RES-2184 series.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib property_tests\` (5 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2186

🤖 Generated with [Claude Code](https://claude.com/claude-code)