### PR TITLE
RES-2356: dce — replace O(n²) old-pc lookup with parallel new_to_old vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/audit_log_required.rs": {
       "branch": "res-2342-audit-log-short-circuit",
       "claimed_at": "2026-05-20T13:29:31Z"
+    },
+    "resilient/src/dce.rs": {
+      "branch": "res-2356-dce-relink-on-square",
+      "claimed_at": "2026-05-20T14:35:57Z"
     }
   }
 }

--- a/resilient/src/dce.rs
+++ b/resilient/src/dce.rs
@@ -88,6 +88,11 @@ fn remove_unreachable(chunk: &mut Chunk) {
     let mut old_to_new = vec![usize::MAX; n + 1];
     let mut new_code: Vec<Op> = Vec::with_capacity(n);
     let mut new_line_info: Vec<u32> = Vec::with_capacity(n);
+    // RES-2356: parallel `new_to_old[new_pc] = old_pc` lookup avoids
+    // the O(n) `(0..n).find(...)` per surviving jump in the relink
+    // pass. Building it during compaction is free; the lookup is
+    // then O(1).
+    let mut new_to_old: Vec<usize> = Vec::with_capacity(n);
 
     // Capture jump targets from original offsets BEFORE we mutate.
     let orig_targets: Vec<Option<usize>> = chunk
@@ -100,6 +105,7 @@ fn remove_unreachable(chunk: &mut Chunk) {
     for (pc, &op) in chunk.code.iter().enumerate() {
         if reachable[pc] {
             old_to_new[pc] = new_code.len();
+            new_to_old.push(pc);
             new_code.push(op);
             new_line_info.push(chunk.line_info[pc]);
         }
@@ -112,10 +118,9 @@ fn remove_unreachable(chunk: &mut Chunk) {
         if !is_jump_op(*op) {
             continue;
         }
-        // Find the old PC that produced this new_pc position.
-        let Some(old_pc) = (0..n).find(|&p| old_to_new[p] == new_pc) else {
-            continue;
-        };
+        // RES-2356: O(1) parallel-vec lookup replaces the prior
+        // `(0..n).find(|&p| old_to_new[p] == new_pc)` linear scan.
+        let old_pc = new_to_old[new_pc];
         let Some(old_target) = orig_targets[old_pc] else {
             continue;
         };
@@ -233,6 +238,14 @@ fn fold_constant_branches(chunk: &mut Chunk) {
     let mut old_to_new: Vec<usize> = vec![usize::MAX; chunk.code.len() + 1];
     // For folded Const+cond-jump → Jump replacements: (new_pc, orig_abs_target).
     let mut replacement_jumps: Vec<(usize, usize)> = Vec::new();
+    // RES-2356: parallel `new_to_old[new_pc] = old_pc` table avoids
+    // the O(n) `(0..chunk.code.len()).find(...)` per surviving jump
+    // in the relink pass. For RemoveBoth we push nothing; for
+    // ReplaceWithJump we push the Const's old_pc (the relink path
+    // skips replacement-Jump entries via the `replacement_jumps`
+    // check above and re-targets them through `replacement_jumps`
+    // below).
+    let mut new_to_old: Vec<usize> = Vec::with_capacity(chunk.code.len());
     // RES-1415: track whether any fold fired so the jump-fixup pass
     // (O(jumps × code.len()) per the post-pass linear scan below)
     // can be skipped when no Const+cond-jump pair matched. Mirrors
@@ -260,6 +273,7 @@ fn fold_constant_branches(chunk: &mut Chunk) {
                     let new_pc = new_code.len();
                     new_code.push(Op::Jump(0));
                     new_line_info.push(chunk.line_info[i]);
+                    new_to_old.push(i);
                     replacement_jumps.push((new_pc, old_target_pc));
                     old_to_new[i + 1] = new_code.len(); // second op is dropped
                     folded_any = true;
@@ -272,6 +286,7 @@ fn fold_constant_branches(chunk: &mut Chunk) {
         // No fold — copy verbatim.
         new_code.push(chunk.code[i]);
         new_line_info.push(chunk.line_info[i]);
+        new_to_old.push(i);
         i += 1;
     }
     // Sentinel: end-of-code target.
@@ -296,10 +311,10 @@ fn fold_constant_branches(chunk: &mut Chunk) {
         if replacement_jumps.iter().any(|(rp, _)| *rp == new_pc) {
             continue;
         }
-        // Find the originating old PC by scanning old_to_new.
-        let Some(old_pc) = (0..chunk.code.len()).find(|&p| old_to_new[p] == new_pc) else {
-            continue;
-        };
+        // RES-2356: O(1) parallel-vec lookup replaces the prior
+        // `(0..chunk.code.len()).find(|&p| old_to_new[p] == new_pc)`
+        // linear scan.
+        let old_pc = new_to_old[new_pc];
         let Some(old_target) = orig_targets[old_pc] else {
             continue;
         };


### PR DESCRIPTION
## Summary

- Replace `(0..n).find(|&p| old_to_new[p] == new_pc)` linear scans in both `remove_unreachable` and `fold_constant_branches` with a precomputed `new_to_old: Vec<usize>`.
- O(j × n) → O(j + n) per DCE invocation (j = jumps, n = chunk size).

## Why

The relink pass walks `new_code` and, for each surviving jump op, needs to know the original PC. The previous shape recomputed that via a linear scan of `old_to_new`. But the information is already available during the compaction loop — when we push to `new_code`, we know the originating old `pc`.

Tracking a parallel `new_to_old: Vec<usize>` makes the lookup an array index.

## Wins

- Removes the quadratic relink term from both DCE rules.
- DCE runs per compiled function (`compiler.rs:248`) plus once for `main` (`compiler.rs:309`). On programs with many functions / many jumps per function, this dominates relink cost.
- No behavior change — `new_to_old[new_pc]` returns exactly what the `find` returned before.

## Mechanism

`remove_unreachable`:
- Push `pc` to `new_to_old` alongside `new_code.push(op)` inside the reachability loop.
- Relink: `let old_pc = new_to_old[new_pc];` replaces the `find`.

`fold_constant_branches`:
- Push `i` (the originating old PC) to `new_to_old` on both the verbatim-copy and `ReplaceWithJump` branches. The `RemoveBoth` branch pushes nothing (no new_code entry).
- For `ReplaceWithJump` entries, the entry maps back to the Const's old_pc — but the relink pass skips these entries via the existing `replacement_jumps.iter().any(...)` filter and re-targets them through `replacement_jumps` separately, so the back-pointer is unused for those slots. Kept consistent so the parallel-vec invariant `new_to_old.len() == new_code.len()` holds.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib dce` (12/12 green — reachability + constant-branch fold + line-info sync tests)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Closes #2354

🤖 Generated with [Claude Code](https://claude.com/claude-code)