### PR TITLE
RES-2474: reject string + non-primitive in type checker

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -38546,6 +38546,24 @@ mod tests {
     }
 
     #[test]
+    fn typecheck_rejects_string_plus_array() {
+        let err = typecheck_src(r#"let s = "arr: " + [1, 2, 3];"#).unwrap_err();
+        assert!(
+            err.contains("cannot concatenate string with"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn typecheck_accepts_string_plus_primitives() {
+        typecheck_src(r#"let a = "x=" + 42;"#).unwrap();
+        typecheck_src(r#"let b = "pi=" + 3.14;"#).unwrap();
+        typecheck_src(r#"let c = "ok=" + true;"#).unwrap();
+        typecheck_src(r#"let d = "hi " + "world";"#).unwrap();
+    }
+
+    #[test]
     fn typecheck_rejects_try_on_non_result() {
         let err = typecheck_src("let x = 42?;").unwrap_err();
         assert!(err.contains("? operator"), "unexpected: {}", err);

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -7670,9 +7670,31 @@ impl TypeChecker {
                 match *operator {
                     "+" => {
                         // String-plus-primitive coercion (RES-008): if
-                        // either side is a string, the result is a string.
+                        // either side is a string AND the other side is a
+                        // stringifiable primitive, the result is a string.
+                        // Only Int, Float, Bool, String, and Any are
+                        // coercible — compound types (Array, Struct, etc.)
+                        // must use explicit to_string() conversion.
+                        let can_coerce_to_string = |t: &Type| {
+                            matches!(
+                                t,
+                                Type::String | Type::Int | Type::Float | Type::Bool | Type::Any
+                            ) || is_pinned_int(t)
+                        };
                         if left_type == Type::String || right_type == Type::String {
-                            return Ok(Type::String);
+                            if can_coerce_to_string(&left_type) && can_coerce_to_string(&right_type)
+                            {
+                                return Ok(Type::String);
+                            }
+                            let bad = if left_type == Type::String {
+                                &right_type
+                            } else {
+                                &left_type
+                            };
+                            return Err(format!(
+                                "cannot concatenate string with {} — use to_string() for explicit conversion",
+                                bad
+                            ));
                         }
                         // Array concat.
                         if compatible(&left_type, &Type::Array)


### PR DESCRIPTION
## Summary
- The type checker accepted `string + <any_type>` for concatenation, but the runtime only handles String/Int/Float/Bool coercion — causing runtime crashes for `string + array`, `string + struct`, etc.
- Now restricts `+` coercion to primitive types the runtime can actually stringify, with a clear diagnostic for non-primitive operands.

## Test plan
- [x] `typecheck_rejects_string_plus_array` — verifies Array is rejected
- [x] `typecheck_accepts_string_plus_primitives` — verifies String/Int/Float/Bool still work
- [x] All 4,706 existing tests pass

Closes #2456

🤖 Generated with [Claude Code](https://claude.com/claude-code)