### PR TITLE
RES-2364: degraded_mode — switch marker gate to call_ident_with_prefix, drop redundant any_node

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -48,10 +48,6 @@
       "branch": "res-1248-playground-rust-cache",
       "claimed_at": "2026-05-12T03:10:39Z"
     },
-    "resilient/src/degraded_mode.rs": {
-      "branch": "res-1252-degraded-mode-fast-reject",
-      "claimed_at": "2026-05-12T03:27:30Z"
-    },
     "resilient/src/secret_erasure.rs": {
       "branch": "res-1256-secret-erasure-fast-reject",
       "claimed_at": "2026-05-12T03:39:06Z"
@@ -215,10 +211,6 @@
     "resilient/src/monomorph.rs": {
       "branch": "res-1924-monomorph-presize",
       "claimed_at": "2026-05-19T17:31:00Z"
-    },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-1766-typechecker-hot-presize",
-      "claimed_at": "2026-05-13T11:55:37Z"
     },
     "resilient/src/supervisor.rs": {
       "branch": "res-1770-verifier-presize",
@@ -467,6 +459,14 @@
     "resilient/src/epoch_ordering.rs": {
       "branch": "res-2346-epoch-ordering-stream-prev",
       "claimed_at": "2026-05-20T13:58:05Z"
+    },
+    "resilient/src/degraded_mode.rs": {
+      "branch": "res-2364-degraded-mode-marker-gate",
+      "claimed_at": "2026-05-20T15:00:34Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-2364-degraded-mode-marker-gate",
+      "claimed_at": "2026-05-20T15:00:34Z"
     }
   }
 }

--- a/resilient/src/degraded_mode.rs
+++ b/resilient/src/degraded_mode.rs
@@ -23,36 +23,18 @@
 )]
 
 use crate::Node;
-use crate::uniqueness_walk::{any_node, for_each_function};
+use crate::uniqueness_walk::for_each_function;
 
 const CRITICAL_PREFIXES: &[&str] = &["assert_critical_", "abort_", "halt_"];
 const RECOVERY_PREFIXES: &[&str] = &["degraded_", "safe_mode_", "recover_"];
 
 pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1252: fast-reject. `scan_blocks` recursively visits every
-    // block in every function and runs `any_node` per statement just
-    // to find a `CRITICAL_PREFIXES`-named call. For programs that
-    // declare no `assert_critical_*` / `abort_*` / `halt_*` call (the
-    // overwhelming majority of `cargo test` inputs and the entire
-    // `examples/` tree), the entire triple loop produces nothing.
-    //
-    // Pre-scan the whole program once via `any_node` (RES-1238
-    // already made this early-terminating). If no critical call
-    // exists anywhere in the AST, the pass returns `Ok(())`
-    // immediately — strictly cheaper than the existing
-    // `for_each_function → scan_blocks(recursive) → per-stmt
-    // any_node` triple loop on the same input. If any critical call
-    // exists, the existing `scan_blocks` path runs unchanged.
-    let has_critical = any_node(program, |n| match n {
-        Node::CallExpression { function, .. } => match function.as_ref() {
-            Node::Identifier { name, .. } => CRITICAL_PREFIXES.iter().any(|p| name.starts_with(*p)),
-            _ => false,
-        },
-        _ => false,
-    });
-    if !has_critical {
-        return Ok(());
-    }
+    // RES-1252 / RES-2364: the typechecker gates this call behind
+    // `markers.any_call_ident_with_prefix(CRITICAL_PREFIXES)`, so
+    // the program is guaranteed to contain at least one
+    // `CallExpression` whose callee has a CRITICAL prefix. The
+    // previous internal `any_node` pre-scan was redundant — removed
+    // along with the `any_node` import.
     for_each_function(program, |fname, _params, body| {
         scan_blocks(fname, body);
     });

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4904,10 +4904,16 @@ impl TypeChecker {
                     crate::audit_log_required::check(program, source_path)?;
                 }
                 // Ralph-Loop-Uniqueness #20: degraded mode after critical assert.
-                // RES-1585 gate: pass scans fn names with CRITICAL_PREFIXES
-                // (and RECOVERY_PREFIXES are looked up only when CRITICAL
-                // matches at least once, so the same gate covers both).
-                if markers.any_fn_name_with_prefix(&["assert_critical_", "abort_", "halt_"]) {
+                // RES-1585 / RES-2364 gate: the pass scans
+                // CallExpression callees (not function declarations)
+                // for CRITICAL_PREFIXES. The previous
+                // `any_fn_name_with_prefix` gate fired on
+                // declarations only, which both over-triggered
+                // (declared-but-uncalled helpers entered the pass)
+                // and under-triggered (calls to externally-declared
+                // critical fns were missed). `any_call_ident_with_prefix`
+                // matches the pass's actual trigger condition exactly.
+                if markers.any_call_ident_with_prefix(&["assert_critical_", "abort_", "halt_"]) {
                     crate::degraded_mode::check(program, source_path)?;
                 }
                 // Ralph-Loop-Uniqueness #21: crash-only modules.


### PR DESCRIPTION
## Summary

- Switch typechecker EXTENSION_PASSES gate for `degraded_mode::check` from `any_fn_name_with_prefix` to `any_call_ident_with_prefix`.
- Drop the now-redundant internal `any_node` pre-scan and `any_node` import.

## Why

`degraded_mode`'s internal `calls_critical` helper scans `Node::CallExpression` callees, not function declarations. The previous gate was:

1. **Over-triggering**: programs declaring `fn assert_critical_X()` but never calling it entered the pass only to no-op via the internal `any_node` pre-scan.
2. **Under-triggering**: programs calling externally-declared critical helpers (extern / imported) were missed entirely — the pass should run but was skipped (a latent correctness gap).

`Markers::any_call_ident_with_prefix` (pass_gate.rs:422) reads the `call_idents` set already populated by `Markers::scan`. This is exactly the condition the pass checks for.

## Wins

- **Correctness fix**: external critical-call sites now correctly trigger the pass.
- **Tighter gate**: programs with declared-but-uncalled critical helpers skip entirely.
- **One whole-AST walk removed** from the pass entry — the marker is O(1) over `call_idents`.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib degraded_mode` (3/3 green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Same pattern as RES-2362 (`monotonic_field`), RES-2342 (`audit_log_required`).

Closes #2362

🤖 Generated with [Claude Code](https://claude.com/claude-code)