### PR TITLE
RES-2426: secret_erasure::collect_local_secrets — borrow leaked names from AST

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -52,10 +52,6 @@
       "branch": "res-1252-degraded-mode-fast-reject",
       "claimed_at": "2026-05-12T03:27:30Z"
     },
-    "resilient/src/secret_erasure.rs": {
-      "branch": "res-1256-secret-erasure-fast-reject",
-      "claimed_at": "2026-05-12T03:39:06Z"
-    },
     "resilient/src/monotonic_field.rs": {
       "branch": "res-1262-monotonic-fast-reject",
       "claimed_at": "2026-05-12T03:53:13Z"
@@ -467,6 +463,10 @@
     "resilient/src/jit_backend.rs": {
       "branch": "res-2412-jit-move-maps",
       "claimed_at": "2026-05-20T17:38:14Z"
+    },
+    "resilient/src/secret_erasure.rs": {
+      "branch": "res-2426-secret-erasure-borrow",
+      "claimed_at": "2026-05-20T18:21:21Z"
     }
   }
 }

--- a/resilient/src/secret_erasure.rs
+++ b/resilient/src/secret_erasure.rs
@@ -55,10 +55,10 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         return Ok(());
     }
     for_each_function(program, |fname, _params, body| {
-        let mut leaks = Vec::new();
+        let mut leaks: Vec<&str> = Vec::new();
         collect_local_secrets(body, &mut leaks);
         for var in leaks {
-            if !is_wiped(body, &var) && !is_returned(body, &var) {
+            if !is_wiped(body, var) && !is_returned(body, var) {
                 eprintln!(
                     "warning: function '{fname}' binds secret '{var}' but never \
                      calls zeroize()/zero_out()/wipe() on it before exit — \
@@ -70,9 +70,17 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn collect_local_secrets(body: &Node, out: &mut Vec<String>) {
-    let mut seen = std::collections::HashSet::new();
-    let mut sink = |n: &Node| {
+/// RES-2426: borrow each candidate-secret binding's name out of the
+/// AST instead of cloning into owned `String`s. `uniqueness_walk::visit`
+/// propagates the lifetime (RES-1238), so both the dedup `HashSet` and
+/// the output `Vec` can hold `&'a str` borrowed from the inner
+/// `String` in the AST. Callers (`is_wiped`, `is_returned`) already
+/// take `var: &str`, so the for-loop just passes `var` directly
+/// instead of `&var`. Drops 2N `String::clone` allocations per
+/// function for N candidate-secret bindings.
+fn collect_local_secrets<'a>(body: &'a Node, out: &mut Vec<&'a str>) {
+    let mut seen: std::collections::HashSet<&'a str> = std::collections::HashSet::new();
+    let mut sink = |n: &'a Node| {
         let (name, type_annot) = match n {
             Node::LetStatement {
                 name, type_annot, ..
@@ -80,13 +88,13 @@ fn collect_local_secrets(body: &Node, out: &mut Vec<String>) {
             Node::StaticLet { name, .. } => (name, None),
             _ => return,
         };
-        if !seen.insert(name.clone()) {
+        if !seen.insert(name.as_str()) {
             return;
         }
         let by_name = SECRET_NAME_PREFIXES.iter().any(|p| name.starts_with(*p));
         let by_type = type_annot.map(is_secret_type).unwrap_or(false);
         if by_name || by_type {
-            out.push(name.clone());
+            out.push(name.as_str());
         }
     };
     crate::uniqueness_walk::visit(body, &mut sink);


### PR DESCRIPTION
## Summary

Closes #2426.

`collect_local_secrets` (secret_erasure.rs:73) cloned each candidate-secret binding name twice — once into a dedup `HashSet<String>`, once into the output `Vec<String>`. The caller only ever used the names by reference (`is_wiped` / `is_returned` take `&str`).

`uniqueness_walk::visit` already propagates the AST lifetime (RES-1238), so both collections can hold `&'a str` borrowing directly from inner `String`s in the AST. Changed `collect_local_secrets` to push `&'a str` into a `Vec<&'a str>` and updated the caller's for-loop to pass `var` directly (drop the `&`).

## Test plan

- [x] `cargo build` green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] All 3 secret_erasure tests pass: `empty_program_returns_ok`, `no_secret_binding_skips_check`, `non_secret_named_binding_skips_check`.

The secret_erasure pass runs whenever a program has bindings whose names match `key_`, `secret_`, etc. For N candidate bindings per function, the previous shape paid 2N `String::clone` allocations; the new shape pays zero. Same pattern as RES-2406 / RES-2408 / RES-2410 / RES-2416 / RES-2418 / RES-2420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)