### PR TITLE
RES-2298: bounded_blocking — drop redundant has_bound_suffix pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -404,10 +404,6 @@
       "branch": "res-2214-try-catch-emitted-variants-borrow",
       "claimed_at": "2026-05-20T05:34:11Z"
     },
-    "resilient/src/bounded_blocking.rs": {
-      "branch": "res-2218-bounded-blocking-borrow-callees",
-      "claimed_at": "2026-05-20T05:47:46Z"
-    },
     "resilient/src/labeled_break.rs": {
       "branch": "res-2220-labeled-break-borrow-fn-name",
       "claimed_at": "2026-05-20T05:55:47Z"
@@ -467,6 +463,10 @@
     "resilient/src/mutation_testing.rs": {
       "branch": "res-2288-mutation-fn-name-borrow",
       "claimed_at": "2026-05-20T09:50:03Z"
+    },
+    "resilient/src/bounded_blocking.rs": {
+      "branch": "res-2298-bounded-blocking-drop-prescan",
+      "claimed_at": "2026-05-20T10:23:57Z"
     }
   }
 }

--- a/resilient/src/bounded_blocking.rs
+++ b/resilient/src/bounded_blocking.rs
@@ -38,26 +38,15 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
-    // RES-1218: fast-reject. The transitive-blocking analysis below
-    // only fires for functions whose name ends in one of the
-    // `_bound{N}` suffixes — the per-function `visit(body, ...)`
-    // walk that builds `callees` + `blocking_calls` is dead work for
-    // every other program. The overwhelming majority of `cargo test`
-    // inputs declare zero `_bound{N}` functions, so a cheap O(N)
-    // suffix scan over the top-level statement list short-circuits
-    // the entire AST walk in that case. Mirrors RES-1211's
-    // `isr_call_graph::check` fast-reject (which used the same shape
-    // for `is_isr_name`).
-    let has_bound_suffix = stmts.iter().any(|s| {
-        if let Node::Function { name, .. } = &s.node {
-            SUFFIXES.iter().any(|(suffix, _)| name.ends_with(*suffix))
-        } else {
-            false
-        }
-    });
-    if !has_bound_suffix {
-        return Ok(());
-    }
+    // RES-1218 / RES-2298: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.any_fn_name_with_suffix(&["_bound1", "_bound2",
+    // "_bound4", "_bound8"])`, so the program is guaranteed to
+    // contain at least one `_bound{N}`-suffixed function. The previous
+    // internal `stmts.iter().any(...)` pre-scan walked the full
+    // top-level statement list a second time for the same signal
+    // Markers already computed during the shared whole-AST walk.
+    // Mirrors RES-1916 / RES-1917 / RES-2292 / RES-2294 / RES-2296.
     // RES-1511: borrow each top-level fn name as `&str` from the
     // AST into the outer `callees` / `blocking_calls` HashMaps and
     // the `decls` Vec.


### PR DESCRIPTION
Closes #2298

## Summary

- Remove the internal `stmts.iter().any(...)` pre-scan from `bounded_blocking::check`
- The typechecker's `<EXTENSION_PASSES>` block already gates the call behind `markers.any_fn_name_with_suffix(&["_bound1", "_bound2", "_bound4", "_bound8"])`
- Downstream loop builds the call-graph map only for Function statements — semantics preserved

## Why this matters

Same shape as RES-2292 / RES-2294 / RES-2296 and the RES-1916 / RES-1917 series. Pre-scan duplicated a signal Markers::scan already computed during the shared whole-AST walk.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib bounded_blocking` — 2 passed (empty_program_returns_ok, program_without_trigger_returns_ok)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)