### PR TITLE
RES-2380: verifier_actors render_clause — direct-write into &mut String

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -252,10 +252,6 @@
       "branch": "res-1802-traits-presize",
       "claimed_at": "2026-05-13T13:02:04Z"
     },
-    "resilient/src/verifier_actors.rs": {
-      "branch": "res-1808-flatten-body-presize",
-      "claimed_at": "2026-05-13T13:17:34Z"
-    },
     "resilient/src/format_builtin.rs": {
       "branch": "res-1816-format-template-fast-reject",
       "claimed_at": "2026-05-13T13:34:15Z"
@@ -455,6 +451,10 @@
     "resilient/src/semantic_regression.rs": {
       "branch": "res-2372-semantic-regression-borrow-guard",
       "claimed_at": "2026-05-20T15:31:40Z"
+    },
+    "resilient/src/verifier_actors.rs": {
+      "branch": "res-2380-verifier-actors-render-direct",
+      "claimed_at": "2026-05-20T15:58:41Z"
     }
   }
 }

--- a/resilient/src/verifier_actors.rs
+++ b/resilient/src/verifier_actors.rs
@@ -387,38 +387,66 @@ fn prove_or_unsupported(_expr: &Node, _timeout_ms: u32) -> ActorProofResult {
 /// full pretty-printer lives in `formatter.rs`; this is the minimum
 /// needed so users can distinguish which invariant a verdict is about.
 fn render_clause(node: &Node) -> String {
+    // RES-2380: pre-allocate one buffer and recurse via `render_into`
+    // so nested expressions write directly into the same `String`.
+    // The previous shape allocated a fresh `String` per recursive call
+    // and joined them via `format!` — for an obligation of depth D
+    // the parent calls re-copied all the child text, costing
+    // O(D × total_text). The buffer reuse drops it to O(total_text).
+    // Same direct-write shape as RES-2322 / RES-2330 / RES-2270 /
+    // RES-2262.
+    let mut out = String::with_capacity(64);
+    render_into(node, &mut out);
+    out
+}
+
+fn render_into(node: &Node, out: &mut String) {
+    use std::fmt::Write as _;
     match node {
         Node::InfixExpression {
             left,
             operator,
             right,
             ..
-        } => format!(
-            "{} {} {}",
-            render_clause(left),
-            operator,
-            render_clause(right)
-        ),
+        } => {
+            render_into(left, out);
+            let _ = write!(out, " {} ", operator);
+            render_into(right, out);
+        }
         Node::PrefixExpression {
             operator, right, ..
         } => {
-            format!("{}{}", operator, render_clause(right))
+            out.push_str(operator);
+            render_into(right, out);
         }
-        Node::Identifier { name, .. } => name.clone(),
-        Node::IntegerLiteral { value, .. } => value.to_string(),
-        Node::BooleanLiteral { value, .. } => value.to_string(),
+        Node::Identifier { name, .. } => out.push_str(name),
+        Node::IntegerLiteral { value, .. } => {
+            let _ = write!(out, "{}", value);
+        }
+        Node::BooleanLiteral { value, .. } => {
+            let _ = write!(out, "{}", value);
+        }
         Node::FieldAccess { target, field, .. } => {
-            format!("{}.{}", render_clause(target), field)
+            render_into(target, out);
+            out.push('.');
+            out.push_str(field);
         }
         Node::CallExpression {
             function,
             arguments,
             ..
         } => {
-            let args: Vec<String> = arguments.iter().map(render_clause).collect();
-            format!("{}({})", render_clause(function), args.join(", "))
+            render_into(function, out);
+            out.push('(');
+            for (i, a) in arguments.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                render_into(a, out);
+            }
+            out.push(')');
         }
-        _ => "<expr>".to_string(),
+        _ => out.push_str("<expr>"),
     }
 }
 


### PR DESCRIPTION
## Summary

- Add an inner `render_into(node, out: &mut String)` so nested-expression rendering writes into one buffer instead of allocating per recursive call.
- Drops O(D × total_text) intermediates → O(total_text) per `render_clause` call.

## Why

`render_clause` is invoked per `always` clause per actor per Z3 verification round. The previous recursive `format!` shape allocated a fresh String per call and re-copied child text up the call stack. For deeply nested invariants (`state.field == K + offset + delta`-style obligations), depth-D work scaled quadratically with text length.

## Mechanism

\`\`\`rust
fn render_clause(node: &Node) -> String {
    let mut out = String::with_capacity(64);
    render_into(node, &mut out);
    out
}

fn render_into(node: &Node, out: &mut String) {
    use std::fmt::Write as _;
    match node {
        Node::InfixExpression { left, operator, right, .. } => {
            render_into(left, out);
            let _ = write!(out, " {} ", operator);
            render_into(right, out);
        }
        Node::CallExpression { function, arguments, .. } => {
            render_into(function, out);
            out.push('(');
            for (i, a) in arguments.iter().enumerate() {
                if i > 0 { out.push_str(", "); }
                render_into(a, out);
            }
            out.push(')');
        }
        // …
    }
}
\`\`\`

Same direct-write shape as RES-2322 (`repl::contracts_output`), RES-2330 (`ai_threat_model::report`), RES-2270 (`fingerprint::node_text`), RES-2262 (`lexer_unicode`).

## Wins

- O(D × total_text) → O(total_text) for the rendering phase.
- Zero String allocations on the recursive descent (only the outer buffer).
- Same output text — `render_clause_produces_readable_infix` pins the format and still passes.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib 'verifier_actors::'` (7/7 green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Closes #2378

🤖 Generated with [Claude Code](https://claude.com/claude-code)