### PR TITLE
RES-2316: full_modules — drop redundant has_module_or_use pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -404,10 +404,6 @@
       "branch": "res-2224-struct-exhaust-borrow-fn-name",
       "claimed_at": "2026-05-20T06:03:00Z"
     },
-    "resilient/src/full_modules.rs": {
-      "branch": "res-2236-full-modules-build-skip-clone",
-      "claimed_at": "2026-05-20T06:40:00Z"
-    },
     "resilient/src/crash_only_cert.rs": {
       "branch": "res-2240-crash-only-cert-hashset",
       "claimed_at": "2026-05-20T07:01:18Z"
@@ -459,6 +455,10 @@
     "resilient/src/sensor_freshness.rs": {
       "branch": "res-2292-sensor-freshness-drop-prescan",
       "claimed_at": "2026-05-20T10:04:18Z"
+    },
+    "resilient/src/full_modules.rs": {
+      "branch": "res-2316-full-modules-drop-prescan",
+      "claimed_at": "2026-05-20T11:22:37Z"
     }
   }
 }

--- a/resilient/src/full_modules.rs
+++ b/resilient/src/full_modules.rs
@@ -126,21 +126,14 @@ pub fn detect_cycle(graph: &ModuleGraph) -> Option<Vec<String>> {
 }
 
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
-    // RES-1246: fast-reject. `build` walks every top-level statement
-    // looking for `Node::ModuleDecl` or `Node::Use`. For every
-    // program that declares neither — basically everything in
-    // `examples/` and most of the test suite — the walk produces an
-    // empty `ModuleGraph::deps` and `detect_cycle` returns None.
-    // Skip both calls by pre-scanning the top-level statement list
-    // for the only two variants that contribute to the graph.
-    if let Node::Program(stmts) = program {
-        let has_module_or_use = stmts
-            .iter()
-            .any(|s| matches!(&s.node, Node::ModuleDecl { .. } | Node::Use { .. }));
-        if !has_module_or_use {
-            return Ok(());
-        }
-    }
+    // RES-1246 / RES-2316: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.has_module_decl || markers.has_use`, so the program
+    // is guaranteed to contain at least one ModuleDecl or Use. The
+    // previous internal `stmts.iter().any(...)` pre-scan walked the
+    // full top-level statement list a second time for the same
+    // signal Markers already computed. Mirrors RES-2292 through
+    // RES-2314.
     let g = build(program);
     if let Some(cycle) = detect_cycle(&g) {
         return Err(format!(


### PR DESCRIPTION
Closes #2316

Continues the marker-gating cleanup series. Same shape as RES-2292 through RES-2314.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib full_modules` — 2 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)