### PR TITLE
RES-2248: fmt_validation — return Cow<str> from static_template, drop StringLiteral clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -459,6 +459,10 @@
     "resilient/src/iterator_protocol.rs": {
       "branch": "res-2244-iterator-protocol-lazy",
       "claimed_at": "2026-05-20T07:11:33Z"
+    },
+    "resilient/src/fmt_validation.rs": {
+      "branch": "res-2248-fmt-validation-cow-template",
+      "claimed_at": "2026-05-20T07:26:07Z"
     }
   }
 }

--- a/resilient/src/fmt_validation.rs
+++ b/resilient/src/fmt_validation.rs
@@ -51,9 +51,18 @@ pub fn analyze(program: &Node) -> Vec<String> {
 ///
 /// Returns `None` for dynamic templates — runtime values that cannot
 /// be validated at compile time.
-fn static_template(node: &Node) -> Option<String> {
+///
+/// RES-2248: returns `Cow<str>` so the StringLiteral arm (the common
+/// case — `format("hello {}", x)` style) can borrow directly from the
+/// AST instead of cloning the template into a fresh `String`. The
+/// InterpolatedString arm still allocates (we need to concatenate the
+/// literal parts), but `Cow::Owned` wraps the produced `String`
+/// transparently for the caller. The caller's only consumer is
+/// `parse_template(&tmpl)`, which takes `&str` — works identically
+/// for both `Cow::Borrowed` and `Cow::Owned` via `Deref`.
+fn static_template(node: &Node) -> Option<std::borrow::Cow<'_, str>> {
     match node {
-        Node::StringLiteral { value, .. } => Some(value.clone()),
+        Node::StringLiteral { value, .. } => Some(std::borrow::Cow::Borrowed(value.as_str())),
         Node::InterpolatedString { parts, .. } => {
             let mut buf = String::new();
             for p in parts {
@@ -62,7 +71,7 @@ fn static_template(node: &Node) -> Option<String> {
                     crate::string_interp::StringPart::Expr(_) => return None,
                 }
             }
-            Some(buf)
+            Some(std::borrow::Cow::Owned(buf))
         }
         _ => None,
     }


### PR DESCRIPTION
Closes #2248.

`fmt_validation::static_template` returned `Option<String>`, cloning the
template's `value` from `Node::StringLiteral` per call. The caller's only
consumer is `parse_template(&tmpl)` which takes `&str` — the clone is pure
overhead.

### Change

```rust
// Before
fn static_template(node: &Node) -> Option<String> {
    match node {
        Node::StringLiteral { value, .. } => Some(value.clone()),
        Node::InterpolatedString { parts, .. } => { /* concat */ Some(buf) }
        _ => None,
    }
}

// After
fn static_template(node: &Node) -> Option<Cow<'_, str>> {
    match node {
        Node::StringLiteral { value, .. } => Some(Cow::Borrowed(value.as_str())),
        Node::InterpolatedString { parts, .. } => { /* concat */ Some(Cow::Owned(buf)) }
        _ => None,
    }
}
```

The caller's `parse_template(&tmpl)` works identically for both Cow variants
via `Deref`.

### Impact

One `String::clone()` per `format("static-str", ...)` call site eliminated at
typecheck time. The pass is gated by `markers.call_idents.contains("format")`,
so savings scale with format call-site count on programs using format()
(typically 5-50 per program).

### Tests

- All 7 existing `fmt_validation::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean