### PR TITLE
RES-2304: heap_budget — drop redundant has_budget pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -467,6 +467,10 @@
     "resilient/src/mutation_testing.rs": {
       "branch": "res-2288-mutation-fn-name-borrow",
       "claimed_at": "2026-05-20T09:50:03Z"
+    },
+    "resilient/src/heap_budget.rs": {
+      "branch": "res-2304-heap-budget-drop-prescan",
+      "claimed_at": "2026-05-20T10:41:03Z"
     }
   }
 }

--- a/resilient/src/heap_budget.rs
+++ b/resilient/src/heap_budget.rs
@@ -34,16 +34,16 @@ const ALLOC_FNS: &[&str] = &[
 ];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1222: fast-reject — see stack_budget for the same pattern.
-    // Skip the closure dispatch for programs that declare no
-    // `_alloc{N}` suffix.
-    let Node::Program(stmts) = program else {
-        return Ok(());
-    };
-    let has_budget = stmts
-        .iter()
-        .any(|s| matches!(&s.node, Node::Function { name, .. } if parse_budget(name).is_some()));
-    if !has_budget {
+    // RES-1222 / RES-2304: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.any_fn_name_with_suffix(&["_alloc0", "_alloc1",
+    // "_alloc2", "_alloc3", "_alloc4", "_alloc5"])`, so the program
+    // is guaranteed to contain at least one `_alloc{N}`-suffixed
+    // function. The previous internal `stmts.iter().any(...)`
+    // pre-scan walked the full top-level statement list a second
+    // time for the same signal Markers already computed. Mirrors
+    // RES-2292 / RES-2294 / RES-2296 / RES-2298 / RES-2300 / RES-2302.
+    if !matches!(program, Node::Program(_)) {
         return Ok(());
     }
     for_each_function(program, |fname, _params, body| {


### PR DESCRIPTION
Closes #2304

Continues the marker-gating cleanup series. The typechecker already gates `heap_budget::check` behind `markers.any_fn_name_with_suffix(&["_alloc0", "_alloc1", "_alloc2", "_alloc3", "_alloc4", "_alloc5"])`. The internal `stmts.iter().any(...)` pre-scan duplicated that signal — dead work on the typechecker path.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib heap_budget` — 2 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)