### PR TITLE
RES-2440: CI clippy — add --all-targets to match CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: cargo clippy
         if: needs.changes.outputs.docs_only != 'true'
-        run: cargo clippy --locked -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: cargo test
         if: needs.changes.outputs.docs_only != 'true'

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -463,6 +463,10 @@
     "resilient/src/typechecker.rs": {
       "branch": "res-2436-gate-mutation-fingerprint",
       "claimed_at": "2026-05-23T06:28:25Z"
+    },
+    ".github/workflows/ci.yml": {
+      "branch": "res-2440-clippy-all-targets",
+      "claimed_at": "2026-05-23T07:01:46Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `--all-targets` to the CI clippy step so it checks test, bench, and example code in addition to the library target
- Aligns CI gate with CLAUDE.md's prescribed `cargo clippy --all-targets -- -D warnings`
- Catches clippy warnings in `#[cfg(test)]` modules that were previously invisible to CI

## Context

The CI ran `cargo clippy --locked -- -D warnings` (library only), but CLAUDE.md prescribes `cargo clippy --all-targets -- -D warnings`. This meant clippy warnings in test code could slip through CI undetected. With `--all-targets`, clippy also checks test and bench targets, ensuring comprehensive lint coverage.

Verified locally: `cargo clippy --all-targets -- -D warnings` is clean — no new warnings surface.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean locally
- [x] CI will run the updated step and validate

Closes #2440

🤖 Generated with [Claude Code](https://claude.com/claude-code)