### PR TITLE
RES-2226: audit_log_required — switch has_audited_write detector from visit to any_node

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -88,10 +88,6 @@
       "branch": "res-1252-degraded-mode-fast-reject",
       "claimed_at": "2026-05-12T03:27:30Z"
     },
-    "resilient/src/audit_log_required.rs": {
-      "branch": "res-1254-audit-log-fast-reject",
-      "claimed_at": "2026-05-12T03:32:45Z"
-    },
     "resilient/src/secret_erasure.rs": {
       "branch": "res-1256-secret-erasure-fast-reject",
       "claimed_at": "2026-05-12T03:39:06Z"
@@ -463,6 +459,10 @@
     "resilient/src/labeled_break.rs": {
       "branch": "res-2220-labeled-break-borrow-fn-name",
       "claimed_at": "2026-05-20T05:55:47Z"
+    },
+    "resilient/src/audit_log_required.rs": {
+      "branch": "res-2226-audit-log-any-node",
+      "claimed_at": "2026-05-20T06:14:36Z"
     }
   }
 }

--- a/resilient/src/audit_log_required.rs
+++ b/resilient/src/audit_log_required.rs
@@ -18,7 +18,7 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, for_each_function, visit};
+use crate::uniqueness_walk::{any_node, for_each_function};
 
 const AUDIT_FNS: &[&str] = &["audit_log", "journal", "record_event", "emit_audit"];
 
@@ -29,13 +29,21 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // least one audited-prefixed/suffixed field assignment. The
     // previous `any_node` pre-scan was redundant — removed.
     for_each_function(program, |fname, _params, body| {
-        let mut has_audited_write = false;
-        visit(body, &mut |n| {
-            if let Node::FieldAssignment { field, .. } = n {
-                if field.starts_with("audited_") || field.ends_with("_audited") {
-                    has_audited_write = true;
-                }
+        // RES-2226: switch the audited-write detector from `visit`
+        // (unconditional whole-body walk) to `any_node` (early-
+        // terminating). `visit` set a `has_audited_write` flag mid-
+        // walk and continued visiting siblings/cousins until the
+        // entire body had been traversed. `any_node` propagates the
+        // hit upward and skips the rest of the tree. For functions
+        // with even a single audited write, the walk now stops at
+        // the first match — typically after a handful of nodes
+        // instead of the full body. Mirrors the audit pass's own
+        // `logged` detector below, which already uses `any_node`.
+        let has_audited_write = any_node(body, |n| match n {
+            Node::FieldAssignment { field, .. } => {
+                field.starts_with("audited_") || field.ends_with("_audited")
             }
+            _ => false,
         });
         if !has_audited_write {
             return;


### PR DESCRIPTION
Closes #2226.

`audit_log_required::check` walked each function body twice:

1. First walk (`visit`) detected audited-prefixed FieldAssignments and set a flag — but `visit` continued traversing the rest of the body even after the flag flipped.
2. Second walk (`any_node`) checked for audit-call presence with proper short-circuit.

This PR removes the asymmetry: the audited-write detector now uses `any_node` too, propagating the first match upward and skipping the rest of the tree.

### Change

```rust
// before
let mut has_audited_write = false;
visit(body, &mut |n| {
    if let Node::FieldAssignment { field, .. } = n {
        if field.starts_with("audited_") || field.ends_with("_audited") {
            has_audited_write = true;
        }
    }
});

// after
let has_audited_write = any_node(body, |n| match n {
    Node::FieldAssignment { field, .. } => {
        field.starts_with("audited_") || field.ends_with("_audited")
    }
    _ => false,
});
```

### Impact

For functions with audited writes, the walk stops at the first match — a handful of nodes vs. the full body. The check is gated behind RES-1254's typechecker marker, so this only fires on programs using audited fields.

### Tests

- All 3 existing `audit_log_required::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1254-audit-log-fast-reject` file claim (PR #1255 merged on 2026-05-12) before claiming for this PR.