### PR TITLE
RES-2348: toctou_guard — borrow names + args from AST (drop per-call String clones)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/audit_log_required.rs": {
       "branch": "res-2342-audit-log-short-circuit",
       "claimed_at": "2026-05-20T13:29:31Z"
+    },
+    "resilient/src/toctou_guard.rs": {
+      "branch": "res-2348-toctou-guard-borrow-strs",
+      "claimed_at": "2026-05-20T14:06:56Z"
     }
   }
 }

--- a/resilient/src/toctou_guard.rs
+++ b/resilient/src/toctou_guard.rs
@@ -32,28 +32,36 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // `markers.any_call_ident_with_suffix` with the same CHECK_SUFFIXES.
     // The previous `any_node` pre-scan was redundant — removed.
     for_each_function(program, |fname, _params, body| {
-        let mut events: Vec<(bool, String, Option<String>)> = Vec::new();
-        // (is_check, fn_name, first_ident_arg)
+        // RES-2348: borrow callee names and first-arg names/values
+        // directly from the AST instead of cloning into `String`.
+        // `visit<'a>(&'a Node, &mut impl FnMut(&'a Node))` (RES-1238)
+        // threads the AST lifetime through the closure, so
+        // `name.as_str()` / `value.as_str()` are valid for the lifetime
+        // of `body` — i.e., across all closure invocations and the
+        // pair-search loop that follows. Drops two `String::clone`s
+        // per matched call and shrinks each Vec entry from
+        // `(bool, String, Option<String>)` to `(bool, &str, Option<&str>)`.
+        let mut events: Vec<(bool, &str, Option<&str>)> = Vec::new();
+        // (is_check, fn_name, first_ident_or_strlit_arg)
         visit(body, &mut |n| {
             if let Node::CallExpression {
                 function,
                 arguments,
                 ..
             } = n
+                && let Node::Identifier { name, .. } = function.as_ref()
             {
-                if let Node::Identifier { name, .. } = function.as_ref() {
-                    let arg = arguments.first().and_then(|a| match a {
-                        Node::Identifier { name, .. } => Some(name.clone()),
-                        Node::StringLiteral { value, .. } => Some(value.clone()),
-                        _ => None,
-                    });
-                    if CHECK_SUFFIXES.iter().any(|s| name.ends_with(*s)) {
-                        events.push((true, name.clone(), arg));
-                    } else if USE_SUFFIXES.iter().any(|s| name.ends_with(*s))
-                        && !name.starts_with("atomic_")
-                    {
-                        events.push((false, name.clone(), arg));
-                    }
+                let arg = arguments.first().and_then(|a| match a {
+                    Node::Identifier { name, .. } => Some(name.as_str()),
+                    Node::StringLiteral { value, .. } => Some(value.as_str()),
+                    _ => None,
+                });
+                if CHECK_SUFFIXES.iter().any(|s| name.ends_with(*s)) {
+                    events.push((true, name.as_str(), arg));
+                } else if USE_SUFFIXES.iter().any(|s| name.ends_with(*s))
+                    && !name.starts_with("atomic_")
+                {
+                    events.push((false, name.as_str(), arg));
                 }
             }
         });
@@ -62,12 +70,12 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
             if !*is_check {
                 continue;
             }
-            let Some(carg) = carg else { continue };
+            let Some(carg) = *carg else { continue };
             for (is_check2, uname, uarg) in events.iter().skip(i + 1) {
                 if *is_check2 {
                     continue;
                 }
-                if uarg.as_deref() == Some(carg) {
+                if *uarg == Some(carg) {
                     eprintln!(
                         "warning: in '{fname}', TOCTOU: '{cname}({carg})' followed \
                          by '{uname}({carg})' — use atomic_{uname} or wrap both \


### PR DESCRIPTION
## Summary

- Switch `events: Vec<(bool, String, Option<String>)>` to `Vec<(bool, &str, Option<&str>)>` in `toctou_guard::check`.
- Borrow callee names and first-arg names/values directly from the AST instead of cloning per match.

## Why

`uniqueness_walk::visit<'a>(&'a Node, &mut impl FnMut(&'a Node))` (RES-1238) propagates the AST lifetime to the closure. The `&'a str` borrows are valid for the entire per-function pair-search loop, so cloning into `String` was pure overhead — strings never escape and are never mutated.

## Wins

- Drops two `String::clone`s per matched check/use call (callee name + first-arg name/value).
- Shrinks each Vec entry from `(bool, String, Option<String>)` (~48 bytes after padding) to `(bool, &str, Option<&str>)` (~32 bytes).
- Same diagnostic output and same comparison semantics — `*uarg == Some(carg)` is equivalent to the prior `uarg.as_deref() == Some(carg)`.

Same pattern as RES-2346 (epoch_ordering), RES-2340 (ghost_types), RES-2334 (blame_attribution).

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib toctou_guard` (3/3 green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Closes #2346

🤖 Generated with [Claude Code](https://claude.com/claude-code)