### PR TITLE
RES-2270: behavioral_fingerprint::node_text — direct-write recursion, drop O(N) intermediate allocs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -192,10 +192,6 @@
       "branch": "res-2170-prob-contracts-drop-fn-name",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/behavioral_fingerprint.rs": {
-      "branch": "res-2122-fingerprint-drop-function-name",
-      "claimed_at": "2026-05-19T00:00:00Z"
-    },
     "resilient/src/contract_inference.rs": {
       "branch": "res-2210-contract-inference-option-complex",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -467,6 +463,10 @@
     "resilient/src/recovers_to_bmc.rs": {
       "branch": "res-2264-bmc-write-direct",
       "claimed_at": "2026-05-20T08:18:41Z"
+    },
+    "resilient/src/behavioral_fingerprint.rs": {
+      "branch": "res-2270-fingerprint-node-text-direct",
+      "claimed_at": "2026-05-20T08:32:47Z"
     }
   }
 }

--- a/resilient/src/behavioral_fingerprint.rs
+++ b/resilient/src/behavioral_fingerprint.rs
@@ -114,32 +114,79 @@ fn compute_fingerprint(
 }
 
 fn node_text(n: &Node) -> String {
+    // RES-2270: keep the public `String`-returning signature stable
+    // for `compute_fingerprint`'s downstream `Vec<String>::sort` +
+    // `hash`, but route through a `&mut String` helper so the
+    // recursive walk writes into one buffer instead of allocating a
+    // fresh `String` at every nesting level. For a depth-N
+    // expression the old shape allocated O(N) intermediate Strings
+    // (each `node_text(left)` / `node_text(right)` recursive
+    // result, plus the per-level `format!()` output); the new
+    // shape allocates exactly 1.
+    //
+    // Same hash output is preserved — the textual encoding is
+    // identical, just written into a shared buffer.
+    let mut out = String::new();
+    write_node_text(n, &mut out);
+    out
+}
+
+/// Write the contract-fingerprint textual encoding of `n` directly
+/// into `out`. Each recursive arm appends to the shared buffer,
+/// eliminating per-level `String` allocations.
+fn write_node_text(n: &Node, out: &mut String) {
+    use std::fmt::Write;
     match n {
-        Node::Identifier { name, .. } => name.clone(),
-        Node::IntegerLiteral { value, .. } => value.to_string(),
-        Node::FloatLiteral { value, .. } => value.to_string(),
-        Node::BooleanLiteral { value, .. } => value.to_string(),
-        Node::StringLiteral { value, .. } => format!("{value:?}"),
+        Node::Identifier { name, .. } => out.push_str(name),
+        Node::IntegerLiteral { value, .. } => {
+            let _ = write!(out, "{}", value);
+        }
+        Node::FloatLiteral { value, .. } => {
+            let _ = write!(out, "{}", value);
+        }
+        Node::BooleanLiteral { value, .. } => {
+            let _ = write!(out, "{}", value);
+        }
+        Node::StringLiteral { value, .. } => {
+            let _ = write!(out, "{value:?}");
+        }
         Node::InfixExpression {
             left,
             operator,
             right,
             ..
-        } => format!("({} {operator} {})", node_text(left), node_text(right)),
+        } => {
+            out.push('(');
+            write_node_text(left, out);
+            let _ = write!(out, " {operator} ");
+            write_node_text(right, out);
+            out.push(')');
+        }
         Node::PrefixExpression {
             operator, right, ..
         } => {
-            format!("({operator}{})", node_text(right))
+            let _ = write!(out, "({operator}");
+            write_node_text(right, out);
+            out.push(')');
         }
         Node::CallExpression {
             function,
             arguments,
             ..
         } => {
-            let args: Vec<String> = arguments.iter().map(node_text).collect();
-            format!("{}({})", node_text(function), args.join(", "))
+            write_node_text(function, out);
+            out.push('(');
+            for (i, a) in arguments.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                write_node_text(a, out);
+            }
+            out.push(')');
         }
-        _ => format!("{:?}", std::ptr::addr_of!(*n)),
+        _ => {
+            let _ = write!(out, "{:?}", std::ptr::addr_of!(*n));
+        }
     }
 }
 


### PR DESCRIPTION
Closes #2270.

`behavioral_fingerprint::node_text` was a recursive AST→text encoder that allocated a fresh `String` at every nesting level via `format!()`:

```rust
Node::InfixExpression { left, operator, right, .. } =>
    format!("({} {operator} {})", node_text(left), node_text(right)),
Node::CallExpression { function, arguments, .. } => {
    let args: Vec<String> = arguments.iter().map(node_text).collect();
    format!("{}({})", node_text(function), args.join(", "))
}
```

For depth-N contract expressions, that's **O(N) intermediate Strings** per `node_text(req)` call. `compute_fingerprint` calls `node_text` per `requires` × `ensures` per Function.

### Change

Public signature stable; route through a `write_node_text(&Node, &mut String)` helper that appends to a shared buffer:

```rust
fn node_text(n: &Node) -> String {
    let mut out = String::new();
    write_node_text(n, &mut out);
    out
}

fn write_node_text(n: &Node, out: &mut String) {
    use std::fmt::Write;
    match n {
        Node::InfixExpression { left, operator, right, .. } => {
            out.push('(');
            write_node_text(left, out);
            let _ = write!(out, " {operator} ");
            write_node_text(right, out);
            out.push(')');
        }
        // ... leaves use push_str / write! directly
    }
}
```

Textual encoding preserved — fingerprint hashes unchanged (verified by `check_ok_when_fingerprints_match` test).

### Impact

For depth-N contract expressions: O(N) intermediate `String` allocations → 1. `compute_fingerprint` runs per Function × (requires + ensures), so contract-rich programs benefit most.

Mirrors RES-2268 (recovers_to_bmc::node_to_smtlib2) — same recursive-direct-write pattern.

### Tests

- All 9 existing `behavioral_fingerprint::tests::*` pass unchanged (including hash-equivalence tests)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-2122-fingerprint-drop-function-name` file claim (PR #2123 merged on 2026-05-20) before claiming for this PR.