### PR TITLE
RES-2346: epoch_ordering — stream prev instead of allocating Vec<(String, u32)>

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/audit_log_required.rs": {
       "branch": "res-2342-audit-log-short-circuit",
       "claimed_at": "2026-05-20T13:29:31Z"
+    },
+    "resilient/src/epoch_ordering.rs": {
+      "branch": "res-2346-epoch-ordering-stream-prev",
+      "claimed_at": "2026-05-20T13:58:05Z"
     }
   }
 }

--- a/resilient/src/epoch_ordering.rs
+++ b/resilient/src/epoch_ordering.rs
@@ -27,26 +27,32 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // identifier. The previous `any_node` pre-scan was redundant —
     // removed.
     for_each_function(program, |fname, _params, body| {
-        let mut sequence: Vec<(String, u32)> = Vec::new();
+        // RES-2346: stream the previous epoch call instead of
+        // collecting every match into `Vec<(String, u32)>`. The
+        // pairwise check only ever consults the immediately
+        // preceding call (the `windows(2)` loop), so a running
+        // `Option<(&str, u32)>` produces the same diagnostics
+        // without per-call `String::clone` and without the Vec
+        // allocation/second pass. `visit<'a>(…, FnMut(&'a Node))`
+        // (RES-1238) propagates the AST lifetime so `name.as_str()`
+        // is valid across closure invocations.
+        let mut prev: Option<(&str, u32)> = None;
         visit(body, &mut |n| {
-            if let Node::CallExpression { function, .. } = n {
-                if let Node::Identifier { name, .. } = function.as_ref() {
-                    if let Some(e) = epoch_of(name) {
-                        sequence.push((name.clone(), e));
-                    }
+            if let Node::CallExpression { function, .. } = n
+                && let Node::Identifier { name, .. } = function.as_ref()
+                && let Some(e) = epoch_of(name)
+            {
+                if let Some((a, ea)) = prev
+                    && ea > e
+                {
+                    eprintln!(
+                        "warning: in '{fname}', epoch-ordered call '{a}' (epoch {ea}) \
+                         precedes '{name}' (epoch {e}) — epochs must be non-decreasing"
+                    );
                 }
+                prev = Some((name.as_str(), e));
             }
         });
-        for w in sequence.windows(2) {
-            let (a, ea) = &w[0];
-            let (b, eb) = &w[1];
-            if ea > eb {
-                eprintln!(
-                    "warning: in '{fname}', epoch-ordered call '{a}' (epoch {ea}) \
-                     precedes '{b}' (epoch {eb}) — epochs must be non-decreasing"
-                );
-            }
-        }
     });
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Replace per-function `Vec<(String, u32)>` + `windows(2)` shape in `epoch_ordering::check` with a running `Option<(&str, u32)>`.
- Drops the `String::clone` on every `_epoch<N>` call, the Vec allocation, and the second pass over the sequence.

## Why

The pairwise out-of-order check only ever compares against the immediately preceding epoch call. Collecting every match into a heap-allocated Vec (and cloning each callee name into it) was pure overhead — the streaming `Option` produces identical diagnostics at zero allocation in the no-warning case.

`uniqueness_walk::visit<'a>(&'a Node, &mut impl FnMut(&'a Node))` (RES-1238) propagates the AST lifetime to the closure, so the `&'a str` borrow of `Identifier::name` is valid across closure invocations and across the comparison with the previously stored `&str`.

## Mechanism

\`\`\`rust
let mut prev: Option<(&str, u32)> = None;
visit(body, &mut |n| {
    if let Node::CallExpression { function, .. } = n
        && let Node::Identifier { name, .. } = function.as_ref()
        && let Some(e) = epoch_of(name)
    {
        if let Some((a, ea)) = prev && ea > e {
            eprintln!("warning: in '{fname}', epoch-ordered call '{a}' (epoch {ea}) \
                       precedes '{name}' (epoch {e}) — epochs must be non-decreasing");
        }
        prev = Some((name.as_str(), e));
    }
});
\`\`\`

Pre-order traversal is unchanged, so the comparison semantics match.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml` (all green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] Pre-existing `epoch_of_parses_suffix`, `empty_program_returns_ok`, `program_without_epoch_calls_returns_ok` still pass

Closes #2344

🤖 Generated with [Claude Code](https://claude.com/claude-code)