### PR TITLE
RES-2252: vibe_debt — lift per-fn tmp HashMap outside loop, reuse via clear()

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -192,10 +192,6 @@
       "branch": "res-2170-prob-contracts-drop-fn-name",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/typestate_types.rs": {
-      "branch": "res-1756-program-collect-presize",
-      "claimed_at": "2026-05-13T11:30:51Z"
-    },
     "resilient/src/behavioral_fingerprint.rs": {
       "branch": "res-2122-fingerprint-drop-function-name",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -203,10 +199,6 @@
     "resilient/src/contract_inference.rs": {
       "branch": "res-2210-contract-inference-option-complex",
       "claimed_at": "2026-05-19T00:00:00Z"
-    },
-    "resilient/src/vibe_debt.rs": {
-      "branch": "res-1756-program-collect-presize",
-      "claimed_at": "2026-05-13T11:30:51Z"
     },
     "resilient/src/resilience_score.rs": {
       "branch": "res-1990-resilience-buffer-reuse",
@@ -463,6 +455,10 @@
     "resilient/src/fmt_validation.rs": {
       "branch": "res-2248-fmt-validation-cow-template",
       "claimed_at": "2026-05-20T07:26:07Z"
+    },
+    "resilient/src/vibe_debt.rs": {
+      "branch": "res-2252-vibe-debt-reuse-tmp",
+      "claimed_at": "2026-05-20T07:50:25Z"
     }
   }
 }

--- a/resilient/src/vibe_debt.rs
+++ b/resilient/src/vibe_debt.rs
@@ -74,6 +74,18 @@ pub fn analyze(program: &Node) -> VibeDebtReport {
     // RES-1756: pre-size to stmts.len() — every top-level statement
     // is potentially a function and pushes one entry.
     let mut entries = Vec::with_capacity(stmts.len());
+    // RES-2252: lift the per-fn `tmp` HashMap outside the loop and
+    // `clear()` between iterations. `HashMap::clear` retains the
+    // bucket allocation, so the second-and-later functions reuse
+    // the buffer instead of paying a fresh first-push doubling
+    // chain each iteration. For an N-function program, this is
+    // ~N-1 HashMap allocations eliminated. Mirrors the buffer-
+    // reuse shape applied to:
+    //   * RES-1966 (isr_call_graph BFS state)
+    //   * RES-1988 (vibe_debt's outer `refs` lift — different map)
+    //   * RES-1990 (resilience_score self_call_buf)
+    //   * RES-1944 (graph_connected_components)
+    let mut tmp: HashMap<&str, u32> = HashMap::new();
     for s in stmts {
         if let Node::Function {
             name,
@@ -85,11 +97,9 @@ pub fn analyze(program: &Node) -> VibeDebtReport {
             ..
         } = &s.node
         {
-            let self_calls = {
-                let mut tmp: HashMap<&str, u32> = HashMap::new();
-                collect_refs(body, &mut tmp);
-                tmp.get(name.as_str()).copied().unwrap_or(0)
-            };
+            tmp.clear();
+            collect_refs(body, &mut tmp);
+            let self_calls = tmp.get(name.as_str()).copied().unwrap_or(0);
             let external = refs
                 .get(name.as_str())
                 .copied()


### PR DESCRIPTION
Closes #2252.

`vibe_debt::analyze` previously allocated a fresh `tmp: HashMap<&str, u32>`
inside the per-function loop:

```rust
for s in stmts {
    if let Node::Function { name, body, .. } = &s.node {
        let self_calls = {
            let mut tmp: HashMap<&str, u32> = HashMap::new();
            collect_refs(body, &mut tmp);
            tmp.get(name.as_str()).copied().unwrap_or(0)
        };
        ...
    }
}
```

For an N-function program, that's N HashMap first-push doubling chains.

### Change

Lift `tmp` outside the loop and `clear()` between iterations:

```rust
let mut tmp: HashMap<&str, u32> = HashMap::new();
for s in stmts {
    if let Node::Function { name, body, .. } = &s.node {
        tmp.clear();
        collect_refs(body, &mut tmp);
        let self_calls = tmp.get(name.as_str()).copied().unwrap_or(0);
        ...
    }
}
```

`HashMap::clear()` retains bucket allocation. The second-and-later functions
reuse the buffer instead of paying a fresh first-push doubling chain.

### Impact

For an N-function program, ~N-1 HashMap first-push allocations eliminated per
`vibe_debt::analyze` call. `analyze` is called by `autopilot::run`.

Mirrors the buffer-reuse pattern from RES-1966 (isr_call_graph BFS state),
RES-1988 (vibe_debt's outer `refs`), RES-1990 (resilience_score
self_call_buf), and RES-1944 (graph_connected_components).

### Tests

- All 6 existing `vibe_debt::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1756-program-collect-presize` file claim
(PR #1757 merged on 2026-05-13) before claiming for this PR.