### PR TITLE
RES-2254: string_interp::eval_interp — append values directly via Write, skip String alloc

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -336,10 +336,6 @@
       "branch": "res-1820-radix-int-fast-reject",
       "claimed_at": "2026-05-13T13:43:38Z"
     },
-    "resilient/src/string_interp.rs": {
-      "branch": "res-1822-string-interp-expr-presize",
-      "claimed_at": "2026-05-13T13:50:23Z"
-    },
     "resilient/src/vm.rs": {
       "branch": "res-1830-vm-run-direct-locals-presize",
       "claimed_at": "2026-05-13T14:15:49Z"
@@ -463,6 +459,10 @@
     "resilient/src/fmt_validation.rs": {
       "branch": "res-2248-fmt-validation-cow-template",
       "claimed_at": "2026-05-20T07:26:07Z"
+    },
+    "resilient/src/string_interp.rs": {
+      "branch": "res-2254-string-interp-direct-write",
+      "claimed_at": "2026-05-20T07:57:00Z"
     }
   }
 }

--- a/resilient/src/string_interp.rs
+++ b/resilient/src/string_interp.rs
@@ -161,26 +161,47 @@ pub(crate) fn eval_interp(interp: &mut Interpreter, parts: &[StringPart]) -> RRe
             StringPart::Literal(s) => out.push_str(s),
             StringPart::Expr(expr) => {
                 let val = interp.eval(expr)?;
-                out.push_str(&value_to_string(val));
+                // RES-2254: append the value directly to `out` instead
+                // of materializing it into a `String` first. For
+                // numeric / bool / "other" arms, `value_to_string`
+                // previously allocated a fresh `String` (via
+                // `i.to_string()`, `format!()`) just to immediately
+                // copy it into `out` via `push_str`. `write!(out,
+                // "{}", x)` formats straight into `out`'s buffer.
+                append_value(&mut out, val);
             }
         }
     }
     Ok(Value::String(out))
 }
 
-/// Convert a [`Value`] to its plain text form for string interpolation.
+/// Append a [`Value`]'s plain text form directly to an output buffer.
 ///
 /// Strings yield their raw contents (no surrounding quotes).
-/// Integers, floats, and booleans convert via `Display`.
+/// Integers, floats, and booleans format via `Display`.
 /// All other values (arrays, structs, maps, etc.) use the `Display`
 /// implementation of `Value`, which matches what `println` would show.
-fn value_to_string(v: Value) -> String {
+///
+/// RES-2254: writes through `std::fmt::Write` instead of returning a
+/// fresh `String`. For interpolation-heavy code (log messages, debug
+/// prints), this eliminates one `String` allocation per interpolated
+/// expression of a non-String value.
+fn append_value(out: &mut String, v: Value) {
+    use std::fmt::Write;
     match v {
-        Value::String(s) => s,
-        Value::Int(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::Bool(b) => b.to_string(),
-        other => format!("{}", other),
+        Value::String(s) => out.push_str(&s),
+        Value::Int(i) => {
+            let _ = write!(out, "{}", i);
+        }
+        Value::Float(f) => {
+            let _ = write!(out, "{}", f);
+        }
+        Value::Bool(b) => {
+            let _ = write!(out, "{}", b);
+        }
+        other => {
+            let _ = write!(out, "{}", other);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #2254.

`string_interp::eval_interp` previously evaluated each `${expr}` placeholder
and piped the result through `value_to_string(val) -> String`:

```rust
StringPart::Expr(expr) => {
    let val = interp.eval(expr)?;
    out.push_str(&value_to_string(val));  // 2nd alloc + immediate copy
}
```

`value_to_string` allocated a fresh `String` per non-String value (via
`i.to_string()` / `format!()`) only to be immediately `push_str`'d.

### Change

Replace `value_to_string` with `append_value(&mut String, Value)` that writes
through `std::fmt::Write` directly to `out`:

```rust
fn append_value(out: &mut String, v: Value) {
    use std::fmt::Write;
    match v {
        Value::String(s) => out.push_str(&s),
        Value::Int(i) => { let _ = write!(out, "{}", i); }
        Value::Float(f) => { let _ = write!(out, "{}", f); }
        Value::Bool(b) => { let _ = write!(out, "{}", b); }
        other => { let _ = write!(out, "{}", other); }
    }
}
```

`String::write_fmt` formats straight into the buffer — no intermediate
allocation.

### Impact

For interpolation-heavy code (log messages, debug prints), one `String`
allocation per interpolated expression of a non-String value, eliminated.

### Tests

- All 8 existing `string_interp::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Continues the eval-perf series (recent commits: RES-1899 / RES-1902 /
RES-1906-1909 / RES-1912-1915 / RES-2250 / RES-2252).

Also released the stale `res-1822-string-interp-expr-presize` file claim
(PR #1823 merged on 2026-05-13) before claiming for this PR.