### PR TITLE
RES-2338: cfg_attr::node_item_name — return Option<&str>, drop per-attribute clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -459,6 +459,10 @@
     "resilient/src/blame_attribution.rs": {
       "branch": "res-2334-blame-attribution-entry-skip",
       "claimed_at": "2026-05-20T12:52:54Z"
+    },
+    "resilient/src/cfg_attr.rs": {
+      "branch": "res-2338-cfg-attr-item-name-borrow",
+      "claimed_at": "2026-05-20T13:09:36Z"
     }
   }
 }

--- a/resilient/src/cfg_attr.rs
+++ b/resilient/src/cfg_attr.rs
@@ -361,7 +361,7 @@ fn parse_feature_attribute(parser: &mut Parser, name: String) -> Option<crate::N
         && let Some(item_name) = node_item_name(node)
     {
         crate::feature_attrs::record(
-            &item_name,
+            item_name,
             crate::feature_attrs::AttrRecord {
                 name,
                 args: args.trim().to_string(),
@@ -375,15 +375,22 @@ fn parse_feature_attribute(parser: &mut Parser, name: String) -> Option<crate::N
 /// Best-effort: extract the declared name from a top-level node so the
 /// attribute registry can key its entry. Returns `None` for unnamed
 /// statements (let-bindings, expressions).
-fn node_item_name(node: &crate::Node) -> Option<String> {
+///
+/// RES-2338: returns `&str` borrowed from the AST instead of an owned
+/// `String`. The sole caller passes the name straight into
+/// `feature_attrs::record(item_name, ...)`, which already takes
+/// `&str` — the per-attribute `name.clone()` was pure overhead.
+/// Saves one `String` allocation per `#[cfg(...)]` / `#[refinement]`
+/// / `#[recursive]` / etc. attribute record.
+fn node_item_name(node: &crate::Node) -> Option<&str> {
     match node {
-        crate::Node::Function { name, .. } => Some(name.clone()),
-        crate::Node::StructDecl { name, .. } => Some(name.clone()),
-        crate::Node::TypeAlias { name, .. } => Some(name.clone()),
-        crate::Node::NewtypeDecl { name, .. } => Some(name.clone()),
-        crate::Node::EnumDecl { name, .. } => Some(name.clone()),
-        crate::Node::TraitDecl { name, .. } => Some(name.clone()),
-        crate::Node::ActorDecl { name, .. } => Some(name.clone()),
+        crate::Node::Function { name, .. } => Some(name.as_str()),
+        crate::Node::StructDecl { name, .. } => Some(name.as_str()),
+        crate::Node::TypeAlias { name, .. } => Some(name.as_str()),
+        crate::Node::NewtypeDecl { name, .. } => Some(name.as_str()),
+        crate::Node::EnumDecl { name, .. } => Some(name.as_str()),
+        crate::Node::TraitDecl { name, .. } => Some(name.as_str()),
+        crate::Node::ActorDecl { name, .. } => Some(name.as_str()),
         _ => None,
     }
 }


### PR DESCRIPTION
Closes #2336

`node_item_name` returned `Option<String>` and cloned the AST's name slot per supported variant. The sole caller passes the result straight into `feature_attrs::record(item_name, ...)` which already takes `&str` — the owned String was pure overhead.

Return `Option<&str>` borrowed from the AST. One less `String::clone` per `#[cfg(...)]` / `#[refinement]` / `#[recursive]` / `#[derive(...)]` / etc. attribute record.

Same AST-borrow pattern as RES-1500 / RES-1509 / RES-1511 / RES-1525 / RES-1537.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib cfg_attr` — 13 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)