### PR TITLE
RES-2272: lint::clause_text — direct-write recursion, drop O(N) intermediate allocs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -264,14 +264,6 @@
       "branch": "res-1770-verifier-presize",
       "claimed_at": "2026-05-13T11:59:58Z"
     },
-    "resilient/src/recovery_checker.rs": {
-      "branch": "res-1774-recovery-lint-presize",
-      "claimed_at": "2026-05-13T12:06:03Z"
-    },
-    "resilient/src/lint.rs": {
-      "branch": "res-1774-recovery-lint-presize",
-      "claimed_at": "2026-05-13T12:06:03Z"
-    },
     "resilient/src/hw_state_machine.rs": {
       "branch": "res-2010-hw-state-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -467,6 +459,10 @@
     "resilient/src/recovers_to_bmc.rs": {
       "branch": "res-2268-smtlib2-direct-write",
       "claimed_at": "2026-05-20T08:29:05Z"
+    },
+    "resilient/src/lint.rs": {
+      "branch": "res-2272-lint-clause-text-direct",
+      "claimed_at": "2026-05-20T08:36:08Z"
     }
   }
 }

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -6595,30 +6595,68 @@ fn run_l0073_duplicate_contract_clause(program: &Node, out: &mut Vec<Lint>) {
 }
 
 fn clause_text(n: &Node) -> String {
+    // RES-2272: route through a `&mut String` helper so the recursive
+    // walk writes into one buffer instead of allocating a fresh
+    // `String` at every nesting level. For a depth-N expression the
+    // old shape allocated O(N) intermediate Strings (each
+    // `clause_text(left)` / `clause_text(right)` result, plus the
+    // per-level `format!()` output); the new shape allocates 1.
+    // Same recursive-direct-write pattern as RES-2268 (smtlib2) and
+    // RES-2270 (behavioral_fingerprint::node_text).
+    let mut out = String::new();
+    write_clause_text(n, &mut out);
+    out
+}
+
+/// Write the lint-canonical text encoding of `n` into `out`. Each
+/// recursive arm appends to the shared buffer, eliminating per-
+/// level `String` allocations. Same textual output as the
+/// `String`-returning shape — `check_duplicate_clauses`'s `HashSet`
+/// lookups continue to match identical clauses.
+fn write_clause_text(n: &Node, out: &mut String) {
+    use std::fmt::Write;
     match n {
-        Node::Identifier { name, .. } => name.clone(),
-        Node::BooleanLiteral { value, .. } => value.to_string(),
-        Node::IntegerLiteral { value, .. } => value.to_string(),
+        Node::Identifier { name, .. } => out.push_str(name),
+        Node::BooleanLiteral { value, .. } => {
+            let _ = write!(out, "{}", value);
+        }
+        Node::IntegerLiteral { value, .. } => {
+            let _ = write!(out, "{}", value);
+        }
         Node::InfixExpression {
             left,
             operator,
             right,
             ..
-        } => format!("{} {operator} {}", clause_text(left), clause_text(right)),
+        } => {
+            write_clause_text(left, out);
+            let _ = write!(out, " {operator} ");
+            write_clause_text(right, out);
+        }
         Node::PrefixExpression {
             operator, right, ..
         } => {
-            format!("{operator}{}", clause_text(right))
+            out.push_str(operator);
+            write_clause_text(right, out);
         }
         Node::CallExpression {
             function,
             arguments,
             ..
         } => {
-            let args: Vec<String> = arguments.iter().map(clause_text).collect();
-            format!("{}({})", clause_text(function), args.join(", "))
+            write_clause_text(function, out);
+            out.push('(');
+            for (i, a) in arguments.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                write_clause_text(a, out);
+            }
+            out.push(')');
         }
-        _ => format!("{:?}", n as *const _),
+        _ => {
+            let _ = write!(out, "{:?}", n as *const _);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #2272.

`lint::clause_text` was a recursive AST→canonical-text encoder used by L0073 (duplicate `requires`/`ensures` detection). It allocated a fresh `String` at every nesting level via `format!()`:

```rust
Node::InfixExpression { left, operator, right, .. } => 
    format!("{} {operator} {}", clause_text(left), clause_text(right)),
Node::CallExpression { function, arguments, .. } => {
    let args: Vec<String> = arguments.iter().map(clause_text).collect();
    format!("{}({})", clause_text(function), args.join(", "))
}
```

For a depth-N contract expression, that's **O(N) intermediate Strings** per call. `check_duplicate_clauses` runs per Function × (requires + ensures).

### Change

Public signature stable; route through a `write_clause_text(&Node, &mut String)` helper:

```rust
fn clause_text(n: &Node) -> String {
    let mut out = String::new();
    write_clause_text(n, &mut out);
    out
}

fn write_clause_text(n: &Node, out: &mut String) {
    use std::fmt::Write;
    match n {
        Node::InfixExpression { left, operator, right, .. } => {
            write_clause_text(left, out);
            let _ = write!(out, " {operator} ");
            write_clause_text(right, out);
        }
        // ... leaves use push_str / write! directly
    }
}
```

Textual encoding preserved — L0073 still matches identical clauses (verified by 336 lint tests).

### Impact

For depth-N contract expressions: O(N) intermediate `String` allocations → 1. Runs per Function × (requires + ensures) on every lint pass — contract-heavy programs benefit most.

Mirrors RES-2268 (recovers_to_bmc::node_to_smtlib2) and RES-2270 (behavioral_fingerprint::node_text).

### Tests

- All 336 existing `lint::tests::*` pass unchanged
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Also released the stale `res-1774-recovery-lint-presize` file claim (PR #1775 merged on 2026-05-13) before claiming for this PR.