### PR TITLE
RES-2520: add map key support to VM LoadIndex/StoreIndex

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -7,6 +7,10 @@
     "resilient/src/lib.rs": {
       "branch": "res-2518-slice-sentinel-collision",
       "claimed_at": "2026-05-25T12:30:00Z"
+    },
+    "resilient/src/vm.rs": {
+      "branch": "res-2520-vm-map-index",
+      "claimed_at": "2026-05-25T12:39:43Z"
     }
   }
 }

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -1019,44 +1019,51 @@ fn run_inner(
             Op::LoadIndex => {
                 let idx_val = stack.pop().ok_or(VmError::EmptyStack)?;
                 let target = stack.pop().ok_or(VmError::EmptyStack)?;
-                let Value::Int(idx) = idx_val else {
-                    return Err(VmError::TypeMismatch("LoadIndex (non-int index)"));
-                };
-                match target {
-                    Value::Array(mut items) => {
-                        let len = items.len() as i64;
-                        let resolved = if idx < 0 { idx + len } else { idx };
-                        if resolved < 0 || resolved >= len {
-                            return Err(VmError::ArrayIndexOutOfBounds {
-                                index: idx,
-                                len: items.len(),
-                            });
+                if let Value::Map(m) = target {
+                    let mk =
+                        crate::MapKey::from_value(&idx_val).map_err(VmError::BuiltinCallFailed)?;
+                    let v = m.get(&mk).cloned().unwrap_or(Value::Void);
+                    stack.push(v);
+                } else {
+                    let Value::Int(idx) = idx_val else {
+                        return Err(VmError::TypeMismatch("LoadIndex (non-int index)"));
+                    };
+                    match target {
+                        Value::Array(mut items) => {
+                            let len = items.len() as i64;
+                            let resolved = if idx < 0 { idx + len } else { idx };
+                            if resolved < 0 || resolved >= len {
+                                return Err(VmError::ArrayIndexOutOfBounds {
+                                    index: idx,
+                                    len: items.len(),
+                                });
+                            }
+                            stack.push(items.swap_remove(resolved as usize));
                         }
-                        stack.push(items.swap_remove(resolved as usize));
-                    }
-                    Value::Tuple(mut items) => {
-                        if idx < 0 || (idx as usize) >= items.len() {
-                            return Err(VmError::ArrayIndexOutOfBounds {
-                                index: idx,
-                                len: items.len(),
-                            });
+                        Value::Tuple(mut items) => {
+                            if idx < 0 || (idx as usize) >= items.len() {
+                                return Err(VmError::ArrayIndexOutOfBounds {
+                                    index: idx,
+                                    len: items.len(),
+                                });
+                            }
+                            stack.push(items.swap_remove(idx as usize));
                         }
-                        stack.push(items.swap_remove(idx as usize));
-                    }
-                    Value::String(s) => {
-                        let len = s.chars().count();
-                        let len_i = len as i64;
-                        let resolved = if idx < 0 { idx + len_i } else { idx };
-                        if resolved < 0 || resolved >= len_i {
-                            return Err(VmError::ArrayIndexOutOfBounds { index: idx, len });
+                        Value::String(s) => {
+                            let len = s.chars().count();
+                            let len_i = len as i64;
+                            let resolved = if idx < 0 { idx + len_i } else { idx };
+                            if resolved < 0 || resolved >= len_i {
+                                return Err(VmError::ArrayIndexOutOfBounds { index: idx, len });
+                            }
+                            let ch = s
+                                .chars()
+                                .nth(resolved as usize)
+                                .expect("index already bounds-checked");
+                            stack.push(Value::String(ch.to_string()));
                         }
-                        let ch = s
-                            .chars()
-                            .nth(resolved as usize)
-                            .expect("index already bounds-checked");
-                        stack.push(Value::String(ch.to_string()));
+                        _ => return Err(VmError::TypeMismatch("LoadIndex (non-indexable target)")),
                     }
-                    _ => return Err(VmError::TypeMismatch("LoadIndex (non-array target)")),
                 }
             }
             // RES-407: emitted only when `bounds_check::check_array_bounds`
@@ -1085,28 +1092,34 @@ fn run_inner(
             }
             Op::StoreIndex => {
                 // Stack layout on entry (top → bottom):
-                //   [v, idx, arr, ...]
+                //   [v, idx, container, ...]
                 // Pop in reverse-push order.
                 let v = stack.pop().ok_or(VmError::EmptyStack)?;
                 let idx_val = stack.pop().ok_or(VmError::EmptyStack)?;
-                let arr_val = stack.pop().ok_or(VmError::EmptyStack)?;
-                let Value::Int(idx) = idx_val else {
-                    return Err(VmError::TypeMismatch("StoreIndex (non-int index)"));
-                };
-                let Value::Array(mut items) = arr_val else {
-                    return Err(VmError::TypeMismatch("StoreIndex (non-array target)"));
-                };
-                if idx < 0 || (idx as usize) >= items.len() {
-                    return Err(VmError::ArrayIndexOutOfBounds {
-                        index: idx,
-                        len: items.len(),
-                    });
+                let container = stack.pop().ok_or(VmError::EmptyStack)?;
+                if let Value::Map(mut m) = container {
+                    let mk =
+                        crate::MapKey::from_value(&idx_val).map_err(VmError::BuiltinCallFailed)?;
+                    m.insert(mk, v);
+                    stack.push(Value::Map(m));
+                } else {
+                    let Value::Int(idx) = idx_val else {
+                        return Err(VmError::TypeMismatch("StoreIndex (non-int index)"));
+                    };
+                    let Value::Array(mut items) = container else {
+                        return Err(VmError::TypeMismatch("StoreIndex (non-array target)"));
+                    };
+                    let len = items.len() as i64;
+                    let resolved = if idx < 0 { idx + len } else { idx };
+                    if resolved < 0 || resolved >= len {
+                        return Err(VmError::ArrayIndexOutOfBounds {
+                            index: idx,
+                            len: items.len(),
+                        });
+                    }
+                    items[resolved as usize] = v;
+                    stack.push(Value::Array(items));
                 }
-                items[idx as usize] = v;
-                // Push the modified array back so the enclosing
-                // compile pattern (`StoreLocal` after `StoreIndex`)
-                // can write it into the local slot.
-                stack.push(Value::Array(items));
             }
             // ---- RES-335: struct ops ----
             Op::StructLiteral {
@@ -5161,5 +5174,42 @@ mod tests {
     fn vm_load_index_negative_string_out_of_range() {
         let result = compile_run(r#"let s = "hi"; s[-3]"#);
         assert!(result.is_err(), "s[-3] on 2-char string should error");
+    }
+
+    #[test]
+    fn vm_load_index_map_string_key() {
+        let result = compile_run(r#"let m = {"a" -> 42, "b" -> 99}; m["a"]"#).unwrap();
+        assert_int(result, 42);
+    }
+
+    #[test]
+    fn vm_load_index_map_int_key() {
+        let result = compile_run(r#"let m = {1 -> "one", 2 -> "two"}; m[1]"#).unwrap();
+        match result {
+            Value::String(s) => assert_eq!(s, "one"),
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn vm_load_index_map_missing_key_returns_void() {
+        let result = compile_run(r#"let m = {"a" -> 1}; m["missing"]"#).unwrap();
+        assert!(
+            matches!(result, Value::Void),
+            "missing key should return Void, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn vm_store_index_map_string_key() {
+        let result = compile_run(r#"let mut m = {"x" -> 0}; m["x"] = 77; m["x"]"#).unwrap();
+        assert_int(result, 77);
+    }
+
+    #[test]
+    fn vm_store_index_map_insert_new_key() {
+        let result = compile_run(r#"let mut m = {"a" -> 1}; m["b"] = 2; m["b"]"#).unwrap();
+        assert_int(result, 2);
     }
 }


### PR DESCRIPTION
## Summary

- Extend `Op::LoadIndex` to handle `Value::Map` targets with `MapKey` (String/Int/Bool) lookups
- Extend `Op::StoreIndex` to handle `Value::Map` targets with `MapKey` insert/update
- Also fixes `StoreIndex` negative index wrapping for arrays (previously only positive indices)
- 5 new tests covering map string-key read, int-key read, missing-key Void return, map store update, and map store insert

Closes #2502

## Problem

The VM's `LoadIndex` and `StoreIndex` immediately destructured the index as `Value::Int`, rejecting any non-integer key with a type mismatch error. This meant `m["key"]` on a `Value::Map` failed with:

```
VM runtime error: vm: type mismatch in LoadIndex (non-int index)
```

The tree-walking interpreter handled this correctly — this was a VM-only regression.

## Fix

Before assuming an integer index, check if the target is a `Value::Map`. If so, convert the index to a `MapKey` via `MapKey::from_value` and perform the lookup/insert. Otherwise, fall through to the existing int-index path for arrays/tuples/strings.

## Test plan

- [x] `vm_load_index_map_string_key` — `m["a"]` returns correct value
- [x] `vm_load_index_map_int_key` — `m[1]` returns correct value
- [x] `vm_load_index_map_missing_key_returns_void` — missing key returns `Void`
- [x] `vm_store_index_map_string_key` — `m["x"] = 77` updates existing key
- [x] `vm_store_index_map_insert_new_key` — `m["b"] = 2` inserts new key
- [x] All 4967 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)