### PR TITLE
RES-2430: lock_ordering — nested pair_sites map drops per-iter (b,a) tuple clone

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -112,10 +112,6 @@
       "branch": "res-1538-termination-fn-info-borrow",
       "claimed_at": "2026-05-12T15:15:14Z"
     },
-    "resilient/src/lock_ordering.rs": {
-      "branch": "res-1752-lock-ordering-presize",
-      "claimed_at": "2026-05-13T11:18:18Z"
-    },
     "resilient/src/power_contracts.rs": {
       "branch": "res-2018-attr-move-item",
       "claimed_at": "2026-05-19T00:00:00Z"
@@ -212,10 +208,6 @@
       "branch": "res-2014-assoc-const-nested-map",
       "claimed_at": "2026-05-19T00:00:00Z"
     },
-    "resilient/src/rate_limit_static.rs": {
-      "branch": "res-1962-reentrancy-rate-limit-presize",
-      "claimed_at": "2026-05-19T18:59:39Z"
-    },
     "resilient/src/sum_types.rs": {
       "branch": "res-1788-rate-limit-presize",
       "claimed_at": "2026-05-13T12:35:40Z"
@@ -303,10 +295,6 @@
     "resilient/src/assume_axioms.rs": {
       "branch": "res-1958-assume-axioms-presize",
       "claimed_at": "2026-05-19T18:52:28Z"
-    },
-    "resilient/src/reentrancy_guard.rs": {
-      "branch": "res-1962-reentrancy-rate-limit-presize",
-      "claimed_at": "2026-05-19T18:59:39Z"
     },
     "resilient/src/array_binary_search.rs": {
       "branch": "res-2034-binary-search-no-intermediate-vec",
@@ -467,6 +455,10 @@
     "resilient/src/behavioral_fingerprint.rs": {
       "branch": "res-2424-node-text-direct",
       "claimed_at": "2026-05-20T18:13:31Z"
+    },
+    "resilient/src/lock_ordering.rs": {
+      "branch": "res-2430-lock-ordering-nested",
+      "claimed_at": "2026-05-20T18:31:31Z"
     }
   }
 }

--- a/resilient/src/lock_ordering.rs
+++ b/resilient/src/lock_ordering.rs
@@ -41,7 +41,17 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // a combined check on `markers.call_idents` for LOCK_FNS/UNLOCK_FNS
     // names and `lock_`/`unlock_` prefixes. The previous `any_node`
     // pre-scan was redundant — removed.
-    let mut pair_sites: HashMap<(String, String), Vec<String>> = HashMap::new();
+    //
+    // RES-2430: nested map shape — `prior -> current -> fn_names`.
+    // The previous flat `HashMap<(String, String), Vec<String>>`
+    // forced the inversion-check loop to allocate two transient
+    // `String`s per pair-site entry just to construct the reversed
+    // `(b, a)` key (stdlib has no `Borrow<(&str, &str)>` impl for
+    // `(String, String)`). Nested lookups use the existing
+    // `String: Borrow<str>` impl on each level with zero
+    // allocations. Same shape as RES-2008 / RES-2010 / RES-2012 /
+    // RES-2014 / RES-2184 / RES-2194 / RES-2418.
+    let mut pair_sites: HashMap<String, HashMap<String, Vec<String>>> = HashMap::new();
     for stmt in stmts {
         if let Node::Function { name, body, .. } = &stmt.node {
             collect_pairs(name, body, &mut pair_sites);
@@ -50,34 +60,36 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // RES-1524: borrow lock-name pairs into the dedup set instead
     // of cloning. The `pair_sites` map already owns the strings;
     // `reported` only checks "have I warned on this canonical
-    // pair before". Same pattern as RES-1495 / RES-1500 / RES-1520
-    // applied to a tuple key. The `key_ba` lookup also doesn't
-    // need owned strings — `(&str, &str)` works via `Borrow` on
-    // tuple-of-borrows.
+    // pair before".
     let mut reported: HashSet<(&str, &str)> = HashSet::new();
-    for ((a, b), fns_ab) in &pair_sites {
-        let key_ba = (b.clone(), a.clone());
-        if let Some(fns_ba) = pair_sites.get(&key_ba) {
-            let canon: (&str, &str) = if a < b {
-                (a.as_str(), b.as_str())
-            } else {
-                (b.as_str(), a.as_str())
-            };
-            if !reported.insert(canon) {
-                continue;
+    for (a, by_b) in &pair_sites {
+        for (b, fns_ab) in by_b {
+            if let Some(fns_ba) = pair_sites.get(b).and_then(|m| m.get(a)) {
+                let canon: (&str, &str) = if a < b {
+                    (a.as_str(), b.as_str())
+                } else {
+                    (b.as_str(), a.as_str())
+                };
+                if !reported.insert(canon) {
+                    continue;
+                }
+                eprintln!(
+                    "warning: lock-ordering inversion: '{a}' before '{b}' in [{}] vs \
+                     '{b}' before '{a}' in [{}] — deadlock risk",
+                    fns_ab.join(", "),
+                    fns_ba.join(", ")
+                );
             }
-            eprintln!(
-                "warning: lock-ordering inversion: '{a}' before '{b}' in [{}] vs \
-                 '{b}' before '{a}' in [{}] — deadlock risk",
-                fns_ab.join(", "),
-                fns_ba.join(", ")
-            );
         }
     }
     Ok(())
 }
 
-fn collect_pairs(fn_name: &str, body: &Node, pairs: &mut HashMap<(String, String), Vec<String>>) {
+fn collect_pairs(
+    fn_name: &str,
+    body: &Node,
+    pairs: &mut HashMap<String, HashMap<String, Vec<String>>>,
+) {
     // RES-1752: pre-size — a fn body typically has a small handful
     // of lock/unlock calls. 8 covers the common case without
     // doubling growth from 0.
@@ -106,7 +118,9 @@ fn collect_pairs(fn_name: &str, body: &Node, pairs: &mut HashMap<(String, String
             for prior in &held {
                 if prior != &lk {
                     pairs
-                        .entry((prior.clone(), lk.clone()))
+                        .entry(prior.clone())
+                        .or_default()
+                        .entry(lk.clone())
                         .or_default()
                         .push(fn_name.to_string());
                 }


### PR DESCRIPTION
## Summary

Closes #2430.

`lock_ordering::check` stored co-acquisition pairs in a flat `HashMap<(String, String), Vec<String>>`. The inversion-detection loop allocated two transient `String`s per entry just to construct the reversed key for lookup — stdlib has no `Borrow<(&str, &str)>` impl for `(String, String)`, so the flat-key shape genuinely required the owned-tuple probe.

Re-shaped `pair_sites` as `HashMap<String, HashMap<String, Vec<String>>>` (prior → current → fn_names). The inversion loop chains `.get(b).and_then(|m| m.get(a))` — both lookups use the existing `String: Borrow<str>` impl, zero allocations.

`collect_pairs` builds the nested shape via chained `entry().or_default()` calls — same two clones per insertion as the flat-key version, so the build cost is unchanged. Savings are exclusively in the inversion-check: K unique pairs save 2K transient allocations.

## Test plan

- [x] `cargo build` green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Both `lock_ordering::tests` pass.

Same nested-map shape pattern as RES-2008 / RES-2010 / RES-2012 / RES-2014 / RES-2184 / RES-2194 / RES-2418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)