### PR TITLE
RES-2302: stack_budget — drop redundant has_budget pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -467,6 +467,10 @@
     "resilient/src/mutation_testing.rs": {
       "branch": "res-2288-mutation-fn-name-borrow",
       "claimed_at": "2026-05-20T09:50:03Z"
+    },
+    "resilient/src/stack_budget.rs": {
+      "branch": "res-2302-stack-budget-drop-prescan",
+      "claimed_at": "2026-05-20T10:35:20Z"
     }
   }
 }

--- a/resilient/src/stack_budget.rs
+++ b/resilient/src/stack_budget.rs
@@ -29,20 +29,16 @@ const SUFFIXES: &[(&str, usize)] = &[
 ];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1222: fast-reject. The pass only emits diagnostics for
-    // functions whose name ends in a `_stack{N}` suffix. Programs
-    // that declare no such function get nothing back from the
-    // SUFFIX lookup inside the closure, yet still pay the
-    // `for_each_function` dispatch per function. Scan top-level
-    // names once up front.
-    let Node::Program(stmts) = program else {
-        return Ok(());
-    };
-    let has_budget = stmts.iter().any(|s| {
-        matches!(&s.node, Node::Function { name, .. }
-            if SUFFIXES.iter().any(|(suf, _)| name.ends_with(*suf)))
-    });
-    if !has_budget {
+    // RES-1222 / RES-2302: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.any_fn_name_with_suffix(&["_stack8", "_stack16",
+    // "_stack32", "_stack64"])`, so the program is guaranteed to
+    // contain at least one `_stack{N}`-suffixed function. The
+    // previous internal `stmts.iter().any(...)` pre-scan walked the
+    // full top-level statement list a second time for the same
+    // signal Markers already computed. Mirrors RES-1916 / RES-1917 /
+    // RES-2292 / RES-2294 / RES-2296 / RES-2298 / RES-2300.
+    if !matches!(program, Node::Program(_)) {
         return Ok(());
     }
     for_each_function(program, |fname, params, body| {


### PR DESCRIPTION
Closes #2302

Continues the marker-gating cleanup series — same shape as RES-2292 / RES-2294 / RES-2296 / RES-2298 / RES-2300.

The typechecker already gates `stack_budget::check` behind `markers.any_fn_name_with_suffix(&["_stack8", "_stack16", "_stack32", "_stack64"])`. The internal `stmts.iter().any(...)` pre-scan duplicated that signal — dead work on the typechecker path.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib stack_budget` — 2 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)