### PR TITLE
RES-2204: coverage_warnings borrows function name + static-str messages

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -447,6 +447,10 @@
     "resilient/src/property_tests.rs": {
       "branch": "res-2186-property-tests-cleanup",
       "claimed_at": "2026-05-20T04:27:32Z"
+    },
+    "resilient/src/coverage_warnings.rs": {
+      "branch": "res-2204-coverage-warnings-borrow",
+      "claimed_at": "2026-05-20T05:05:42Z"
     }
   }
 }

--- a/resilient/src/coverage_warnings.rs
+++ b/resilient/src/coverage_warnings.rs
@@ -22,26 +22,33 @@
 
 use crate::Node;
 
+/// RES-2204: parameterized over the AST lifetime so warnings borrow
+/// the offending function's name from `Node::Function { name, .. }`
+/// and the message is a `&'static str` (every warning's message is a
+/// compile-time literal). The previous shape paid two allocations
+/// per emitted warning — one `fn_name.to_string()` and one
+/// `.into()` on the literal — for data that already lives behind
+/// the program AST + at static lifetime.
 #[derive(Debug, Clone)]
-pub struct CoverageWarning {
-    pub function: String,
-    pub message: String,
+pub struct CoverageWarning<'a> {
+    pub function: &'a str,
+    pub message: &'static str,
 }
 
-pub fn analyze(program: &Node) -> Vec<CoverageWarning> {
+pub fn analyze<'a>(program: &'a Node) -> Vec<CoverageWarning<'a>> {
     let mut out = Vec::new();
     let Node::Program(stmts) = program else {
         return out;
     };
     for s in stmts {
         if let Node::Function { name, body, .. } = &s.node {
-            walk(body, name, &mut out);
+            walk(body, name.as_str(), &mut out);
         }
     }
     out
 }
 
-fn walk(node: &Node, fn_name: &str, out: &mut Vec<CoverageWarning>) {
+fn walk<'a>(node: &'a Node, fn_name: &'a str, out: &mut Vec<CoverageWarning<'a>>) {
     match node {
         Node::IfStatement {
             consequence,
@@ -51,16 +58,16 @@ fn walk(node: &Node, fn_name: &str, out: &mut Vec<CoverageWarning>) {
             let cons_returns_err = block_returns_err(consequence);
             if cons_returns_err {
                 out.push(CoverageWarning {
-                    function: fn_name.to_string(),
-                    message: "if-branch returns Err but no test exercises this path".into(),
+                    function: fn_name,
+                    message: "if-branch returns Err but no test exercises this path",
                 });
             }
             walk(consequence, fn_name, out);
             if let Some(alt) = alternative {
                 if block_returns_err(alt) {
                     out.push(CoverageWarning {
-                        function: fn_name.to_string(),
-                        message: "else-branch returns Err — verify a test exercises it".into(),
+                        function: fn_name,
+                        message: "else-branch returns Err — verify a test exercises it",
                     });
                 }
                 walk(alt, fn_name, out);
@@ -107,15 +114,19 @@ fn is_err_call(node: &Node) -> bool {
 
 /// Warn when a Block has a `return` statement followed by non-trivial
 /// statements (unreachable code after return).
-fn check_unreachable_after_return(stmts: &[Node], fn_name: &str, out: &mut Vec<CoverageWarning>) {
+fn check_unreachable_after_return<'a>(
+    stmts: &'a [Node],
+    fn_name: &'a str,
+    out: &mut Vec<CoverageWarning<'a>>,
+) {
     let mut saw_return = false;
     for stmt in stmts {
         if saw_return {
             // Any statement after an unconditional return is unreachable.
             if !is_trivial_stmt(stmt) {
                 out.push(CoverageWarning {
-                    function: fn_name.to_string(),
-                    message: "unreachable code after `return` statement".into(),
+                    function: fn_name,
+                    message: "unreachable code after `return` statement",
                 });
                 return; // one warning per block is enough
             }
@@ -135,10 +146,10 @@ fn is_trivial_stmt(node: &Node) -> bool {
 /// Warn when all match arms are literal patterns (integer, bool, or string)
 /// and there is no catch-all arm (`_`, identifier binding, or `..`).
 /// Such a match silently falls through if the scrutinee takes any unlisted value.
-fn check_all_literal_match_no_wildcard(
+fn check_all_literal_match_no_wildcard<'a>(
     arms: &[(crate::Pattern, Option<Node>, Node)],
-    fn_name: &str,
-    out: &mut Vec<CoverageWarning>,
+    fn_name: &'a str,
+    out: &mut Vec<CoverageWarning<'a>>,
 ) {
     if arms.is_empty() {
         return;
@@ -147,10 +158,9 @@ fn check_all_literal_match_no_wildcard(
     let has_wildcard = arms.iter().any(|(p, g, _)| is_catch_all_arm(p, g));
     if all_literals && !has_wildcard {
         out.push(CoverageWarning {
-            function: fn_name.to_string(),
+            function: fn_name,
             message: "match covers only literal values with no wildcard arm — \
-                      unhandled values will fall through at runtime"
-                .into(),
+                      unhandled values will fall through at runtime",
         });
     }
 }


### PR DESCRIPTION
## Summary

- \`CoverageWarning<'a> { function: &'a str, message: &'static str }\` — parameterized over the AST lifetime.
- \`analyze\`, \`walk\`, and the two helper checks thread \`<'a>\` through; every push allocates zero strings.

## Why

The four \`message\` values are compile-time literals (4 distinct strings across the file). The \`function\` lives at \`Node::Function { name }\` in the AST for the entire analysis. Previous shape paid 2 allocations per emitted warning for data that's either statically known or already borrowed-accessible.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib coverage_warnings\` (7 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2204

🤖 Generated with [Claude Code](https://claude.com/claude-code)