### PR TITLE
RES-2282: info_flow walk_calls — filter at push time

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -467,6 +467,10 @@
     "resilient/src/formatter.rs": {
       "branch": "res-2274-formatter-write-direct",
       "claimed_at": "2026-05-20T08:42:42Z"
+    },
+    "resilient/src/info_flow.rs": {
+      "branch": "res-2282-info-flow-walk-filter",
+      "claimed_at": "2026-05-20T09:23:02Z"
     }
   }
 }

--- a/resilient/src/info_flow.rs
+++ b/resilient/src/info_flow.rs
@@ -67,16 +67,21 @@ pub fn check_program(program: &Node) -> Vec<String> {
     for s in stmts {
         if let Node::Function { name, body, .. } = &s.node {
             if public_fns.contains(name.as_str()) {
-                // walk body: any call to a secret-tagged fn is a leak.
+                // RES-2282: walk the body once, pushing only callees
+                // that match `secret_fns`. The previous shape collected
+                // every CallExpression's callee identifier into a
+                // `Vec<&str>` and then filtered against `secret_fns`
+                // — for programs where most calls are to non-secret
+                // fns (the common case), most pushes were dead
+                // weight. Filtering at push time also lets us drop
+                // the post-walk iteration entirely.
                 let mut leaks: Vec<&str> = Vec::new();
-                walk_calls(body, &mut leaks);
+                walk_calls(body, &secret_fns, &mut leaks);
                 for callee in leaks {
-                    if secret_fns.contains(callee) {
-                        errors.push(format!(
-                            "info-flow: `{}` is `#[public]` but transitively calls `#[secret]` fn `{}`",
-                            name, callee
-                        ));
-                    }
+                    errors.push(format!(
+                        "info-flow: `{}` is `#[public]` but transitively calls `#[secret]` fn `{}`",
+                        name, callee
+                    ));
                 }
             }
         }
@@ -84,7 +89,7 @@ pub fn check_program(program: &Node) -> Vec<String> {
     errors
 }
 
-fn walk_calls<'a>(node: &'a Node, out: &mut Vec<&'a str>) {
+fn walk_calls<'a>(node: &'a Node, secret_fns: &HashSet<&str>, out: &mut Vec<&'a str>) {
     match node {
         Node::CallExpression {
             function,
@@ -92,30 +97,33 @@ fn walk_calls<'a>(node: &'a Node, out: &mut Vec<&'a str>) {
             ..
         } => {
             if let Node::Identifier { name, .. } = function.as_ref() {
-                out.push(name.as_str());
+                let callee = name.as_str();
+                if secret_fns.contains(callee) {
+                    out.push(callee);
+                }
             }
             for a in arguments {
-                walk_calls(a, out);
+                walk_calls(a, secret_fns, out);
             }
         }
         Node::Block { stmts, .. } => {
             for s in stmts {
-                walk_calls(s, out);
+                walk_calls(s, secret_fns, out);
             }
         }
-        Node::ReturnStatement { value: Some(e), .. } => walk_calls(e, out),
-        Node::LetStatement { value, .. } => walk_calls(value, out),
-        Node::ExpressionStatement { expr, .. } => walk_calls(expr, out),
+        Node::ReturnStatement { value: Some(e), .. } => walk_calls(e, secret_fns, out),
+        Node::LetStatement { value, .. } => walk_calls(value, secret_fns, out),
+        Node::ExpressionStatement { expr, .. } => walk_calls(expr, secret_fns, out),
         Node::IfStatement {
             condition,
             consequence,
             alternative,
             ..
         } => {
-            walk_calls(condition, out);
-            walk_calls(consequence, out);
+            walk_calls(condition, secret_fns, out);
+            walk_calls(consequence, secret_fns, out);
             if let Some(e) = alternative {
-                walk_calls(e, out);
+                walk_calls(e, secret_fns, out);
             }
         }
         _ => {}


### PR DESCRIPTION
Closes #2282

## Summary

- Thread `&secret_fns` into `info_flow::walk_calls` and only push callees that match
- The caller's post-walk loop now just emits one diagnostic per pushed entry — the filter and the push collapse into a single step

## Why this matters

The old shape pushed *every* `CallExpression`'s callee identifier into a `Vec<&str>`, then iterated to filter. For a public-tagged fn body with N call sites and S secret-tagged callees (S << N in practice), that's (N - S) wasted `Vec` pushes plus a redundant linear scan. Filtering at push time eliminates both.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib info_flow` — 3 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)