### PR TITLE
RES-2324: mcp_server tool_resilient_run — drop push_str(&format!()) antipattern

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -455,6 +455,10 @@
     "resilient/src/idempotent_handler.rs": {
       "branch": "res-2308-idempotent-handler-drop-prescan",
       "claimed_at": "2026-05-20T10:53:02Z"
+    },
+    "resilient/src/mcp_server.rs": {
+      "branch": "res-2324-mcp-server-write-direct",
+      "claimed_at": "2026-05-20T12:01:58Z"
     }
   }
 }

--- a/resilient/src/mcp_server.rs
+++ b/resilient/src/mcp_server.rs
@@ -1292,6 +1292,12 @@ fn tool_vm_run(args: &Value) -> Result<String, String> {
     let (vm_result, captured) =
         crate::output_sink::with_captured_output(|| crate::vm::run(&compiled));
 
+    // RES-2324: write directly via `std::fmt::Write` instead of the
+    // `push_str(&format!(...))` antipattern. Each `format!()`
+    // previously allocated an intermediate `String` only to be
+    // immediately `push_str`'d into the response buffer. Same shape
+    // as RES-2256 / RES-2258 / RES-2260 / RES-2322.
+    use std::fmt::Write as _;
     match vm_result {
         Ok(value) => {
             let mut out = String::new();
@@ -1304,7 +1310,8 @@ fn tool_vm_run(args: &Value) -> Result<String, String> {
                 if !out.is_empty() {
                     out.push('\n');
                 }
-                out.push_str(&format!("Result: {val_str}"));
+                out.push_str("Result: ");
+                out.push_str(&val_str);
             }
             if out.is_empty() {
                 out.push_str("OK — program exited with no output.");
@@ -1318,7 +1325,7 @@ fn tool_vm_run(args: &Value) -> Result<String, String> {
                 msg.push_str(&captured);
                 msg.push('\n');
             }
-            msg.push_str(&format!("VM error: {e}"));
+            let _ = write!(msg, "VM error: {e}");
             Err(msg)
         }
     }


### PR DESCRIPTION
Closes #2324

Continues the write-direct refactor series — same shape as RES-2256 / RES-2258 / RES-2260 / RES-2322.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib mcp_server` — 83 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)