### PR TITLE
RES-2196: hw_state_machine — drop redundant PeripheralSpec::name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -301,7 +301,7 @@
       "claimed_at": "2026-05-13T12:06:03Z"
     },
     "resilient/src/hw_state_machine.rs": {
-      "branch": "res-2010-hw-state-nested-map",
+      "branch": "res-2196-hw-state-machine-drop-name",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/default_trait_methods.rs": {

--- a/resilient/src/hw_state_machine.rs
+++ b/resilient/src/hw_state_machine.rs
@@ -12,9 +12,15 @@ use crate::Node;
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
+/// RES-2196: dropped the redundant `name: String` field. The only
+/// reader was `install`'s key clone (`g.insert(s.name.clone(), s)`),
+/// which used it strictly as the HashMap key the spec was stored
+/// under. The field stored exactly what the registry key encoded.
+/// Pipeline now carries `(String, PeripheralSpec)` tuples from
+/// `collect()` to `install()`. Same dead-field pattern as RES-2106 /
+/// … / RES-2194.
 #[derive(Debug, Clone)]
 pub struct PeripheralSpec {
-    pub name: String,
     pub states: Vec<String>,
     /// Nested map: `current_state -> (method -> next_state)`.
     ///
@@ -30,14 +36,13 @@ pub struct PeripheralSpec {
 static PERIPHERALS: LazyLock<RwLock<HashMap<String, PeripheralSpec>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
-pub fn collect() -> Vec<PeripheralSpec> {
+pub fn collect() -> Vec<(String, PeripheralSpec)> {
     let attrs = crate::feature_attrs::find_kind("peripheral");
     // RES-1784: pre-size to attrs.len() — exactly one push per
     // attribute record.
     let mut out = Vec::with_capacity(attrs.len());
     for (item, rec) in attrs {
         let mut spec = PeripheralSpec {
-            name: item,
             states: Vec::new(),
             transitions: HashMap::new(),
             initial_state: String::new(),
@@ -72,17 +77,19 @@ pub fn collect() -> Vec<PeripheralSpec> {
                 }
             }
         }
-        out.push(spec);
+        out.push((item, spec));
     }
     out
 }
 
-pub fn install(specs: Vec<PeripheralSpec>) {
+pub fn install(specs: Vec<(String, PeripheralSpec)>) {
     if let Ok(mut g) = PERIPHERALS.write() {
         g.clear();
-        for s in specs {
-            g.insert(s.name.clone(), s);
-        }
+        // RES-2196: move (name, spec) pairs straight from `collect()`
+        // into the map. The previous shape per-spec cloned `s.name`
+        // to produce the key, since the field and the key encoded
+        // the same string.
+        g.extend(specs);
     }
 }
 


### PR DESCRIPTION
## Summary

- Removes \`pub name: String\` from \`PeripheralSpec\`.
- \`collect()\` returns \`Vec<(String, PeripheralSpec)>\`.
- \`install()\` uses \`g.extend(specs)\` — no per-entry clone.

## Why

The only reader was \`install\`'s key clone — the field stored exactly what the registry HashMap key encoded. Pure overhead per \`#[peripheral(...)]\` attribute per \`check()\` invocation. Same dead-field pattern as RES-2106 / … / RES-2194.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib hw_state\` (3 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2196

🤖 Generated with [Claude Code](https://claude.com/claude-code)