### PR TITLE
RES-2416: recovers_to_bmc::enumerate_prefixes — return borrowed slice (drop Vec clone)

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -384,10 +384,6 @@
       "branch": "res-2260-json-escape-write-direct",
       "claimed_at": "2026-05-20T08:12:01Z"
     },
-    "resilient/src/recovers_to_bmc.rs": {
-      "branch": "res-2268-smtlib2-direct-write",
-      "claimed_at": "2026-05-20T08:29:05Z"
-    },
     "resilient/src/lint.rs": {
       "branch": "res-2272-lint-clause-text-direct",
       "claimed_at": "2026-05-20T08:36:08Z"
@@ -463,6 +459,10 @@
     "resilient/src/row_polymorphism.rs": {
       "branch": "res-2398-row-polymorphism-drop-fn-name",
       "claimed_at": "2026-05-20T16:41:54Z"
+    },
+    "resilient/src/recovers_to_bmc.rs": {
+      "branch": "res-2416-enumerate-prefixes-borrow",
+      "claimed_at": "2026-05-20T17:49:09Z"
     }
   }
 }

--- a/resilient/src/recovers_to_bmc.rs
+++ b/resilient/src/recovers_to_bmc.rs
@@ -277,8 +277,15 @@ impl ControlFlowGraph {
     }
 
     /// Enumerate all instruction-boundary prefixes in the CFG.
-    fn enumerate_prefixes(&self) -> Vec<(usize, Span)> {
-        self.prefix_boundaries.clone()
+    ///
+    /// RES-2416: returns a borrowed slice — every caller (production
+    /// `bmc_check` and the three test helpers below) only iterates
+    /// the result or reads its `.len()`. The previous owned-`Vec`
+    /// return cloned `prefix_boundaries` for nothing per call.
+    /// `(usize, Span)` is `Copy`, so consumers can still destructure
+    /// without lifetime gymnastics.
+    fn enumerate_prefixes(&self) -> &[(usize, Span)] {
+        &self.prefix_boundaries
     }
 }
 
@@ -500,7 +507,7 @@ pub(crate) fn check_recovers_to_bmc(
     let cfg = ControlFlowGraph::from_body(fn_body);
     let prefixes = cfg.enumerate_prefixes();
 
-    for (prefix_id, span) in &prefixes {
+    for (prefix_id, span) in prefixes {
         let obligation = generate_prefix_obligation(*prefix_id, requires_clauses, recovers_clause);
         // RES-1857 Phase 3: invoke Z3 on the obligation string.
         solve_bmc_obligation(fn_name, *prefix_id, span, &obligation)?;


### PR DESCRIPTION
## Summary

Closes #2416.

`ControlFlowGraph::enumerate_prefixes` (recovers_to_bmc.rs:280) returned an owned `Vec<(usize, Span)>` by cloning `self.prefix_boundaries`. All four callers (production `bmc_check` + three tests) only iterate the result or read `.len()` — nothing modifies the elements, so the clone was pure plumbing.

Changed the return type to `&[(usize, Span)]` and dropped the redundant `&` in the production iteration site. Tests use only `.len()`, which works unchanged on a slice.

## Test plan

- [x] `cargo build` green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] All 13 `recovers_to_bmc::tests` pass: linear body, if/else, while-loop boundary, generated SMT-LIB2 obligation shape, `bmc_check` simple-fn return.

The recovers_to BMC pass runs once per `recovers_to`-annotated function; dropping one Vec allocation per function eliminates the AST-allocation overhead in front of the Z3 solver calls. Same pattern as RES-2406 / RES-2408 / RES-2410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)