### PR TITLE
RES-2212: region_inference::resolve walks union-find via borrowed Region refs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -241,7 +241,7 @@
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/region_inference.rs": {
-      "branch": "res-2146-region-inference-callee-info-borrow",
+      "branch": "res-2212-region-inference-resolve-borrow",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/mutual_recursion_scc.rs": {

--- a/resilient/src/region_inference.rs
+++ b/resilient/src/region_inference.rs
@@ -63,14 +63,24 @@ impl RegionTable {
     ///
     /// Follows variable chains until a `Region::Named` or an unbound
     /// `Region::Var` is reached.
-    pub fn resolve(&self, mut r: Region) -> Region {
+    ///
+    /// RES-2212: walk the union-find chain via `&Region` borrows from
+    /// the `parent` HashMap. The previous shape did `r = parent.clone()`
+    /// at every step — a fresh `Region` allocation per chain link
+    /// (including a `String` clone whenever a `Named(_)` was bumped
+    /// out by an intermediate `Var(_)`). For chain depth D with a
+    /// `Named` target, the new loop clones the final `String` exactly
+    /// once and otherwise just walks `u32` indices.
+    pub fn resolve(&self, r: Region) -> Region {
+        let mut current_var = match r {
+            Region::Var(v) => v.0,
+            Region::Named(_) => return r,
+        };
         loop {
-            match &r {
-                Region::Var(v) => match self.parent.get(&v.0) {
-                    Some(parent) => r = parent.clone(),
-                    None => return r,
-                },
-                Region::Named(_) => return r,
+            match self.parent.get(&current_var) {
+                None => return Region::Var(RegionVar(current_var)),
+                Some(Region::Var(v)) => current_var = v.0,
+                Some(Region::Named(name)) => return Region::Named(name.clone()),
             }
         }
     }


### PR DESCRIPTION
## Summary

\`RegionTable::resolve\` previously cloned each parent on every chain step:
\`r = parent.clone()\` — D allocations for chain depth D, each \`Region::Named\` clone wrapping a \`String\` clone.

Walk the chain via \`&Region\` borrows; track a \`u32\` index between steps; materialise the terminal \`Region\` exactly once.

## Why

The borrow checker calls \`resolve\` on every unification + every parameter/local region lookup. For chain depth D:
- \`Named\` target: D allocations → 1 \`String\` clone.
- Unbound \`Var\` target: D allocations → 0.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib region_inference\` (15 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2212

🤖 Generated with [Claude Code](https://claude.com/claude-code)