### PR TITLE
RES-2206: atomic_types — check moves owned names via declare_owned

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -447,6 +447,10 @@
     "resilient/src/property_tests.rs": {
       "branch": "res-2186-property-tests-cleanup",
       "claimed_at": "2026-05-20T04:27:32Z"
+    },
+    "resilient/src/atomic_types.rs": {
+      "branch": "res-2206-atomic-types-skip-declare-clone",
+      "claimed_at": "2026-05-20T05:12:29Z"
     }
   }
 }

--- a/resilient/src/atomic_types.rs
+++ b/resilient/src/atomic_types.rs
@@ -40,9 +40,20 @@ pub fn collect_names() -> Vec<String> {
 // the actual insert. One acquire is enough.
 
 pub fn declare(name: &str, initial: i64) {
+    declare_owned(name.to_string(), initial);
+}
+
+/// RES-2206: inner helper that consumes an owned `String` instead of
+/// cloning from a borrow. The `check` path below collects owned
+/// names from `feature_attrs::find_kind("atomic")` and immediately
+/// throws them away — moving each name straight into the registry
+/// avoids the `name.to_string()` clone that the previous shape paid
+/// per `#[atomic]` attribute on top of the `collect_names` owned
+/// strings the attribute walker had already produced.
+fn declare_owned(name: String, initial: i64) {
     if let Ok(mut g) = REGISTRY.write() {
         let r = g.get_or_insert_with(AtomicRegistry::default);
-        r.cells.insert(name.to_string(), AtomicI64::new(initial));
+        r.cells.insert(name, AtomicI64::new(initial));
     }
 }
 
@@ -76,8 +87,13 @@ pub fn fetch_add(name: &str, delta: i64) -> Option<i64> {
 }
 
 pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+    // RES-2206: move each owned `String` straight into the registry
+    // via `declare_owned`. The previous `declare(&n, 0)` form borrowed
+    // `n` into `declare`, which then called `name.to_string()` —
+    // paying a fresh allocation per `#[atomic]` name on top of the
+    // one `collect_names` already produced.
     for n in collect_names() {
-        declare(&n, 0);
+        declare_owned(n, 0);
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add private \`declare_owned(name: String, initial: i64)\` that moves the owned name straight into the registry.
- \`check\` calls \`declare_owned(n, 0)\` instead of \`declare(&n, 0)\` to avoid the redundant \`name.to_string()\` clone.
- \`pub fn declare(&str, ...)\` keeps its borrow-taking signature for external callers and delegates via \`declare_owned(name.to_string(), initial)\`.

## Why

The check path collected owned \`String\` names from \`feature_attrs::find_kind("atomic")\` then re-allocated each one inside \`declare\` via \`name.to_string()\`. For N \`#[atomic]\` attributes, 2N allocations where N would suffice. The pub API stays unchanged.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib atomic\` (2 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2206

🤖 Generated with [Claude Code](https://claude.com/claude-code)