### PR TITLE
RES-2232: priority_inheritance — short-circuit PI/raw-lock detection with any_node

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -44,10 +44,6 @@
       "branch": "res-1217-handler-suffix-fast-reject",
       "claimed_at": "2026-05-12T02:07:46Z"
     },
-    "resilient/src/priority_inheritance.rs": {
-      "branch": "res-1232-priority-fast-reject",
-      "claimed_at": "2026-05-12T02:35:05Z"
-    },
     "resilient/src/crash_only_cert.rs": {
       "branch": "res-1236-crash-only-cert-fast-reject",
       "claimed_at": "2026-05-12T02:42:33Z"
@@ -463,6 +459,10 @@
     "resilient/src/labeled_break.rs": {
       "branch": "res-2220-labeled-break-borrow-fn-name",
       "claimed_at": "2026-05-20T05:55:47Z"
+    },
+    "resilient/src/priority_inheritance.rs": {
+      "branch": "res-2232-priority-inherit-short-circuit",
+      "claimed_at": "2026-05-20T06:23:14Z"
     }
   }
 }

--- a/resilient/src/priority_inheritance.rs
+++ b/resilient/src/priority_inheritance.rs
@@ -20,7 +20,7 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{for_each_function, visit};
+use crate::uniqueness_walk::{any_node, for_each_function};
 
 const LOW_PRI_PREFIXES: &[&str] = &["low_pri_", "bg_", "idle_"];
 const PI_VARIANTS: &[&str] = &["pi_lock", "pi_acquire", "with_priority_inherit"];
@@ -58,21 +58,36 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         if !LOW_PRI_PREFIXES.iter().any(|p| fname.starts_with(*p)) {
             return;
         }
-        let mut raw_lock_seen = false;
-        let mut pi_seen = false;
-        visit(body, &mut |n| {
-            if let Node::CallExpression { function, .. } = n {
-                if let Node::Identifier { name, .. } = function.as_ref() {
-                    if RAW_LOCKS.contains(&name.as_str()) {
-                        raw_lock_seen = true;
-                    }
-                    if PI_VARIANTS.contains(&name.as_str()) {
-                        pi_seen = true;
-                    }
-                }
-            }
+        // RES-2232: short-circuit both walks. The previous `visit`
+        // call traversed the whole body unconditionally just to set
+        // two boolean flags. We only warn when `raw_lock_seen &&
+        // !pi_seen`, so:
+        //   1. If any PI variant appears anywhere in the body, we
+        //      never warn — bail out the moment we see one.
+        //   2. Otherwise check for any raw lock; warn on first hit.
+        // `any_node` (RES-1238 early-terminating) propagates the
+        // first match upward and skips the rest of the tree. For
+        // bodies that either use PI (correct case) or hit a raw lock
+        // early (warning case), the walk stops at a handful of nodes
+        // instead of the full body.
+        let pi_seen = any_node(body, |n| match n {
+            Node::CallExpression { function, .. } => match function.as_ref() {
+                Node::Identifier { name, .. } => PI_VARIANTS.contains(&name.as_str()),
+                _ => false,
+            },
+            _ => false,
         });
-        if raw_lock_seen && !pi_seen {
+        if pi_seen {
+            return;
+        }
+        let raw_lock_seen = any_node(body, |n| match n {
+            Node::CallExpression { function, .. } => match function.as_ref() {
+                Node::Identifier { name, .. } => RAW_LOCKS.contains(&name.as_str()),
+                _ => false,
+            },
+            _ => false,
+        });
+        if raw_lock_seen {
             eprintln!(
                 "warning: low-priority fn '{fname}' acquires a non-PI lock — \
                  will cause priority inversion. Use pi_lock/pi_acquire/with_priority_inherit"


### PR DESCRIPTION
Closes #2232.

`priority_inheritance::check` previously walked each candidate function body
via `visit` to set two boolean flags (`raw_lock_seen`, `pi_seen`), then decided
to warn based on `raw_lock_seen && !pi_seen`. `visit` is unconditional —
it kept traversing the whole body even when the answer was already determined.

### Change

Split into two short-circuit `any_node` walks:

```rust
// 1. If any PI variant call exists, no warning is possible — bail
let pi_seen = any_node(body, |n| ... PI_VARIANTS.contains(&name.as_str()) ...);
if pi_seen { return; }

// 2. Otherwise, warn on first raw lock found
let raw_lock_seen = any_node(body, |n| ... RAW_LOCKS.contains(&name.as_str()) ...);
if raw_lock_seen { eprintln!(...) }
```

### Impact

For functions in the `low_pri_*`/`bg_*`/`idle_*` family, the walk now stops at the
first match. Most candidate functions either use PI variants (no walk past first PI call)
or use raw locks (no walk past first lock call).

Same short-circuit pattern as RES-2226 (audit_log_required).

### Tests

- All 3 existing `priority_inheritance::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1232-priority-fast-reject` file claim
(PR #1233 merged on 2026-05-12) before claiming for this PR.