### PR TITLE
RES-2388: stack_contracts — drop dead StackSpec::fn_name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -124,10 +124,6 @@
       "branch": "res-2190-wcet-contracts-drop-fn-name",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/stack_contracts.rs": {
-      "branch": "res-1784-attr-collects-3",
-      "claimed_at": "2026-05-13T12:28:38Z"
-    },
     "resilient/src/intent_blocks.rs": {
       "branch": "res-1994-intent-blocks-drop-fnames",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -459,6 +455,10 @@
     "resilient/src/bytecode.rs": {
       "branch": "res-2378-bytecode-constant-pool-index",
       "claimed_at": "2026-05-20T15:51:09Z"
+    },
+    "resilient/src/stack_contracts.rs": {
+      "branch": "res-2388-stack-contracts-drop-fn-name",
+      "claimed_at": "2026-05-20T16:15:32Z"
     }
   }
 }

--- a/resilient/src/stack_contracts.rs
+++ b/resilient/src/stack_contracts.rs
@@ -10,15 +10,22 @@
 use crate::Node;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+/// RES-2388: dropped the redundant `fn_name: String` field. The two
+/// readers in `check` (`bodies.get(spec.fn_name.as_str())` lookup +
+/// the budget-exceeded error format) used it strictly as a name tied
+/// to the attribute owner. The field stored exactly what the
+/// attribute key encoded. Pipeline now carries `(String, StackSpec)`
+/// tuples from `collect()` to `check()`, matching the shape that
+/// `wcet_contracts` (RES-2190), `probabilistic_contracts` (RES-2170),
+/// and `power_contracts` (RES-2386) already use.
+#[derive(Debug, Clone, Copy)]
 pub struct StackSpec {
-    pub fn_name: String,
     pub budget_bytes: u64,
 }
 
 const FRAME_BYTES: u64 = 64;
 
-pub fn collect() -> Vec<StackSpec> {
+pub fn collect() -> Vec<(String, StackSpec)> {
     let attrs = crate::feature_attrs::find_kind("stack");
     // RES-1784: pre-size to attrs.len() — conditional push (only when
     // `bytes` chunk parses), so this is an upper bound.
@@ -40,10 +47,7 @@ pub fn collect() -> Vec<StackSpec> {
             }
         }
         if let Some(n) = budget_bytes {
-            out.push(StackSpec {
-                fn_name: item,
-                budget_bytes: n,
-            });
+            out.push((item, StackSpec { budget_bytes: n }));
         }
     }
     out
@@ -106,14 +110,14 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             _ => None,
         })
         .collect();
-    for spec in &specs {
-        if let Some(body) = bodies.get(spec.fn_name.as_str()) {
+    for (fn_name, spec) in &specs {
+        if let Some(body) = bodies.get(fn_name.as_str()) {
             let depth = max_call_depth(body, 1);
             let bytes = depth * FRAME_BYTES;
             if bytes > spec.budget_bytes {
                 return Err(format!(
                     "{}:0:0: error: `{}` stack budget exceeded: estimated {} bytes (depth {}) > declared {} bytes",
-                    source_path, spec.fn_name, bytes, depth, spec.budget_bytes
+                    source_path, fn_name, bytes, depth, spec.budget_bytes
                 ));
             }
         }


### PR DESCRIPTION
## Summary

- Drop `StackSpec::fn_name: String` and switch `collect()` to return `Vec<(String, StackSpec)>`.
- Final dead-field elimination across the contracts family — completes the pattern shipped by RES-2190 / RES-2170 / RES-2386.

## Why

`StackSpec::fn_name` duplicated the attribute key. The two readers in `check` used it strictly as the lookup key + the error format — same as the wcet/prob/power cases that already shipped.

`StackSpec` is `pub` but grep confirms zero external readers.

## Wins

- Drops one `String` per `#[stack(...)]` attribute.
- `StackSpec` becomes `Copy`.
- Aligns the contracts family.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib 'stack_contracts::'` (4/4 green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Closes #2386

🤖 Generated with [Claude Code](https://claude.com/claude-code)