### PR TITLE
RES-2428: reentrancy_guard — borrow callee names into HashSet<&'a str>

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -212,10 +212,6 @@
       "branch": "res-2014-assoc-const-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/rate_limit_static.rs": {
-      "branch": "res-1962-reentrancy-rate-limit-presize",
-      "claimed_at": "2026-05-19T18:59:39Z"
-    },
     "resilient/src/sum_types.rs": {
       "branch": "res-1788-rate-limit-presize",
       "claimed_at": "2026-05-13T12:35:40Z"
@@ -303,10 +299,6 @@
     "resilient/src/assume_axioms.rs": {
       "branch": "res-1958-assume-axioms-presize",
       "claimed_at": "2026-05-19T18:52:28Z"
-    },
-    "resilient/src/reentrancy_guard.rs": {
-      "branch": "res-1962-reentrancy-rate-limit-presize",
-      "claimed_at": "2026-05-19T18:59:39Z"
     },
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
@@ -467,6 +459,10 @@
     "resilient/src/behavioral_fingerprint.rs": {
       "branch": "res-2424-node-text-direct",
       "claimed_at": "2026-05-20T18:13:31Z"
+    },
+    "resilient/src/reentrancy_guard.rs": {
+      "branch": "res-2428-reentrancy-borrow",
+      "claimed_at": "2026-05-20T18:25:34Z"
     }
   }
 }

--- a/resilient/src/reentrancy_guard.rs
+++ b/resilient/src/reentrancy_guard.rs
@@ -45,27 +45,31 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         return Ok(());
     }
     // RES-1519: borrow each top-level fn name as `&str` from the
-    // AST into the `callees` HashMap and `roots` Vec. The inner
-    // `cs: HashSet<String>` keeps owned Strings because
-    // `uniqueness_walk::visit` uses a HRTB closure that can't bind
-    // the outer AST lifetime — same limitation hit by
-    // RES-1509 / RES-1511. Pair with `reaches_self` borrowing into
-    // the graph for the DFS (mirror of RES-1471 / RES-1474 / RES-1477).
+    // AST into the `callees` HashMap and `roots` Vec.
+    //
+    // RES-2428: the inner `cs` set now also borrows callee names as
+    // `&'a str` from the AST. The previous comment cited an HRTB
+    // limitation on `uniqueness_walk::visit`'s closure, but that
+    // constraint was lifted by RES-1238 (visit gained the
+    // `f: &mut impl FnMut(&'a Node)` signature that propagates the
+    // outer AST lifetime). With the lifetime bound through, the
+    // closure can hand `name.as_str()` directly into the set.
+    //
     // RES-1742: pre-size the call-graph map to stmts.len() (upper
     // bound — every top-level statement could be a Function). The
     // per-fn callees HashSet starts empty; 8 fits a typical body.
-    let mut callees: HashMap<&str, HashSet<String>> = HashMap::with_capacity(stmts.len());
+    let mut callees: HashMap<&str, HashSet<&str>> = HashMap::with_capacity(stmts.len());
     // RES-1962: pre-size to 4 — typical non-reentrant fn count is low
     // (1-5 fns matching NR_PREFIXES / NR_SUFFIXES per program).
     let mut roots: Vec<&str> = Vec::with_capacity(4);
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {
-            let mut cs = HashSet::with_capacity(8);
+            let mut cs: HashSet<&str> = HashSet::with_capacity(8);
             visit(body, &mut |n| {
-                if let Node::CallExpression { function, .. } = n {
-                    if let Node::Identifier { name, .. } = function.as_ref() {
-                        cs.insert(name.clone());
-                    }
+                if let Node::CallExpression { function, .. } = n
+                    && let Node::Identifier { name, .. } = function.as_ref()
+                {
+                    cs.insert(name.as_str());
                 }
             });
             callees.insert(name.as_str(), cs);
@@ -91,13 +95,16 @@ fn is_nonreentrant(name: &str) -> bool {
         || NR_SUFFIXES.iter().any(|s| name.ends_with(*s))
 }
 
-fn reaches_self<'a>(callees: &'a HashMap<&'a str, HashSet<String>>, start: &str) -> bool {
+fn reaches_self<'a>(callees: &'a HashMap<&'a str, HashSet<&'a str>>, start: &str) -> bool {
     // RES-1962: pre-size the DFS visited set to `callees.len()` —
     // exact upper bound, each callee is visited at most once.
     let mut seen: HashSet<&'a str> = HashSet::with_capacity(callees.len());
+    // RES-2428: callees inner sets are now `HashSet<&'a str>` directly,
+    // so the seed walk is a simple `.copied()` over the borrowed slice
+    // — no per-element `String::as_str` reach.
     let mut stack: Vec<&'a str> = callees
         .get(start)
-        .map(|cs| cs.iter().map(String::as_str).collect())
+        .map(|cs| cs.iter().copied().collect())
         .unwrap_or_default();
     while let Some(c) = stack.pop() {
         if c == start {
@@ -108,7 +115,7 @@ fn reaches_self<'a>(callees: &'a HashMap<&'a str, HashSet<String>>, start: &str)
         }
         if let Some(cs) = callees.get(c) {
             for cc in cs {
-                stack.push(cc.as_str());
+                stack.push(*cc);
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #2428.

`reentrancy_guard::check` recorded every callee name into a `HashSet<String>` by cloning. The previous comment cited an HRTB limitation on `uniqueness_walk::visit`'s closure — but that was lifted by RES-1238, which gave visit the signature `f: &mut impl FnMut(&'a Node)` so the closure can bind `'a` and hand back `&'a str`.

Changed `callees: HashMap<&str, HashSet<&str>>` and use `cs.insert(name.as_str())`. Updated `reaches_self` accordingly (seed walk uses `.copied()`, DFS push uses `*cc`). Stale HRTB comment replaced with the RES-1238 explanation.

## Test plan

- [x] `cargo build` green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] All 3 reentrancy_guard tests pass.

The pass runs once per program that declares a `nonreentrant_*` / `*_critical` / `*_atomic` / `*_oneshot` function. For M functions averaging K call expressions per body, the previous shape paid M*K `String::clone` allocations; new shape pays zero. Same pattern as RES-2406 / RES-2408 / RES-2410 / RES-2416 / RES-2418 / RES-2420 / RES-2426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)