### PR TITLE
RES-2526: emit diagnostic on integer literal overflow instead of silent zero

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,3 +1,12 @@
 {
-  "claims": {}
+  "claims": {
+    "resilient/src/lib.rs": {
+      "branch": "res-2526-int-overflow-diagnostic",
+      "claimed_at": "2026-05-25T13:35:06Z"
+    },
+    "resilient/src/lexer_logos.rs": {
+      "branch": "res-2526-int-overflow-diagnostic",
+      "claimed_at": "2026-05-25T13:35:06Z"
+    }
+  }
 }

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -347,42 +347,86 @@ enum Tok {
 /// allocation is pure overhead. Same shape as `int_lit` / `float_lit`
 /// which already gate on `contains('_')`.
 fn hex_int(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
-    let body = &lex.slice()[2..];
-    // Matches the hand-rolled lexer's best-effort fallback: on overflow
-    // or an empty body (which the regex's `+` already forbids, but we
-    // keep the guard to mirror semantics), emit 0.
-    if body.contains('_') {
-        Some(i64::from_str_radix(&body.replace('_', ""), 16).unwrap_or(0))
+    let slice = lex.slice();
+    let body = &slice[2..];
+    let cleaned = if body.contains('_') {
+        std::borrow::Cow::Owned(body.replace('_', ""))
     } else {
-        Some(i64::from_str_radix(body, 16).unwrap_or(0))
+        std::borrow::Cow::Borrowed(body)
+    };
+    match i64::from_str_radix(&cleaned, 16) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            eprintln!(
+                "<input>:0:0: error: integer literal `{}` overflows i64 (max {})",
+                slice,
+                i64::MAX
+            );
+            Some(0)
+        }
     }
 }
 
 fn bin_int(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
-    let body = &lex.slice()[2..];
-    if body.contains('_') {
-        Some(i64::from_str_radix(&body.replace('_', ""), 2).unwrap_or(0))
+    let slice = lex.slice();
+    let body = &slice[2..];
+    let cleaned = if body.contains('_') {
+        std::borrow::Cow::Owned(body.replace('_', ""))
     } else {
-        Some(i64::from_str_radix(body, 2).unwrap_or(0))
+        std::borrow::Cow::Borrowed(body)
+    };
+    match i64::from_str_radix(&cleaned, 2) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            eprintln!(
+                "<input>:0:0: error: integer literal `{}` overflows i64 (max {})",
+                slice,
+                i64::MAX
+            );
+            Some(0)
+        }
     }
 }
 
 fn oct_int(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
-    let body = &lex.slice()[2..];
-    if body.contains('_') {
-        Some(i64::from_str_radix(&body.replace('_', ""), 8).unwrap_or(0))
+    let slice = lex.slice();
+    let body = &slice[2..];
+    let cleaned = if body.contains('_') {
+        std::borrow::Cow::Owned(body.replace('_', ""))
     } else {
-        Some(i64::from_str_radix(body, 8).unwrap_or(0))
+        std::borrow::Cow::Borrowed(body)
+    };
+    match i64::from_str_radix(&cleaned, 8) {
+        Ok(n) => Some(n),
+        Err(_) => {
+            eprintln!(
+                "<input>:0:0: error: integer literal `{}` overflows i64 (max {})",
+                slice,
+                i64::MAX
+            );
+            Some(0)
+        }
     }
 }
 
 /// RES-909: decimal int literal with optional `_` separators.
 fn int_lit(lex: &mut logos::Lexer<Tok>) -> Option<i64> {
     let slice = lex.slice();
-    if slice.contains('_') {
-        slice.replace('_', "").parse::<i64>().ok()
+    let cleaned = if slice.contains('_') {
+        std::borrow::Cow::Owned(slice.replace('_', ""))
     } else {
-        slice.parse::<i64>().ok()
+        std::borrow::Cow::Borrowed(slice)
+    };
+    match cleaned.parse::<i64>() {
+        Ok(n) => Some(n),
+        Err(_) => {
+            eprintln!(
+                "<input>:0:0: error: integer literal `{}` overflows i64 (max {})",
+                slice,
+                i64::MAX
+            );
+            Some(0)
+        }
     }
 }
 

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -1596,7 +1596,19 @@ impl Lexer {
         if is_float {
             Token::FloatLiteral(number_str.parse::<f64>().unwrap_or(0.0))
         } else {
-            Token::IntLiteral(number_str.parse::<i64>().unwrap_or(0))
+            match number_str.parse::<i64>() {
+                Ok(n) => Token::IntLiteral(n),
+                Err(_) => {
+                    eprintln!(
+                        "<input>:{}:{}: error: integer literal `{}` overflows i64 (max {})",
+                        self.last_token_line,
+                        self.last_token_column,
+                        number_str,
+                        i64::MAX
+                    );
+                    Token::IntLiteral(0)
+                }
+            }
         }
     }
 
@@ -1622,13 +1634,14 @@ impl Lexer {
         match i64::from_str_radix(&cleaned, radix) {
             Ok(n) => Token::IntLiteral(n),
             Err(_) => {
-                // Overflow or invalid — fall back to 0 and let the
-                // parser (or runtime) catch anomalies. A real language
-                // would report this through the diagnostics pipeline;
-                // once the lexer gains a diagnostic channel (G5), this
-                // branch should use it. For now: note the prefix in
-                // the returned string representation of a dummy token.
-                let _ = prefix;
+                eprintln!(
+                    "<input>:{}:{}: error: integer literal `{}{}` overflows i64 (max {})",
+                    self.last_token_line,
+                    self.last_token_column,
+                    prefix,
+                    cleaned,
+                    i64::MAX
+                );
                 Token::IntLiteral(0)
             }
         }
@@ -37950,6 +37963,46 @@ mod tests {
             Value::Float(v) => assert!((v - 1234.5e10).abs() < 1.0, "f = {}", v),
             other => panic!("expected Float, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn lexer_int_overflow_produces_zero_with_diagnostic() {
+        let toks = tokenize("99999999999999999999");
+        assert!(
+            matches!(toks[0], Token::IntLiteral(0)),
+            "overflowed int literal should produce IntLiteral(0), got {:?}",
+            toks[0]
+        );
+    }
+
+    #[test]
+    fn lexer_hex_overflow_produces_zero_with_diagnostic() {
+        let toks = tokenize("0xFFFFFFFFFFFFFFFFFF");
+        assert!(
+            matches!(toks[0], Token::IntLiteral(0)),
+            "overflowed hex literal should produce IntLiteral(0), got {:?}",
+            toks[0]
+        );
+    }
+
+    #[test]
+    fn lexer_max_i64_parses_correctly() {
+        let toks = tokenize("9223372036854775807");
+        assert!(
+            matches!(toks[0], Token::IntLiteral(9223372036854775807)),
+            "i64::MAX should parse correctly, got {:?}",
+            toks[0]
+        );
+    }
+
+    #[test]
+    fn lexer_i64_max_plus_one_overflows() {
+        let toks = tokenize("9223372036854775808");
+        assert!(
+            matches!(toks[0], Token::IntLiteral(0)),
+            "i64::MAX+1 should overflow to IntLiteral(0), got {:?}",
+            toks[0]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Integer literals exceeding i64 range (e.g., `9223372036854775808`) now emit a diagnostic error instead of silently producing `IntLiteral(0)`
- Fixed in both the hand-written lexer (lib.rs `read_number` and `read_radix_number`) and the logos-based lexer (lexer_logos.rs `int_lit`, `hex_int`, `oct_int`, `bin_int`)
- Still produces `IntLiteral(0)` for error recovery, but the user sees the overflow diagnostic
- 4 new tests: overflow detection for decimal and hex, i64::MAX boundary, i64::MAX+1 overflow

## Test plan

- [x] 4830 compiler tests pass (4826 existing + 4 new)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] Manual verification: `99999999999999999999` now prints overflow error

Closes #2509

🤖 Generated with [Claude Code](https://claude.com/claude-code)