### PR TITLE
RES-2310: crash_only — drop redundant has_crash pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -112,10 +112,6 @@
       "branch": "res-1523-imports-canon-move",
       "claimed_at": "2026-05-12T13:18:45Z"
     },
-    "resilient/src/crash_only.rs": {
-      "branch": "res-1520-crash-only-name-borrow",
-      "claimed_at": "2026-05-12T13:33:00Z"
-    },
     "resilient/src/deadlock_freedom.rs": {
       "branch": "res-1522-deadlock-actors-borrow",
       "claimed_at": "2026-05-12T13:34:45Z"
@@ -459,6 +455,10 @@
     "resilient/src/sensor_freshness.rs": {
       "branch": "res-2292-sensor-freshness-drop-prescan",
       "claimed_at": "2026-05-20T10:04:18Z"
+    },
+    "resilient/src/crash_only.rs": {
+      "branch": "res-2310-crash-only-drop-prescan",
+      "claimed_at": "2026-05-20T11:00:18Z"
     }
   }
 }

--- a/resilient/src/crash_only.rs
+++ b/resilient/src/crash_only.rs
@@ -24,20 +24,14 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     let Node::Program(stmts) = program else {
         return Ok(());
     };
-    // RES-1224: fast-reject. The diagnostic only fires for functions
-    // whose name starts with `crash_`, so if none exists the
-    // `HashSet<String>` of every top-level function name (N string
-    // allocations plus bucket overhead) is pure waste. Programs
-    // without `crash_*` functions — basically everything in
-    // `examples/` and the test suite — get to skip the allocation
-    // entirely. Same shape as RES-1211 / RES-1214 / RES-1217 /
-    // RES-1218 / RES-1222.
-    let has_crash = stmts
-        .iter()
-        .any(|s| matches!(&s.node, Node::Function { name, .. } if name.starts_with("crash_")));
-    if !has_crash {
-        return Ok(());
-    }
+    // RES-1224 / RES-2310: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.any_fn_name_with_prefix(&["crash_"])`, so the program
+    // is guaranteed to contain at least one `crash_`-prefixed
+    // function. The previous internal `stmts.iter().any(...)`
+    // pre-scan walked the full top-level statement list a second
+    // time for the same signal Markers already computed. Mirrors
+    // RES-2292 through RES-2308.
     // RES-1520: borrow each top-level fn name as `&str` from the
     // AST into the lookup set. The contains check below uses
     // `&str` (via `Borrow<str>`), so the cloned `String` keys were


### PR DESCRIPTION
Closes #2310

Continues the marker-gating cleanup series. Same shape as RES-2292 through RES-2308.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib crash_only` — all crash_only + crash_only_cert tests pass (5 total)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)