### PR TITLE
RES-2314: generics — drop redundant has_generic_fn pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -76,10 +76,6 @@
       "branch": "res-1281-unsafe-check-fast-reject",
       "claimed_at": "2026-05-12T04:21:23Z"
     },
-    "resilient/src/generics.rs": {
-      "branch": "res-1523-generics-locals-borrow",
-      "claimed_at": "2026-05-12T13:40:00Z"
-    },
     "resilient/src/feature_attrs.rs": {
       "branch": "res-2088-feature-attrs-record-borrow",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -459,6 +455,10 @@
     "resilient/src/sensor_freshness.rs": {
       "branch": "res-2292-sensor-freshness-drop-prescan",
       "claimed_at": "2026-05-20T10:04:18Z"
+    },
+    "resilient/src/generics.rs": {
+      "branch": "res-2314-generics-drop-prescan",
+      "claimed_at": "2026-05-20T11:14:54Z"
     }
   }
 }

--- a/resilient/src/generics.rs
+++ b/resilient/src/generics.rs
@@ -192,22 +192,13 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         Node::Program(stmts) => stmts,
         _ => return Ok(()),
     };
-    // RES-1288: fast-reject. The per-function work in `check_node`
-    // — the duplicate-type-parameter scan and the body-consistency
-    // walk — only fires for functions that declare type parameters.
-    // For programs that declare zero generic functions (the
-    // overwhelming majority of `cargo test` inputs and the entire
-    // `examples/` tree), the outer iteration destructures every
-    // `Node::Function` and allocates a per-function `HashSet`
-    // before discovering `type_params` is empty. Pre-scan once for
-    // any `Function` with non-empty `type_params` and skip the
-    // entire pass when none exists.
-    let has_generic_fn = stmts
-        .iter()
-        .any(|s| matches!(&s.node, Node::Function { type_params, .. } if !type_params.is_empty()));
-    if !has_generic_fn {
-        return Ok(());
-    }
+    // RES-1288 / RES-2314: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind `markers.has_generic_fn`, so
+    // the program is guaranteed to contain at least one Function
+    // with non-empty `type_params`. The previous internal
+    // `stmts.iter().any(...)` pre-scan walked the full top-level
+    // statement list a second time for the same signal Markers
+    // already computed. Mirrors RES-2292 through RES-2312.
     for stmt in stmts {
         check_node(&stmt.node)?;
     }


### PR DESCRIPTION
Closes #2314

Continues the marker-gating cleanup series. Same shape as RES-2292 through RES-2312.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib generics` — 12 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)