### PR TITLE
RES-2412: jit_backend — move (not clone) functions/fn_asts maps into LowerCtx

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/row_polymorphism.rs": {
       "branch": "res-2398-row-polymorphism-drop-fn-name",
       "claimed_at": "2026-05-20T16:41:54Z"
+    },
+    "resilient/src/jit_backend.rs": {
+      "branch": "res-2412-jit-move-maps",
+      "claimed_at": "2026-05-20T17:38:14Z"
     }
   }
 }

--- a/resilient/src/jit_backend.rs
+++ b/resilient/src/jit_backend.rs
@@ -1390,10 +1390,18 @@ fn run_internal(program: &Node) -> Result<(i64, JitCache), JitError> {
         bcx.switch_to_block(entry);
         bcx.seal_block(entry);
 
+        // RES-2412: move the program-wide function maps into `lctx`
+        // instead of cloning. Pass 2 above has already consumed every
+        // by-reference use; the fall-through path (define_function,
+        // finalize_definitions, function-pointer invoke) never reads
+        // the original locals. `fn_asts` in particular carries a full
+        // AST body per user-defined function — the previous clone
+        // copied every parameter list and every body Node tree per
+        // JIT invocation.
         let mut lctx = LowerCtx::new(imports);
-        lctx.functions = functions.clone();
-        lctx.function_arities = function_arities.clone();
-        lctx.fn_asts = fn_asts.clone();
+        lctx.functions = functions;
+        lctx.function_arities = function_arities;
+        lctx.fn_asts = fn_asts;
         compile_statements(stmts, &mut bcx, &mut lctx, &mut module)?;
         bcx.finalize();
     }
@@ -1583,11 +1591,16 @@ pub(crate) fn jit_run_ast_with_entries(
         bcx.switch_to_block(entry);
         bcx.seal_block(entry);
 
+        // RES-2412: same move-instead-of-clone as `run_internal`,
+        // with `foreign_entries` (declared `mut` in the function
+        // signature) added — pass 0 + pass 2 have consumed all
+        // by-reference uses, and the post-block compile/run path
+        // never reads them again.
         let mut lctx = LowerCtx::new(imports);
-        lctx.functions = functions.clone();
-        lctx.function_arities = function_arities.clone();
-        lctx.fn_asts = fn_asts.clone();
-        lctx.foreign_entries = foreign_entries.clone();
+        lctx.functions = functions;
+        lctx.function_arities = function_arities;
+        lctx.fn_asts = fn_asts;
+        lctx.foreign_entries = foreign_entries;
         compile_statements(stmts, &mut bcx, &mut lctx, &mut module)?;
         bcx.finalize();
     }


### PR DESCRIPTION
## Summary

Closes #2412.

Two JIT entry points (`run_internal` at jit_backend.rs:1276, `jit_run_ast_with_entries` at :1469) deep-cloned the program-wide function maps when threading them into the main-compile `LowerCtx`:

```rust
lctx.functions = functions.clone();
lctx.function_arities = function_arities.clone();
lctx.fn_asts = fn_asts.clone();
// + foreign_entries.clone() in jit_run_ast_with_entries
```

`fn_asts` is `HashMap<String, (Vec<(String, String)>, Node)>` — N full AST bodies for N user-defined functions, cloned every JIT invocation even though the originals are never read after this point.

Replaced the three clones with moves in both functions; also moved `foreign_entries` (declared `mut foreign_entries: Vec<ForeignJitEntry>`) in `jit_run_ast_with_entries`. Pass 0 (FFI declares) and pass 2 (per-fn compile via `compile_function_with_ffi`) above have already consumed all by-reference uses.

The per-fn helpers (`compile_function`, `compile_function_with_ffi`) take their maps by reference from the caller — they must clone for their own lctx and are left untouched.

## Test plan

- [x] `cargo build --features jit` green.
- [x] `cargo clippy --features jit --all-targets -- -D warnings` clean.
- [x] All 139 `jit_backend::tests` pass (TCO sums, bubble sort, deep recursion, RES-380 abort flow, ...).

Pure refactor — no behaviour change. JIT is on the hot path for `rz run --jit` and the REPL; cutting N deep AST clones per invocation scales with program size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)