### PR TITLE
RES-2306: bandwidth_budget — drop redundant has_budget pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -467,6 +467,10 @@
     "resilient/src/mutation_testing.rs": {
       "branch": "res-2288-mutation-fn-name-borrow",
       "claimed_at": "2026-05-20T09:50:03Z"
+    },
+    "resilient/src/bandwidth_budget.rs": {
+      "branch": "res-2306-bandwidth-budget-drop-prescan",
+      "claimed_at": "2026-05-20T10:46:57Z"
     }
   }
 }

--- a/resilient/src/bandwidth_budget.rs
+++ b/resilient/src/bandwidth_budget.rs
@@ -41,17 +41,16 @@ const BUDGETS: &[(usize, &str)] = &[
 ];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1222: fast-reject — see stack_budget for the same pattern.
-    // Skip the closure dispatch for programs that declare no
-    // `_iobytes{N}` suffix.
-    let Node::Program(stmts) = program else {
-        return Ok(());
-    };
-    let has_budget = stmts.iter().any(|s| {
-        matches!(&s.node, Node::Function { name, .. }
-            if BUDGETS.iter().any(|(_, suf)| name.ends_with(*suf)))
-    });
-    if !has_budget {
+    // RES-1222 / RES-2306: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.any_fn_name_with_suffix(&["_iobytes16", "_iobytes32",
+    // "_iobytes64", "_iobytes128", "_iobytes256", "_iobytes512"])`,
+    // so the program is guaranteed to contain at least one
+    // `_iobytes{N}`-suffixed function. The previous internal
+    // `stmts.iter().any(...)` pre-scan walked the full top-level
+    // statement list a second time for the same signal Markers
+    // already computed. Mirrors RES-2292 through RES-2304.
+    if !matches!(program, Node::Program(_)) {
         return Ok(());
     }
     for_each_function(program, |fname, _params, body| {


### PR DESCRIPTION
Closes #2306

Continues the marker-gating cleanup series — same shape as RES-2292 through RES-2304.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib bandwidth_budget` — 2 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)