### PR TITLE
RES-2262: lexer_logos — drop 3 push_str(&format!()) sites in string-escape parsing

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -324,10 +324,6 @@
       "branch": "res-1816-format-template-fast-reject",
       "claimed_at": "2026-05-13T13:34:15Z"
     },
-    "resilient/src/lexer_logos.rs": {
-      "branch": "res-1820-radix-int-fast-reject",
-      "claimed_at": "2026-05-13T13:43:38Z"
-    },
     "resilient/src/string_interp.rs": {
       "branch": "res-1822-string-interp-expr-presize",
       "claimed_at": "2026-05-13T13:50:23Z"
@@ -463,6 +459,10 @@
     "resilient/src/autopilot.rs": {
       "branch": "res-2256-autopilot-write-direct",
       "claimed_at": "2026-05-20T08:06:02Z"
+    },
+    "resilient/src/lexer_logos.rs": {
+      "branch": "res-2262-lexer-unicode-write-direct",
+      "claimed_at": "2026-05-20T08:15:10Z"
     }
   }
 }

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -510,7 +510,14 @@ fn string_lit(lex: &mut logos::Lexer<Tok>) -> String {
                     let h2 = chars.next();
                     match (h1, h2) {
                         (Some(a), Some(b)) if a.is_ascii_hexdigit() && b.is_ascii_hexdigit() => {
-                            let byte = u8::from_str_radix(&format!("{a}{b}"), 16).unwrap();
+                            // RES-2262: compute the byte directly from the
+                            // two hex digits instead of formatting them
+                            // into a `String` and re-parsing via
+                            // `u8::from_str_radix`. Both `a` and `b` are
+                            // ASCII hex per the guard above, so
+                            // `to_digit(16)` is infallible.
+                            let byte = ((a.to_digit(16).unwrap() << 4)
+                                | b.to_digit(16).unwrap()) as u8;
                             out.push(byte as char);
                         }
                         (h1, h2) => {
@@ -550,10 +557,15 @@ fn string_lit(lex: &mut logos::Lexer<Tok>) -> String {
                                 out.push(ch);
                             } else {
                                 // Invalid code point — preserve literally.
-                                out.push_str(&format!("\\u{{{hex}}}"));
+                                // RES-2262: write directly into `out`
+                                // instead of `push_str(&format!())`.
+                                use std::fmt::Write;
+                                let _ = write!(out, "\\u{{{hex}}}");
                             }
                         } else {
-                            out.push_str(&format!("\\u{{{hex}}}"));
+                            // RES-2262: same direct-write fix.
+                            use std::fmt::Write;
+                            let _ = write!(out, "\\u{{{hex}}}");
                         }
                     } else {
                         // `\u` not followed by `{` — preserve.


### PR DESCRIPTION
Closes #2262.

`lexer_logos::string_lit_escape` had three avoidable allocations:

1. **`\xHH` byte escape**: `u8::from_str_radix(&format!("{a}{b}"), 16)` formatted two hex digits into a `String` only to re-parse it.
2. **`\u{HEX}` invalid-codepoint path**: `out.push_str(&format!("\\u{{{hex}}}"))` — allocated to preserve literally.
3. **`\u{HEX}` malformed-hex path**: same.

### Change

1. Compute the byte directly via `(a.to_digit(16).unwrap() << 4) | b.to_digit(16).unwrap()` — both `a` and `b` are ASCII hex per the guard, so `to_digit(16)` is infallible.

2-3. `write!(out, "\\u{{{hex}}}")` writes straight into the buffer.

### Impact

The lexer runs on every source file parse — every `cargo test`, every `--watch` compile. String literals with `\xHH` or invalid `\u{...}` escapes save one allocation per such escape.

Continues the write-direct series (RES-2256 / RES-2258 / RES-2260).

### Tests

- All 4685 lib tests pass unchanged (lexer_logos has no direct tests but is exercised broadly via lexer module tests, 18 of which validate string-literal handling)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1820-radix-int-fast-reject` file claim (PR #1821 merged on 2026-05-13) before claiming for this PR.