### PR TITLE
RES-2414: linear — skip redundant bindings snap clones in If/Match arm walks

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/row_polymorphism.rs": {
       "branch": "res-2398-row-polymorphism-drop-fn-name",
       "claimed_at": "2026-05-20T16:41:54Z"
+    },
+    "resilient/src/linear.rs": {
+      "branch": "res-2414-linear-snap-clones",
+      "claimed_at": "2026-05-20T17:44:54Z"
     }
   }
 }

--- a/resilient/src/linear.rs
+++ b/resilient/src/linear.rs
@@ -288,10 +288,18 @@ fn walk(
                 // Without Z3, use the conservative snapshot/restore
                 // approach: each branch starts fresh, consumption
                 // in one branch doesn't affect the merge.
+                //
+                // RES-2414: gate the inter-branch `snap.clone()` on
+                // there actually being an alternative branch. When
+                // `alternative` is `None`, the trailing
+                // `*bindings = snap;` already overwrites whatever
+                // bindings ended up as after `consequence`, so the
+                // intermediate clone was pure waste. Same shape as
+                // RES-1386's fix in `verifier_loop_invariants`.
                 let snap = bindings.clone();
                 walk(consequence, bindings, fn_name, source_path)?;
-                *bindings = snap.clone();
                 if let Some(alt) = alternative {
+                    *bindings = snap.clone();
                     walk(alt, bindings, fn_name, source_path)?;
                 }
                 *bindings = snap;
@@ -318,9 +326,20 @@ fn walk(
             scrutinee, arms, ..
         } => {
             walk(scrutinee, bindings, fn_name, source_path)?;
+            // RES-2414: the first arm walks against `bindings`
+            // directly — at this point it equals `snap`, so the
+            // previous `*bindings = snap.clone();` on the very
+            // first iteration was assigning a fresh copy of a value
+            // bindings already held. Only subsequent arms need the
+            // restore-from-snap; we skip the leading clone via an
+            // `is_first` gate.
             let snap = bindings.clone();
+            let mut is_first = true;
             for (_, guard, body) in arms {
-                *bindings = snap.clone();
+                if !is_first {
+                    *bindings = snap.clone();
+                }
+                is_first = false;
                 if let Some(g) = guard {
                     walk(g, bindings, fn_name, source_path)?;
                 }


### PR DESCRIPTION
## Summary

Closes #2414.

Two `bindings.clone()` calls in `linear::walk` paid for restores that were already covered by later moves.

**Non-z3 If arm (lines 286–298):** when `alternative` is `None`, the trailing `*bindings = snap;` already overwrote whatever `*bindings = snap.clone();` had produced. Gated the intermediate clone on `alternative.is_some()` — same shape as RES-1386's fix in `verifier_loop_invariants::walk`.

**Match arm (lines 317–330):** on the first arm iteration, `bindings` already equals `snap` (just cloned from current bindings), so the leading `*bindings = snap.clone();` was assigning bindings a fresh copy of a value it already held. Peeled the first iter via an `is_first` gate so only iters 2..N pay the restore clone — savings of `arms.len() - 1` instead of the previous `arms.len()`.

## Test plan

- [x] `cargo build` green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] All 52 linear-related tests pass: consumes-twice rejection, double-consume in arm, deep linear recursion runtime-error path, linear_value_used_once_is_accepted, etc.

`linear::walk` runs as a typechecker pass on any program with `#[linear]`-typed bindings. The bindings HashMap carries `String` keys and `LinearBinding` values — neither side is free to clone.

Pure refactor — no behaviour change. Same pattern as RES-1386: drop snapshot clones whose effect is always overwritten before being observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)