### PR TITLE
RES-2220: labeled_break — borrow DeepBreakWarning::function from program AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -459,6 +459,10 @@
     "resilient/src/bounded_blocking.rs": {
       "branch": "res-2218-bounded-blocking-borrow-callees",
       "claimed_at": "2026-05-20T05:47:46Z"
+    },
+    "resilient/src/labeled_break.rs": {
+      "branch": "res-2220-labeled-break-borrow-fn-name",
+      "claimed_at": "2026-05-20T05:55:47Z"
     }
   }
 }

--- a/resilient/src/labeled_break.rs
+++ b/resilient/src/labeled_break.rs
@@ -14,30 +14,35 @@
 
 use crate::Node;
 
+// RES-2220: borrow `function` as `&'a str` from the AST. The only
+// reader of this field is `check`'s `eprintln!` formatter, which
+// only needs to print the name. The owned `String` was paying a
+// per-warning `to_string()` allocation for data already living
+// behind `&Node`. Same shape as RES-2204 (coverage_warnings).
 #[derive(Debug, Clone)]
-pub struct DeepBreakWarning {
-    pub function: String,
+pub struct DeepBreakWarning<'a> {
+    pub function: &'a str,
     pub depth: u32,
 }
 
-pub fn analyze(program: &Node) -> Vec<DeepBreakWarning> {
+pub fn analyze<'a>(program: &'a Node) -> Vec<DeepBreakWarning<'a>> {
     let mut out = Vec::new();
     let Node::Program(stmts) = program else {
         return out;
     };
     for s in stmts {
         if let Node::Function { name, body, .. } = &s.node {
-            walk(body, name, 0, &mut out);
+            walk(body, name.as_str(), 0, &mut out);
         }
     }
     out
 }
 
-fn walk(node: &Node, fn_name: &str, depth: u32, out: &mut Vec<DeepBreakWarning>) {
+fn walk<'a>(node: &'a Node, fn_name: &'a str, depth: u32, out: &mut Vec<DeepBreakWarning<'a>>) {
     match node {
         Node::Break { .. } | Node::Continue { .. } if depth >= 3 => {
             out.push(DeepBreakWarning {
-                function: fn_name.to_string(),
+                function: fn_name,
                 depth,
             });
         }


### PR DESCRIPTION
Closes #2220.

`labeled_break::DeepBreakWarning` previously stored `function: String`,
forcing a `fn_name.to_string()` allocation per deeply-nested break/continue.
The walker already had `fn_name: &str`, so the clone was pure overhead.

### Change

```rust
pub struct DeepBreakWarning<'a> {
    pub function: &'a str,
    pub depth: u32,
}
pub fn analyze<'a>(program: &'a Node) -> Vec<DeepBreakWarning<'a>>
```

Walker threads `'a` and pushes `function: fn_name` directly.

### Impact

One `String::to_string()` per (depth >= 3) break/continue, eliminated.

### Tests

- All 10 existing `labeled_break::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Continues the AST-borrow series:
RES-2148 / RES-2150 / RES-2152 / RES-2164 / RES-2204 / RES-2214 / RES-2216 / RES-2218.