### PR TITLE
RES-2216: lean_spec::list_emittable returns Vec<&str> borrowed from program AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -229,7 +229,7 @@
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/lean_spec.rs": {
-      "branch": "res-1980-lean-spec-write",
+      "branch": "res-2216-lean-spec-list-emittable-borrow",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
     "resilient/src/autopilot.rs": {

--- a/resilient/src/lean_spec.rs
+++ b/resilient/src/lean_spec.rs
@@ -293,7 +293,13 @@ pub fn try_emit_for_fn(program: &Node, fn_name: &str) -> Result<String, String> 
     Err(format!("function `{fn_name}` not found"))
 }
 
-pub fn list_emittable(program: &Node) -> Vec<String> {
+/// RES-2216: borrow each emittable function name from the program AST.
+/// The two consumers (`check`'s `emittable.join(", ")` + the test's
+/// `names.contains(&"easy")`) both only read each name; the previous
+/// shape paid one `String::clone()` per Lean-emittable fn for data
+/// already living behind `&s.node`. `<&str>::join(", ")` returns a
+/// fresh `String` so the eprintln output is unchanged.
+pub fn list_emittable(program: &Node) -> Vec<&str> {
     let Node::Program(stmts) = program else {
         return Vec::new();
     };
@@ -303,7 +309,7 @@ pub fn list_emittable(program: &Node) -> Vec<String> {
     for s in stmts {
         if let Node::Function { name, .. } = &s.node {
             if lower_function(&s.node).is_ok() {
-                out.push(name.clone());
+                out.push(name.as_str());
             }
         }
     }
@@ -338,7 +344,7 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
             ..
         } = &s.node
         {
-            if emittable.contains(name) && (!requires.is_empty() || !ensures.is_empty()) {
+            if emittable.contains(&name.as_str()) && (!requires.is_empty() || !ensures.is_empty()) {
                 eprintln!(
                     "lean-spec:   `{name}` has {} requires + {} ensures clause(s) — \
                      use `rz emit-lean {name}` to generate the theorem",
@@ -420,8 +426,8 @@ mod tests {
         "#;
         let (prog, _) = parse(src);
         let names = list_emittable(&prog);
-        assert!(names.contains(&"easy".to_string()));
-        assert!(!names.contains(&"hard".to_string()));
+        assert!(names.contains(&"easy"));
+        assert!(!names.contains(&"hard"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

\`pub fn list_emittable(program: &Node) -> Vec<String>\` → \`Vec<&str>\` borrowed from the AST. Per-name \`String::clone()\` dropped; \`<&str>::join(", ")\` still produces a fresh \`String\` so the \`eprintln\` output is unchanged. Consumer's \`emittable.contains(name)\` becomes \`emittable.contains(&name.as_str())\`.

## Why

The two consumers (\`check\`'s join + the test) only read each name; the data lives behind \`&s.node\` for the entire \`check\` call. The previous \`name.clone()\` per emittable fn was throwaway.

Same AST-borrow pattern as RES-2092 / RES-2148 / RES-2150 / RES-2152 / RES-2154 / RES-2158 / RES-2160 / RES-2164 / RES-2204 / RES-2214.

## Test plan

- [x] \`cargo build --manifest-path resilient/Cargo.toml\`
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib lean_spec\` (12 passed)
- [x] \`cargo test --manifest-path resilient/Cargo.toml --lib\` (4685 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\`

Closes #2216

🤖 Generated with [Claude Code](https://claude.com/claude-code)