### PR TITLE
RES-2300: rate_limit_static — drop redundant pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -272,10 +272,6 @@
       "branch": "res-2014-assoc-const-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/rate_limit_static.rs": {
-      "branch": "res-1962-reentrancy-rate-limit-presize",
-      "claimed_at": "2026-05-19T18:59:39Z"
-    },
     "resilient/src/sum_types.rs": {
       "branch": "res-1788-rate-limit-presize",
       "claimed_at": "2026-05-13T12:35:40Z"
@@ -363,10 +359,6 @@
     "resilient/src/assume_axioms.rs": {
       "branch": "res-1958-assume-axioms-presize",
       "claimed_at": "2026-05-19T18:52:28Z"
-    },
-    "resilient/src/reentrancy_guard.rs": {
-      "branch": "res-1962-reentrancy-rate-limit-presize",
-      "claimed_at": "2026-05-19T18:59:39Z"
     },
     "resilient/src/isr_call_graph.rs": {
       "branch": "res-1966-isr-bfs-reuse",
@@ -467,6 +459,10 @@
     "resilient/src/mutation_testing.rs": {
       "branch": "res-2288-mutation-fn-name-borrow",
       "claimed_at": "2026-05-20T09:50:03Z"
+    },
+    "resilient/src/rate_limit_static.rs": {
+      "branch": "res-2300-rate-limit-drop-prescan",
+      "claimed_at": "2026-05-20T10:29:53Z"
     }
   }
 }

--- a/resilient/src/rate_limit_static.rs
+++ b/resilient/src/rate_limit_static.rs
@@ -28,23 +28,16 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
-    // RES-1228: fast-reject. The diagnostic only fires for functions
-    // whose name ends in `_oncepertick` / `_singleshot` / `_few`.
-    // Programs without any such suffix don't need the program-wide
-    // call-site count — yet the existing code walks every function
-    // body and populates a `HashMap<String, usize>` of every callee
-    // first, then loops `decls` looking for the suffix. Pre-scan
-    // top-level names for the suffix once up front; if none match,
-    // return immediately and skip both the AST traversals and the
-    // HashMap allocation. Same shape as RES-1211 / RES-1214 /
-    // RES-1217 / RES-1218 / RES-1222 / RES-1224.
-    let has_rate_limited = stmts.iter().any(|s| {
-        matches!(&s.node, Node::Function { name, .. }
-            if ONCE_SUFFIXES.iter().any(|suf| name.ends_with(*suf)) || name.ends_with(FEW_SUFFIX))
-    });
-    if !has_rate_limited {
-        return Ok(());
-    }
+    // RES-1228 / RES-2300: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.any_fn_name_with_suffix(&["_oncepertick",
+    // "_singleshot", "_few"])`, so the program is guaranteed to
+    // contain at least one rate-limited-suffixed function. The
+    // previous internal `stmts.iter().any(...)` pre-scan walked the
+    // full top-level statement list a second time for the same
+    // signal Markers already computed during the shared whole-AST
+    // walk. Mirrors RES-1916 / RES-1917 / RES-2292 / RES-2294 /
+    // RES-2296 / RES-2298.
     // RES-1515: borrow the top-level fn names into `decls` as `&str`
     // instead of cloning. The `counts` HashMap still needs owned
     // String keys because `uniqueness_walk::visit` uses a HRTB


### PR DESCRIPTION
Closes #2300

Continues the marker-gating cleanup series — same shape as the just-shipped RES-2292, RES-2294, RES-2296, RES-2298.

The typechecker already gates `rate_limit_static::check` behind `markers.any_fn_name_with_suffix(&["_oncepertick", "_singleshot", "_few"])`. The internal `stmts.iter().any(...)` pre-scan was duplicating that signal — dead work on the typechecker path.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib rate_limit_static` — 3 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)