### PR TITLE
RES-2390: phantom_types — drop dead PhantomSpec::type_name field

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -459,6 +459,10 @@
     "resilient/src/intent_blocks.rs": {
       "branch": "res-2384-intent-blocks-drop-raw-args",
       "claimed_at": "2026-05-20T16:08:40Z"
+    },
+    "resilient/src/phantom_types.rs": {
+      "branch": "res-2390-phantom-types-drop-type-name",
+      "claimed_at": "2026-05-20T16:19:52Z"
     }
   }
 }

--- a/resilient/src/phantom_types.rs
+++ b/resilient/src/phantom_types.rs
@@ -15,16 +15,22 @@ use crate::Node;
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
+/// RES-2390: dropped the redundant `type_name: String` field. The
+/// only consumer was `install()`, which used it as the HashMap key
+/// — every registered entry stored the type name twice. Pipeline now
+/// carries `(String, PhantomSpec)` tuples from `collect()` to
+/// `install()`, matching the shape that `wcet_contracts` (RES-2190),
+/// `probabilistic_contracts` (RES-2170), `power_contracts` (RES-2386),
+/// and `stack_contracts` (RES-2388) use.
 #[derive(Debug, Clone)]
 pub struct PhantomSpec {
-    pub type_name: String,
     pub unit: String,
 }
 
 static SPECS: LazyLock<RwLock<HashMap<String, PhantomSpec>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
-pub fn collect() -> Vec<PhantomSpec> {
+pub fn collect() -> Vec<(String, PhantomSpec)> {
     let attrs = crate::feature_attrs::find_kind("phantom");
     // RES-1754: pre-size to attrs.len() — conditional push (only when
     // the `units` chunk parsed non-empty), so this is an upper bound.
@@ -40,21 +46,20 @@ pub fn collect() -> Vec<PhantomSpec> {
             }
         }
         if !unit.is_empty() {
-            out.push(PhantomSpec {
-                type_name: item,
-                unit,
-            });
+            out.push((item, PhantomSpec { unit }));
         }
     }
     out
 }
 
-pub fn install(specs: Vec<PhantomSpec>) {
+pub fn install(specs: Vec<(String, PhantomSpec)>) {
     if let Ok(mut g) = SPECS.write() {
         g.clear();
-        for s in specs {
-            g.insert(s.type_name.clone(), s);
-        }
+        // RES-2390: move (type_name, spec) tuples straight from
+        // `collect()`. The previous shape cloned `s.type_name` to
+        // produce the key, since the field and the key encoded the
+        // same string.
+        g.extend(specs);
     }
 }
 


### PR DESCRIPTION
## Summary

- Drop `PhantomSpec::type_name: String` and switch `collect()` to return `Vec<(String, PhantomSpec)>`.
- `install` consumes tuples directly via `g.extend(specs)`.

## Why

The only consumer of `type_name` was `install()`, which used it as the HashMap key — every registered entry stored the same string in both the key AND the value's field. probabilistic_contracts.rs:20 listed this as a known dead-field case but the elimination was never applied.

Brings phantom_types in line with wcet (RES-2190), prob (RES-2170), power (RES-2386), and stack (RES-2388) — all of which use the `Vec<(String, Spec)>` collect-tuple shape.

`PhantomSpec` is `pub` but grep confirms zero external readers.

## Wins

- One `String::clone` dropped per `#[phantom(...)]` attribute at install.
- 24 bytes of duplicated storage dropped per registered spec.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib 'phantom_types::'` (4/4 green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Closes #2388

🤖 Generated with [Claude Code](https://claude.com/claude-code)