### PR TITLE
RES-2352: modules::check — drop dead seen_order, short-circuit identifier walk

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/audit_log_required.rs": {
       "branch": "res-2342-audit-log-short-circuit",
       "claimed_at": "2026-05-20T13:29:31Z"
+    },
+    "resilient/src/modules.rs": {
+      "branch": "res-2352-modules-check-short-circuit",
+      "claimed_at": "2026-05-20T14:26:16Z"
     }
   }
 }

--- a/resilient/src/modules.rs
+++ b/resilient/src/modules.rs
@@ -88,7 +88,6 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // First pass: collect module name → exported item names.
     let mut module_items: std::collections::HashMap<&str, std::collections::HashSet<&str>> =
         std::collections::HashMap::new();
-    let mut seen_order: Vec<&str> = Vec::new();
 
     for s in stmts {
         if let Node::ModuleDecl { name, body, .. } = &s.node {
@@ -100,7 +99,6 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
                     source_path, n
                 ));
             }
-            seen_order.push(n);
             let mut exports: std::collections::HashSet<&str> = std::collections::HashSet::new();
             for item in body {
                 match item {
@@ -124,15 +122,21 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         return Ok(());
     }
 
-    // Second pass: walk all identifier nodes for `mod::item` references.
+    // Second pass: walk identifier nodes for `mod::item` references.
     // The typechecker's "undefined variable" check catches unresolved
-    // identifiers; we only want to surface a *better* message for the case
-    // where the module IS declared but the specific item IS NOT.
+    // identifiers; we only want to surface a *better* message for the
+    // case where the module IS declared but the specific item IS NOT.
+    //
+    // RES-2352: use `any_node` instead of `visit` so the walk
+    // terminates on the first unresolved reference. The previous shape
+    // toggled an `Option<String>` then checked it at the top of the
+    // closure, but `visit` still recurses through every remaining node
+    // — every post-match call paid the dispatch in `walk_children` for
+    // no reason. `any_node` (RES-1238) propagates `true` upward and
+    // short-circuits siblings/aunts/the rest of the tree. Same shape
+    // as RES-2340 (ghost_types) and RES-2342 (audit_log_required).
     let mut unresolved: Option<String> = None;
-    crate::uniqueness_walk::visit(program, &mut |n| {
-        if unresolved.is_some() {
-            return;
-        }
+    crate::uniqueness_walk::any_node(program, |n| {
         if let Node::Identifier { name, .. } = n
             && let Some((mod_name, item_name)) = name.split_once("::")
             && let Some(exports) = module_items.get(mod_name)
@@ -142,6 +146,9 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
                 "{}: error: module `{}` does not export `{}`",
                 source_path, mod_name, item_name
             ));
+            true
+        } else {
+            false
         }
     });
 


### PR DESCRIPTION
## Summary

- Delete dead `seen_order: Vec<&str>` (built but never read).
- Replace `visit` with `any_node` in the second-pass identifier walk so it terminates on the first unresolved `mod::item` reference.

## Why

The previous `visit`-based shape had a `unresolved.is_some()` early-exit at the top of the closure, but `visit` still recursed through every remaining node — the closure became a no-op but `walk_children` dispatch fired for every sibling/aunt/descendant. `any_node` (RES-1238) propagates `true` upward and actually short-circuits the tree walk.

Same first-match semantics (both `visit` and `any_node` use pre-order traversal), same error message, fewer node visits on programs with at least one unresolved reference.

The `seen_order` Vec was orphaned by an earlier refactor — `module_items: HashMap<&str, HashSet<&str>>` already tracks declared modules and is the only consumer of that information.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib modules` (11/11 green incl. duplicate-module + unresolved-item tests)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Same pattern as RES-2340 (ghost_types), RES-2342 (audit_log_required).

Closes #2350

🤖 Generated with [Claude Code](https://claude.com/claude-code)