### PR TITLE
RES-2292: sensor_freshness — drop redundant has_sensor pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -20,18 +20,6 @@
       "branch": "res-2166-incremental-verify-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/watchdog_feed.rs": {
-      "branch": "res-1218-param-type-fast-reject",
-      "claimed_at": "2026-05-12T02:11:38Z"
-    },
-    "resilient/src/sensor_freshness.rs": {
-      "branch": "res-1218-param-type-fast-reject",
-      "claimed_at": "2026-05-12T02:11:38Z"
-    },
-    "resilient/src/transaction_commit.rs": {
-      "branch": "res-1218-param-type-fast-reject",
-      "claimed_at": "2026-05-12T02:11:38Z"
-    },
     "resilient/src/backpressure_safe.rs": {
       "branch": "res-1217-handler-suffix-fast-reject",
       "claimed_at": "2026-05-12T02:07:46Z"
@@ -467,6 +455,10 @@
     "resilient/src/mutation_testing.rs": {
       "branch": "res-2288-mutation-fn-name-borrow",
       "claimed_at": "2026-05-20T09:50:03Z"
+    },
+    "resilient/src/sensor_freshness.rs": {
+      "branch": "res-2292-sensor-freshness-drop-prescan",
+      "claimed_at": "2026-05-20T10:04:18Z"
     }
   }
 }

--- a/resilient/src/sensor_freshness.rs
+++ b/resilient/src/sensor_freshness.rs
@@ -45,15 +45,16 @@ enum FreshOrder {
 }
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1218: fast-reject — skip for programs with no Sensor-typed parameters.
-    let Node::Program(stmts) = program else {
-        return Ok(());
-    };
-    let has_sensor = stmts.iter().any(|s| {
-        matches!(&s.node, Node::Function { parameters, .. }
-            if parameters.iter().any(|(ty, _)| SENSOR_TYPE_PREFIXES.iter().any(|p| ty.starts_with(*p))))
-    });
-    if !has_sensor {
+    // RES-1218 / RES-2292: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.any_param_type_with_prefix(&["Sensor", "&Sensor", "&mut Sensor"])`,
+    // so the program is guaranteed to contain at least one Sensor-
+    // typed parameter. The previous internal `stmts.iter().any(...)`
+    // pre-scan walked the full top-level statement list a second time
+    // for the same signal Markers already computed during the shared
+    // whole-AST walk. Mirrors RES-1916 / RES-1917's removal of
+    // redundant `any_node` pre-scans from marker-gated passes.
+    if !matches!(program, Node::Program(_)) {
         return Ok(());
     }
     for_each_function(program, |name, params, body| {


### PR DESCRIPTION
Closes #2292

## Summary

- Remove the internal `stmts.iter().any(...)` pre-scan from `sensor_freshness::check`
- The typechecker's `<EXTENSION_PASSES>` block already gates the call behind `markers.any_param_type_with_prefix(&["Sensor", "&Sensor", "&mut Sensor"])`
- Per-function `for_each_function` body still short-circuits via `sensors.is_empty()` — defense in depth for callers that bypass Markers

## Why this matters

The pre-scan walked every top-level Function and every parameter for a signal `Markers::scan` already computed during the shared whole-AST walk (RES-1593). Pure dead work on the typechecker path. Mirrors the RES-1916 / RES-1917 series that retired redundant `any_node` pre-scans from marker-gated passes.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib sensor_freshness` — 7 passed (read_before_fresh_is_stale, fresh_before_read_is_safe, if_else_both_fresh_before_read_is_safe, if_else_one_branch_stale_is_detected, no_fresh_check_at_all_is_stale, program_without_trigger_returns_ok, empty_program_returns_ok)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)