### PR TITLE
RES-2208: ghost_types::is_ghost — hold read guard, drop per-call HashSet deep clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -447,6 +447,10 @@
     "resilient/src/property_tests.rs": {
       "branch": "res-2186-property-tests-cleanup",
       "claimed_at": "2026-05-20T04:27:32Z"
+    },
+    "resilient/src/ghost_types.rs": {
+      "branch": "res-2208-ghost-types-is-ghost-borrow-guard",
+      "claimed_at": "2026-05-20T05:15:41Z"
     }
   }
 }

--- a/resilient/src/ghost_types.rs
+++ b/resilient/src/ghost_types.rs
@@ -32,11 +32,19 @@ pub fn install(set: HashSet<String>) {
 }
 
 pub fn is_ghost(name: &str) -> bool {
+    // RES-2208: hold the read guard and probe the HashSet directly.
+    // The previous `and_then(|g| g.clone())` form cloned the
+    // entire `Option<HashSet<String>>` (deep-copying every ghost-fn
+    // name) just to call `.contains(&str)` on it. `is_ghost` runs
+    // per CallExpression during typecheck — for any program with
+    // call sites and at least one `#[ghost]` attribute, the deep
+    // clone fired on every call-site visit. Same lock-then-borrow
+    // shape as RES-1544 / RES-1547 / RES-1549 / RES-1552 / RES-2112
+    // / RES-2114 / RES-2116 / RES-2120.
     GHOST_FNS
         .read()
         .ok()
-        .and_then(|g| g.clone())
-        .map(|s| s.contains(name))
+        .map(|g| g.as_ref().is_some_and(|s| s.contains(name)))
         .unwrap_or(false)
 }
 


### PR DESCRIPTION
## Summary

\`is_ghost\` previously cloned the entire \`Option<HashSet<String>>\` per call:

\`\`\`rust
.and_then(|g| g.clone())   // <- deep-copies every ghost-fn name
.map(|s| s.contains(name))
\`\`\`

Switch to lock-then-borrow:

\`\`\`rust
.map(|g| g.as_ref().is_some_and(|s| s.contains(name)))
\`\`\`

The HashSet is probed in place via \`.contains(&str)\` (works through \`Borrow<str>\`); no clone.

## Why

The typechecker calls \`is_ghost\` per \`Node::CallExpression\` to ensure non-ghost code doesn't reach into ghost-tagged fns. For any program with at least one \`#[ghost]\` attribute, the deep clone fired on every call-site visit — N × K wasted String clones per typecheck where N = call sites and K = ghost fn count.

Same lock-then-borrow shape as RES-1544 / RES-1547 / RES-1549 / RES-1552 / RES-2112 / RES-2114 / RES-2116 / RES-2120.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib ghost\` (3 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2208

🤖 Generated with [Claude Code](https://claude.com/claude-code)