### PR TITLE
RES-2260: json_builtins::json_escape_string — write! directly for \u escape

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -376,10 +376,6 @@
       "branch": "res-1942-data-utils-presize",
       "claimed_at": "2026-05-19T18:14:43Z"
     },
-    "resilient/src/json_builtins.rs": {
-      "branch": "res-1946-json-parser-presize",
-      "claimed_at": "2026-05-19T18:22:09Z"
-    },
     "resilient/src/numeric_units.rs": {
       "branch": "res-2162-numeric-units-borrow-keys",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -463,6 +459,10 @@
     "resilient/src/autopilot.rs": {
       "branch": "res-2256-autopilot-write-direct",
       "claimed_at": "2026-05-20T08:06:02Z"
+    },
+    "resilient/src/json_builtins.rs": {
+      "branch": "res-2260-json-escape-write-direct",
+      "claimed_at": "2026-05-20T08:12:01Z"
     }
   }
 }

--- a/resilient/src/json_builtins.rs
+++ b/resilient/src/json_builtins.rs
@@ -106,6 +106,14 @@ fn serialize_value(v: &Value) -> RResult<String> {
 }
 
 fn json_escape_string(s: &str) -> String {
+    // RES-2260: write the control-char escape directly via `std::fmt::
+    // Write` instead of `push_str(&format!(...))`. Each control
+    // character previously allocated a 6-char `String` only to be
+    // immediately `push_str`'d. For strings containing control bytes
+    // (binary blobs, structured logs), N control chars meant N
+    // avoidable allocations. Mirrors RES-2256 (autopilot format_report)
+    // and RES-2258 (causal_trace format_chain).
+    use std::fmt::Write;
     let mut out = String::with_capacity(s.len() + 2);
     out.push('"');
     for c in s.chars() {
@@ -116,7 +124,7 @@ fn json_escape_string(s: &str) -> String {
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),
             c if (c as u32) < 0x20 => {
-                out.push_str(&format!("\\u{:04x}", c as u32));
+                let _ = write!(out, "\\u{:04x}", c as u32);
             }
             c => out.push(c),
         }


### PR DESCRIPTION
Closes #2260.

`json_builtins::json_escape_string` previously used the
`push_str(&format!(...))` antipattern for the control-character `\u{XXXX}`
escape:

```rust
c if (c as u32) < 0x20 => {
    out.push_str(&format!("\\u{:04x}", c as u32));
}
```

Each control character allocated a 6-char `String` only to be immediately
`push_str`'d.

### Change

```rust
use std::fmt::Write;
c if (c as u32) < 0x20 => {
    let _ = write!(out, "\\u{:04x}", c as u32);
}
```

### Impact

For strings with N control bytes (binary blobs, structured logs, escape-heavy
JSON), N intermediate `String` allocations eliminated. `json_escape_string`
runs on every `to_json(value)` call.

Mirrors RES-2256 (autopilot format_report), RES-2258 (causal_trace
format_chain), and RES-2254 (string_interp).

### Tests

- All 26 existing `json_builtins::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1946-json-parser-presize` file claim
(PR #1947 merged on 2026-05-19) before claiming for this PR.