### PR TITLE
RES-2344: bounds_check Block arm — lazy ctx clone, only when literal-len let encountered

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/cfg_attr.rs": {
       "branch": "res-2338-cfg-attr-item-name-borrow",
       "claimed_at": "2026-05-20T13:09:36Z"
+    },
+    "resilient/src/bounds_check.rs": {
+      "branch": "res-2344-bounds-check-lazy-ctx-clone",
+      "claimed_at": "2026-05-20T13:41:01Z"
     }
   }
 }

--- a/resilient/src/bounds_check.rs
+++ b/resilient/src/bounds_check.rs
@@ -186,17 +186,25 @@ fn walk_toplevel(node: &Node, source_path: &str, errors: &mut Vec<String>) {
 fn walk_node(node: &Node, ctx: &BoundsCtx, source_path: &str, errors: &mut Vec<String>) {
     match node {
         Node::Block { stmts, .. } => {
-            // Track literal-length lets introduced in this block so
-            // subsequent statements can use them as a fast path.
-            let mut block_ctx = ctx.clone();
+            // RES-2344: lazy-clone the context — only allocate a fresh
+            // `BoundsCtx` when a literal-length `let` actually needs
+            // to extend `literal_len`. The previous shape did
+            // `let mut block_ctx = ctx.clone()` unconditionally, which
+            // deep-cloned the axioms `Vec<Node>` + `literal_len`
+            // `HashMap<String, i64>` for every Block visited — most
+            // blocks (function bodies without literal-array lets)
+            // never write to either, so the clone was pure waste.
+            // For a deeply-nested program, this drops O(depth) full
+            // ctx clones to O(blocks-that-introduce-literal-lens).
+            let mut block_ctx: Option<BoundsCtx> = None;
             for stmt in stmts {
-                walk_node(stmt, &block_ctx, source_path, errors);
+                let ctx_ref = block_ctx.as_ref().unwrap_or(ctx);
+                walk_node(stmt, ctx_ref, source_path, errors);
                 if let Node::LetStatement { name, value, .. } = stmt
                     && let Node::ArrayLiteral { items, .. } = value.as_ref()
                 {
-                    block_ctx
-                        .literal_len
-                        .insert(name.clone(), items.len() as i64);
+                    let c = block_ctx.get_or_insert_with(|| ctx.clone());
+                    c.literal_len.insert(name.clone(), items.len() as i64);
                 }
             }
         }


### PR DESCRIPTION
Closes #2342

## Summary

- Switch `Node::Block` arm from unconditional `ctx.clone()` to lazy `Option<BoundsCtx>` with `get_or_insert_with`
- Walker reads via `block_ctx.as_ref().unwrap_or(ctx)` — falls back to parent context until a literal-len let demands mutation
- Drops O(depth) wasted full ctx clones per `check_array_bounds` to O(literal-let-introducing-blocks)

## Why this matters

`BoundsCtx` carries `axioms: Vec<Node>` + `literal_len: HashMap<String, i64>`. Deep-cloning per Block was the dominant cost on programs with index expressions but no literal-array lets — the common case. The new shape only pays the clone when actually needed.

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — 4685 lib tests pass; 0 failed across 39 buckets
- [x] `cargo test --lib bounds_check` — 8 passed (in-bounds / out-of-bounds / dynamic / strict-mode / span-recording)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)