### PR TITLE
RES-2308: idempotent_handler — drop redundant has_idempotent pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -20,14 +20,6 @@
       "branch": "res-2166-incremental-verify-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/backpressure_safe.rs": {
-      "branch": "res-1217-handler-suffix-fast-reject",
-      "claimed_at": "2026-05-12T02:07:46Z"
-    },
-    "resilient/src/idempotent_handler.rs": {
-      "branch": "res-1217-handler-suffix-fast-reject",
-      "claimed_at": "2026-05-12T02:07:46Z"
-    },
     "resilient/src/priority_inheritance.rs": {
       "branch": "res-1232-priority-fast-reject",
       "claimed_at": "2026-05-12T02:35:05Z"
@@ -459,6 +451,10 @@
     "resilient/src/sensor_freshness.rs": {
       "branch": "res-2292-sensor-freshness-drop-prescan",
       "claimed_at": "2026-05-20T10:04:18Z"
+    },
+    "resilient/src/idempotent_handler.rs": {
+      "branch": "res-2308-idempotent-handler-drop-prescan",
+      "claimed_at": "2026-05-20T10:53:02Z"
     }
   }
 }

--- a/resilient/src/idempotent_handler.rs
+++ b/resilient/src/idempotent_handler.rs
@@ -25,17 +25,15 @@ use crate::uniqueness_walk::{any_node, for_each_function};
 const DEDUPE_FNS: &[&str] = &["is_duplicate", "was_seen", "dedupe", "is_processed"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1217: fast-reject — same shape as `backpressure_safe`.
-    // The pass only emits diagnostics for functions whose name
-    // ends in `_idempotent`; for every other program the entire
-    // walk is wasted work.
-    let Node::Program(stmts) = program else {
-        return Ok(());
-    };
-    let has_idempotent = stmts
-        .iter()
-        .any(|s| matches!(&s.node, Node::Function { name, .. } if name.ends_with("_idempotent")));
-    if !has_idempotent {
+    // RES-1217 / RES-2308: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.any_fn_name_with_suffix(&["_idempotent"])`, so the
+    // program is guaranteed to contain at least one
+    // `_idempotent`-suffixed function. The previous internal
+    // `stmts.iter().any(...)` pre-scan walked the full top-level
+    // statement list a second time for the same signal Markers
+    // already computed. Mirrors RES-2292 through RES-2306.
+    if !matches!(program, Node::Program(_)) {
         return Ok(());
     }
     for_each_function(program, |fname, _params, body| {


### PR DESCRIPTION
Closes #2308

Continues the marker-gating cleanup series — same shape as RES-2292 through RES-2306.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib idempotent_handler` — 3 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)