### PR TITLE
RES-2528: add for-in loop support for maps in interpreter and VM

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,20 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-2526-int-overflow-diagnostic",
-      "claimed_at": "2026-05-25T13:35:06Z"
+      "branch": "res-2528-map-iteration",
+      "claimed_at": "2026-05-25T13:53:15Z"
     },
-    "resilient/src/lexer_logos.rs": {
-      "branch": "res-2526-int-overflow-diagnostic",
-      "claimed_at": "2026-05-25T13:35:06Z"
+    "resilient/src/compiler.rs": {
+      "branch": "res-2528-map-iteration",
+      "claimed_at": "2026-05-25T13:53:15Z"
+    },
+    "resilient/src/vm.rs": {
+      "branch": "res-2528-map-iteration",
+      "claimed_at": "2026-05-25T13:53:15Z"
+    },
+    "resilient/src/bytecode.rs": {
+      "branch": "res-2528-map-iteration",
+      "claimed_at": "2026-05-25T13:53:15Z"
     }
   }
 }

--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -228,6 +228,13 @@ pub enum Op {
     ///
     /// Emitted for `expr?` (`Node::TryExpression`) nodes.
     TryUnwrap,
+    /// RES-2528: normalize an iterable for `for-in` loops. Pop TOS:
+    ///   - `Array` / `String` → push back unchanged (LoadIndex handles both).
+    ///   - `Map` → convert to sorted keys array, push that instead.
+    ///
+    /// Emitted by `compile_for_in` after evaluating the iterable so the
+    /// rest of the loop (len + sequential LoadIndex) works uniformly.
+    IterPrepare,
 }
 
 /// One compiled chunk of bytecode. `code` is the instruction stream;

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -1566,7 +1566,10 @@ fn compile_for_in(
     *next_local += 1;
     locals.insert(name.to_string(), name_slot);
 
-    // 1. Evaluate iterable, store in arr_slot.
+    // 1. Evaluate iterable, normalize for iteration, store in arr_slot.
+    //    IterPrepare converts maps to their sorted-keys array so the
+    //    sequential LoadIndex loop below works uniformly for arrays,
+    //    strings, and maps.
     compile_expr(
         iterable,
         chunk,
@@ -1578,6 +1581,7 @@ fn compile_for_in(
         next_fn_idx,
         line,
     )?;
+    chunk.emit(Op::IterPrepare, line);
     chunk.emit(Op::StoreLocal(arr_slot), line);
 
     // 2. Compute length via the canonical `len` builtin and

--- a/resilient/src/disasm.rs
+++ b/resilient/src/disasm.rs
@@ -228,6 +228,7 @@ fn write_op(
         Op::MakeTuple { len } => write!(out, "MakeTuple {}", len)?,
         Op::CallClosure { arity } => write!(out, "CallClosure arity={}", arity)?,
         Op::TryUnwrap => write!(out, "TryUnwrap")?,
+        Op::IterPrepare => write!(out, "IterPrepare")?,
     }
     Ok(())
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -19478,8 +19478,9 @@ fn builtin_len(args: &[Value]) -> RResult<Value> {
         [Value::Array(items)] => Ok(Value::Int(items.len() as i64)),
         // RES-932: tuple length for tuple-pattern matching in the bytecode VM.
         [Value::Tuple(items)] => Ok(Value::Int(items.len() as i64)),
+        [Value::Map(m)] => Ok(Value::Int(m.len() as i64)),
         [other] => Err(format!(
-            "len: expected string, array, or tuple, got {}",
+            "len: expected string, array, tuple, or map, got {}",
             other
         )),
         _ => Err(format!("len: expected 1 argument, got {}", args.len())),
@@ -24235,7 +24236,17 @@ impl Interpreter {
         let iter_val = self.eval(iterable)?;
         let items = match iter_val {
             Value::Array(v) => v,
-            other => return Err(format!("`for` iterable must be an array, got {}", other)),
+            Value::Map(m) => {
+                let mut keys: Vec<&MapKey> = m.keys().collect();
+                keys.sort_unstable_by(|a, b| crate::map_entries_merge::cmp_map_keys(a, b));
+                keys.into_iter().map(|k| k.to_value()).collect()
+            }
+            other => {
+                return Err(format!(
+                    "`for` iterable must be an array or map, got {}",
+                    other
+                ));
+            }
         };
         for item in items {
             self.env.set(name.to_string(), item);
@@ -37573,6 +37584,60 @@ mod tests {
             Value::Map(m) => assert_eq!(m.len(), 0),
             other => panic!("expected empty Map, got {:?}", other),
         }
+    }
+
+    // --- RES-2528: for-in over maps ---
+
+    #[test]
+    fn for_in_map_iterates_keys_interpreter() {
+        let src = r#"
+            let m = {"b" -> 2, "a" -> 1};
+            let result = [];
+            for k in m {
+                result = push(result, k);
+            }
+        "#;
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        interp.eval(&program).unwrap();
+        let result = interp.env.get("result").expect("binding `result`");
+        match result {
+            Value::Array(items) => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(&items[0], Value::String(s) if s == "a"));
+                assert!(matches!(&items[1], Value::String(s) if s == "b"));
+            }
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn for_in_map_access_values_interpreter() {
+        let src = r#"
+            let m = {"x" -> 10, "y" -> 20};
+            let total = 0;
+            for k in m {
+                total = total + m[k];
+            }
+        "#;
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        interp.eval(&program).unwrap();
+        let total = interp.env.get("total").expect("binding `total`");
+        assert!(matches!(total, Value::Int(30)), "got {:?}", total);
+    }
+
+    #[test]
+    fn len_supports_maps() {
+        let src = r#"let n = len({"a" -> 1, "b" -> 2, "c" -> 3});"#;
+        let (program, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut interp = Interpreter::new();
+        interp.eval(&program).unwrap();
+        let n = interp.env.get("n").expect("binding `n`");
+        assert!(matches!(n, Value::Int(3)), "got {:?}", n);
     }
 
     // --- RES-153: struct field assignment ---

--- a/resilient/src/map_entries_merge.rs
+++ b/resilient/src/map_entries_merge.rs
@@ -18,6 +18,10 @@ use crate::{MapKey, RResult, Value};
 
 /// Deterministic ordering matching `map_keys`. Sorts `Int` < `Str` <
 /// `Bool` cross-variant; within each variant uses the natural order.
+pub(crate) fn cmp_map_keys(a: &MapKey, b: &MapKey) -> std::cmp::Ordering {
+    cmp_keys(a, b)
+}
+
 fn cmp_keys(a: &MapKey, b: &MapKey) -> std::cmp::Ordering {
     match (a, b) {
         (MapKey::Int(x), MapKey::Int(y)) => x.cmp(y),

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -1016,6 +1016,23 @@ fn run_inner(
                     }
                 }
             }
+            Op::IterPrepare => {
+                let v = stack.pop().ok_or(VmError::EmptyStack)?;
+                match v {
+                    Value::Array(_) | Value::String(_) => stack.push(v),
+                    Value::Map(m) => {
+                        let mut keys: Vec<&crate::MapKey> = m.keys().collect();
+                        keys.sort_unstable_by(|a, b| crate::map_entries_merge::cmp_map_keys(a, b));
+                        let arr: Vec<Value> = keys.into_iter().map(|k| k.to_value()).collect();
+                        stack.push(Value::Array(arr));
+                    }
+                    _ => {
+                        return Err(VmError::TypeMismatch(
+                            "IterPrepare: expected Array, String, or Map",
+                        ));
+                    }
+                }
+            }
             Op::LoadIndex => {
                 let idx_val = stack.pop().ok_or(VmError::EmptyStack)?;
                 let target = stack.pop().ok_or(VmError::EmptyStack)?;
@@ -1484,6 +1501,7 @@ fn op_to_index(op: Op) -> usize {
         Op::MakeTuple { .. } => OP_KIND_MAKE_TUPLE,
         Op::CallClosure { .. } => OP_KIND_CALL_CLOSURE,
         Op::TryUnwrap => OP_KIND_TRY_UNWRAP,
+        Op::IterPrepare => OP_KIND_ITER_PREPARE,
     }
 }
 
@@ -1500,7 +1518,8 @@ const OP_KIND_ASSERT_FAIL: usize = 40;
 const OP_KIND_MAKE_TUPLE: usize = 41;
 const OP_KIND_CALL_CLOSURE: usize = 42;
 const OP_KIND_TRY_UNWRAP: usize = 43;
-const HANDLER_TABLE_LEN: usize = 44;
+const OP_KIND_ITER_PREPARE: usize = 44;
+const HANDLER_TABLE_LEN: usize = 45;
 
 /// The dispatch table. Each entry is a handler keyed by the index
 /// returned from `op_to_index`. Built once at compile time.
@@ -1550,6 +1569,7 @@ static HANDLERS: [Handler; HANDLER_TABLE_LEN] = {
     table[OP_KIND_MAKE_TUPLE] = h_make_tuple;
     table[OP_KIND_CALL_CLOSURE] = h_call_closure;
     table[OP_KIND_TRY_UNWRAP] = h_try_unwrap;
+    table[OP_KIND_ITER_PREPARE] = h_iter_prepare;
     table
 };
 
@@ -2496,6 +2516,25 @@ fn h_try_unwrap(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
             "TryUnwrap: expected Result or Option",
         )),
     }
+}
+
+fn h_iter_prepare(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
+    let v = state.stack.pop().ok_or(VmError::EmptyStack)?;
+    match v {
+        Value::Array(_) | Value::String(_) => state.stack.push(v),
+        Value::Map(m) => {
+            let mut keys: Vec<&crate::MapKey> = m.keys().collect();
+            keys.sort_unstable_by(|a, b| crate::map_entries_merge::cmp_map_keys(a, b));
+            let arr: Vec<Value> = keys.into_iter().map(|k| k.to_value()).collect();
+            state.stack.push(Value::Array(arr));
+        }
+        _ => {
+            return Err(VmError::TypeMismatch(
+                "IterPrepare: expected Array, String, or Map",
+            ));
+        }
+    }
+    Ok(Step::Continue)
 }
 
 #[cfg(test)]
@@ -5210,6 +5249,86 @@ mod tests {
     #[test]
     fn vm_store_index_map_insert_new_key() {
         let result = compile_run(r#"let mut m = {"a" -> 1}; m["b"] = 2; m["b"]"#).unwrap();
+        assert_int(result, 2);
+    }
+
+    // ── RES-2528: for-in over maps in the VM ────────────────────────
+
+    #[test]
+    fn vm_for_in_map_iterates_keys() {
+        let src = r#"
+            let m = {"b" -> 20, "a" -> 10};
+            let result = [];
+            for k in m {
+                result = push(result, k);
+            }
+            result
+        "#;
+        let result = compile_run(src).unwrap();
+        match result {
+            Value::Array(items) => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(&items[0], Value::String(s) if s == "a"));
+                assert!(matches!(&items[1], Value::String(s) if s == "b"));
+            }
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn vm_for_in_map_access_values() {
+        let src = r#"
+            let m = {"x" -> 10, "y" -> 20};
+            let total = 0;
+            for k in m {
+                total = total + m[k];
+            }
+            total
+        "#;
+        let result = compile_run(src).unwrap();
+        assert_int(result, 30);
+    }
+
+    #[test]
+    fn vm_for_in_map_empty() {
+        let src = r#"
+            let m = {};
+            let count = 0;
+            for k in m {
+                count = count + 1;
+            }
+            count
+        "#;
+        let result = compile_run(src).unwrap();
+        assert_int(result, 0);
+    }
+
+    #[test]
+    fn vm_for_in_map_int_keys() {
+        let src = r#"
+            let m = {3 -> "c", 1 -> "a", 2 -> "b"};
+            let result = [];
+            for k in m {
+                result = push(result, k);
+            }
+            result
+        "#;
+        let result = compile_run(src).unwrap();
+        match result {
+            Value::Array(items) => {
+                assert_eq!(items.len(), 3);
+                assert!(matches!(&items[0], Value::Int(1)));
+                assert!(matches!(&items[1], Value::Int(2)));
+                assert!(matches!(&items[2], Value::Int(3)));
+            }
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn vm_len_map() {
+        let src = r#"len({"a" -> 1, "b" -> 2})"#;
+        let result = compile_run(src).unwrap();
         assert_int(result, 2);
     }
 }


### PR DESCRIPTION
## Summary

- Maps are now iterable with `for k in map` — binds each key in deterministic sorted order
- Added `IterPrepare` VM opcode that normalizes iterables (maps → sorted keys array, arrays/strings pass through)
- `len()` builtin now supports maps
- 8 new tests covering interpreter and VM paths

## Problem

`for x in map` was broken in both execution modes:
- **Interpreter**: rejected maps with "iterable must be an array"
- **VM**: used `LoadIndex` with integer indices 0..len, which performed key lookups (`map[Int(0)]`) instead of positional iteration — producing `Void` for non-integer-keyed maps

## Design

The loop variable receives **keys** (matching Python/JS `for k in dict` semantics). Users access values via `map[k]` in the loop body. Keys are yielded in deterministic sorted order (Int < Str < Bool).

The VM fix adds a single `IterPrepare` opcode emitted after evaluating the for-in iterable. For maps, it extracts the sorted keys as an array; for arrays and strings, it's a no-op passthrough. The rest of the loop (`len` + sequential `LoadIndex`) works unchanged.

Closes #2511

## Test plan

- [x] `for k in {"b" -> 2, "a" -> 1}` yields keys `["a", "b"]` (interpreter)
- [x] `for k in {"x" -> 10, "y" -> 20} { total += m[k] }` sums to 30 (interpreter)
- [x] `len({"a" -> 1, "b" -> 2, "c" -> 3})` returns 3
- [x] VM: `for k in map` iterates keys in sorted order
- [x] VM: `for k in map { map[k] }` accesses values correctly
- [x] VM: empty map iteration executes zero body iterations
- [x] VM: integer-keyed maps iterate keys in numeric order
- [x] VM: `len(map)` returns entry count
- [x] All existing for-in tests for arrays, strings, ranges still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)