### PR TITLE
RES-2244: iterator_protocol — right-size HashSet pre-alloc to typical impl count

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -8,10 +8,6 @@
       "branch": "res-2136-array-set-hashset-membership",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/iterator_protocol.rs": {
-      "branch": "res-1758-more-collect-presize",
-      "claimed_at": "2026-05-13T11:38:11Z"
-    },
     ".github/workflows/embedded.yml": {
       "branch": "res-1198-embedded-rust-cache",
       "claimed_at": "2026-05-12T01:23:24Z"
@@ -219,10 +215,6 @@
     "resilient/src/lean_spec.rs": {
       "branch": "res-1980-lean-spec-write",
       "claimed_at": "2026-05-19T00:00:00Z"
-    },
-    "resilient/src/autopilot.rs": {
-      "branch": "res-1758-more-collect-presize",
-      "claimed_at": "2026-05-13T11:38:11Z"
     },
     "resilient/src/semver_behavior.rs": {
       "branch": "res-2006-semver-baseline-borrow",
@@ -463,6 +455,10 @@
     "resilient/src/crash_only_cert.rs": {
       "branch": "res-2240-crash-only-cert-hashset",
       "claimed_at": "2026-05-20T07:01:18Z"
+    },
+    "resilient/src/iterator_protocol.rs": {
+      "branch": "res-2244-iterator-protocol-lazy",
+      "claimed_at": "2026-05-20T07:11:33Z"
     }
   }
 }

--- a/resilient/src/iterator_protocol.rs
+++ b/resilient/src/iterator_protocol.rs
@@ -42,7 +42,16 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // guaranteed to contain at least one Iterator impl. The previous
     // `any_node` pre-scan was redundant — removed. (The typechecker
     // else branch installs an empty set directly.)
-    let mut iters = HashSet::with_capacity(stmts.len());
+    // RES-2244: pre-size to 4 — typical Iterator impl count is 1-5
+    // even on iterator-heavy programs. The previous `with_capacity(
+    // stmts.len())` allocated bucket space for every top-level
+    // statement, ~95% of which are NOT Iterator impls (most stmts
+    // are Functions / StructDecls / TypeAliases). For a 100-stmt
+    // program with 2 Iterator impls, this drops the HashSet from
+    // ~200-slot pre-alloc to ~8-slot. Mirrors RES-2242
+    // (assume_axioms lazy alloc) — favour the common iterator-count
+    // case over the rare iterator-heavy upper bound.
+    let mut iters = HashSet::with_capacity(4);
     for s in stmts {
         if let Node::ImplBlock {
             trait_name,


### PR DESCRIPTION
Closes #2244.

`iterator_protocol::check` previously pre-sized `iters: HashSet<String>` to
`stmts.len()`, but only inserts on `ImplBlock { trait_name: Some("Iterator") }`.
For typical iterator-using programs (1-5 impls), this over-allocates by a
factor of 20-100x.

### Change

```rust
// Before
let mut iters = HashSet::with_capacity(stmts.len());

// After  
let mut iters = HashSet::with_capacity(4);
```

For a 100-stmt program with 2 Iterator impls:
- Before: HashSet::with_capacity(100) → ~200-bucket alloc
- After: HashSet::with_capacity(4) → ~8-bucket alloc

### Impact

The check is gated by `markers.has_impl_for_trait("Iterator")`, so this matters
only for programs that opt into the iterator protocol. For those programs, every
typecheck pays the over-allocation.

Same right-size-the-common-case pattern as RES-2242 (assume_axioms lazy alloc).

### Tests

- All 3 existing `iterator_protocol::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1758-more-collect-presize` file claim
(PR #1759 merged on 2026-05-13) before claiming for this PR.