### PR TITLE
RES-2190: wcet_contracts — drop redundant WcetSpec::fn_name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -173,8 +173,8 @@
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/wcet_contracts.rs": {
-      "branch": "res-1764-attr-collect-presize",
-      "claimed_at": "2026-05-13T11:45:18Z"
+      "branch": "res-2190-wcet-contracts-drop-fn-name",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/stack_contracts.rs": {
       "branch": "res-1784-attr-collects-3",

--- a/resilient/src/wcet_contracts.rs
+++ b/resilient/src/wcet_contracts.rs
@@ -19,13 +19,19 @@
 use crate::Node;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+/// RES-2190: dropped the redundant `fn_name: String` field. The two
+/// readers in `check` (`bodies.get(spec.fn_name.as_str())` lookup +
+/// the error-message format) used it strictly as a name tied to the
+/// attribute owner. The field stored exactly what the attribute key
+/// encoded. Pipeline now carries `(String, WcetSpec)` tuples from
+/// `collect()` to `check()`. Same dead-field pattern as RES-2106 / …
+/// / RES-2188.
+#[derive(Debug, Clone, Copy)]
 pub struct WcetSpec {
-    pub fn_name: String,
     pub budget_cycles: u64,
 }
 
-pub fn collect() -> Vec<WcetSpec> {
+pub fn collect() -> Vec<(String, WcetSpec)> {
     let attrs = crate::feature_attrs::find_kind("wcet");
     // RES-1764: pre-size to attrs.len() — conditional push (only when
     // the `cycles` chunk parses), upper bound.
@@ -48,10 +54,7 @@ pub fn collect() -> Vec<WcetSpec> {
             }
         }
         if let Some(n) = budget_cycles {
-            out.push(WcetSpec {
-                fn_name: item,
-                budget_cycles: n,
-            });
+            out.push((item, WcetSpec { budget_cycles: n }));
         }
     }
     out
@@ -104,13 +107,13 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             _ => None,
         })
         .collect();
-    for spec in &specs {
-        if let Some(body) = bodies.get(spec.fn_name.as_str()) {
+    for (fn_name, spec) in &specs {
+        if let Some(body) = bodies.get(fn_name.as_str()) {
             let est = estimate_wcet(body);
             if est > spec.budget_cycles {
                 return Err(format!(
                     "{}:0:0: error: `{}` WCET budget exceeded: estimated {} > declared {}",
-                    source_path, spec.fn_name, est, spec.budget_cycles
+                    source_path, fn_name, est, spec.budget_cycles
                 ));
             }
         }


### PR DESCRIPTION
## Summary

- Removes \`pub fn_name: String\` from \`WcetSpec\`.
- \`WcetSpec\` becomes \`Copy\` (just \`u64\`).
- \`collect()\` returns \`Vec<(String, WcetSpec)>\`.
- \`check\` destructures \`(fn_name, spec)\`.

## Why

Same dead-field pattern as the just-shipped RES-2188 sibling on \`PowerSpec\` — \`fn_name\` had two readers in \`check\` (HashMap lookup + error format), both used it as a name tied to the attribute owner. The field stored exactly what the attribute key encoded.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib wcet\` (2 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2190

🤖 Generated with [Claude Code](https://claude.com/claude-code)