### PR TITLE
RES-2228: reentrancy_guard — borrow callee names as &'a str (drop stale HRTB clone)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -312,10 +312,6 @@
       "branch": "res-2014-assoc-const-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/rate_limit_static.rs": {
-      "branch": "res-1962-reentrancy-rate-limit-presize",
-      "claimed_at": "2026-05-19T18:59:39Z"
-    },
     "resilient/src/sum_types.rs": {
       "branch": "res-1788-rate-limit-presize",
       "claimed_at": "2026-05-13T12:35:40Z"
@@ -416,10 +412,6 @@
       "branch": "res-1958-assume-axioms-presize",
       "claimed_at": "2026-05-19T18:52:28Z"
     },
-    "resilient/src/reentrancy_guard.rs": {
-      "branch": "res-1962-reentrancy-rate-limit-presize",
-      "claimed_at": "2026-05-19T18:59:39Z"
-    },
     "resilient/src/isr_call_graph.rs": {
       "branch": "res-1966-isr-bfs-reuse",
       "claimed_at": "2026-05-19T19:06:11Z"
@@ -463,6 +455,10 @@
     "resilient/src/labeled_break.rs": {
       "branch": "res-2220-labeled-break-borrow-fn-name",
       "claimed_at": "2026-05-20T05:55:47Z"
+    },
+    "resilient/src/reentrancy_guard.rs": {
+      "branch": "res-2228-reentrancy-borrow-callees",
+      "claimed_at": "2026-05-20T06:17:05Z"
     }
   }
 }

--- a/resilient/src/reentrancy_guard.rs
+++ b/resilient/src/reentrancy_guard.rs
@@ -45,26 +45,29 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         return Ok(());
     }
     // RES-1519: borrow each top-level fn name as `&str` from the
-    // AST into the `callees` HashMap and `roots` Vec. The inner
-    // `cs: HashSet<String>` keeps owned Strings because
-    // `uniqueness_walk::visit` uses a HRTB closure that can't bind
-    // the outer AST lifetime — same limitation hit by
-    // RES-1509 / RES-1511. Pair with `reaches_self` borrowing into
-    // the graph for the DFS (mirror of RES-1471 / RES-1474 / RES-1477).
+    // AST into the `callees` HashMap and `roots` Vec.
+    // RES-2228: also borrow inner callee names as `&'a str` from
+    // the AST. The stale comment from RES-1519 said
+    // `uniqueness_walk::visit` used an HRTB closure that couldn't
+    // bind the AST lifetime — RES-1603 long ago gave `visit` an
+    // explicit `'a` parameter (`FnMut(&'a Node)`), so the closure
+    // captures `cs: &mut HashSet<&'a str>` and inserts `name.as_str()`
+    // directly. Mirrors RES-2218 (bounded_blocking) which retired
+    // the same stale myth.
     // RES-1742: pre-size the call-graph map to stmts.len() (upper
     // bound — every top-level statement could be a Function). The
     // per-fn callees HashSet starts empty; 8 fits a typical body.
-    let mut callees: HashMap<&str, HashSet<String>> = HashMap::with_capacity(stmts.len());
+    let mut callees: HashMap<&str, HashSet<&str>> = HashMap::with_capacity(stmts.len());
     // RES-1962: pre-size to 4 — typical non-reentrant fn count is low
     // (1-5 fns matching NR_PREFIXES / NR_SUFFIXES per program).
     let mut roots: Vec<&str> = Vec::with_capacity(4);
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {
-            let mut cs = HashSet::with_capacity(8);
+            let mut cs: HashSet<&str> = HashSet::with_capacity(8);
             visit(body, &mut |n| {
                 if let Node::CallExpression { function, .. } = n {
                     if let Node::Identifier { name, .. } = function.as_ref() {
-                        cs.insert(name.clone());
+                        cs.insert(name.as_str());
                     }
                 }
             });
@@ -91,13 +94,16 @@ fn is_nonreentrant(name: &str) -> bool {
         || NR_SUFFIXES.iter().any(|s| name.ends_with(*s))
 }
 
-fn reaches_self<'a>(callees: &'a HashMap<&'a str, HashSet<String>>, start: &str) -> bool {
+// RES-2228: callees values are now `HashSet<&'a str>` (was
+// `HashSet<String>`), so the initial-stack init and per-edge
+// `String::as_str()` step are gone — push the borrow directly.
+fn reaches_self<'a>(callees: &HashMap<&'a str, HashSet<&'a str>>, start: &str) -> bool {
     // RES-1962: pre-size the DFS visited set to `callees.len()` —
     // exact upper bound, each callee is visited at most once.
     let mut seen: HashSet<&'a str> = HashSet::with_capacity(callees.len());
     let mut stack: Vec<&'a str> = callees
         .get(start)
-        .map(|cs| cs.iter().map(String::as_str).collect())
+        .map(|cs| cs.iter().copied().collect())
         .unwrap_or_default();
     while let Some(c) = stack.pop() {
         if c == start {
@@ -107,8 +113,8 @@ fn reaches_self<'a>(callees: &'a HashMap<&'a str, HashSet<String>>, start: &str)
             continue;
         }
         if let Some(cs) = callees.get(c) {
-            for cc in cs {
-                stack.push(cc.as_str());
+            for &cc in cs {
+                stack.push(cc);
             }
         }
     }


### PR DESCRIPTION
Closes #2228.

`reentrancy_guard::check` built a per-function callees HashSet by walking the
body via `uniqueness_walk::visit`. The pre-RES-2228 code did
`cs.insert(name.clone())` per call expression because the original RES-1519
comment claimed the HRTB closure shape prevented borrowing names from the AST.

That comment was stale: RES-1603 long ago gave `visit` an explicit lifetime
parameter `pub(crate) fn visit<'a>(node: &'a Node, f: &mut impl FnMut(&'a Node))`,
so the closure now propagates the AST lifetime and lets us hold borrowed
`&'a str` in the HashSet. Same myth-retirement as RES-2218 (bounded_blocking).

### Change

- `callees: HashMap<&str, HashSet<String>>` → `HashMap<&str, HashSet<&'a str>>`
- inner `cs.insert(name.clone())` → `cs.insert(name.as_str())`
- `reaches_self` signature drops the `HashSet<String>`; per-edge `String::as_str()` and the `iter().map(String::as_str)` adapter are gone

### Impact

One `String::clone()` per call expression in every top-level fn body,
eliminated when the program triggers the `is_nonreentrant` (NR-prefix/suffix)
fast-reject. Same AST-borrow pattern as RES-2148 / RES-2150 / RES-2218.

Also released the stale `res-1962-reentrancy-rate-limit-presize` file claim
(PR #1963 merged on 2026-05-19) before claiming for this PR.

### Tests

- All 3 existing `reentrancy_guard::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean