### PR TITLE
RES-2296: transaction_commit — drop redundant has_tx pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -20,18 +20,6 @@
       "branch": "res-2166-incremental-verify-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/watchdog_feed.rs": {
-      "branch": "res-1218-param-type-fast-reject",
-      "claimed_at": "2026-05-12T02:11:38Z"
-    },
-    "resilient/src/sensor_freshness.rs": {
-      "branch": "res-1218-param-type-fast-reject",
-      "claimed_at": "2026-05-12T02:11:38Z"
-    },
-    "resilient/src/transaction_commit.rs": {
-      "branch": "res-1218-param-type-fast-reject",
-      "claimed_at": "2026-05-12T02:11:38Z"
-    },
     "resilient/src/backpressure_safe.rs": {
       "branch": "res-1217-handler-suffix-fast-reject",
       "claimed_at": "2026-05-12T02:07:46Z"
@@ -467,6 +455,10 @@
     "resilient/src/mutation_testing.rs": {
       "branch": "res-2288-mutation-fn-name-borrow",
       "claimed_at": "2026-05-20T09:50:03Z"
+    },
+    "resilient/src/transaction_commit.rs": {
+      "branch": "res-2296-tx-commit-drop-prescan",
+      "claimed_at": "2026-05-20T10:16:14Z"
     }
   }
 }

--- a/resilient/src/transaction_commit.rs
+++ b/resilient/src/transaction_commit.rs
@@ -43,15 +43,16 @@ const CLOSE_METHODS: &[&str] = &["commit", "rollback", "abort", "finish", "close
 const CLOSE_FREE_FNS: &[&str] = &["commit", "rollback", "abort_tx", "commit_tx"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1218: fast-reject — skip allocation for programs with no Transaction params.
-    let Node::Program(stmts) = program else {
-        return Ok(());
-    };
-    let has_tx = stmts.iter().any(|s| {
-        matches!(&s.node, Node::Function { parameters, .. }
-            if parameters.iter().any(|(ty, _)| TX_TYPES.contains(&ty.as_str())))
-    });
-    if !has_tx {
+    // RES-1218 / RES-2296: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind `markers.any_param_type_in(&[
+    // "Transaction", "Tx", "&Transaction", "&mut Transaction",
+    // "&Tx", "&mut Tx"])`, so the program is guaranteed to contain
+    // at least one Transaction-typed parameter. The previous internal
+    // `stmts.iter().any(...)` pre-scan walked the full top-level
+    // statement list a second time for the same signal Markers
+    // already computed during the shared whole-AST walk. Mirrors
+    // RES-1916 / RES-1917 / RES-2292 / RES-2294.
+    if !matches!(program, Node::Program(_)) {
         return Ok(());
     }
     for_each_function(program, |fname, params, body| {


### PR DESCRIPTION
Closes #2296

## Summary

- Remove the internal `stmts.iter().any(...)` pre-scan from `transaction_commit::check`
- The typechecker's `<EXTENSION_PASSES>` block already gates the call behind `markers.any_param_type_in(&["Transaction", "Tx", "&Transaction", "&mut Transaction", "&Tx", "&mut Tx"])`
- Per-function `for_each_function` body still short-circuits via `txs.is_empty()` — defense in depth for callers that bypass Markers

## Why this matters

Same shape as RES-2292 / RES-2294 and the RES-1916 / RES-1917 series. The pre-scan walked every top-level Function and every parameter for a signal `Markers::scan` already computed during the shared whole-AST walk (RES-1593). Pure dead work on the typechecker path.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib transaction_commit` — 9 passed (path_analysis_always_closes_linear, path_analysis_if_else_both_close, path_analysis_if_else_one_branch_missing, path_analysis_unclosed_early_return, no_tx_param_skips_check, tx_with_commit_before_return_is_ok, tx_without_commit_returns_ok_warning_only, etc.)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)