### PR TITLE
RES-2192: stack_contracts — drop redundant StackSpec::fn_name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -177,8 +177,8 @@
       "claimed_at": "2026-05-13T11:45:18Z"
     },
     "resilient/src/stack_contracts.rs": {
-      "branch": "res-1784-attr-collects-3",
-      "claimed_at": "2026-05-13T12:28:38Z"
+      "branch": "res-2192-stack-contracts-drop-fn-name",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/intent_blocks.rs": {
       "branch": "res-1994-intent-blocks-drop-fnames",

--- a/resilient/src/stack_contracts.rs
+++ b/resilient/src/stack_contracts.rs
@@ -10,15 +10,22 @@
 use crate::Node;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+/// RES-2192: dropped the redundant `fn_name: String` field. The two
+/// readers in `check` (`bodies.get(spec.fn_name.as_str())` lookup +
+/// the error-message format) used it strictly as a name tied to the
+/// attribute owner. The field stored exactly what the attribute key
+/// encoded. Pipeline now carries `(String, StackSpec)` tuples from
+/// `collect()` to `check()`. Same dead-field pattern as RES-2106 / …
+/// / RES-2190 — direct sibling of RES-2188 (PowerSpec) and RES-2190
+/// (WcetSpec).
+#[derive(Debug, Clone, Copy)]
 pub struct StackSpec {
-    pub fn_name: String,
     pub budget_bytes: u64,
 }
 
 const FRAME_BYTES: u64 = 64;
 
-pub fn collect() -> Vec<StackSpec> {
+pub fn collect() -> Vec<(String, StackSpec)> {
     let attrs = crate::feature_attrs::find_kind("stack");
     // RES-1784: pre-size to attrs.len() — conditional push (only when
     // `bytes` chunk parses), so this is an upper bound.
@@ -40,10 +47,7 @@ pub fn collect() -> Vec<StackSpec> {
             }
         }
         if let Some(n) = budget_bytes {
-            out.push(StackSpec {
-                fn_name: item,
-                budget_bytes: n,
-            });
+            out.push((item, StackSpec { budget_bytes: n }));
         }
     }
     out
@@ -106,14 +110,14 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             _ => None,
         })
         .collect();
-    for spec in &specs {
-        if let Some(body) = bodies.get(spec.fn_name.as_str()) {
+    for (fn_name, spec) in &specs {
+        if let Some(body) = bodies.get(fn_name.as_str()) {
             let depth = max_call_depth(body, 1);
             let bytes = depth * FRAME_BYTES;
             if bytes > spec.budget_bytes {
                 return Err(format!(
                     "{}:0:0: error: `{}` stack budget exceeded: estimated {} bytes (depth {}) > declared {} bytes",
-                    source_path, spec.fn_name, bytes, depth, spec.budget_bytes
+                    source_path, fn_name, bytes, depth, spec.budget_bytes
                 ));
             }
         }


### PR DESCRIPTION
## Summary

- Removes \`pub fn_name: String\` from \`StackSpec\`.
- \`StackSpec\` becomes \`Copy\` (just \`u64\`).
- \`collect()\` returns \`Vec<(String, StackSpec)>\`.
- \`check\` destructures \`(fn_name, spec)\`.

## Why

Same dead-field pattern as the just-shipped RES-2188 (PowerSpec) and RES-2190 (WcetSpec) — completes the budget-contract trio. \`fn_name\` had two readers in \`check\` (HashMap lookup + error format), both used it strictly as a name tied to the attribute owner.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib stack_contracts\` (4 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2192

🤖 Generated with [Claude Code](https://claude.com/claude-code)