### PR TITLE
RES-2360: isr_call_graph — borrow callee names into HashSet<&'a str>

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -340,10 +340,6 @@
       "branch": "res-1962-reentrancy-rate-limit-presize",
       "claimed_at": "2026-05-19T18:59:39Z"
     },
-    "resilient/src/isr_call_graph.rs": {
-      "branch": "res-1966-isr-bfs-reuse",
-      "claimed_at": "2026-05-19T19:06:11Z"
-    },
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
       "claimed_at": "2026-05-19T22:27:31Z"
@@ -467,6 +463,10 @@
     "resilient/src/epoch_ordering.rs": {
       "branch": "res-2346-epoch-ordering-stream-prev",
       "claimed_at": "2026-05-20T13:58:05Z"
+    },
+    "resilient/src/isr_call_graph.rs": {
+      "branch": "res-2360-isr-call-graph-borrow",
+      "claimed_at": "2026-05-20T14:47:02Z"
     }
   }
 }

--- a/resilient/src/isr_call_graph.rs
+++ b/resilient/src/isr_call_graph.rs
@@ -63,15 +63,16 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     if !has_isr {
         return Ok(());
     }
-    // RES-1509: borrow each top-level fn name as `&str` from the
-    // AST instead of cloning into the `callees` HashMap key and
-    // `isr_roots` Vec. `collect_callees` inside the visit closure
-    // still produces owned Strings (HRTB closure can't bind the
-    // outer `'a`), but the *outer* map keys and root list don't
-    // need ownership — same pattern as RES-1495 / RES-1500 etc.
+    // RES-1509 / RES-2360: borrow each top-level fn name AND each
+    // collected callee as `&str` from the AST. Previously
+    // `collect_callees` returned `HashSet<String>` cloning every
+    // callee name; the comment claimed the HRTB closure couldn't
+    // bind the outer `'a`, but `visit<'a>(&'a Node, &mut impl
+    // FnMut(&'a Node))` does propagate the AST lifetime through
+    // the closure parameter, so the borrow is sound.
     // RES-1744: pre-size the call-graph map to stmts.len() (upper
     // bound). Same shape as RES-1742 for reentrancy_guard.
-    let mut callees: HashMap<&str, HashSet<String>> = HashMap::with_capacity(stmts.len());
+    let mut callees: HashMap<&str, HashSet<&str>> = HashMap::with_capacity(stmts.len());
     // RES-1966: pre-size to 4 — typical ISR count is 1-5.
     let mut isr_roots: Vec<&str> = Vec::with_capacity(4);
     for stmt in stmts {
@@ -104,14 +105,14 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
                 continue;
             }
             if let Some(cs) = callees.get(fname) {
-                for c in cs {
+                for &c in cs {
                     if is_isr_unsafe_call(c) {
                         eprintln!(
                             "warning: ISR '{root}' transitively calls ISR-hostile '{c}' \
                              via '{fname}' — interrupt context must not block or allocate"
                         );
                     }
-                    q.push_back(c.as_str());
+                    q.push_back(c);
                 }
             }
         }
@@ -128,14 +129,19 @@ fn is_isr_unsafe_call(name: &str) -> bool {
     UNSAFE_PRIMS.contains(&name) || UNSAFE_NAME_SUFFIXES.iter().any(|s| name.ends_with(*s))
 }
 
-fn collect_callees(body: &Node) -> HashSet<String> {
+fn collect_callees(body: &Node) -> HashSet<&str> {
     // RES-1966: pre-size to 8 — typical fn bodies have 1-10 call
     // sites.
+    // RES-2360: borrow the callee identifier name from the AST
+    // (`name.as_str()`) instead of cloning into a `String`.
+    // `visit<'a>(&'a Node, &mut impl FnMut(&'a Node))` propagates
+    // the AST lifetime to the closure, so the `&'a str` borrow is
+    // valid for the lifetime of `body`.
     let mut out = HashSet::with_capacity(8);
     visit(body, &mut |n| {
         if let Node::CallExpression { function, .. } = n {
             if let Node::Identifier { name, .. } = function.as_ref() {
-                out.insert(name.clone());
+                out.insert(name.as_str());
             }
         }
     });


### PR DESCRIPTION
## Summary

- Switch `collect_callees` return type from `HashSet<String>` to `HashSet<&'a str>`.
- Switch outer `callees: HashMap<&str, HashSet<String>>` to `HashMap<&str, HashSet<&str>>`.
- Drops one `String::clone` per CallExpression visited during the call-graph build.

## Why

The historical comment in `check` (\"`collect_callees` inside the visit closure still produces owned Strings (HRTB closure can't bind the outer 'a)\") is misleading — `uniqueness_walk::visit<'a>(&'a Node, &mut impl FnMut(&'a Node))` propagates the AST lifetime through the closure parameter. The clone-per-call-site was incremental scope, not a borrow-checker limitation.

For programs that contain at least one `_isr` / `_irq`-named function (i.e., embedded firmware — the actual target audience for this pass), `collect_callees` runs once per top-level fn body. On typical codebases, the clone savings compound across hundreds of call sites.

## Mechanism

\`\`\`rust
fn collect_callees(body: &Node) -> HashSet<&str> {
    let mut out = HashSet::with_capacity(8);
    visit(body, &mut |n| {
        if let Node::CallExpression { function, .. } = n {
            if let Node::Identifier { name, .. } = function.as_ref() {
                out.insert(name.as_str());   // &'a str, was name.clone() → String
            }
        }
    });
    out
}
\`\`\`

BFS body shifts one line: `for c in cs { ... q.push_back(c.as_str()); }` becomes `for &c in cs { ... q.push_back(c); }` because iterating `HashSet<&'a str>` yields `&&'a str`.

## Wins

- ~1 `String::clone` saved per call site, per fn body, per compile pass.
- `HashSet` entry shrinks from `String` (24B header) to `&str` (16B).
- Same BFS traversal order, same diagnostic output.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib isr_call_graph` (2/2 green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Same pattern as RES-2354 (recovery_checker), RES-2348 (toctou_guard), RES-2334 (blame_attribution).

Closes #2358

🤖 Generated with [Claude Code](https://claude.com/claude-code)