### PR TITLE
RES-2238: recovery_checker — borrow Context::extern_fns + current_fn from program AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -288,14 +288,6 @@
       "branch": "res-1770-verifier-presize",
       "claimed_at": "2026-05-13T11:59:58Z"
     },
-    "resilient/src/recovery_checker.rs": {
-      "branch": "res-1774-recovery-lint-presize",
-      "claimed_at": "2026-05-13T12:06:03Z"
-    },
-    "resilient/src/lint.rs": {
-      "branch": "res-1774-recovery-lint-presize",
-      "claimed_at": "2026-05-13T12:06:03Z"
-    },
     "resilient/src/hw_state_machine.rs": {
       "branch": "res-2010-hw-state-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -463,6 +455,10 @@
     "resilient/src/struct_exhaustiveness.rs": {
       "branch": "res-2224-struct-exhaust-borrow-fn-name",
       "claimed_at": "2026-05-20T06:03:00Z"
+    },
+    "resilient/src/recovery_checker.rs": {
+      "branch": "res-2238-recovery-checker-borrow",
+      "claimed_at": "2026-05-20T06:46:59Z"
     }
   }
 }

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -22,12 +22,20 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     Ok(())
 }
 
-struct Context {
-    extern_fns: HashSet<String>,
-    current_fn: Option<String>,
+// RES-2238: `extern_fns` + `current_fn` now borrow `&'a str` from the
+// program AST. The previous shape paid:
+//   * `decl.resilient_name.clone()` per extern declaration (collect_declarations)
+//   * `name.clone()` per Function entered (walk_for_live_blocks)
+// Both Strings live entirely behind `&program` for the duration of
+// `check()`, so the owned-key shape was pure overhead. Mirrors the
+// AST-borrow series (RES-2148 / RES-2150 / RES-2218 / RES-2228 /
+// RES-2234).
+struct Context<'a> {
+    extern_fns: HashSet<&'a str>,
+    current_fn: Option<&'a str>,
 }
 
-impl Context {
+impl<'a> Context<'a> {
     fn new() -> Self {
         Context {
             extern_fns: HashSet::new(),
@@ -35,7 +43,7 @@ impl Context {
         }
     }
 
-    fn collect_declarations(&mut self, program: &Node) {
+    fn collect_declarations(&mut self, program: &'a Node) {
         let Node::Program(statements) = program else {
             return;
         };
@@ -54,13 +62,13 @@ impl Context {
         for stmt in statements {
             if let Node::Extern { decls, .. } = &stmt.node {
                 for decl in decls {
-                    self.extern_fns.insert(decl.resilient_name.clone());
+                    self.extern_fns.insert(decl.resilient_name.as_str());
                 }
             }
         }
     }
 
-    fn check_live_blocks(&mut self, program: &Node) {
+    fn check_live_blocks(&mut self, program: &'a Node) {
         let Node::Program(statements) = program else {
             return;
         };
@@ -69,11 +77,11 @@ impl Context {
         }
     }
 
-    fn walk_for_live_blocks(&mut self, node: &Node) {
+    fn walk_for_live_blocks(&mut self, node: &'a Node) {
         match node {
             Node::Function { name, body, .. } => {
                 let prev_fn = self.current_fn.take();
-                self.current_fn = Some(name.clone());
+                self.current_fn = Some(name.as_str());
                 self.walk_for_live_blocks(body);
                 self.current_fn = prev_fn;
             }
@@ -116,7 +124,7 @@ impl Context {
         }
     }
 
-    fn check_node(&mut self, node: &Node) {
+    fn check_node(&mut self, node: &'a Node) {
         match node {
             Node::CallExpression {
                 function,
@@ -137,7 +145,7 @@ impl Context {
                             cannot be modeled as TLA+ action",
                             fn_name
                         );
-                    } else if let Some(current) = self.current_fn.as_deref()
+                    } else if let Some(current) = self.current_fn
                         && fn_name == current
                     {
                         eprintln!(


### PR DESCRIPTION
Closes #2238.

`recovery_checker::Context` previously held two owned-String fields populated
from the program AST:

```rust
struct Context {
    extern_fns: HashSet<String>,    // populated via decl.resilient_name.clone()
    current_fn: Option<String>,     // populated via name.clone() per Function visited
}
```

Both strings live entirely behind `&program` for the duration of `check()` —
owned keys were pure overhead.

### Change

```rust
struct Context<'a> {
    extern_fns: HashSet<&'a str>,
    current_fn: Option<&'a str>,
}
```

`walk_for_live_blocks` + `check_node` thread `'a`. The `current_fn` comparison
simplifies from `as_deref()` to direct `Option<&str>` use.

### Impact

One `String::clone()` per extern decl + one per Function entered, eliminated.
The check is gated behind `markers.has_live_block`, so this only fires for
programs that use `live { ... }` blocks. For those programs, every extern +
every function visited pays the clone tax now removed.

Same AST-borrow pattern as RES-2148 / RES-2150 / RES-2218 / RES-2228 / RES-2234.

### Tests

- All 4 existing `recovery_checker::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1774-recovery-lint-presize` file claim (PR #1775
merged on 2026-05-13) before claiming for this PR.