### PR TITLE
RES-2536: fix VM closures not persisting mutations to captured variables

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,20 @@
 {
   "claims": {
     "resilient/src/vm.rs": {
-      "branch": "res-2534-handler-table-sync",
-      "claimed_at": "2026-05-25T14:50:48Z"
+      "branch": "res-2536-closure-upvalue-mutation",
+      "claimed_at": "2026-05-25T15:02:29Z"
+    },
+    "resilient/src/compiler.rs": {
+      "branch": "res-2536-closure-upvalue-mutation",
+      "claimed_at": "2026-05-25T15:02:29Z"
+    },
+    "resilient/src/bytecode.rs": {
+      "branch": "res-2536-closure-upvalue-mutation",
+      "claimed_at": "2026-05-25T15:02:29Z"
+    },
+    "resilient/src/disasm.rs": {
+      "branch": "res-2536-closure-upvalue-mutation",
+      "claimed_at": "2026-05-25T15:02:29Z"
     }
   }
 }

--- a/resilient/examples/vm_closure_mutation.expected.txt
+++ b/resilient/examples/vm_closure_mutation.expected.txt
@@ -1,0 +1,2 @@
+3
+Program executed successfully

--- a/resilient/examples/vm_closure_mutation.rz
+++ b/resilient/examples/vm_closure_mutation.rz
@@ -1,0 +1,6 @@
+let x = 0;
+let inc = fn() { x = x + 1; };
+inc();
+inc();
+inc();
+println(x);

--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -111,13 +111,21 @@ pub enum Op {
     /// wire the actual slab; today the dispatch arm returns
     /// `VmError::Unsupported`.
     LoadUpvalue(u16),
+    /// RES-2536: pop TOS and write it to BOTH the local slot
+    /// (locals_base + local_slot) AND frame.upvalues[upvalue_idx].
+    /// Persists closure mutations so the value is retained across calls.
+    /// Encoded as (upvalue_idx, local_slot) packed into (u16, u16).
+    StoreUpvalue { upvalue_idx: u16, local_slot: u16 },
     /// RES-169c: call a closure value sitting below `arity` arguments
     /// on the operand stack. Stack layout before this op:
     ///   `[..., closure, arg0, arg1, …, argArity-1]`
     /// Pops `arity` args (reverse order → source order in the new
     /// frame's locals), then pops the closure, creates a new
     /// `CallFrame` with the closure's `fn_idx` and `upvalues` slab.
-    CallClosure { arity: u8 },
+    /// `source_slot` is the caller-frame local slot the closure was
+    /// loaded from (`u16::MAX` if unknown/temporary) — used to
+    /// write back mutated upvalues on return.
+    CallClosure { arity: u8, source_slot: u16 },
     /// RES-384: self-tail-call in tail position. Reuses the current
     /// `CallFrame` instead of pushing a new one, keeping call-stack
     /// depth O(1) for tail-recursive functions. The callee MUST be
@@ -292,6 +300,10 @@ pub struct Function {
     pub arity: u8,
     pub chunk: Chunk,
     pub local_count: u16,
+    /// RES-2536: for closures, the outer-scope local slot each upvalue
+    /// was captured from. `source_slots[i]` is the caller-frame slot
+    /// for upvalue `i`. Empty for non-closure functions.
+    pub upvalue_source_slots: Box<[u16]>,
 }
 
 /// RES-081: top-level compile output. `main` is the entrypoint

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -376,6 +376,7 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
                 arity,
                 chunk,
                 local_count: next_local,
+                upvalue_source_slots: Box::default(),
             });
         }
     }
@@ -2264,7 +2265,13 @@ fn compile_expr(
                     if arity > u8::MAX as usize {
                         return Err(CompileError::Unsupported("too many args in indirect call"));
                     }
-                    chunk.emit(Op::CallClosure { arity: arity as u8 }, line);
+                    chunk.emit(
+                        Op::CallClosure {
+                            arity: arity as u8,
+                            source_slot: slot,
+                        },
+                        line,
+                    );
                     return Ok(());
                 }
             }
@@ -2771,6 +2778,25 @@ fn compile_expr(
             }
             fn_chunk.emit(Op::ReturnFromCall, 0);
 
+            // RES-2536: rewrite StoreLocal ops that target upvalue
+            // slots to StoreUpvalue, which persists the mutation in
+            // the closure's upvalue slab for cross-call visibility.
+            if upvalue_count > 0 {
+                let ub = upvalue_base;
+                let limit = ub + upvalue_count as u16;
+                for op in fn_chunk.code.iter_mut() {
+                    if let Op::StoreLocal(slot) = *op
+                        && slot >= ub
+                        && slot < limit
+                    {
+                        *op = Op::StoreUpvalue {
+                            upvalue_idx: slot - ub,
+                            local_slot: slot,
+                        };
+                    }
+                }
+            }
+
             let local_count = fn_next_local;
             // Insert at fn_idx (pre-allocated index). fns may have grown via
             // nested FunctionLiterals; we need to push a placeholder then
@@ -2779,12 +2805,15 @@ fn compile_expr(
             // also increment next_fn_idx, fn_idx may not equal fns.len() by
             // the time we reach here. Use a placeholder-then-overwrite strategy:
             // extend fns to at least fn_idx+1 with placeholders.
+            let source_slots: Box<[u16]> =
+                captured.iter().map(|(s, _)| *s).collect::<Vec<_>>().into();
             while fns.len() <= fn_idx as usize {
                 fns.push(Function {
                     name: "<closure_placeholder>".into(),
                     arity: 0,
                     chunk: Chunk::with_capacity(0),
                     local_count: 0,
+                    upvalue_source_slots: Box::default(),
                 });
             }
             fns[fn_idx as usize] = Function {
@@ -2792,6 +2821,7 @@ fn compile_expr(
                 arity,
                 chunk: fn_chunk,
                 local_count,
+                upvalue_source_slots: source_slots,
             };
 
             // Emit: push each captured value onto the stack, then MakeClosure.

--- a/resilient/src/disasm.rs
+++ b/resilient/src/disasm.rs
@@ -226,7 +226,17 @@ fn write_op(
         Op::Shr => write!(out, "Shr")?,
         Op::AssertFail => write!(out, "AssertFail")?,
         Op::MakeTuple { len } => write!(out, "MakeTuple {}", len)?,
-        Op::CallClosure { arity } => write!(out, "CallClosure arity={}", arity)?,
+        Op::CallClosure { arity, source_slot } => {
+            if source_slot == u16::MAX {
+                write!(out, "CallClosure arity={}", arity)?
+            } else {
+                write!(out, "CallClosure arity={} src={}", arity, source_slot)?
+            }
+        }
+        Op::StoreUpvalue {
+            upvalue_idx,
+            local_slot,
+        } => write!(out, "StoreUpvalue uv={} local={}", upvalue_idx, local_slot)?,
         Op::TryUnwrap => write!(out, "TryUnwrap")?,
         Op::IterPrepare => write!(out, "IterPrepare")?,
         Op::LoadGlobal(idx) => write!(out, "LoadGlobal {}", idx)?,
@@ -318,6 +328,7 @@ mod tests {
                 arity: 0,
                 chunk: mk_chunk(vec![Op::Return], vec![], vec![1]),
                 local_count: 0,
+                upvalue_source_slots: Box::default(),
             }],
             #[cfg(feature = "ffi")]
             foreign_syms: Vec::new(),
@@ -345,12 +356,14 @@ mod tests {
                         vec![1, 1],
                     ),
                     local_count: 1,
+                    upvalue_source_slots: Box::default(),
                 },
                 Function {
                     name: "beta".to_string(),
                     arity: 2,
                     chunk: mk_chunk(vec![Op::Return], vec![], vec![1]),
                     local_count: 2,
+                    upvalue_source_slots: Box::default(),
                 },
             ],
             #[cfg(feature = "ffi")]
@@ -404,6 +417,7 @@ mod tests {
                     vec![1, 1],
                 ),
                 local_count: 1,
+                upvalue_source_slots: Box::default(),
             }],
             #[cfg(feature = "ffi")]
             foreign_syms: Vec::new(),
@@ -481,6 +495,7 @@ mod tests {
                 arity: 1,
                 chunk: Chunk::new(),
                 local_count: 0,
+                upvalue_source_slots: Box::default(),
             }],
             #[cfg(feature = "ffi")]
             foreign_syms: Vec::new(),

--- a/resilient/src/inline.rs
+++ b/resilient/src/inline.rs
@@ -657,6 +657,7 @@ mod tests {
             name: "id".to_string(),
             arity: 1,
             local_count: 1,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(
                 vec![Op::LoadLocal(0), Op::ReturnFromCall, Op::ReturnFromCall],
                 vec![],
@@ -671,6 +672,7 @@ mod tests {
             name: "add1".to_string(),
             arity: 1,
             local_count: 1,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(
                 vec![
                     Op::LoadLocal(0),
@@ -691,6 +693,7 @@ mod tests {
             name: "rec".to_string(),
             arity: 0,
             local_count: 0,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(vec![Op::Call(0), Op::ReturnFromCall], vec![], vec![1, 1]),
         }
     }
@@ -713,6 +716,7 @@ mod tests {
             name: "big".to_string(),
             arity: 1,
             local_count: 1,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(code, vec![Value::Int(0)], lines),
         }
     }
@@ -759,6 +763,7 @@ mod tests {
             name: "boundary".to_string(),
             arity: 1,
             local_count: 1,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(code, vec![], lines),
         };
         let funcs = vec![func];
@@ -777,6 +782,7 @@ mod tests {
             name: "over".to_string(),
             arity: 1,
             local_count: 1,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(code, vec![], lines),
         };
         let funcs = vec![func];
@@ -789,6 +795,7 @@ mod tests {
             name: "tc".to_string(),
             arity: 0,
             local_count: 0,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(vec![Op::TailCall(0), Op::Return], vec![], vec![1, 1]),
         };
         let funcs = vec![func];
@@ -801,6 +808,7 @@ mod tests {
             name: "ffi_caller".to_string(),
             arity: 0,
             local_count: 0,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(
                 vec![Op::CallForeign(0), Op::ReturnFromCall],
                 vec![],
@@ -817,6 +825,7 @@ mod tests {
             name: "cl".to_string(),
             arity: 0,
             local_count: 0,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(
                 vec![
                     Op::MakeClosure {
@@ -942,6 +951,7 @@ mod tests {
             name: "zero".to_string(),
             arity: 0,
             local_count: 0,
+            upvalue_source_slots: Box::default(),
             chunk: mk_chunk(
                 vec![Op::Const(0), Op::ReturnFromCall, Op::ReturnFromCall],
                 vec![Value::Int(0)],

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9952,6 +9952,10 @@ enum Value {
     Closure {
         fn_idx: u16,
         upvalues: Box<[Value]>,
+        /// RES-2536: caller-frame local slots that each upvalue was
+        /// captured from. On return, mutated upvalues are written
+        /// back to these slots in the caller's locals.
+        source_slots: Box<[u16]>,
     },
     /// FFI v1: resolved foreign symbol, callable from Resilient source.
     /// The Arc holds both the resolved ptr and the signature; the
@@ -10112,7 +10116,9 @@ impl std::fmt::Debug for Value {
             // RES-169a: skeleton Debug for the VM-side closure value.
             // Not constructed today; kept for completeness so a
             // future test printf doesn't silently no-op.
-            Value::Closure { fn_idx, upvalues } => {
+            Value::Closure {
+                fn_idx, upvalues, ..
+            } => {
                 write!(f, "Closure(fn={}, {} upvalues)", fn_idx, upvalues.len())
             }
             #[cfg(feature = "ffi")]

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -359,6 +359,15 @@ struct CallFrame {
     /// RES-169c: captured values for this closure frame. Empty for
     /// regular (non-closure) calls; `LoadUpvalue(i)` indexes here.
     upvalues: Box<[Value]>,
+    /// RES-2536: absolute index into the `locals` slab where the
+    /// closure value lives in the caller's frame. `None` for non-closure
+    /// calls or temporary closures. Used by `ReturnFromCall` to write
+    /// mutated upvalues back to the `Value::Closure`.
+    closure_home: Option<usize>,
+    /// RES-2536: for each upvalue, the caller-frame local slot it was
+    /// captured from. On return, mutated upvalues are written back to
+    /// both the `Value::Closure` and the caller's local slots.
+    source_slots: Box<[u16]>,
 }
 
 /// RES-329: dispatch strategy. The default match-based loop and the
@@ -464,6 +473,8 @@ fn run_inner(
         pc: 0,
         locals_base: 0,
         upvalues: Box::default(),
+        closure_home: None,
+        source_slots: Box::default(),
     });
 
     loop {
@@ -665,6 +676,8 @@ fn run_inner(
                     pc: 0,
                     locals_base: base,
                     upvalues: Box::default(),
+                    closure_home: None,
+                    source_slots: Box::default(),
                 });
             }
             Op::ReturnFromCall => {
@@ -676,10 +689,23 @@ fn run_inner(
                 let ret = stack.pop().unwrap_or(Value::Void);
                 let popped = frames.pop().ok_or(VmError::CallStackUnderflow)?;
                 if frames.is_empty() {
-                    // ReturnFromCall at top level — shouldn't happen
-                    // for well-formed programs. Treat as halt so
-                    // hand-rolled chunks don't panic.
                     return Ok(ret);
+                }
+                if !popped.upvalues.is_empty() {
+                    let caller_base = frames.last().map_or(0, |f| f.locals_base);
+                    for (i, val) in popped.upvalues.iter().enumerate() {
+                        if let Some(&src) = popped.source_slots.get(i) {
+                            let abs = caller_base + src as usize;
+                            if abs < locals.len() {
+                                locals[abs] = val.clone();
+                            }
+                        }
+                    }
+                    if let Some(home) = popped.closure_home
+                        && let Some(Value::Closure { upvalues, .. }) = locals.get_mut(home)
+                    {
+                        *upvalues = popped.upvalues;
+                    }
                 }
                 locals.truncate(popped.locals_base);
                 stack.push(ret);
@@ -856,9 +882,15 @@ fn run_inner(
                 let split = stack.len() - upvalue_count as usize;
                 let captured: Box<[Value]> =
                     stack.drain(split..).collect::<Vec<_>>().into_boxed_slice();
+                let src = program
+                    .functions
+                    .get(fn_idx as usize)
+                    .map(|f| f.upvalue_source_slots.clone())
+                    .unwrap_or_default();
                 stack.push(Value::Closure {
                     fn_idx,
                     upvalues: captured,
+                    source_slots: src,
                 });
             }
             Op::LoadUpvalue(idx) => {
@@ -870,18 +902,44 @@ fn run_inner(
                     .clone();
                 stack.push(v);
             }
-            Op::CallClosure { arity } => {
+            Op::StoreUpvalue {
+                upvalue_idx,
+                local_slot,
+            } => {
+                let v = stack.pop().ok_or(VmError::EmptyStack)?;
+                let frame_idx = frames.len() - 1;
+                let frame = &mut frames[frame_idx];
+                let abs = frame.locals_base + local_slot as usize;
+                if locals.len() <= abs {
+                    locals.resize(abs + 1, Value::Void);
+                }
+                locals[abs] = v.clone();
+                if let Some(uv) = frame.upvalues.get_mut(upvalue_idx as usize) {
+                    *uv = v;
+                }
+            }
+            Op::CallClosure { arity, source_slot } => {
                 if stack.len() < arity as usize + 1 {
                     return Err(VmError::EmptyStack);
                 }
                 if frames.len() >= MAX_CALL_DEPTH {
                     return Err(VmError::CallStackOverflow);
                 }
+                let caller_base = frames.last().map_or(0, |f| f.locals_base);
+                let home = if source_slot != u16::MAX {
+                    Some(caller_base + source_slot as usize)
+                } else {
+                    None
+                };
                 let split = stack.len() - arity as usize;
                 let args: Vec<Value> = stack.drain(split..).collect();
                 let closure = stack.pop().ok_or(VmError::EmptyStack)?;
-                let (fn_idx, captured) = match closure {
-                    Value::Closure { fn_idx, upvalues } => (fn_idx, upvalues),
+                let (fn_idx, captured, src_slots) = match closure {
+                    Value::Closure {
+                        fn_idx,
+                        upvalues,
+                        source_slots,
+                    } => (fn_idx, upvalues, source_slots),
                     _ => return Err(VmError::TypeMismatch("CallClosure: expected Closure")),
                 };
                 let func = program
@@ -898,6 +956,8 @@ fn run_inner(
                     pc: 0,
                     locals_base: base,
                     upvalues: captured,
+                    closure_home: home,
+                    source_slots: src_slots,
                 });
                 continue;
             }
@@ -1531,6 +1591,7 @@ fn op_to_index(op: Op) -> usize {
         Op::IterPrepare => OP_KIND_ITER_PREPARE,
         Op::LoadGlobal(_) => OP_KIND_LOAD_GLOBAL,
         Op::StoreGlobal(_) => OP_KIND_STORE_GLOBAL,
+        Op::StoreUpvalue { .. } => OP_KIND_STORE_UPVALUE,
     }
 }
 
@@ -1550,7 +1611,8 @@ const OP_KIND_TRY_UNWRAP: usize = 43;
 const OP_KIND_ITER_PREPARE: usize = 44;
 const OP_KIND_LOAD_GLOBAL: usize = 45;
 const OP_KIND_STORE_GLOBAL: usize = 46;
-const HANDLER_TABLE_LEN: usize = 47;
+const OP_KIND_STORE_UPVALUE: usize = 47;
+const HANDLER_TABLE_LEN: usize = 48;
 
 /// The dispatch table. Each entry is a handler keyed by the index
 /// returned from `op_to_index`. Built once at compile time.
@@ -1603,6 +1665,7 @@ static HANDLERS: [Handler; HANDLER_TABLE_LEN] = {
     table[OP_KIND_ITER_PREPARE] = h_iter_prepare;
     table[OP_KIND_LOAD_GLOBAL] = h_load_global;
     table[OP_KIND_STORE_GLOBAL] = h_store_global;
+    table[OP_KIND_STORE_UPVALUE] = h_store_upvalue;
     table
 };
 
@@ -1630,6 +1693,8 @@ fn run_direct(
         pc: 0,
         locals_base: 0,
         upvalues: Box::default(),
+        closure_home: None,
+        source_slots: Box::default(),
     });
 
     loop {
@@ -1639,11 +1704,26 @@ fn run_direct(
         *last_pc = (state.frames[frame_idx].chunk_idx, pc + 1);
 
         if pc >= chunk.code.len() {
-            // Implicit return — main halts, fn body returns Void.
             if state.frames.len() == 1 {
                 return Ok(state.stack.pop().unwrap_or(Value::Void));
             }
             let popped = state.frames.pop().ok_or(VmError::CallStackUnderflow)?;
+            if !popped.upvalues.is_empty() {
+                let caller_base = state.frames.last().map_or(0, |f| f.locals_base);
+                for (i, val) in popped.upvalues.iter().enumerate() {
+                    if let Some(&src) = popped.source_slots.get(i) {
+                        let abs = caller_base + src as usize;
+                        if abs < state.locals.len() {
+                            state.locals[abs] = val.clone();
+                        }
+                    }
+                }
+                if let Some(home) = popped.closure_home
+                    && let Some(Value::Closure { upvalues, .. }) = state.locals.get_mut(home)
+                {
+                    *upvalues = popped.upvalues;
+                }
+            }
             state.locals.truncate(popped.locals_base);
             state.stack.push(Value::Void);
             continue;
@@ -1883,6 +1963,8 @@ fn h_call(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
         pc: 0,
         locals_base: base,
         upvalues: Box::default(),
+        closure_home: None,
+        source_slots: Box::default(),
     });
     Ok(Step::Continue)
 }
@@ -1893,6 +1975,22 @@ fn h_return_from_call(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError>
     let popped = state.frames.pop().ok_or(VmError::CallStackUnderflow)?;
     if state.frames.is_empty() {
         return Ok(Step::Halt(ret));
+    }
+    if !popped.upvalues.is_empty() {
+        let caller_base = state.frames.last().map_or(0, |f| f.locals_base);
+        for (i, val) in popped.upvalues.iter().enumerate() {
+            if let Some(&src) = popped.source_slots.get(i) {
+                let abs = caller_base + src as usize;
+                if abs < state.locals.len() {
+                    state.locals[abs] = val.clone();
+                }
+            }
+        }
+        if let Some(home) = popped.closure_home
+            && let Some(Value::Closure { upvalues, .. }) = state.locals.get_mut(home)
+        {
+            *upvalues = popped.upvalues;
+        }
     }
     state.locals.truncate(popped.locals_base);
     state.stack.push(ret);
@@ -2090,9 +2188,16 @@ fn h_make_closure(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
         .drain(split..)
         .collect::<Vec<_>>()
         .into_boxed_slice();
+    let src = state
+        .program
+        .functions
+        .get(fn_idx as usize)
+        .map(|f| f.upvalue_source_slots.clone())
+        .unwrap_or_default();
     state.stack.push(Value::Closure {
         fn_idx,
         upvalues: captured,
+        source_slots: src,
     });
     Ok(Step::Continue)
 }
@@ -2114,7 +2219,7 @@ fn h_load_upvalue(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
 
 #[inline(never)]
 fn h_call_closure(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
-    let Op::CallClosure { arity } = op else {
+    let Op::CallClosure { arity, source_slot } = op else {
         unreachable!()
     };
     if state.stack.len() < arity as usize + 1 {
@@ -2123,11 +2228,21 @@ fn h_call_closure(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
     if state.frames.len() >= MAX_CALL_DEPTH {
         return Err(VmError::CallStackOverflow);
     }
+    let caller_base = state.frames.last().map_or(0, |f| f.locals_base);
+    let home = if source_slot != u16::MAX {
+        Some(caller_base + source_slot as usize)
+    } else {
+        None
+    };
     let split = state.stack.len() - arity as usize;
     let args: Vec<Value> = state.stack.drain(split..).collect();
     let closure = state.stack.pop().ok_or(VmError::EmptyStack)?;
-    let (fn_idx, captured) = match closure {
-        Value::Closure { fn_idx, upvalues } => (fn_idx, upvalues),
+    let (fn_idx, captured, src_slots) = match closure {
+        Value::Closure {
+            fn_idx,
+            upvalues,
+            source_slots,
+        } => (fn_idx, upvalues, source_slots),
         _ => return Err(VmError::TypeMismatch("CallClosure: expected Closure")),
     };
     let func = state
@@ -2147,6 +2262,8 @@ fn h_call_closure(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
         pc: 0,
         locals_base: base,
         upvalues: captured,
+        closure_home: home,
+        source_slots: src_slots,
     });
     Ok(Step::Continue)
 }
@@ -2620,6 +2737,29 @@ fn h_store_global(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
     Ok(Step::Continue)
 }
 
+#[inline(never)]
+fn h_store_upvalue(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
+    let Op::StoreUpvalue {
+        upvalue_idx,
+        local_slot,
+    } = op
+    else {
+        unreachable!()
+    };
+    let v = state.stack.pop().ok_or(VmError::EmptyStack)?;
+    let frame_idx = state.frame_idx();
+    let frame = &mut state.frames[frame_idx];
+    let abs = frame.locals_base + local_slot as usize;
+    if state.locals.len() <= abs {
+        state.locals.resize(abs + 1, Value::Void);
+    }
+    state.locals[abs] = v.clone();
+    if let Some(uv) = frame.upvalues.get_mut(upvalue_idx as usize) {
+        *uv = v;
+    }
+    Ok(Step::Continue)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2859,6 +2999,7 @@ mod tests {
             arity: 0,
             chunk: body,
             local_count: 0,
+            upvalue_source_slots: Box::default(),
         };
         let mut main = Chunk::new();
         main.code.push(Op::Call(0));
@@ -3125,6 +3266,7 @@ mod tests {
                 name: "f".into(),
                 arity: 0,
                 local_count: 0,
+                upvalue_source_slots: Box::default(),
                 chunk: body,
             }],
             #[cfg(feature = "ffi")]
@@ -3132,7 +3274,9 @@ mod tests {
         };
         let v = run(&p).unwrap();
         match v {
-            Value::Closure { fn_idx, upvalues } => {
+            Value::Closure {
+                fn_idx, upvalues, ..
+            } => {
                 assert_eq!(fn_idx, 0);
                 assert_eq!(upvalues.len(), 0);
             }
@@ -3166,6 +3310,7 @@ mod tests {
         let c = Value::Closure {
             fn_idx: 5,
             upvalues: vec![Value::Int(1), Value::Int(2)].into_boxed_slice(),
+            source_slots: Box::default(),
         };
         assert_eq!(format!("{:?}", c), "Closure(fn=5, 2 upvalues)");
         assert_eq!(format!("{}", c), "<closure>");
@@ -4025,6 +4170,7 @@ mod tests {
             arity: 0,
             chunk: body,
             local_count: 0,
+            upvalue_source_slots: Box::default(),
         };
         let mut main = Chunk::new();
         main.code.push(Op::Call(0));
@@ -4062,6 +4208,7 @@ mod tests {
                 name: "f".into(),
                 arity: 0,
                 local_count: 0,
+                upvalue_source_slots: Box::default(),
                 chunk: body,
             }],
             #[cfg(feature = "ffi")]
@@ -4131,12 +4278,19 @@ mod tests {
             Op::Shr,
             Op::AssertFail,
             Op::MakeTuple { len: 0 },
-            Op::CallClosure { arity: 0 },
+            Op::CallClosure {
+                arity: 0,
+                source_slot: u16::MAX,
+            },
             Op::TryUnwrap,
             Op::IterPrepare,
             Op::LoadGlobal(0),
             Op::StoreGlobal(0),
             Op::LoadIndexUnchecked,
+            Op::StoreUpvalue {
+                upvalue_idx: 0,
+                local_slot: 0,
+            },
         ];
         for op in samples {
             let idx = op_to_index(*op);
@@ -5495,5 +5649,35 @@ mod tests {
     fn res2534_string_repeat_ok_both_dispatch() {
         let src = r#""ab" * 3"#;
         assert_both_eq(src);
+    }
+
+    // ── RES-2536: closure upvalue mutation ───────────────────────────────
+
+    #[test]
+    fn res2536_closure_mutation_persists_across_calls() {
+        let src = "let x = 0; let inc = fn() { x = x + 1; }; inc(); inc(); x";
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 2);
+    }
+
+    #[test]
+    fn res2536_closure_mutation_three_calls() {
+        let src = "let x = 10; let dec = fn() { x = x - 1; }; dec(); dec(); dec(); x";
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 7);
+    }
+
+    #[test]
+    fn res2536_closure_captures_multiple_vars() {
+        let src = "let a = 1; let b = 2; let swap = fn() { let t = a; a = b; b = t; }; swap(); a + b * 10";
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 12);
+    }
+
+    #[test]
+    fn res2536_closure_read_without_mutation_unchanged() {
+        let src = "let x = 42; let read = fn() -> int { return x; }; read()";
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 42);
     }
 }


### PR DESCRIPTION
## Summary

- **Tier 1 correctness bug**: the VM and tree-walker disagreed on closure mutation semantics. `let x = 0; let inc = fn() { x = x + 1; }; inc(); inc(); println(x);` printed `2` in the tree-walker but `0` in the VM.
- **Root cause**: closures captured upvalues by value at `MakeClosure` time. `StoreLocal` in the closure body wrote to a frame-local copy, and `ReturnFromCall` discarded the frame without persisting changes. The next call re-loaded stale upvalues.
- **Fix**: Added `StoreUpvalue { upvalue_idx, local_slot }` opcode that writes to both the local slot and `frame.upvalues[idx]`. Compiler post-processes closure body bytecode, rewriting `StoreLocal` ops on upvalue slots to `StoreUpvalue`. On `ReturnFromCall`, mutated upvalues are written back to (1) the caller's local slots via `source_slots` mapping, and (2) the `Value::Closure` in the caller's locals via `closure_home`.
- **Changed `CallClosure`** to carry `source_slot: u16` (caller-frame slot of the closure; `u16::MAX` for temporaries)
- **Extended `Value::Closure`** with `source_slots: Box<[u16]>` (caller-frame slots each upvalue was captured from)
- **Extended `Function`** with `upvalue_source_slots: Box<[u16]>` (stored at compile time)

## Test plan

- [x] `res2536_closure_mutation_persists_across_calls` — `inc(); inc(); x` returns 2 on both dispatch paths
- [x] `res2536_closure_mutation_three_calls` — 3 decrements accumulate correctly
- [x] `res2536_closure_captures_multiple_vars` — multi-var swap works
- [x] `res2536_closure_read_without_mutation_unchanged` — read-only capture unaffected
- [x] Golden file `vm_closure_mutation.rz` / `.expected.txt`
- [x] All existing closure tests remain green
- [x] All existing dispatch-parity tests remain green

Closes #2519

🤖 Generated with [Claude Code](https://claude.com/claude-code)