### PR TITLE
RES-2224: struct_exhaustiveness — borrow ExhaustivenessWarning::function from program AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -72,10 +72,6 @@
       "branch": "res-2030-stats-single-pass",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/struct_exhaustiveness.rs": {
-      "branch": "res-2022-exhaustiveness-static-msg",
-      "claimed_at": "2026-05-19T00:00:00Z"
-    },
     "resilient/src/ai_threat_model.rs": {
       "branch": "res-1986-block-shape-direct-write",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -463,6 +459,10 @@
     "resilient/src/labeled_break.rs": {
       "branch": "res-2220-labeled-break-borrow-fn-name",
       "claimed_at": "2026-05-20T05:55:47Z"
+    },
+    "resilient/src/struct_exhaustiveness.rs": {
+      "branch": "res-2224-struct-exhaust-borrow-fn-name",
+      "claimed_at": "2026-05-20T06:03:00Z"
     }
   }
 }

--- a/resilient/src/struct_exhaustiveness.rs
+++ b/resilient/src/struct_exhaustiveness.rs
@@ -17,9 +17,13 @@
 
 use crate::Node;
 
+// RES-2224: borrow `function` as `&'a str` from the program AST.
+// The walker already had `fn_name: &str`, so the per-warning
+// `fn_name.to_string()` was pure overhead. Same shape as
+// RES-2204 (coverage_warnings) and RES-2220 (labeled_break::DeepBreakWarning).
 #[derive(Debug, Clone)]
-pub struct ExhaustivenessWarning {
-    pub function: String,
+pub struct ExhaustivenessWarning<'a> {
+    pub function: &'a str,
     /// RES-2022: `&'static str` because the sole push site populates
     /// this from a string literal. The previous `String` shape forced
     /// a `.into()` allocation per push for content that already lived
@@ -51,20 +55,20 @@ fn struct_arm_is_unguarded_catch_all(
     }
 }
 
-pub fn analyze(program: &Node) -> Vec<ExhaustivenessWarning> {
+pub fn analyze<'a>(program: &'a Node) -> Vec<ExhaustivenessWarning<'a>> {
     let mut out = Vec::new();
     let Node::Program(stmts) = program else {
         return out;
     };
     for s in stmts {
         if let Node::Function { name, body, .. } = &s.node {
-            walk(body, name, &mut out);
+            walk(body, name.as_str(), &mut out);
         }
     }
     out
 }
 
-fn walk(node: &Node, fn_name: &str, out: &mut Vec<ExhaustivenessWarning>) {
+fn walk<'a>(node: &'a Node, fn_name: &'a str, out: &mut Vec<ExhaustivenessWarning<'a>>) {
     match node {
         Node::Match { arms, .. } => {
             let all_struct = arms
@@ -75,7 +79,7 @@ fn walk(node: &Node, fn_name: &str, out: &mut Vec<ExhaustivenessWarning>) {
                 .any(|(p, g, _)| struct_arm_is_unguarded_catch_all(p, g));
             if all_struct && !arms.is_empty() && !has_cover {
                 out.push(ExhaustivenessWarning {
-                    function: fn_name.to_string(),
+                    function: fn_name,
                     message: "Non-exhaustive match on struct — add a wildcard arm \
                               (`_`, an identifier, or `StructName { .. }`)",
                 });


### PR DESCRIPTION
Closes #2224.

`struct_exhaustiveness::ExhaustivenessWarning::function` was `String`,
forcing a `fn_name.to_string()` allocation per non-exhaustive struct-match
warning. The walker already had `fn_name: &str` — the clone was pure overhead.

Sibling fix to RES-2022 (`message: &'static str`) — `function` was the
remaining owned allocation in the struct.

### Change

```rust
pub struct ExhaustivenessWarning<'a> {
    pub function: &'a str,
    pub message: &'static str,
}
pub fn analyze<'a>(program: &'a Node) -> Vec<ExhaustivenessWarning<'a>>
```

The walker threads `'a` and pushes `function: fn_name` directly.

Also released the stale `res-2022-exhaustiveness-static-msg` file
claim (PR #2023 merged on 2026-05-19) before claiming for this PR.

### Impact

One `String::to_string()` per non-exhaustive struct-match warning, eliminated.

### Tests

- All 8 existing `struct_exhaustiveness::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Continues the AST-borrow series:
RES-2148 / RES-2150 / RES-2152 / RES-2164 / RES-2204 / RES-2214 / RES-2216 / RES-2218 / RES-2220 / RES-2222.