### PR TITLE
RES-2198: session_types — drop redundant SessionSpec::channel_name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -261,8 +261,8 @@
       "claimed_at": "2026-05-13T11:45:18Z"
     },
     "resilient/src/session_types.rs": {
-      "branch": "res-1764-attr-collect-presize",
-      "claimed_at": "2026-05-13T11:45:18Z"
+      "branch": "res-2198-session-types-drop-channel-name",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/mmio_regmap.rs": {
       "branch": "res-1764-attr-collect-presize",

--- a/resilient/src/session_types.rs
+++ b/resilient/src/session_types.rs
@@ -28,9 +28,14 @@ pub enum SessionOp {
     Close,
 }
 
+/// RES-2198: dropped the redundant `channel_name: String` field. The
+/// only reader was `install`'s key clone (`g.insert(s.channel_name.clone(), s)`),
+/// which used it strictly as the HashMap key the spec was stored
+/// under. The field stored exactly what the registry key encoded.
+/// Pipeline now carries `(String, SessionSpec)` tuples from `collect()`
+/// to `install()`. Same dead-field pattern as RES-2106 / … / RES-2196.
 #[derive(Debug, Clone)]
 pub struct SessionSpec {
-    pub channel_name: String,
     pub protocol: Vec<SessionOp>,
 }
 
@@ -59,7 +64,7 @@ pub fn parse_protocol(s: &str) -> Vec<SessionOp> {
     out
 }
 
-pub fn collect() -> Vec<SessionSpec> {
+pub fn collect() -> Vec<(String, SessionSpec)> {
     let attrs = crate::feature_attrs::find_kind("session");
     // RES-1764: pre-size to attrs.len() — exactly one push per
     // attribute record.
@@ -74,20 +79,24 @@ pub fn collect() -> Vec<SessionSpec> {
                 }
             }
         }
-        out.push(SessionSpec {
-            channel_name: item,
-            protocol: parse_protocol(&proto_str),
-        });
+        out.push((
+            item,
+            SessionSpec {
+                protocol: parse_protocol(&proto_str),
+            },
+        ));
     }
     out
 }
 
-pub fn install(specs: Vec<SessionSpec>) {
+pub fn install(specs: Vec<(String, SessionSpec)>) {
     if let Ok(mut g) = SPECS.write() {
         g.clear();
-        for s in specs {
-            g.insert(s.channel_name.clone(), s);
-        }
+        // RES-2198: move (channel_name, spec) pairs straight from
+        // `collect()` into the map. The previous shape per-spec cloned
+        // `s.channel_name` to produce the key, since the field and
+        // the key encoded the same string.
+        g.extend(specs);
     }
 }
 


### PR DESCRIPTION
## Summary

- Removes \`pub channel_name: String\` from \`SessionSpec\`.
- \`collect()\` returns \`Vec<(String, SessionSpec)>\`.
- \`install()\` uses \`g.extend(specs)\` — no per-entry clone.

## Why

The only reader was \`install\`'s key clone — the field stored exactly what the registry HashMap key encoded. Pure overhead per \`#[session(...)]\` attribute per \`check()\` invocation. Same dead-field pattern as RES-2106 / … / RES-2196.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib session\` (2 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2198

🤖 Generated with [Claude Code](https://claude.com/claude-code)