### PR TITLE
RES-2318: traits — drop redundant has_trait_work pre-scan (marker-gated)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -284,10 +284,6 @@
       "branch": "res-1794-infer-named-args-presize",
       "claimed_at": "2026-05-13T12:47:28Z"
     },
-    "resilient/src/traits.rs": {
-      "branch": "res-1802-traits-presize",
-      "claimed_at": "2026-05-13T13:02:04Z"
-    },
     "resilient/src/verifier_actors.rs": {
       "branch": "res-1808-flatten-body-presize",
       "claimed_at": "2026-05-13T13:17:34Z"
@@ -459,6 +455,10 @@
     "resilient/src/sensor_freshness.rs": {
       "branch": "res-2292-sensor-freshness-drop-prescan",
       "claimed_at": "2026-05-20T10:04:18Z"
+    },
+    "resilient/src/traits.rs": {
+      "branch": "res-2318-traits-drop-prescan",
+      "claimed_at": "2026-05-20T11:29:04Z"
     }
   }
 }

--- a/resilient/src/traits.rs
+++ b/resilient/src/traits.rs
@@ -329,38 +329,21 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         _ => return Ok(()),
     };
 
-    // RES-1391: complete fast-reject. The earlier RES-1230 draft
-    // checked only `TraitDecl` and broke the unknown-trait
-    // diagnostics, because the pass also validates trait *references*
-    // in `impl Trait for Type` blocks and `<T: Trait>` bounds — both
-    // of which can appear in programs without any TraitDecl.
+    // RES-1391 / RES-2318: the typechecker's `<EXTENSION_PASSES>`
+    // dispatch gates this call behind
+    // `markers.has_trait_decl || !markers.impl_trait_names.is_empty()
+    // || markers.has_generic_fn`, which covers exactly the three
+    // signals the internal pre-scan checks. The previous internal
+    // `stmts.iter().any(...)` pre-scan walked the full top-level
+    // statement list a second time for the same signals Markers
+    // already computed during the shared whole-AST walk. Mirrors
+    // RES-2292 through RES-2316.
     //
-    // A correct fast-reject needs all three signals: any TraitDecl,
-    // any ImplBlock carrying a `trait_name`, or any Function with
-    // type-params / non-empty type-param bounds. Programs without
-    // any of these have no trait-validation work to do — Pass 1's
-    // collection is empty, Pass 2's impl scan finds nothing to
-    // validate, Pass 3 has no bounds to check, and
-    // `walk_call_sites` would early-return at
-    // `if type_params.is_empty()` for every callee. Same
-    // fast-reject pattern as RES-1281 / RES-1290 / RES-1294 /
-    // RES-1297 / RES-1311 / RES-1316 / RES-1320 / RES-1376.
-    let has_trait_work = stmts.iter().any(|s| match &s.node {
-        Node::TraitDecl { .. } => true,
-        Node::ImplBlock {
-            trait_name: Some(_),
-            ..
-        } => true,
-        Node::Function {
-            type_params,
-            type_param_bounds,
-            ..
-        } => !type_params.is_empty() || type_param_bounds.iter().any(|bs| !bs.is_empty()),
-        _ => false,
-    });
-    if !has_trait_work {
-        return Ok(());
-    }
+    // Note: `type_param_bounds.iter().any(|bs| !bs.is_empty())` was
+    // a strictly weaker condition than `!type_params.is_empty()`
+    // given the parser's parallel-Vec invariant — both checks
+    // collapse to "any fn has type params" which is exactly
+    // `markers.has_generic_fn`.
 
     // Pass 1: collect trait declarations.
     let mut traits: HashMap<String, (Vec<TraitMethodSig>, Vec<AssociatedTypeDecl>, Span)> =


### PR DESCRIPTION
Closes #2318

Continues the marker-gating cleanup series. Same shape as RES-2292 through RES-2316.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib traits` — 17 passed (trait decl, impl coverage, bound validation, associated types)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)