### PR TITLE
RES-2202: mutation_testing — kind as &'static str + skip fn_name clone in summarize

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -369,8 +369,8 @@
       "claimed_at": "2026-05-19T05:02:34Z"
     },
     "resilient/src/mutation_testing.rs": {
-      "branch": "res-1918-mutation-testing-walker-coverage",
-      "claimed_at": "2026-05-19T16:38:37Z"
+      "branch": "res-2202-mutation-static-kind",
+      "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/verifier_z3.rs": {
       "branch": "res-1920-collect-cert-idents-single-walk",

--- a/resilient/src/mutation_testing.rs
+++ b/resilient/src/mutation_testing.rs
@@ -24,10 +24,19 @@
 use crate::Node;
 use std::collections::HashMap;
 
+/// RES-2202: `kind` is now `&'static str`. Every call site in
+/// `generate_in` passes a string literal ("arithmetic", "boundary",
+/// "relational", "logical", "bitwise", "shift", "unary"), so there
+/// was never a runtime-computed kind value — the previous `String`
+/// shape forced a `kind.into()` allocation per Mutation push for
+/// data that lives at static lifetime. Downstream `summarize`
+/// kept the kind in a `Vec<String>`; switching to `Vec<&'static str>`
+/// drops both the per-push alloc AND the per-summarize-push
+/// `m.kind.clone()` (now a `Copy` of a `&str`).
 #[derive(Debug, Clone)]
 pub struct Mutation {
     pub fn_name: String,
-    pub kind: String,
+    pub kind: &'static str,
     pub description: String,
 }
 
@@ -58,10 +67,15 @@ pub fn generate(program: &Node) -> Vec<Mutation> {
     out
 }
 
-fn push(out: &mut Vec<Mutation>, fn_name: &str, kind: &str, description: impl Into<String>) {
+fn push(
+    out: &mut Vec<Mutation>,
+    fn_name: &str,
+    kind: &'static str,
+    description: impl Into<String>,
+) {
     out.push(Mutation {
         fn_name: fn_name.to_string(),
-        kind: kind.into(),
+        kind,
         description: description.into(),
     });
 }
@@ -339,13 +353,26 @@ fn generate_in(node: &Node, fn_name: &str, out: &mut Vec<Mutation>) {
 }
 
 /// Per-function mutation summary: function name → (total sites, kinds).
-pub fn summarize(mutations: &[Mutation]) -> HashMap<String, (usize, Vec<String>)> {
-    let mut map: HashMap<String, (usize, Vec<String>)> = HashMap::new();
+///
+/// RES-2202: `kinds` is `Vec<&'static str>` because `Mutation::kind`
+/// is `&'static str` (mutation categories are compile-time literals).
+/// The previous `Vec<String>` shape paid a per-push `m.kind.clone()`
+/// for data with static lifetime.
+///
+/// The fn-name lookup uses a get-or-insert dance instead of
+/// `entry(m.fn_name.clone()).or_default()` so the `String` is only
+/// allocated on the cold first-mutation-for-this-fn branch.
+/// Subsequent mutations for the same fn pay zero allocations.
+pub fn summarize(mutations: &[Mutation]) -> HashMap<String, (usize, Vec<&'static str>)> {
+    let mut map: HashMap<String, (usize, Vec<&'static str>)> = HashMap::new();
     for m in mutations {
-        let e = map.entry(m.fn_name.clone()).or_default();
-        e.0 += 1;
-        if !e.1.contains(&m.kind) {
-            e.1.push(m.kind.clone());
+        if let Some(e) = map.get_mut(m.fn_name.as_str()) {
+            e.0 += 1;
+            if !e.1.contains(&m.kind) {
+                e.1.push(m.kind);
+            }
+        } else {
+            map.insert(m.fn_name.clone(), (1, vec![m.kind]));
         }
     }
     map


### PR DESCRIPTION
## Summary

Two adjacent allocator wins on \`mutation_testing::{check, summarize}\`:

1. **\`Mutation::kind: String\` → \`&'static str\`.** All call sites in \`generate_in\` pass string literals ("arithmetic", "boundary", "relational", etc.). The previous \`String\` shape forced a \`kind.into()\` allocation per push. Now the field is a \`Copy\` pointer.
2. **\`summarize\` get-or-insert.** Replaced \`map.entry(m.fn_name.clone()).or_default()\` with \`get_mut\` + cold-branch \`insert\`. For N mutations across F functions, saves (N - F) \`String::clone()\` per call.

\`summarize\` returns \`HashMap<String, (usize, Vec<&'static str>)>\` to propagate the \`Copy\` kind through.

## Why

The mutation walker traverses every \`Node::InfixExpression\` / \`Node::PrefixExpression\` in the program. On a non-trivial codebase that produces thousands of mutations per \`check()\` invocation; eliminating one String allocation per mutation (and one fn-name clone per mutation past the first per fn) compounds into a real allocator-time win.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib mutation\` (37 passed including all 9 mutation_testing tests)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2202

🤖 Generated with [Claude Code](https://claude.com/claude-code)