### PR TITLE
RES-2200: mmio_regmap — drop redundant MmioRegmap::struct_name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -265,8 +265,8 @@
       "claimed_at": "2026-05-13T11:45:18Z"
     },
     "resilient/src/mmio_regmap.rs": {
-      "branch": "res-1764-attr-collect-presize",
-      "claimed_at": "2026-05-13T11:45:18Z"
+      "branch": "res-2200-mmio-regmap-drop-struct-name",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/macros.rs": {
       "branch": "res-1764-attr-collect-presize",

--- a/resilient/src/mmio_regmap.rs
+++ b/resilient/src/mmio_regmap.rs
@@ -14,9 +14,16 @@ use crate::Node;
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
-#[derive(Debug, Clone)]
+/// RES-2200: dropped the redundant `struct_name: String` field. Two
+/// readers — `install`'s key clone and the overlap-check error
+/// format — both used it strictly as a name tied to the registry
+/// entry. The field stored exactly what the registry HashMap key
+/// encoded. Pipeline now carries `(String, MmioRegmap)` tuples from
+/// `collect()` to `install()`; the overlap check walks the tuple
+/// vec and reads the name from the tuple. Same dead-field pattern
+/// as RES-2106 / … / RES-2198.
+#[derive(Debug, Clone, Copy)]
 pub struct MmioRegmap {
-    pub struct_name: String,
     pub base_addr: u64,
     pub size_bytes: u64,
 }
@@ -33,7 +40,7 @@ fn parse_addr(s: &str) -> Option<u64> {
     }
 }
 
-pub fn collect() -> Vec<MmioRegmap> {
+pub fn collect() -> Vec<(String, MmioRegmap)> {
     let attrs = crate::feature_attrs::find_kind("mmio");
     // RES-1764: pre-size to attrs.len() — conditional push (only when
     // both base and size parse non-zero), upper bound.
@@ -60,21 +67,25 @@ pub fn collect() -> Vec<MmioRegmap> {
                 }
             }
         }
-        out.push(MmioRegmap {
-            struct_name: item,
-            base_addr: base,
-            size_bytes: size,
-        });
+        out.push((
+            item,
+            MmioRegmap {
+                base_addr: base,
+                size_bytes: size,
+            },
+        ));
     }
     out
 }
 
-pub fn install(maps: Vec<MmioRegmap>) {
+pub fn install(maps: Vec<(String, MmioRegmap)>) {
     if let Ok(mut g) = REGMAPS.write() {
         g.clear();
-        for m in maps {
-            g.insert(m.struct_name.clone(), m);
-        }
+        // RES-2200: move (name, map) pairs straight from `collect()`
+        // into the registry. The previous shape per-map cloned
+        // `m.struct_name` to produce the key, since the field and
+        // the key encoded the same string.
+        g.extend(maps);
     }
 }
 
@@ -100,15 +111,15 @@ pub(crate) fn check(_program: &Node, source_path: &str) -> Result<(), String> {
     // overlap check returns Err on real bug — install never runs on
     // failure, which is the right behavior (don't pollute the
     // registry with overlapping maps).
-    for (i, a) in maps.iter().enumerate() {
-        for b in &maps[i + 1..] {
+    for (i, (a_name, a)) in maps.iter().enumerate() {
+        for (b_name, b) in &maps[i + 1..] {
             let a_end = a.base_addr.saturating_add(a.size_bytes);
             let b_end = b.base_addr.saturating_add(b.size_bytes);
             let overlap = a.base_addr < b_end && b.base_addr < a_end;
             if overlap {
                 return Err(format!(
                     "{}:0:0: error: MMIO regmaps `{}` and `{}` overlap in address space",
-                    source_path, a.struct_name, b.struct_name
+                    source_path, a_name, b_name
                 ));
             }
         }
@@ -134,8 +145,9 @@ mod tests {
             },
         );
         let m = collect();
-        assert_eq!(m[0].base_addr, 0x40010800);
-        assert_eq!(m[0].size_bytes, 0x400);
+        assert_eq!(m[0].0, "GPIOA");
+        assert_eq!(m[0].1.base_addr, 0x40010800);
+        assert_eq!(m[0].1.size_bytes, 0x400);
         crate::feature_attrs::reset();
     }
 


### PR DESCRIPTION
## Summary

- Removes \`pub struct_name: String\` from \`MmioRegmap\`.
- \`MmioRegmap\` becomes \`Copy\` (two u64s).
- \`collect()\` returns \`Vec<(String, MmioRegmap)>\`.
- \`install()\` uses \`g.extend(maps)\` — no per-entry clone.
- Overlap check destructures the tuple to read each map's name for the error message.

## Why

Two readers (install's key clone + overlap-check error format) both used \`struct_name\` strictly as a name tied to the registry entry. Pure overhead per \`#[mmio(...)]\` attribute per \`check()\` invocation. Same dead-field pattern as RES-2106 / … / RES-2198.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib mmio\` (2 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2200

🤖 Generated with [Claude Code](https://claude.com/claude-code)