### PR TITLE
RES-2276: verifier_actors::render_clause — direct-write recursion

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -308,10 +308,6 @@
       "branch": "res-1802-traits-presize",
       "claimed_at": "2026-05-13T13:02:04Z"
     },
-    "resilient/src/verifier_actors.rs": {
-      "branch": "res-1808-flatten-body-presize",
-      "claimed_at": "2026-05-13T13:17:34Z"
-    },
     "resilient/src/format_builtin.rs": {
       "branch": "res-1816-format-template-fast-reject",
       "claimed_at": "2026-05-13T13:34:15Z"
@@ -463,6 +459,10 @@
     "resilient/src/lint.rs": {
       "branch": "res-2272-lint-clause-text-direct",
       "claimed_at": "2026-05-20T08:36:08Z"
+    },
+    "resilient/src/verifier_actors.rs": {
+      "branch": "res-2276-verifier-actors-render-direct",
+      "claimed_at": "2026-05-20T08:56:57Z"
     }
   }
 }

--- a/resilient/src/verifier_actors.rs
+++ b/resilient/src/verifier_actors.rs
@@ -386,39 +386,70 @@ fn prove_or_unsupported(_expr: &Node, _timeout_ms: u32) -> ActorProofResult {
 /// Best-effort rendering of an `always` clause for diagnostics. A
 /// full pretty-printer lives in `formatter.rs`; this is the minimum
 /// needed so users can distinguish which invariant a verdict is about.
+///
+/// RES-2276: previously the recursive arms each produced an
+/// intermediate `String` via `format!(...)` and then concatenated up
+/// the call chain — every interior node paid one `String` allocation
+/// per arm, plus call sites in `Node::CallExpression` paid an extra
+/// `Vec<String> + Vec::join`. The new shape routes through
+/// `write_clause(node, &mut String)`, which appends directly into a
+/// single shared buffer that the entry point owns. Same byte output;
+/// O(depth) fewer allocations.
 fn render_clause(node: &Node) -> String {
+    let mut out = String::new();
+    write_clause(node, &mut out);
+    out
+}
+
+fn write_clause(node: &Node, out: &mut String) {
+    use std::fmt::Write as _;
     match node {
         Node::InfixExpression {
             left,
             operator,
             right,
             ..
-        } => format!(
-            "{} {} {}",
-            render_clause(left),
-            operator,
-            render_clause(right)
-        ),
+        } => {
+            write_clause(left, out);
+            out.push(' ');
+            out.push_str(operator);
+            out.push(' ');
+            write_clause(right, out);
+        }
         Node::PrefixExpression {
             operator, right, ..
         } => {
-            format!("{}{}", operator, render_clause(right))
+            out.push_str(operator);
+            write_clause(right, out);
         }
-        Node::Identifier { name, .. } => name.clone(),
-        Node::IntegerLiteral { value, .. } => value.to_string(),
-        Node::BooleanLiteral { value, .. } => value.to_string(),
+        Node::Identifier { name, .. } => out.push_str(name),
+        Node::IntegerLiteral { value, .. } => {
+            let _ = write!(out, "{}", value);
+        }
+        Node::BooleanLiteral { value, .. } => {
+            let _ = write!(out, "{}", value);
+        }
         Node::FieldAccess { target, field, .. } => {
-            format!("{}.{}", render_clause(target), field)
+            write_clause(target, out);
+            out.push('.');
+            out.push_str(field);
         }
         Node::CallExpression {
             function,
             arguments,
             ..
         } => {
-            let args: Vec<String> = arguments.iter().map(render_clause).collect();
-            format!("{}({})", render_clause(function), args.join(", "))
+            write_clause(function, out);
+            out.push('(');
+            for (i, a) in arguments.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                write_clause(a, out);
+            }
+            out.push(')');
         }
-        _ => "<expr>".to_string(),
+        _ => out.push_str("<expr>"),
     }
 }
 


### PR DESCRIPTION
Closes #2276

## Summary

- Refactors `verifier_actors::render_clause` (the `always`-clause diagnostic pretty-printer) to drop the recursive `format!(...)` allocation chain.
- Public signature unchanged (`fn render_clause(&Node) -> String`); the entry point now allocates a single buffer and routes recursion through `write_clause(node, &mut String)`, which appends segments directly via `push_str` / `push` / `write!`.
- Eliminates 2 transient `String`s per `InfixExpression`, 1 per `FieldAccess`/`PrefixExpression`, and `Vec<String> + Vec::join(", ")` per `CallExpression` arm.

## Why this matters

Each `always` clause on each `ActorDecl` allocates one diagnostic label per verification pass. The old shape paid O(depth) `String` allocations per label; the new shape pays exactly one. Continues the direct-write refactor series alongside RES-2268 (`recovers_to_bmc::node_to_smtlib2`), RES-2270 (`behavioral_fingerprint::node_text`), and RES-2272 (`lint::clause_text`).

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml --locked` — clean
- [x] `cargo test --manifest-path resilient/Cargo.toml --locked` — 4685 passed; 0 failed
- [x] `cargo test --lib verifier_actors` — 7 passed including `render_clause_produces_readable_infix` (byte-for-byte output check)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)