### PR TITLE
RES-2286: lint L0017 — borrow names into scope stack instead of cloning

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -456,10 +456,6 @@
       "branch": "res-2268-smtlib2-direct-write",
       "claimed_at": "2026-05-20T08:29:05Z"
     },
-    "resilient/src/lint.rs": {
-      "branch": "res-2272-lint-clause-text-direct",
-      "claimed_at": "2026-05-20T08:36:08Z"
-    },
     "resilient/src/formatter.rs": {
       "branch": "res-2274-formatter-write-direct",
       "claimed_at": "2026-05-20T08:42:42Z"
@@ -467,6 +463,10 @@
     "resilient/src/verifier_loop_invariants.rs": {
       "branch": "res-2280-wp-substitute-skip",
       "claimed_at": "2026-05-20T09:12:26Z"
+    },
+    "resilient/src/lint.rs": {
+      "branch": "res-2286-l0017-borrow-names",
+      "claimed_at": "2026-05-20T09:40:13Z"
     }
   }
 }

--- a/resilient/src/lint.rs
+++ b/resilient/src/lint.rs
@@ -3091,7 +3091,7 @@ fn l0009_z3_check(
 // five lints actually need to descend through.
 // ============================================================
 
-fn recurse_children<F: FnMut(&Node)>(node: &Node, f: &mut F) {
+fn recurse_children<'a, F: FnMut(&'a Node)>(node: &'a Node, f: &mut F) {
     match node {
         Node::Program(stmts) => {
             for s in stmts {
@@ -4082,8 +4082,15 @@ fn run_l0017_variable_shadowing(program: &Node, out: &mut Vec<Lint>) {
             Node::Function {
                 parameters, body, ..
             } => {
-                let mut scopes: Vec<std::collections::HashSet<String>> =
-                    vec![parameters.iter().map(|(_, name)| name.clone()).collect()];
+                // RES-2286: scope stack stores `&'a str` borrows from
+                // the AST instead of owned `String`s. Both lookups
+                // — `set.contains(name.as_str())` and the per-Let
+                // insertion — work with `&str` directly, so the per-
+                // parameter and per-Let `.clone()` shed their backing
+                // allocations. Same shape as RES-2154 / RES-2238 /
+                // RES-2240.
+                let mut scopes: Vec<std::collections::HashSet<&str>> =
+                    vec![parameters.iter().map(|(_, name)| name.as_str()).collect()];
                 l0017_walk(body, &mut scopes, out);
             }
             Node::ImplBlock { methods, .. } => {
@@ -4092,8 +4099,8 @@ fn run_l0017_variable_shadowing(program: &Node, out: &mut Vec<Lint>) {
                         parameters, body, ..
                     } = method
                     {
-                        let mut scopes: Vec<std::collections::HashSet<String>> =
-                            vec![parameters.iter().map(|(_, name)| name.clone()).collect()];
+                        let mut scopes: Vec<std::collections::HashSet<&str>> =
+                            vec![parameters.iter().map(|(_, name)| name.as_str()).collect()];
                         l0017_walk(body, &mut scopes, out);
                     }
                 }
@@ -4103,9 +4110,9 @@ fn run_l0017_variable_shadowing(program: &Node, out: &mut Vec<Lint>) {
     }
 }
 
-fn l0017_walk(
-    node: &Node,
-    scopes: &mut Vec<std::collections::HashSet<String>>,
+fn l0017_walk<'a>(
+    node: &'a Node,
+    scopes: &mut Vec<std::collections::HashSet<&'a str>>,
     out: &mut Vec<Lint>,
 ) {
     match node {
@@ -4139,7 +4146,7 @@ fn l0017_walk(
                 }
             }
             if let Some(top) = scopes.last_mut() {
-                top.insert(name.clone());
+                top.insert(name.as_str());
             }
             l0017_walk(value, scopes, out);
         }


### PR DESCRIPTION
Closes #2286

## Summary

- Change L0017's scope stack from `Vec<HashSet<String>>` to `Vec<HashSet<&'a str>>` where `'a` is the AST lifetime
- Drop the per-parameter and per-`LetStatement` `name.clone()` — both consumers (`contains` / `insert`) work with `&str` directly
- Thread `<'a>` through `recurse_children` so the `_ =>` arm in `l0017_walk` can pass `child: &'a Node` to the recursive call. No-op at other call sites — Rust infers the lifetime.

## Why this matters

L0017 runs on every Function and every ImplBlock method during the lint pass. The previous shape paid one `String::clone` per parameter at function entry, plus one per `LetStatement` encountered during the body walk. For a typical large fn body with 10-20 lets and 3-5 params, that's 15-25 wasted heap allocations per fn. Same shape as RES-2154 / RES-2238 / RES-2240 — established AST-borrow pattern.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib l0017` — 4 passed (shadows_outer_let, shadows_parameter, silent_when_no_shadowing, silent_for_underscore_prefix)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)