### PR TITLE
RES-2322: repl::contracts_output — writeln! directly, drop push_str(&format!()) antipattern

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -455,6 +455,10 @@
     "resilient/src/idempotent_handler.rs": {
       "branch": "res-2308-idempotent-handler-drop-prescan",
       "claimed_at": "2026-05-20T10:53:02Z"
+    },
+    "resilient/src/repl.rs": {
+      "branch": "res-2322-repl-contracts-write-direct",
+      "claimed_at": "2026-05-20T11:55:36Z"
     }
   }
 }

--- a/resilient/src/repl.rs
+++ b/resilient/src/repl.rs
@@ -589,6 +589,15 @@ impl EnhancedREPL {
         let mut names: Vec<&String> = map.keys().collect();
         names.sort();
 
+        // RES-2322: write directly via `std::fmt::Write` instead of
+        // the `push_str(&format!(...))` antipattern. Each `format!()`
+        // previously allocated an intermediate `String` only to be
+        // immediately `push_str`'d into `out`. For an N-fn program
+        // with K total `requires`/`ensures` clauses, that's N + K
+        // wasted String allocations on the `.contracts` table-emit
+        // path. Mirrors RES-2256 (autopilot::format_report) /
+        // RES-2258 (causal_trace).
+        use std::fmt::Write;
         let mut out = String::new();
         let mut any = false;
 
@@ -601,19 +610,19 @@ impl EnhancedREPL {
             let (requires, ensures) = &map[name];
             for clause in requires {
                 let expr = Self::format_contract_node(clause);
-                out.push_str(&format!("{}  requires  {}  unverified\n", name, expr));
+                let _ = writeln!(out, "{}  requires  {}  unverified", name, expr);
                 any = true;
             }
             for clause in ensures {
                 let expr = Self::format_contract_node(clause);
-                out.push_str(&format!("{}  ensures   {}  unverified\n", name, expr));
+                let _ = writeln!(out, "{}  ensures   {}  unverified", name, expr);
                 any = true;
             }
         }
 
         if !any {
             if let Some(f) = filter {
-                out.push_str(&format!("(no contracts for '{}')\n", f));
+                let _ = writeln!(out, "(no contracts for '{}')", f);
             } else {
                 out.push_str("(no contracts defined)\n");
             }


### PR DESCRIPTION
Closes #2322

## Summary

- Replace four `out.push_str(&format!(...))` sites in `EnhancedREPL::contracts_output` with `writeln!(out, ...)` via `std::fmt::Write`
- Same byte output; drops the per-row intermediate `String` allocation

## Why this matters

For an N-function K-clause table emit, the old shape paid N + K `String` allocations just to immediately copy them into the output buffer. Same write-direct pattern as RES-2256 / RES-2258 / RES-2260 / RES-2262 / RES-2264 / RES-2266 / RES-2268 / RES-2270 / RES-2272.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib repl` — 50 passed (includes REPL helpers + adjacent shared tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)