### PR TITLE
RES-2266: snapshot_regression::serialize — write! directly + drop sort-key clones

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -148,10 +148,6 @@
       "branch": "res-1752-lock-ordering-presize",
       "claimed_at": "2026-05-13T11:18:18Z"
     },
-    "resilient/src/refinement_types.rs": {
-      "branch": "res-1754-collect-presize",
-      "claimed_at": "2026-05-13T11:24:43Z"
-    },
     "resilient/src/power_contracts.rs": {
       "branch": "res-2018-attr-move-item",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -171,22 +167,6 @@
     "resilient/src/row_polymorphism.rs": {
       "branch": "res-1998-row-poly-spec-borrow",
       "claimed_at": "2026-05-19T00:00:00Z"
-    },
-    "resilient/src/phantom_types.rs": {
-      "branch": "res-1754-collect-presize",
-      "claimed_at": "2026-05-13T11:24:43Z"
-    },
-    "resilient/src/lock_priority.rs": {
-      "branch": "res-1754-collect-presize",
-      "claimed_at": "2026-05-13T11:24:43Z"
-    },
-    "resilient/src/snapshot_regression.rs": {
-      "branch": "res-1754-collect-presize",
-      "claimed_at": "2026-05-13T11:24:43Z"
-    },
-    "resilient/src/semantic_regression.rs": {
-      "branch": "res-1754-collect-presize",
-      "claimed_at": "2026-05-13T11:24:43Z"
     },
     "resilient/src/probabilistic_contracts.rs": {
       "branch": "res-2170-prob-contracts-drop-fn-name",
@@ -463,6 +443,10 @@
     "resilient/src/json_builtins.rs": {
       "branch": "res-2260-json-escape-write-direct",
       "claimed_at": "2026-05-20T08:12:01Z"
+    },
+    "resilient/src/snapshot_regression.rs": {
+      "branch": "res-2266-snapshot-serialize-write-direct",
+      "claimed_at": "2026-05-20T08:21:50Z"
     }
   }
 }

--- a/resilient/src/snapshot_regression.rs
+++ b/resilient/src/snapshot_regression.rs
@@ -61,14 +61,25 @@ pub fn diff(
 }
 
 pub fn serialize(snapshots: &HashMap<String, Snapshot>) -> String {
+    // RES-2266: write each entry directly into `s` via `std::fmt::Write`
+    // instead of `push_str(&format!(...))`. Each iteration previously
+    // allocated an intermediate `String` only to be immediately
+    // `push_str`'d. For an N-snapshot baseline, that's N avoidable
+    // String allocations per `serialize` call. Also drop the
+    // per-sort-key `(*k).clone()` — sort_by_key wants `K: Ord`, but
+    // `&&String: Ord` works fine via `Deref`.
+    //
+    // Mirrors RES-2256 / RES-2258 / RES-2260 / RES-2262 / RES-2264.
+    use std::fmt::Write;
     let mut s = String::from("{\n");
     let mut entries: Vec<(&String, &Snapshot)> = snapshots.iter().collect();
-    entries.sort_by_key(|(k, _)| (*k).clone());
+    entries.sort_by_key(|(k, _)| *k);
     for (i, (name, snap)) in entries.iter().enumerate() {
-        s.push_str(&format!(
+        let _ = write!(
+            s,
             r#"  "{}": {{ "digest": {}, "golden_hash": {} }}"#,
             name, snap.fingerprint_digest, snap.golden_output_hash
-        ));
+        );
         if i + 1 < entries.len() {
             s.push(',');
         }


### PR DESCRIPTION
Closes #2266.

`snapshot_regression::serialize` had two allocation hotspots:

1. Per-iteration `s.push_str(&format!(r#"  "{}": ..."#, ...))` — intermediate `String` allocation per snapshot entry.
2. `entries.sort_by_key(|(k, _)| (*k).clone())` — clone of each key String just to sort.

### Change

```rust
use std::fmt::Write;
let mut entries: Vec<(&String, &Snapshot)> = snapshots.iter().collect();
entries.sort_by_key(|(k, _)| *k);  // &&String via Deref
for (i, (name, snap)) in entries.iter().enumerate() {
    let _ = write!(s, r#"  "{}": {{ "digest": {}, "golden_hash": {} }}"#, name, snap.fingerprint_digest, snap.golden_output_hash);
    ...
}
```

### Impact

For an N-snapshot baseline: N intermediate `String` allocations + N sort-key clones eliminated. `serialize` runs when a snapshot baseline is written.

Continues the write-direct series (RES-2256 / RES-2258 / RES-2260 / RES-2262 / RES-2264).

### Tests

- All 6 existing `snapshot_regression::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1754-collect-presize` file claim (PR #1755 merged on 2026-05-13) before claiming for this PR.