### PR TITLE
RES-2476: add lexicographic string comparisons to VM

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -3,6 +3,10 @@
     "resilient/src/lib.rs": {
       "branch": "res-2466-gcd-lcm-overflow",
       "claimed_at": "2026-05-25T05:30:33Z"
+    },
+    "resilient/src/vm.rs": {
+      "branch": "res-2476-vm-string-comparisons",
+      "claimed_at": "2026-05-25T06:40:59Z"
     }
   }
 }

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -774,6 +774,7 @@ fn run_inner(
                 match (a, b) {
                     (Value::Int(x), Value::Int(y)) => stack.push(Value::Bool(x < y)),
                     (Value::Float(x), Value::Float(y)) => stack.push(Value::Bool(x < y)),
+                    (Value::String(ref x), Value::String(ref y)) => stack.push(Value::Bool(x < y)),
                     _ => return Err(VmError::TypeMismatch("Lt")),
                 }
             }
@@ -783,6 +784,7 @@ fn run_inner(
                 match (a, b) {
                     (Value::Int(x), Value::Int(y)) => stack.push(Value::Bool(x <= y)),
                     (Value::Float(x), Value::Float(y)) => stack.push(Value::Bool(x <= y)),
+                    (Value::String(ref x), Value::String(ref y)) => stack.push(Value::Bool(x <= y)),
                     _ => return Err(VmError::TypeMismatch("Le")),
                 }
             }
@@ -792,6 +794,7 @@ fn run_inner(
                 match (a, b) {
                     (Value::Int(x), Value::Int(y)) => stack.push(Value::Bool(x > y)),
                     (Value::Float(x), Value::Float(y)) => stack.push(Value::Bool(x > y)),
+                    (Value::String(ref x), Value::String(ref y)) => stack.push(Value::Bool(x > y)),
                     _ => return Err(VmError::TypeMismatch("Gt")),
                 }
             }
@@ -801,6 +804,7 @@ fn run_inner(
                 match (a, b) {
                     (Value::Int(x), Value::Int(y)) => stack.push(Value::Bool(x >= y)),
                     (Value::Float(x), Value::Float(y)) => stack.push(Value::Bool(x >= y)),
+                    (Value::String(ref x), Value::String(ref y)) => stack.push(Value::Bool(x >= y)),
                     _ => return Err(VmError::TypeMismatch("Ge")),
                 }
             }
@@ -1846,6 +1850,7 @@ fn h_lt(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
     let result = match (a, b) {
         (Value::Int(x), Value::Int(y)) => x < y,
         (Value::Float(x), Value::Float(y)) => x < y,
+        (Value::String(ref x), Value::String(ref y)) => x < y,
         _ => return Err(VmError::TypeMismatch("Lt")),
     };
     state.stack.push(Value::Bool(result));
@@ -1859,6 +1864,7 @@ fn h_le(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
     let result = match (a, b) {
         (Value::Int(x), Value::Int(y)) => x <= y,
         (Value::Float(x), Value::Float(y)) => x <= y,
+        (Value::String(ref x), Value::String(ref y)) => x <= y,
         _ => return Err(VmError::TypeMismatch("Le")),
     };
     state.stack.push(Value::Bool(result));
@@ -1872,6 +1878,7 @@ fn h_gt(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
     let result = match (a, b) {
         (Value::Int(x), Value::Int(y)) => x > y,
         (Value::Float(x), Value::Float(y)) => x > y,
+        (Value::String(ref x), Value::String(ref y)) => x > y,
         _ => return Err(VmError::TypeMismatch("Gt")),
     };
     state.stack.push(Value::Bool(result));
@@ -1885,6 +1892,7 @@ fn h_ge(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
     let result = match (a, b) {
         (Value::Int(x), Value::Int(y)) => x >= y,
         (Value::Float(x), Value::Float(y)) => x >= y,
+        (Value::String(ref x), Value::String(ref y)) => x >= y,
         _ => return Err(VmError::TypeMismatch("Ge")),
     };
     state.stack.push(Value::Bool(result));
@@ -4415,6 +4423,66 @@ mod tests {
         );
         match run(&prog).unwrap() {
             Value::Bool(b) => assert!(b),
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn vm_string_lt() {
+        let prog = const_program(
+            &[Value::String("abc".into()), Value::String("def".into())],
+            &[Op::Const(0), Op::Const(1), Op::Lt, Op::Return],
+        );
+        match run(&prog).unwrap() {
+            Value::Bool(b) => assert!(b, "\"abc\" < \"def\" should be true"),
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn vm_string_gt() {
+        let prog = const_program(
+            &[Value::String("def".into()), Value::String("abc".into())],
+            &[Op::Const(0), Op::Const(1), Op::Gt, Op::Return],
+        );
+        match run(&prog).unwrap() {
+            Value::Bool(b) => assert!(b, "\"def\" > \"abc\" should be true"),
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn vm_string_le_equal() {
+        let prog = const_program(
+            &[Value::String("abc".into()), Value::String("abc".into())],
+            &[Op::Const(0), Op::Const(1), Op::Le, Op::Return],
+        );
+        match run(&prog).unwrap() {
+            Value::Bool(b) => assert!(b, "\"abc\" <= \"abc\" should be true"),
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn vm_string_ge_equal() {
+        let prog = const_program(
+            &[Value::String("abc".into()), Value::String("abc".into())],
+            &[Op::Const(0), Op::Const(1), Op::Ge, Op::Return],
+        );
+        match run(&prog).unwrap() {
+            Value::Bool(b) => assert!(b, "\"abc\" >= \"abc\" should be true"),
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn vm_string_lt_false() {
+        let prog = const_program(
+            &[Value::String("xyz".into()), Value::String("abc".into())],
+            &[Op::Const(0), Op::Const(1), Op::Lt, Op::Return],
+        );
+        match run(&prog).unwrap() {
+            Value::Bool(b) => assert!(!b, "\"xyz\" < \"abc\" should be false"),
             other => panic!("expected Bool, got {:?}", other),
         }
     }


### PR DESCRIPTION
## Summary
- The VM's comparison ops (Lt, Le, Gt, Ge) only handled Int and Float, returning TypeMismatch for strings — while the tree-walker supports lexicographic string comparison via `eval_string_infix_expression`
- Added `Value::String` arms to all four comparison ops in both the switch-dispatch loop and the direct-threaded handlers
- This is the string counterpart to the float arithmetic fix in #2455

## Test plan
- [x] `vm_string_lt` — "abc" < "def" returns true
- [x] `vm_string_gt` — "def" > "abc" returns true  
- [x] `vm_string_le_equal` — "abc" <= "abc" returns true
- [x] `vm_string_ge_equal` — "abc" >= "abc" returns true
- [x] `vm_string_lt_false` — "xyz" < "abc" returns false
- [x] All 4,718 existing tests pass

Closes #2458

🤖 Generated with [Claude Code](https://claude.com/claude-code)