### PR TITLE
RES-2358: enum_exhaustiveness — push into errors directly, drop nested Vec

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/audit_log_required.rs": {
       "branch": "res-2342-audit-log-short-circuit",
       "claimed_at": "2026-05-20T13:29:31Z"
+    },
+    "resilient/src/enum_exhaustiveness.rs": {
+      "branch": "res-2358-enum-exhaustiveness-drop-nested",
+      "claimed_at": "2026-05-20T14:42:30Z"
     }
   }
 }

--- a/resilient/src/enum_exhaustiveness.rs
+++ b/resilient/src/enum_exhaustiveness.rs
@@ -153,11 +153,13 @@ fn walk(
             errors.push(e);
         }
     }
-    // Recurse into children via uniqueness_walk. The closure captures
-    // `errors` by reference, but uniqueness_walk's visitor signature
-    // takes `&mut dyn FnMut(&Node)`, so we collect errors into a
-    // separate Vec and extend after the visit.
-    let mut nested: Vec<ExhaustivenessError> = Vec::new();
+    // Recurse into children via uniqueness_walk. The closure pushes
+    // directly into `errors` — `visit`'s actual signature is
+    // `fn visit<'a>(&'a Node, &mut impl FnMut(&'a Node))` (generic,
+    // not a trait object), so capturing `&mut errors` is fine.
+    // RES-2358: replaced a stale `let mut nested = Vec::new(); …
+    // errors.extend(nested);` workaround that dropped one Vec
+    // allocation + extend memcpy per walk call.
     crate::uniqueness_walk::visit(node, &mut |n| {
         // Skip Function nodes — they will be handled by the outer walk
         // call in analyze() with the correct context name. Processing them
@@ -167,11 +169,10 @@ fn walk(
         }
         if let Node::Match { arms, .. } = n {
             if let Some(e) = check_match(arms, enum_map, context) {
-                nested.push(e);
+                errors.push(e);
             }
         }
     });
-    errors.extend(nested);
 }
 
 /// Analyze the program for non-exhaustive enum matches. Returns one


### PR DESCRIPTION
## Summary

- Drop the local `nested: Vec<ExhaustivenessError>` workaround in `enum_exhaustiveness::walk`.
- Push directly into the outer `errors` Vec from inside the `visit` closure.

## Why

The previous shape's justification (\"uniqueness_walk's visitor signature takes `&mut dyn FnMut(&Node)`\") is stale — the actual signature is `fn visit<'a>(node: &'a Node, f: &mut impl FnMut(&'a Node))`. `impl FnMut` is a generic, not a trait object, so capturing `&mut errors` in the closure compiles fine.

Same first-match semantics, no behavior change.

## Wins

- Drops per-`walk`-call `Vec::new()` allocation when errors are found.
- Drops the `errors.extend(nested)` memcpy.
- Brings the file in line with the visit-with-capture pattern used in info_flow, ghost_types, audit_log_required.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib enum_exhaustiveness` (8/8 green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Closes #2356

🤖 Generated with [Claude Code](https://claude.com/claude-code)