### PR TITLE
RES-2366: async_await + recursive_types — skip HashSet clone in is_X lookup

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -467,6 +467,14 @@
     "resilient/src/epoch_ordering.rs": {
       "branch": "res-2346-epoch-ordering-stream-prev",
       "claimed_at": "2026-05-20T13:58:05Z"
+    },
+    "resilient/src/async_await.rs": {
+      "branch": "res-2366-is-x-rwlock-no-clone",
+      "claimed_at": "2026-05-20T15:16:39Z"
+    },
+    "resilient/src/recursive_types.rs": {
+      "branch": "res-2366-is-x-rwlock-no-clone",
+      "claimed_at": "2026-05-20T15:16:39Z"
     }
   }
 }

--- a/resilient/src/async_await.rs
+++ b/resilient/src/async_await.rs
@@ -36,11 +36,16 @@ pub fn install(set: HashSet<String>) {
 }
 
 pub fn is_async(name: &str) -> bool {
+    // RES-2366: hold the read guard and borrow through the
+    // `Option<HashSet<String>>` instead of cloning the whole set per
+    // lookup. `HashSet::contains` accepts a `&str` via `Borrow<str>`
+    // on `String` keys; the previous `g.clone()` materialized an
+    // owned copy of every entry for nothing. Same lock-then-borrow
+    // shape as RES-1544 / RES-1547 / RES-2006.
     ASYNC_FNS
         .read()
         .ok()
-        .and_then(|g| g.clone())
-        .map(|s| s.contains(name))
+        .and_then(|g| g.as_ref().map(|s| s.contains(name)))
         .unwrap_or(false)
 }
 

--- a/resilient/src/recursive_types.rs
+++ b/resilient/src/recursive_types.rs
@@ -30,11 +30,17 @@ pub fn install(set: HashSet<String>) {
 }
 
 pub fn is_recursive(type_name: &str) -> bool {
+    // RES-2366: hold the read guard and borrow through the
+    // `Option<HashSet<String>>` instead of cloning the whole set per
+    // lookup. The previous `g.clone()` materialized an owned copy of
+    // every entry just to call `.contains()` on it; `HashSet::contains`
+    // accepts a `&str` via `Borrow<str>` on `String` keys, so the
+    // clone was pure overhead. Same lock-then-borrow shape as
+    // RES-1544 / RES-1547 / RES-2006.
     RECURSIVE_TYPES
         .read()
         .ok()
-        .and_then(|g| g.clone())
-        .map(|s| s.contains(type_name))
+        .and_then(|g| g.as_ref().map(|s| s.contains(type_name)))
         .unwrap_or(false)
 }
 


### PR DESCRIPTION
## Summary

- Replace `.and_then(|g| g.clone()).map(|s| s.contains(name))` with `.and_then(|g| g.as_ref().map(|s| s.contains(name)))` in `async_await::is_async` and `recursive_types::is_recursive`.
- Drops the per-lookup `HashSet` clone (N `String` clones for N registered entries).

## Why

Both `is_X` functions held an `RwLock<Option<HashSet<String>>>`, took the read guard, then cloned the entire `Option<HashSet<String>>` just to call `.contains()`. The clone was pure overhead — `HashSet::contains` accepts `&str` via `Borrow<str>` on `String` keys, so the guard's borrow already suffices.

`iterator_protocol::is_iterator` already uses the borrow-through-guard shape (it holds a bare `HashSet` not wrapped in `Option`, but the pattern is identical).

## Mechanism

`g.as_ref()` auto-derefs through `RwLockReadGuard<'_, Option<HashSet<String>>>` to call `Option::as_ref(&Option<HashSet>)`, yielding `Option<&HashSet<String>>`. The bool result is extracted before the guard drops — no escaping borrow.

## Wins

- Drops N `String::clone` per `is_async` / `is_recursive` call.
- Drops the per-call `HashSet` allocation.
- Same return value, same lock semantics.

Same lock-then-borrow shape as RES-1544 / RES-1547 / RES-2006.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib 'async_await::'` (2/2 green)
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib 'recursive_types::'` (5/5 green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Closes #2364

🤖 Generated with [Claude Code](https://claude.com/claude-code)