### PR TITLE
RES-2540: compile struct/enum match patterns in VM bytecode

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,16 @@
 {
   "claims": {
     "resilient/src/compiler.rs": {
-      "branch": "res-2538-nested-fn-in-vm",
-      "claimed_at": "2026-05-25T15:43:38Z"
+      "branch": "res-2540-struct-match-patterns",
+      "claimed_at": "2026-05-25T16:10:22Z"
+    },
+    "resilient/src/type_builtins.rs": {
+      "branch": "res-2540-struct-match-patterns",
+      "claimed_at": "2026-05-25T16:10:22Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "res-2540-struct-match-patterns",
+      "claimed_at": "2026-05-25T16:10:22Z"
     }
   }
 }

--- a/resilient/examples/vm_struct_match.expected.txt
+++ b/resilient/examples/vm_struct_match.expected.txt
@@ -1,0 +1,4 @@
+point(3,5)
+y-axis at 42
+blue
+Program executed successfully

--- a/resilient/examples/vm_struct_match.rz
+++ b/resilient/examples/vm_struct_match.rz
@@ -1,0 +1,25 @@
+struct Point { int x, int y, }
+
+let p1 = new Point { x: 3, y: 5 };
+let r1 = match p1 {
+    Point { x: 0, y } => "origin-x y=" + to_string(y),
+    Point { x, y: 0 } => "origin-y x=" + to_string(x),
+    Point { x, y } => "point(" + to_string(x) + "," + to_string(y) + ")",
+};
+println(r1);
+
+let p2 = new Point { x: 0, y: 42 };
+let r2 = match p2 {
+    Point { x: 0, y } => "y-axis at " + to_string(y),
+    _ => "other",
+};
+println(r2);
+
+enum Color { Red, Green, Blue, }
+let c = Color::Blue;
+let name = match c {
+    Color::Red => "red",
+    Color::Green => "green",
+    Color::Blue => "blue",
+};
+println(name);

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -776,8 +776,10 @@ fn compile_stmt(
         Node::Assume { .. } | Node::InvariantStatement { .. } => Ok(()),
         // Type-level / declaration-only constructs: no runtime bytecode.
         // All type information is handled at parse/typecheck time.
+        Node::EnumDecl { name, variants, .. } => {
+            emit_unit_enum_variants(name, variants, chunk, locals, next_local, line)
+        }
         Node::StructDecl { .. }
-        | Node::EnumDecl { .. }
         | Node::TraitDecl { .. }
         | Node::ImplBlock { .. }
         | Node::TypeAlias { .. }
@@ -792,6 +794,38 @@ fn compile_stmt(
 }
 
 /// Shared assert-lowering logic used by both `compile_stmt` and
+/// RES-2540: bind unit enum variants as locals so `Color::Green` resolves.
+fn emit_unit_enum_variants(
+    enum_name: &str,
+    variants: &[crate::EnumVariant],
+    chunk: &mut Chunk,
+    locals: &mut HashMap<String, u16>,
+    next_local: &mut u16,
+    line: u32,
+) -> Result<(), CompileError> {
+    for v in variants {
+        if !matches!(v.payload, crate::EnumPayload::None) {
+            continue;
+        }
+        let key = format!("{}::{}", enum_name, v.name);
+        let val = Value::EnumVariant {
+            type_name: enum_name.to_string(),
+            variant: v.name.clone(),
+            payload: crate::EnumValuePayload::None,
+        };
+        let const_idx = chunk.add_constant(val)?;
+        chunk.emit(Op::Const(const_idx), line);
+        let slot = *next_local;
+        if slot == u16::MAX {
+            return Err(CompileError::TooManyLocals);
+        }
+        *next_local += 1;
+        locals.insert(key, slot);
+        chunk.emit(local_store_op(slot), line);
+    }
+    Ok(())
+}
+
 /// `compile_stmt_in_fn`. Emits:
 ///   `<cond>; JumpIfTrue(past_fail); Const(msg); AssertFail`
 #[allow(clippy::too_many_arguments)]
@@ -1472,8 +1506,10 @@ fn compile_stmt_in_fn(
         // Verification-only constructs: emit nothing at runtime.
         Node::Assume { .. } | Node::InvariantStatement { .. } => Ok(()),
         // Type-level / declaration-only constructs: no runtime bytecode.
+        Node::EnumDecl { name, variants, .. } => {
+            emit_unit_enum_variants(name, variants, chunk, locals, next_local, line)
+        }
         Node::StructDecl { .. }
-        | Node::EnumDecl { .. }
         | Node::TraitDecl { .. }
         | Node::ImplBlock { .. }
         | Node::TypeAlias { .. }
@@ -1663,9 +1699,11 @@ fn compile_control_flow_in_fn(
             /* in_fn */ true,
             loop_stack,
         ),
+        Node::EnumDecl { name, variants, .. } => {
+            emit_unit_enum_variants(name, variants, chunk, locals, next_local, line)
+        }
         // Type-level / declaration-only constructs: no runtime bytecode.
         Node::StructDecl { .. }
-        | Node::EnumDecl { .. }
         | Node::TraitDecl { .. }
         | Node::ImplBlock { .. }
         | Node::TypeAlias { .. }
@@ -3959,8 +3997,184 @@ fn compile_pattern_check(
                 )?;
             }
         }
-        _ => {
-            return Err(CompileError::Unsupported("complex match pattern"));
+        Pattern::Struct {
+            struct_name,
+            fields,
+            ..
+        } => {
+            let sn_const = chunk.add_string_constant("struct_name")?;
+            chunk.emit(Op::LoadLocal(scrutinee_slot), line);
+            chunk.emit(
+                Op::CallBuiltin {
+                    name_const: sn_const,
+                    arity: 1,
+                },
+                line,
+            );
+            let expected = chunk.add_string_constant(struct_name)?;
+            chunk.emit(Op::Const(expected), line);
+            chunk.emit(Op::Eq, line);
+            let p = chunk.emit(Op::JumpIfFalse(0), line);
+            next_arm_patches.push(p);
+            for (fname, sub_pat) in fields {
+                if *next_local == u16::MAX {
+                    return Err(CompileError::TooManyLocals);
+                }
+                let field_slot = *next_local;
+                *next_local += 1;
+                let fname_idx = chunk.add_string_constant(fname)?;
+                chunk.emit(Op::LoadLocal(scrutinee_slot), line);
+                chunk.emit(
+                    Op::GetField {
+                        name_const: fname_idx,
+                    },
+                    line,
+                );
+                chunk.emit(Op::StoreLocal(field_slot), line);
+                compile_pattern_check(
+                    sub_pat,
+                    field_slot,
+                    chunk,
+                    locals,
+                    next_local,
+                    fn_index,
+                    ffi_index,
+                    fns,
+                    next_fn_idx,
+                    line,
+                    next_arm_patches,
+                )?;
+            }
+        }
+        Pattern::TupleStruct { name, fields } => {
+            let sn_const = chunk.add_string_constant("struct_name")?;
+            chunk.emit(Op::LoadLocal(scrutinee_slot), line);
+            chunk.emit(
+                Op::CallBuiltin {
+                    name_const: sn_const,
+                    arity: 1,
+                },
+                line,
+            );
+            let expected = chunk.add_string_constant(name)?;
+            chunk.emit(Op::Const(expected), line);
+            chunk.emit(Op::Eq, line);
+            let p = chunk.emit(Op::JumpIfFalse(0), line);
+            next_arm_patches.push(p);
+            for (i, sub_pat) in fields.iter().enumerate() {
+                if *next_local == u16::MAX {
+                    return Err(CompileError::TooManyLocals);
+                }
+                let field_slot = *next_local;
+                *next_local += 1;
+                let fname_idx = chunk.add_string_constant(&i.to_string())?;
+                chunk.emit(Op::LoadLocal(scrutinee_slot), line);
+                chunk.emit(
+                    Op::GetField {
+                        name_const: fname_idx,
+                    },
+                    line,
+                );
+                chunk.emit(Op::StoreLocal(field_slot), line);
+                compile_pattern_check(
+                    sub_pat,
+                    field_slot,
+                    chunk,
+                    locals,
+                    next_local,
+                    fn_index,
+                    ffi_index,
+                    fns,
+                    next_fn_idx,
+                    line,
+                    next_arm_patches,
+                )?;
+            }
+        }
+        Pattern::EnumVariant {
+            variant_name,
+            payload,
+            ..
+        } => {
+            let sn_const = chunk.add_string_constant("struct_name")?;
+            chunk.emit(Op::LoadLocal(scrutinee_slot), line);
+            chunk.emit(
+                Op::CallBuiltin {
+                    name_const: sn_const,
+                    arity: 1,
+                },
+                line,
+            );
+            let expected = chunk.add_string_constant(variant_name)?;
+            chunk.emit(Op::Const(expected), line);
+            chunk.emit(Op::Eq, line);
+            let p = chunk.emit(Op::JumpIfFalse(0), line);
+            next_arm_patches.push(p);
+            match payload {
+                crate::EnumPatternPayload::None => {}
+                crate::EnumPatternPayload::Named(fields) => {
+                    for (fname, sub_pat) in fields {
+                        if *next_local == u16::MAX {
+                            return Err(CompileError::TooManyLocals);
+                        }
+                        let field_slot = *next_local;
+                        *next_local += 1;
+                        let fname_idx = chunk.add_string_constant(fname)?;
+                        chunk.emit(Op::LoadLocal(scrutinee_slot), line);
+                        chunk.emit(
+                            Op::GetField {
+                                name_const: fname_idx,
+                            },
+                            line,
+                        );
+                        chunk.emit(Op::StoreLocal(field_slot), line);
+                        compile_pattern_check(
+                            sub_pat,
+                            field_slot,
+                            chunk,
+                            locals,
+                            next_local,
+                            fn_index,
+                            ffi_index,
+                            fns,
+                            next_fn_idx,
+                            line,
+                            next_arm_patches,
+                        )?;
+                    }
+                }
+                crate::EnumPatternPayload::Tuple(sub_pats) => {
+                    for (i, sub_pat) in sub_pats.iter().enumerate() {
+                        if *next_local == u16::MAX {
+                            return Err(CompileError::TooManyLocals);
+                        }
+                        let field_slot = *next_local;
+                        *next_local += 1;
+                        let fname_idx = chunk.add_string_constant(&i.to_string())?;
+                        chunk.emit(Op::LoadLocal(scrutinee_slot), line);
+                        chunk.emit(
+                            Op::GetField {
+                                name_const: fname_idx,
+                            },
+                            line,
+                        );
+                        chunk.emit(Op::StoreLocal(field_slot), line);
+                        compile_pattern_check(
+                            sub_pat,
+                            field_slot,
+                            chunk,
+                            locals,
+                            next_local,
+                            fn_index,
+                            ffi_index,
+                            fns,
+                            next_fn_idx,
+                            line,
+                            next_arm_patches,
+                        )?;
+                    }
+                }
+            }
         }
     }
     Ok(())
@@ -4449,11 +4663,8 @@ mod tests {
     }
 
     #[test]
-    fn compile_unsupported_construct_is_clean_error() {
-        // RES-163: basic match (literal/wildcard arms) is now compiled.
-        // Structural patterns (struct destructuring) are still unsupported.
-        // Use a struct pattern as the "unsupported construct" canary until
-        // struct-pattern lowering ships.
+    fn compile_struct_match_pattern_compiles() {
+        // RES-2540: struct match patterns now compile successfully.
         let p = parse_one(
             r#"struct Point { int x, int y }
             fn classify(Point p) -> int {
@@ -4463,8 +4674,7 @@ mod tests {
                 };
             }"#,
         );
-        let err = compile(&p).unwrap_err();
-        assert!(matches!(err, CompileError::Unsupported(_)), "{:?}", err);
+        assert!(compile(&p).is_ok());
     }
 
     // ---------- RES-334: for-in lowering ----------

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -11833,6 +11833,7 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ),
     // RES-2652: type introspection + result_collect (pure).
     ("type_of", crate::type_builtins::builtin_type_of),
+    ("struct_name", crate::type_builtins::builtin_struct_name),
     (
         "result_collect",
         crate::type_builtins::builtin_result_collect,

--- a/resilient/src/type_builtins.rs
+++ b/resilient/src/type_builtins.rs
@@ -60,6 +60,18 @@ pub(crate) fn builtin_type_of(args: &[Value]) -> RResult<Value> {
     }
 }
 
+pub(crate) fn builtin_struct_name(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Struct { name, .. }] => Ok(Value::String(name.clone())),
+        [Value::EnumVariant { variant, .. }] => Ok(Value::String(variant.clone())),
+        [_] => Err("struct_name: argument is not a struct or enum variant".to_string()),
+        _ => Err(format!(
+            "struct_name: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
 /// `result_collect(arr) -> Result`
 ///
 /// Takes an Array of `Result` values and combines them into a single

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -5709,4 +5709,51 @@ mod tests {
         let src = "fn fib(int n) -> int { fn go(int a, int b, int c) -> int { if c <= 0 { return a; } return go(b, a + b, c - 1); } return go(0, 1, n); } fib(10)";
         assert_int(compile_run(src).unwrap(), 55);
     }
+
+    // ── RES-2540: struct/enum match patterns ──────────────────────────────
+
+    #[test]
+    fn res2540_struct_match_field_binding() {
+        let src = r#"struct Point { int x, int y, }
+let p = new Point { x: 3, y: 5 };
+match p { Point { x, y } => x + y, _ => -1, }"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 8);
+    }
+
+    #[test]
+    fn res2540_struct_match_literal_field() {
+        let src = r#"struct Point { int x, int y, }
+let p = new Point { x: 0, y: 7 };
+match p { Point { x: 0, y } => y, _ => -1, }"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 7);
+    }
+
+    #[test]
+    fn res2540_struct_match_fallthrough() {
+        let src = r#"struct Point { int x, int y, }
+let p = new Point { x: 5, y: 5 };
+match p { Point { x: 0, y } => y, _ => 99, }"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 99);
+    }
+
+    #[test]
+    fn res2540_enum_match_unit_variant() {
+        let src = r#"enum Dir { N, S, E, W, }
+let d = Dir::W;
+match d { Dir::N => 1, Dir::S => 2, Dir::E => 3, Dir::W => 4, }"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 4);
+    }
+
+    #[test]
+    fn res2540_enum_match_first_variant() {
+        let src = r#"enum Dir { N, S, E, W, }
+let d = Dir::N;
+match d { Dir::N => 10, Dir::S => 20, Dir::E => 30, Dir::W => 40, }"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 10);
+    }
 }


### PR DESCRIPTION
Closes #2523

## Summary
- Implement `Pattern::Struct`, `Pattern::TupleStruct`, and `Pattern::EnumVariant` in `compile_pattern_check` — struct match patterns now compile to VM bytecode instead of erroring with `Unsupported`
- Add `builtin_struct_name` to extract the type name from a struct or enum variant at runtime (used by pattern check bytecode)
- Add `emit_unit_enum_variants` to compile `EnumDecl` into local bindings for unit variants, enabling `Color::Green` to resolve in the VM
- 5 new VM tests (`res2540_*`) covering struct field binding, literal field checks, fallthrough to wildcard, and enum variant matching
- Golden test `vm_struct_match.rz` exercising struct + enum patterns end-to-end

## Test changes
- `compile_unsupported_construct_is_clean_error` → renamed to `compile_struct_match_pattern_compiles` and flipped to assert success, since struct patterns are no longer unsupported

## Test plan
- [x] All 4863+ compiler tests pass
- [x] Tree-walker and VM produce identical output for struct/enum match programs
- [x] Golden test verifies multi-arm struct + enum patterns
- [x] clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)