### PR TITLE
RES-2342: audit_log_required — short-circuit has_audited_write detector with any_node

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -52,10 +52,6 @@
       "branch": "res-1252-degraded-mode-fast-reject",
       "claimed_at": "2026-05-12T03:27:30Z"
     },
-    "resilient/src/audit_log_required.rs": {
-      "branch": "res-1254-audit-log-fast-reject",
-      "claimed_at": "2026-05-12T03:32:45Z"
-    },
     "resilient/src/secret_erasure.rs": {
       "branch": "res-1256-secret-erasure-fast-reject",
       "claimed_at": "2026-05-12T03:39:06Z"
@@ -463,6 +459,10 @@
     "resilient/src/cfg_attr.rs": {
       "branch": "res-2338-cfg-attr-item-name-borrow",
       "claimed_at": "2026-05-20T13:09:36Z"
+    },
+    "resilient/src/audit_log_required.rs": {
+      "branch": "res-2342-audit-log-short-circuit",
+      "claimed_at": "2026-05-20T13:29:31Z"
     }
   }
 }

--- a/resilient/src/audit_log_required.rs
+++ b/resilient/src/audit_log_required.rs
@@ -18,7 +18,7 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, for_each_function, visit};
+use crate::uniqueness_walk::{any_node, for_each_function};
 
 const AUDIT_FNS: &[&str] = &["audit_log", "journal", "record_event", "emit_audit"];
 
@@ -29,13 +29,18 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // least one audited-prefixed/suffixed field assignment. The
     // previous `any_node` pre-scan was redundant — removed.
     for_each_function(program, |fname, _params, body| {
-        let mut has_audited_write = false;
-        visit(body, &mut |n| {
-            if let Node::FieldAssignment { field, .. } = n {
-                if field.starts_with("audited_") || field.ends_with("_audited") {
-                    has_audited_write = true;
-                }
-            }
+        // RES-2342: short-circuit the audited-write detector via
+        // `any_node` instead of `visit`. The previous shape walked
+        // the entire body and toggled a `has_audited_write` boolean
+        // — every node past the first hit was wasted work, since
+        // the boolean only ever flipped once. `any_node` returns
+        // `true` on the first match and propagates upward.
+        // Mirrors the early-termination pattern in
+        // `uniqueness_walk::any_node` (RES-1238) and the
+        // RES-2226 / RES-2232 short-circuit shape.
+        let has_audited_write = any_node(body, |n| {
+            matches!(n, Node::FieldAssignment { field, .. }
+                if field.starts_with("audited_") || field.ends_with("_audited"))
         });
         if !has_audited_write {
             return;


### PR DESCRIPTION
Closes #2340

## Summary

- Replace `visit(body, &mut |n| { if matches { has_audited_write = true } })` with `any_node(body, |n| matches!(...))`
- The boolean only ever flipped once — `any_node` returns on the first match instead of walking the whole body
- Drop the unused `visit` import

## Why this matters

The `visit` walker traversed the entire function body even after the first audited-field write was found. For bodies with multiple audited writes (compliance-tagged code typically has several per fn), the post-first-hit walk was pure overhead. `any_node` short-circuits, saving O(remaining-body-size) work per fn.

Hot path during typecheck of audit-tagged codebases (`audit_log_required::check` gates on `markers.any_field_assigned_with_prefix_or_suffix`, which fires whenever audited writes exist).

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib audit_log_required` — 3 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)