### PR TITLE
RES-2294: watchdog_feed — drop redundant has_watchdog pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -20,18 +20,6 @@
       "branch": "res-2166-incremental-verify-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/watchdog_feed.rs": {
-      "branch": "res-1218-param-type-fast-reject",
-      "claimed_at": "2026-05-12T02:11:38Z"
-    },
-    "resilient/src/sensor_freshness.rs": {
-      "branch": "res-1218-param-type-fast-reject",
-      "claimed_at": "2026-05-12T02:11:38Z"
-    },
-    "resilient/src/transaction_commit.rs": {
-      "branch": "res-1218-param-type-fast-reject",
-      "claimed_at": "2026-05-12T02:11:38Z"
-    },
     "resilient/src/backpressure_safe.rs": {
       "branch": "res-1217-handler-suffix-fast-reject",
       "claimed_at": "2026-05-12T02:07:46Z"
@@ -467,6 +455,10 @@
     "resilient/src/mutation_testing.rs": {
       "branch": "res-2288-mutation-fn-name-borrow",
       "claimed_at": "2026-05-20T09:50:03Z"
+    },
+    "resilient/src/watchdog_feed.rs": {
+      "branch": "res-2294-watchdog-feed-drop-prescan",
+      "claimed_at": "2026-05-20T10:10:22Z"
     }
   }
 }

--- a/resilient/src/watchdog_feed.rs
+++ b/resilient/src/watchdog_feed.rs
@@ -33,23 +33,15 @@ const FEED_METHODS: &[&str] = &["feed", "kick", "pet", "reset"];
 const FEED_FREE_FNS: &[&str] = &["feed_watchdog", "kick_watchdog", "pet_watchdog"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1218: fast-reject. The pass only emits diagnostics for
-    // functions whose parameter list contains a `Watchdog`-typed
-    // entry. Programs that declare no such parameter pay the
-    // `for_each_function` closure dispatch plus the per-function
-    // `.collect::<Vec>()` allocation for every function — pure
-    // waste in the overwhelming majority of `examples/` and the
-    // test suite. Scan the top-level parameter lists once up front
-    // and bail; programs that do take a Watchdog hit the same
-    // code path they did before.
-    let Node::Program(stmts) = program else {
-        return Ok(());
-    };
-    let has_watchdog = stmts.iter().any(|s| {
-        matches!(&s.node, Node::Function { parameters, .. }
-            if parameters.iter().any(|(ty, _)| WATCHDOG_TYPES.contains(&ty.as_str())))
-    });
-    if !has_watchdog {
+    // RES-1218 / RES-2294: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.any_param_type_in(&["Watchdog", "&Watchdog", "&mut Watchdog"])`,
+    // so the program is guaranteed to contain at least one Watchdog-
+    // typed parameter. The previous internal `stmts.iter().any(...)`
+    // pre-scan walked the full top-level statement list a second
+    // time for the same signal Markers already computed during the
+    // shared whole-AST walk. Mirrors RES-1916 / RES-1917 / RES-2292.
+    if !matches!(program, Node::Program(_)) {
         return Ok(());
     }
     for_each_function(program, |name, params, body| {


### PR DESCRIPTION
Closes #2294

## Summary

- Remove the internal `stmts.iter().any(...)` pre-scan from `watchdog_feed::check`
- The typechecker's `<EXTENSION_PASSES>` block already gates the call behind `markers.any_param_type_in(&["Watchdog", "&Watchdog", "&mut Watchdog"])`
- Per-function `for_each_function` body still short-circuits via `watchdogs.is_empty()` — defense in depth for callers that bypass Markers

## Why this matters

Same shape as the RES-1916 / RES-1917 series and the just-shipped RES-2292 (sensor_freshness). The pre-scan walked every top-level Function and every parameter for a signal `Markers::scan` already computed during the shared whole-AST walk (RES-1593). Pure dead work on the typechecker path.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib watchdog_feed` — 3 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)