### PR TITLE
RES-2396: diag::expand_tabs — fast-path when line has no tabs

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -32,10 +32,6 @@
       "branch": "res-1238-any-node-early-terminate",
       "claimed_at": "2026-05-12T02:48:11Z"
     },
-    "resilient/src/diag.rs": {
-      "branch": "res-1984-diag-presize-write",
-      "claimed_at": "2026-05-19T00:00:00Z"
-    },
     "resilient/src/array_argminmax.rs": {
       "branch": "res-2026-argminmax-single-pass",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -459,6 +455,10 @@
     "resilient/src/intent_blocks.rs": {
       "branch": "res-2384-intent-blocks-drop-raw-args",
       "claimed_at": "2026-05-20T16:08:40Z"
+    },
+    "resilient/src/diag.rs": {
+      "branch": "res-2396-diag-expand-tabs-fastpath",
+      "claimed_at": "2026-05-20T16:37:00Z"
     }
   }
 }

--- a/resilient/src/diag.rs
+++ b/resilient/src/diag.rs
@@ -165,6 +165,18 @@ fn nth_line(src: &str, n: usize) -> Option<&str> {
 /// underline lines up visually. Non-tab characters are preserved
 /// byte-for-byte (no UTF-8 normalisation).
 fn expand_tabs(line: &str) -> String {
+    // RES-2396: fast-path when the line carries no tab characters
+    // — the overwhelming common case for editor / CI source output.
+    // `str::contains('\t')` is a single SIMD-optimized scan; the
+    // subsequent `to_string()` is one `memcpy` of the source bytes.
+    // The per-char `out.push(c)` loop below is only reached when at
+    // least one tab needs widening.
+    //
+    // `format_diagnostic` calls this on every compiler error / warning,
+    // so the fast-path savings apply to every emitted diagnostic.
+    if !line.contains('\t') {
+        return line.to_string();
+    }
     let mut out = String::with_capacity(line.len());
     for c in line.chars() {
         if c == '\t' {


### PR DESCRIPTION
## Summary

- Add a no-tab fast-path to `diag::expand_tabs` that returns `line.to_string()` directly when no `\t` is present.
- Skips the per-character `out.push(c)` loop for the overwhelming common case.

## Why

`format_diagnostic` invokes `expand_tabs` on every compiler error and warning. The previous shape walked every character of the source line regardless of whether any tab existed — for pure-ASCII no-tab content (typical editor output and CI logs), this was N per-char pushes that could be a single `memcpy`.

`str::contains('\t')` is a SIMD-optimized byte scan in modern Rust stdlib, so the fast-path's overhead is negligible on the tab-containing path.

## Test plan

- [x] `cargo build --manifest-path resilient/Cargo.toml`
- [x] `cargo test --manifest-path resilient/Cargo.toml --lib 'diag::'` (22/22 green, including `tabs_in_source_expand_to_four_spaces` which exercises the slow path)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Closes #2394

🤖 Generated with [Claude Code](https://claude.com/claude-code)