### PR TITLE
RES-2312: type_aliases — drop redundant TypeAlias pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -268,14 +268,6 @@
       "branch": "res-1788-rate-limit-presize",
       "claimed_at": "2026-05-13T12:35:40Z"
     },
-    "resilient/src/type_aliases.rs": {
-      "branch": "res-1790-type-aliases-tuples-presize",
-      "claimed_at": "2026-05-13T12:39:38Z"
-    },
-    "resilient/src/tuples.rs": {
-      "branch": "res-1790-type-aliases-tuples-presize",
-      "claimed_at": "2026-05-13T12:39:38Z"
-    },
     "resilient/src/infer.rs": {
       "branch": "res-1794-infer-named-args-presize",
       "claimed_at": "2026-05-13T12:47:28Z"
@@ -459,6 +451,10 @@
     "resilient/src/sensor_freshness.rs": {
       "branch": "res-2292-sensor-freshness-drop-prescan",
       "claimed_at": "2026-05-20T10:04:18Z"
+    },
+    "resilient/src/type_aliases.rs": {
+      "branch": "res-2312-type-aliases-drop-prescan",
+      "claimed_at": "2026-05-20T11:09:11Z"
     }
   }
 }

--- a/resilient/src/type_aliases.rs
+++ b/resilient/src/type_aliases.rs
@@ -66,18 +66,13 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         return Ok(());
     };
 
-    // RES-1230: fast-reject. The cycle detector only has work to do
-    // when the program declares at least one `type X = Y`. For every
-    // other program — basically every test — the three allocations
-    // below (`aliases` HashMap, `decl_order` Vec, the `color`
-    // HashMap built from `aliases.keys()`) and the DFS loop run for
-    // nothing. Same shape as RES-1211 .. RES-1228.
-    if !statements
-        .iter()
-        .any(|s| matches!(&s.node, Node::TypeAlias { .. }))
-    {
-        return Ok(());
-    }
+    // RES-1230 / RES-2312: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind `markers.has_type_alias`, so
+    // the program is guaranteed to contain at least one
+    // `Node::TypeAlias`. The previous internal `stmts.iter().any(...)`
+    // pre-scan walked the full top-level statement list a second
+    // time for the same signal Markers already computed during the
+    // shared whole-AST walk. Mirrors RES-2292 through RES-2310.
 
     // RES-1537: borrow alias/target names from the AST throughout the
     // cycle detector. The previous shape cloned each alias name into


### PR DESCRIPTION
Closes #2312

Continues the marker-gating cleanup series. Same shape as RES-2292 through RES-2310.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib type_aliases` — 9 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)