### PR TITLE
RES-2218: bounded_blocking — borrow callee names as &'a str

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -455,6 +455,10 @@
     "resilient/src/try_catch.rs": {
       "branch": "res-2214-try-catch-emitted-variants-borrow",
       "claimed_at": "2026-05-20T05:34:11Z"
+    },
+    "resilient/src/bounded_blocking.rs": {
+      "branch": "res-2218-bounded-blocking-borrow-callees",
+      "claimed_at": "2026-05-20T05:47:46Z"
     }
   }
 }

--- a/resilient/src/bounded_blocking.rs
+++ b/resilient/src/bounded_blocking.rs
@@ -60,26 +60,30 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     }
     // RES-1511: borrow each top-level fn name as `&str` from the
     // AST into the outer `callees` / `blocking_calls` HashMaps and
-    // the `decls` Vec. The inner `cs: Vec<String>` keeps owned
-    // Strings because `uniqueness_walk::visit` uses a HRTB closure
-    // that can't bind the AST lifetime (same limitation as
-    // RES-1509 for `isr_call_graph::collect_callees`). Mirror of
-    // RES-1495 / RES-1500 / RES-1503 / RES-1507 / RES-1509.
+    // the `decls` Vec.
+    // RES-2218: also borrow inner callee names as `&'a str` from the
+    // AST. `uniqueness_walk::visit<'a>` propagates the AST lifetime
+    // into the closure (`FnMut(&'a Node)`, RES-1603), so the closure
+    // can capture `cs: &mut Vec<&'a str>` and push `fname.as_str()`.
+    // This eliminates one `String::clone()` per call expression per
+    // `_bound{N}`-triggered check (the prior comment about HRTB
+    // closures preventing this was stale — `visit` was made
+    // lifetime-parameterized in RES-1603).
     // RES-1746: pre-size the three call-graph collections to stmts.len()
     // (upper bound). Same shape as RES-1742 / RES-1744 for the
     // sibling call-graph passes.
-    let mut callees: HashMap<&str, Vec<String>> = HashMap::with_capacity(stmts.len());
+    let mut callees: HashMap<&str, Vec<&str>> = HashMap::with_capacity(stmts.len());
     let mut blocking_calls: HashMap<&str, usize> = HashMap::with_capacity(stmts.len());
     let mut decls: Vec<&str> = Vec::with_capacity(stmts.len());
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {
             decls.push(name.as_str());
-            let mut cs = Vec::new();
+            let mut cs: Vec<&str> = Vec::new();
             let mut bn = 0;
             visit(body, &mut |n| {
                 if let Node::CallExpression { function, .. } = n {
                     if let Node::Identifier { name: fname, .. } = function.as_ref() {
-                        cs.push(fname.clone());
+                        cs.push(fname.as_str());
                         if BLOCKING_PRIMS.contains(&fname.as_str()) || fname.ends_with("_blocking")
                         {
                             bn += 1;
@@ -114,9 +118,11 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
 // one into the `seen` set and the BFS queue. All three parameters
 // share lifetime `'a` so the borrows from `callees` and `start` can
 // flow through `q` and `seen` without per-iteration `String::clone`.
+// RES-2218: callees values are now `Vec<&'a str>` (was `Vec<String>`),
+// so the per-edge `c.as_str()` step is gone — push the borrow directly.
 fn transitive_blocking<'a>(
     start: &'a str,
-    callees: &'a HashMap<&'a str, Vec<String>>,
+    callees: &HashMap<&'a str, Vec<&'a str>>,
     bn: &HashMap<&str, usize>,
 ) -> usize {
     let mut total = 0;
@@ -129,8 +135,8 @@ fn transitive_blocking<'a>(
         }
         total += bn.get(f).copied().unwrap_or(0);
         if let Some(cs) = callees.get(f) {
-            for c in cs {
-                q.push_back(c.as_str());
+            for &c in cs {
+                q.push_back(c);
             }
         }
     }


### PR DESCRIPTION
Closes #2218.

`bounded_blocking::check` builds a per-function callees vector by walking the body
via `uniqueness_walk::visit`. The pre-RES-2218 code did `cs.push(fname.clone())`
per call expression because the original RES-1511 comment claimed the HRTB
closure shape prevented borrowing names from the AST.

That comment was stale: RES-1603 gave `visit` an explicit lifetime
parameter `pub(crate) fn visit<'a>(node: &'a Node, f: &mut impl FnMut(&'a Node))`,
so the closure now propagates the AST lifetime and lets us hold borrowed
`&'a str` in the inner `Vec`. This PR converts the per-call clone into a
zero-alloc borrow:

- `callees: HashMap<&str, Vec<String>>` → `HashMap<&str, Vec<&'a str>>`
- inner `cs: Vec<String>` → `cs: Vec<&'a str>`, push `fname.as_str()`
- `transitive_blocking` signature drops the `Vec<String>`; per-edge `c.as_str()` is gone

### Impact

One `String::clone()` per call expression per top-level function body,
eliminated when the program triggers the `_bound{N}` suffix gate.
On large codebases that opt into bounded-blocking budgets this is per-call,
per-fn — the savings compound.

### Tests

- All existing `bounded_blocking::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- Full `cargo test --manifest-path resilient/Cargo.toml` green

Continues the AST-borrow series:
RES-2148 / RES-2150 / RES-2152 / RES-2164 / RES-2204 / RES-2214 / RES-2216.