### PR TITLE
RES-2240: crash_only_cert — HashSet probe per fn, drop O(N×A) linear search

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -48,10 +48,6 @@
       "branch": "res-1232-priority-fast-reject",
       "claimed_at": "2026-05-12T02:35:05Z"
     },
-    "resilient/src/crash_only_cert.rs": {
-      "branch": "res-1236-crash-only-cert-fast-reject",
-      "claimed_at": "2026-05-12T02:42:33Z"
-    },
     "resilient/src/actor_drain.rs": {
       "branch": "res-2002-actor-drain-single-pass",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -463,6 +459,10 @@
     "resilient/src/full_modules.rs": {
       "branch": "res-2236-full-modules-build-skip-clone",
       "claimed_at": "2026-05-20T06:40:00Z"
+    },
+    "resilient/src/crash_only_cert.rs": {
+      "branch": "res-2240-crash-only-cert-hashset",
+      "claimed_at": "2026-05-20T07:01:18Z"
     }
   }
 }

--- a/resilient/src/crash_only_cert.rs
+++ b/resilient/src/crash_only_cert.rs
@@ -67,15 +67,24 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
+    // RES-2240: collapse the per-Function `attrs.iter().any(|(item, _)|
+    // item == name)` linear search into an O(1) HashSet probe. With
+    // N functions and A crash_only_cert attributes, the previous shape
+    // was O(N×A). For programs that declare even a handful of certified
+    // fns, the HashSet build amortises after a few function visits;
+    // for non-certified fns (the bulk of the walk in mixed programs)
+    // the lookup is now constant-time. Mirrors RES-2138 (autopilot
+    // HashMap-index lookups) and RES-2140 (refinement_types HashMap
+    // registry).
+    let certified: std::collections::HashSet<&str> =
+        attrs.iter().map(|(item, _)| item.as_str()).collect();
     for s in stmts {
         if let Node::Function { name, .. } = &s.node {
-            if attrs.iter().any(|(item, _)| item == name) {
-                if !is_crash_only_certified(&s.node) {
-                    return Err(format!(
-                        "{}:0:0: error: `{}` is `#[crash_only_cert]` but contains a return that is not Err/Ok/result",
-                        _source_path, name
-                    ));
-                }
+            if certified.contains(name.as_str()) && !is_crash_only_certified(&s.node) {
+                return Err(format!(
+                    "{}:0:0: error: `{}` is `#[crash_only_cert]` but contains a return that is not Err/Ok/result",
+                    _source_path, name
+                ));
             }
         }
     }


### PR DESCRIPTION
Closes #2240.

`crash_only_cert::check` previously did a per-function linear scan over the
attrs Vec:

```rust
for s in stmts {
    if let Node::Function { name, .. } = &s.node {
        if attrs.iter().any(|(item, _)| item == name) {  // O(A) per fn
            ...
        }
    }
}
```

### Change

Build a `HashSet<&str>` once from attrs, probe O(1) per function:

```rust
let certified: HashSet<&str> = attrs.iter().map(|(item, _)| item.as_str()).collect();
for s in stmts {
    if let Node::Function { name, .. } = &s.node {
        if certified.contains(name.as_str()) && !is_crash_only_certified(&s.node) {
            ...
        }
    }
}
```

### Impact

O(N×A) → O(N+A). Gated behind RES-1236's `attrs.is_empty()` fast-reject, so
this matters only when the program uses `#[crash_only_cert]`. For those
programs, speedup scales with attribute count.

Mirrors RES-2138 (autopilot HashMap-index lookups) and RES-2140
(refinement_types HashMap registry).

### Tests

- All 2 existing `crash_only_cert::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1236-crash-only-cert-fast-reject` file claim
(PR #1237 merged on 2026-05-12) before claiming for this PR.