### PR TITLE
RES-2354: recovery_checker — borrow extern names + current_fn from AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/audit_log_required.rs": {
       "branch": "res-2342-audit-log-short-circuit",
       "claimed_at": "2026-05-20T13:29:31Z"
+    },
+    "resilient/src/recovery_checker.rs": {
+      "branch": "res-2354-recovery-checker-borrow",
+      "claimed_at": "2026-05-20T14:29:24Z"
     }
   }
 }

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -22,12 +22,19 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     Ok(())
 }
 
-struct Context {
-    extern_fns: HashSet<String>,
-    current_fn: Option<String>,
+// RES-2354: borrow extern fn names and the current-fn name from the
+// AST instead of cloning them per declaration/visit. `HashSet<&'a str>`
+// works for membership lookup the same as `HashSet<String>` did (both
+// answer `contains(&str)`), and `Option<&'a str>` lets the equality
+// check + warning eprintln consume the borrow directly. Drops one
+// `String::clone` per extern decl and one per function visit — both
+// are on the hot path for programs with many `live { … }` blocks.
+struct Context<'a> {
+    extern_fns: HashSet<&'a str>,
+    current_fn: Option<&'a str>,
 }
 
-impl Context {
+impl<'a> Context<'a> {
     fn new() -> Self {
         Context {
             extern_fns: HashSet::new(),
@@ -35,7 +42,7 @@ impl Context {
         }
     }
 
-    fn collect_declarations(&mut self, program: &Node) {
+    fn collect_declarations(&mut self, program: &'a Node) {
         let Node::Program(statements) = program else {
             return;
         };
@@ -54,13 +61,13 @@ impl Context {
         for stmt in statements {
             if let Node::Extern { decls, .. } = &stmt.node {
                 for decl in decls {
-                    self.extern_fns.insert(decl.resilient_name.clone());
+                    self.extern_fns.insert(decl.resilient_name.as_str());
                 }
             }
         }
     }
 
-    fn check_live_blocks(&mut self, program: &Node) {
+    fn check_live_blocks(&mut self, program: &'a Node) {
         let Node::Program(statements) = program else {
             return;
         };
@@ -69,11 +76,11 @@ impl Context {
         }
     }
 
-    fn walk_for_live_blocks(&mut self, node: &Node) {
+    fn walk_for_live_blocks(&mut self, node: &'a Node) {
         match node {
             Node::Function { name, body, .. } => {
                 let prev_fn = self.current_fn.take();
-                self.current_fn = Some(name.clone());
+                self.current_fn = Some(name.as_str());
                 self.walk_for_live_blocks(body);
                 self.current_fn = prev_fn;
             }
@@ -137,7 +144,7 @@ impl Context {
                             cannot be modeled as TLA+ action",
                             fn_name
                         );
-                    } else if let Some(current) = self.current_fn.as_deref()
+                    } else if let Some(current) = self.current_fn
                         && fn_name == current
                     {
                         eprintln!(


### PR DESCRIPTION
## Summary

- Parameterise `Context` with the AST lifetime.
- Switch `extern_fns: HashSet<String>` → `HashSet<&'a str>` and `current_fn: Option<String>` → `Option<&'a str>`.

## Why

`recovery_checker::Context` cloned identifier bytes out of the AST for two fields that only ever support equality / membership lookups against `&str`:

- `self.extern_fns.contains(fn_name)` where `fn_name: &str` — `HashSet<&str>` and `HashSet<String>` answer this identically (`&str: Borrow<str>`).
- `if let Some(current) = self.current_fn.as_deref() && fn_name == current` — pure `&str` comparison.

The clones never escape `check`, so owning the strings was waste.

## Wins

- Drops `decl.resilient_name.clone()` per extern declaration.
- Drops `name.clone()` per `Node::Function` visit (hot path — every function in the program is walked once).
- Shrinks `Context` size: HashSet entry 24B → 16B, `Option<String>` 24B → `Option<&str>` 16B.

## Mechanism

`collect_declarations(&mut self, program: &'a Node)` and `walk_for_live_blocks(&mut self, node: &'a Node)` thread the AST lifetime; `check_node` doesn't store any borrows so it keeps its elided lifetime.

`current_fn`'s only consumer used `Option::as_deref()` to coerce `Option<String>` to `Option<&str>`. With the new type that's the identity coercion, so removed (clippy: `needless_option_as_deref`).

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib recovery_checker` (4/4 green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Same pattern as RES-2348 (toctou_guard), RES-2334 (blame_attribution).

Closes #2352

🤖 Generated with [Claude Code](https://claude.com/claude-code)