### PR TITLE
RES-2432: mutation_testing::contract_coverage — return HashSet<&'a str>

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -396,10 +396,6 @@
       "branch": "res-2280-wp-substitute-skip",
       "claimed_at": "2026-05-20T09:12:26Z"
     },
-    "resilient/src/mutation_testing.rs": {
-      "branch": "res-2288-mutation-fn-name-borrow",
-      "claimed_at": "2026-05-20T09:50:03Z"
-    },
     "resilient/src/sensor_freshness.rs": {
       "branch": "res-2292-sensor-freshness-drop-prescan",
       "claimed_at": "2026-05-20T10:04:18Z"
@@ -467,6 +463,10 @@
     "resilient/src/behavioral_fingerprint.rs": {
       "branch": "res-2424-node-text-direct",
       "claimed_at": "2026-05-20T18:13:31Z"
+    },
+    "resilient/src/mutation_testing.rs": {
+      "branch": "res-2432-contract-coverage-borrow",
+      "claimed_at": "2026-05-20T18:37:49Z"
     }
   }
 }

--- a/resilient/src/mutation_testing.rs
+++ b/resilient/src/mutation_testing.rs
@@ -467,7 +467,15 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
 
 /// Returns the set of function names that have at least one
 /// `requires` or `ensures` contract clause.
-fn contract_coverage(program: &Node) -> std::collections::HashSet<String> {
+///
+/// RES-2432: borrows names from the AST. The only production caller
+/// (`check`) probes the set via `contracted_fns.contains(name.as_str())`
+/// — `HashSet<&str>::contains(&str)` works via the existing
+/// `&str: Borrow<str>` impl, so the API surface is unchanged. The
+/// previous `HashSet<String>` shape paid one `String::clone` per
+/// contracted function for no consumer that actually needed owned
+/// strings.
+fn contract_coverage(program: &Node) -> std::collections::HashSet<&str> {
     let mut out = std::collections::HashSet::new();
     if let Node::Program(stmts) = program {
         for s in stmts {
@@ -479,7 +487,7 @@ fn contract_coverage(program: &Node) -> std::collections::HashSet<String> {
             } = &s.node
             {
                 if !requires.is_empty() || !ensures.is_empty() {
-                    out.insert(name.clone());
+                    out.insert(name.as_str());
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes #2432.

`mutation_testing::contract_coverage` (mutation_testing.rs:470) cloned each contracted-function name into a `HashSet<String>`. The only production caller probes via `contracted_fns.contains(name.as_str())` and never moves names out — the clones existed purely to satisfy the owned-key HashSet shape.

Changed to `HashSet<&str>` borrowing from the AST. `HashSet<&str>::contains(&str)` works via `&str: Borrow<str>`, so no caller-site changes needed. Tests use `cov.contains("f")` which works for both shapes.

## Test plan

- [x] `cargo build` green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] All 34 mutation_testing tests pass — including `contract_coverage_finds_contracted_fn` and `contract_coverage_empty_for_uncontracted_fn`.

`mutation_testing::check` runs once per typecheck on any program that emits a mutation site. For programs with N contracted functions, the previous shape paid N `String::clone` allocations. Same general principle as RES-2406 / RES-2408 / RES-2410 / RES-2416 / RES-2418 / RES-2420 / RES-2426 / RES-2428 / RES-2430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)