### PR TITLE
RES-2542: compile impl method calls in VM bytecode

### DIFF
--- a/resilient/examples/vm_impl_methods.expected.txt
+++ b/resilient/examples/vm_impl_methods.expected.txt
@@ -1,0 +1,3 @@
+10
+15
+Program executed successfully

--- a/resilient/examples/vm_impl_methods.rz
+++ b/resilient/examples/vm_impl_methods.rz
@@ -1,0 +1,17 @@
+struct Counter {
+    int value,
+}
+
+impl Counter {
+    fn get(self) -> int {
+        return self.value;
+    }
+
+    fn add(self, int n) -> int {
+        return self.value + n;
+    }
+}
+
+let c = new Counter { value: 10 };
+println(c.get());
+println(c.add(5));

--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -126,6 +126,11 @@ pub enum Op {
     /// loaded from (`u16::MAX` if unknown/temporary) — used to
     /// write back mutated upvalues on return.
     CallClosure { arity: u8, source_slot: u16 },
+    /// RES-2542: method call on a struct value. The VM pops `arity`
+    /// arguments, then the receiver struct, reads its type name,
+    /// forms `{type_name}${method}`, resolves the function index, and
+    /// calls it with `[receiver, args...]`.
+    CallMethod { method_const: u16, arity: u8 },
     /// RES-384: self-tail-call in tail position. Reuses the current
     /// `CallFrame` instead of pushing a new one, keeping call-stack
     /// depth O(1) for tail-recursive functions. The callee MUST be

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -252,25 +252,51 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
     // resolved_fields pre-size.
     let fn_count = stmts
         .iter()
-        .filter(|s| matches!(&s.node, Node::Function { .. }))
-        .count();
+        .map(|s| match &s.node {
+            Node::Function { .. } => 1,
+            Node::ImplBlock { methods, .. } => methods
+                .iter()
+                .filter(|m| matches!(m, Node::Function { .. }))
+                .count(),
+            _ => 0,
+        })
+        .sum::<usize>();
 
     // Pre-pass: function name → index in the `functions` table.
     let mut fn_index: HashMap<String, u16> = HashMap::with_capacity(fn_count);
     let mut next_fn_idx: u16 = 0;
     for spanned in stmts {
-        if let Node::Function {
-            name, parameters, ..
-        } = &spanned.node
-        {
-            if parameters.len() > u8::MAX as usize {
-                return Err(CompileError::Unsupported("fn with >255 params"));
+        match &spanned.node {
+            Node::Function {
+                name, parameters, ..
+            } => {
+                if parameters.len() > u8::MAX as usize {
+                    return Err(CompileError::Unsupported("fn with >255 params"));
+                }
+                if next_fn_idx == u16::MAX {
+                    return Err(CompileError::Unsupported("program has > 65535 functions"));
+                }
+                fn_index.insert(name.clone(), next_fn_idx);
+                next_fn_idx += 1;
             }
-            if next_fn_idx == u16::MAX {
-                return Err(CompileError::Unsupported("program has > 65535 functions"));
+            Node::ImplBlock { methods, .. } => {
+                for m in methods {
+                    if let Node::Function {
+                        name, parameters, ..
+                    } = m
+                    {
+                        if parameters.len() > u8::MAX as usize {
+                            return Err(CompileError::Unsupported("fn with >255 params"));
+                        }
+                        if next_fn_idx == u16::MAX {
+                            return Err(CompileError::Unsupported("program has > 65535 functions"));
+                        }
+                        fn_index.insert(name.clone(), next_fn_idx);
+                        next_fn_idx += 1;
+                    }
+                }
             }
-            fn_index.insert(name.clone(), next_fn_idx);
-            next_fn_idx += 1;
+            _ => {}
         }
     }
 
@@ -295,61 +321,101 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
         functions.push(placeholder());
     }
     let mut top_idx: usize = 0;
+    let mut compile_fn_body = |name: &str,
+                               parameters: &[(String, String)],
+                               body: &Node,
+                               fn_line: u32,
+                               functions: &mut Vec<Function>,
+                               next_fn_idx: &mut u16|
+     -> Result<(), CompileError> {
+        let arity = parameters.len() as u8;
+        let mut chunk = Chunk::with_capacity(128);
+        let cap = parameters.len().saturating_mul(2).max(8) + globals.len();
+        let mut locals: HashMap<String, u16> = HashMap::with_capacity(cap);
+        for (gname, &gslot) in &globals {
+            locals.insert(gname.clone(), gslot | GLOBAL_FLAG);
+        }
+        let mut next_local: u16 = 0;
+        for (_type_name, pname) in parameters {
+            locals.insert(pname.clone(), next_local);
+            next_local += 1;
+        }
+        let inner = match body {
+            Node::Block { stmts: b, .. } => b.as_slice(),
+            single => std::slice::from_ref(single),
+        };
+        for stmt in inner {
+            let line = node_line(stmt).unwrap_or(fn_line);
+            compile_stmt_in_fn(
+                stmt,
+                &mut chunk,
+                &mut locals,
+                &mut next_local,
+                &fn_index,
+                &ffi_index,
+                functions,
+                next_fn_idx,
+                line,
+                &mut Vec::new(),
+            )?;
+        }
+        chunk.emit(Op::ReturnFromCall, 0);
+        let own_fn_idx = top_idx as u16;
+        rewrite_tail_calls(&mut chunk, own_fn_idx);
+        crate::const_fold::optimize_if_enabled(&mut chunk)
+            .map_err(|_| CompileError::InternalError("constant folder failed"))?;
+        crate::peephole::optimize(&mut chunk)
+            .map_err(|_| CompileError::InternalError("peephole optimizer failed"))?;
+        crate::dce::eliminate(&mut chunk);
+        functions[top_idx] = Function {
+            name: name.to_string(),
+            arity,
+            chunk,
+            local_count: next_local,
+            upvalue_source_slots: Box::default(),
+        };
+        top_idx += 1;
+        Ok(())
+    };
     for spanned in stmts {
-        if let Node::Function {
-            name,
-            parameters,
-            body,
-            ..
-        } = &spanned.node
-        {
-            let arity = parameters.len() as u8;
-            let mut chunk = Chunk::with_capacity(128);
-            let cap = parameters.len().saturating_mul(2).max(8) + globals.len();
-            let mut locals: HashMap<String, u16> = HashMap::with_capacity(cap);
-            for (gname, &gslot) in &globals {
-                locals.insert(gname.clone(), gslot | GLOBAL_FLAG);
-            }
-            let mut next_local: u16 = 0;
-            for (_type_name, pname) in parameters {
-                locals.insert(pname.clone(), next_local);
-                next_local += 1;
-            }
-            let inner = match body.as_ref() {
-                Node::Block { stmts: b, .. } => b,
-                single => std::slice::from_ref(single),
-            };
-            for stmt in inner {
-                let line = node_line(stmt).unwrap_or(spanned.span.start.line as u32);
-                compile_stmt_in_fn(
-                    stmt,
-                    &mut chunk,
-                    &mut locals,
-                    &mut next_local,
-                    &fn_index,
-                    &ffi_index,
+        match &spanned.node {
+            Node::Function {
+                name,
+                parameters,
+                body,
+                ..
+            } => {
+                compile_fn_body(
+                    name,
+                    parameters,
+                    body,
+                    spanned.span.start.line as u32,
                     &mut functions,
                     &mut next_fn_idx,
-                    line,
-                    &mut Vec::new(),
                 )?;
             }
-            chunk.emit(Op::ReturnFromCall, 0);
-            let own_fn_idx = top_idx as u16;
-            rewrite_tail_calls(&mut chunk, own_fn_idx);
-            crate::const_fold::optimize_if_enabled(&mut chunk)
-                .map_err(|_| CompileError::InternalError("constant folder failed"))?;
-            crate::peephole::optimize(&mut chunk)
-                .map_err(|_| CompileError::InternalError("peephole optimizer failed"))?;
-            crate::dce::eliminate(&mut chunk);
-            functions[top_idx] = Function {
-                name: name.clone(),
-                arity,
-                chunk,
-                local_count: next_local,
-                upvalue_source_slots: Box::default(),
-            };
-            top_idx += 1;
+            Node::ImplBlock { methods, .. } => {
+                for m in methods {
+                    if let Node::Function {
+                        name,
+                        parameters,
+                        body,
+                        ..
+                    } = m
+                    {
+                        let line = node_line(m).unwrap_or(spanned.span.start.line as u32);
+                        compile_fn_body(
+                            name,
+                            parameters,
+                            body,
+                            line,
+                            &mut functions,
+                            &mut next_fn_idx,
+                        )?;
+                    }
+                }
+            }
+            _ => {}
         }
     }
 
@@ -376,8 +442,7 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
                 | Node::Extern { .. }
                 | Node::RegionDecl { .. }
                 | Node::StructDecl { .. }
-                // RES-319: newtype declarations are compile-time metadata;
-                // constructor calls are already lowered to NewtypeConstruct.
+                | Node::ImplBlock { .. }
                 | Node::NewtypeDecl { .. }
         ) {
             continue;
@@ -2409,6 +2474,48 @@ fn compile_expr(
                     );
                     return Ok(());
                 }
+            }
+            // RES-2542: method call — `target.method(args)` compiles to
+            // `CallMethod { method_const, arity }`. The receiver is pushed
+            // first, then the arguments, so the VM can prepend it as `self`.
+            if let Node::FieldAccess { target, field, .. } = function.as_ref() {
+                compile_expr(
+                    target,
+                    chunk,
+                    locals,
+                    next_local,
+                    fn_index,
+                    ffi_index,
+                    fns,
+                    next_fn_idx,
+                    line,
+                )?;
+                for arg in arguments {
+                    compile_expr(
+                        arg,
+                        chunk,
+                        locals,
+                        next_local,
+                        fn_index,
+                        ffi_index,
+                        fns,
+                        next_fn_idx,
+                        line,
+                    )?;
+                }
+                let method_const = chunk.add_string_constant(field)?;
+                let arity = arguments.len();
+                if arity > u8::MAX as usize {
+                    return Err(CompileError::Unsupported("method call with > 255 args"));
+                }
+                chunk.emit(
+                    Op::CallMethod {
+                        method_const,
+                        arity: arity as u8,
+                    },
+                    line,
+                );
+                return Ok(());
             }
             let callee_name: &str = match function.as_ref() {
                 Node::Identifier { name, .. } => name.as_str(),

--- a/resilient/src/disasm.rs
+++ b/resilient/src/disasm.rs
@@ -241,6 +241,10 @@ fn write_op(
         Op::IterPrepare => write!(out, "IterPrepare")?,
         Op::LoadGlobal(idx) => write!(out, "LoadGlobal {}", idx)?,
         Op::StoreGlobal(idx) => write!(out, "StoreGlobal {}", idx)?,
+        Op::CallMethod {
+            method_const,
+            arity,
+        } => write!(out, "CallMethod method={} arity={}", method_const, arity)?,
     }
     Ok(())
 }

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -961,6 +961,59 @@ fn run_inner(
                 });
                 continue;
             }
+            Op::CallMethod {
+                method_const,
+                arity,
+            } => {
+                let method = match &chunk.constants[method_const as usize] {
+                    Value::String(s) => s.clone(),
+                    _ => {
+                        return Err(VmError::TypeMismatch(
+                            "CallMethod: bad method name constant",
+                        ));
+                    }
+                };
+                if stack.len() < arity as usize + 1 {
+                    return Err(VmError::EmptyStack);
+                }
+                if frames.len() >= MAX_CALL_DEPTH {
+                    return Err(VmError::CallStackOverflow);
+                }
+                let split = stack.len() - arity as usize;
+                let args: Vec<Value> = stack.drain(split..).collect();
+                let receiver = stack.pop().ok_or(VmError::EmptyStack)?;
+                let struct_name = match &receiver {
+                    Value::Struct { name, .. } => name.clone(),
+                    Value::EnumVariant { type_name, .. } => type_name.clone(),
+                    _ => {
+                        return Err(VmError::TypeMismatch(
+                            "CallMethod: receiver is not a struct or enum",
+                        ));
+                    }
+                };
+                let mangled = format!("{}${}", struct_name, method);
+                let fn_idx = program
+                    .functions
+                    .iter()
+                    .position(|f| f.name == mangled)
+                    .ok_or(VmError::TypeMismatch("CallMethod: method not found"))?;
+                let func = &program.functions[fn_idx];
+                let base = locals.len();
+                locals.resize(base + func.local_count as usize, Value::Void);
+                locals[base] = receiver;
+                for (i, v) in args.into_iter().enumerate() {
+                    locals[base + 1 + i] = v;
+                }
+                frames.push(CallFrame {
+                    chunk_idx: fn_idx,
+                    pc: 0,
+                    locals_base: base,
+                    upvalues: Box::default(),
+                    closure_home: None,
+                    source_slots: Box::default(),
+                });
+                continue;
+            }
             #[cfg(feature = "ffi")]
             Op::CallForeign(idx) => {
                 let sym = program
@@ -1592,6 +1645,7 @@ fn op_to_index(op: Op) -> usize {
         Op::LoadGlobal(_) => OP_KIND_LOAD_GLOBAL,
         Op::StoreGlobal(_) => OP_KIND_STORE_GLOBAL,
         Op::StoreUpvalue { .. } => OP_KIND_STORE_UPVALUE,
+        Op::CallMethod { .. } => OP_KIND_CALL_METHOD,
     }
 }
 
@@ -1612,7 +1666,8 @@ const OP_KIND_ITER_PREPARE: usize = 44;
 const OP_KIND_LOAD_GLOBAL: usize = 45;
 const OP_KIND_STORE_GLOBAL: usize = 46;
 const OP_KIND_STORE_UPVALUE: usize = 47;
-const HANDLER_TABLE_LEN: usize = 48;
+const OP_KIND_CALL_METHOD: usize = 48;
+const HANDLER_TABLE_LEN: usize = 49;
 
 /// The dispatch table. Each entry is a handler keyed by the index
 /// returned from `op_to_index`. Built once at compile time.
@@ -1666,6 +1721,7 @@ static HANDLERS: [Handler; HANDLER_TABLE_LEN] = {
     table[OP_KIND_LOAD_GLOBAL] = h_load_global;
     table[OP_KIND_STORE_GLOBAL] = h_store_global;
     table[OP_KIND_STORE_UPVALUE] = h_store_upvalue;
+    table[OP_KIND_CALL_METHOD] = h_call_method;
     table
 };
 
@@ -2757,6 +2813,69 @@ fn h_store_upvalue(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
     if let Some(uv) = frame.upvalues.get_mut(upvalue_idx as usize) {
         *uv = v;
     }
+    Ok(Step::Continue)
+}
+
+fn h_call_method(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
+    let Op::CallMethod {
+        method_const,
+        arity,
+    } = op
+    else {
+        unreachable!()
+    };
+    let chunk = state.current_chunk();
+    let method = match &chunk.constants[method_const as usize] {
+        Value::String(s) => s.clone(),
+        _ => {
+            return Err(VmError::TypeMismatch(
+                "CallMethod: bad method name constant",
+            ));
+        }
+    };
+    let arity = arity as usize;
+    if state.stack.len() < arity + 1 {
+        return Err(VmError::EmptyStack);
+    }
+    if state.frames.len() >= MAX_CALL_DEPTH {
+        return Err(VmError::CallStackOverflow);
+    }
+    let split = state.stack.len() - arity;
+    let args: Vec<Value> = state.stack.drain(split..).collect();
+    let receiver = state.stack.pop().ok_or(VmError::EmptyStack)?;
+    let struct_name = match &receiver {
+        Value::Struct { name, .. } => name.clone(),
+        Value::EnumVariant { type_name, .. } => type_name.clone(),
+        _ => {
+            return Err(VmError::TypeMismatch(
+                "CallMethod: receiver is not a struct",
+            ));
+        }
+    };
+    let mangled = format!("{}${}", struct_name, method);
+    let fn_idx = state
+        .program
+        .functions
+        .iter()
+        .position(|f| f.name == mangled)
+        .ok_or(VmError::TypeMismatch("CallMethod: method not found"))?;
+    let func = &state.program.functions[fn_idx];
+    let base = state.locals.len();
+    state
+        .locals
+        .resize(base + func.local_count as usize, Value::Void);
+    state.locals[base] = receiver;
+    for (i, v) in args.into_iter().enumerate() {
+        state.locals[base + 1 + i] = v;
+    }
+    state.frames.push(CallFrame {
+        chunk_idx: fn_idx,
+        pc: 0,
+        locals_base: base,
+        upvalues: Box::default(),
+        closure_home: None,
+        source_slots: Box::default(),
+    });
     Ok(Step::Continue)
 }
 
@@ -5755,5 +5874,51 @@ let d = Dir::N;
 match d { Dir::N => 10, Dir::S => 20, Dir::E => 30, Dir::W => 40, }"#;
         assert_both_eq(src);
         assert_int(compile_run(src).unwrap(), 10);
+    }
+
+    // ── RES-2542: impl method calls ──────────────────────────────────────
+
+    #[test]
+    fn res2542_impl_method_no_args() {
+        let src = r#"struct Counter { int value, }
+impl Counter { fn get(self) -> int { return self.value; } }
+let c = new Counter { value: 42 };
+c.get()"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 42);
+    }
+
+    #[test]
+    fn res2542_impl_method_with_arg() {
+        let src = r#"struct Counter { int value, }
+impl Counter { fn add(self, int n) -> int { return self.value + n; } }
+let c = new Counter { value: 10 };
+c.add(5)"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 15);
+    }
+
+    #[test]
+    fn res2542_impl_multiple_methods() {
+        let src = r#"struct Point { int x, int y, }
+impl Point {
+    fn sum(self) -> int { return self.x + self.y; }
+    fn scale(self, int factor) -> int { return self.sum() * factor; }
+}
+let p = new Point { x: 3, y: 4 };
+p.scale(2)"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 14);
+    }
+
+    #[test]
+    fn res2542_impl_method_chaining() {
+        let src = r#"struct Val { int n, }
+impl Val { fn doubled(self) -> int { return self.n * 2; } }
+let a = new Val { n: 5 };
+let b = new Val { n: a.doubled() };
+b.doubled()"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 20);
     }
 }


### PR DESCRIPTION
## Summary

Closes #2525

Adds full support for compiling and executing `impl` method calls in the VM bytecode compiler. Previously, `impl` blocks were only handled by the tree-walking interpreter — the VM would error on any method call with "indirect call on non-identifier".

## Changes

- **New `Op::CallMethod` opcode** (`bytecode.rs`): `CallMethod { method_const: u16, arity: u8 }` — resolves method name at runtime by extracting the struct type from the receiver and forming the mangled name `{StructName}${method}`
- **Compiler pre-pass** (`compiler.rs`): `ImplBlock` methods are now indexed in pass 1 alongside top-level functions, using the mangled `{TypeName}${method}` naming convention
- **Pass 2 compilation** (`compiler.rs`): Refactored pass 2 into a shared `compile_fn_body` closure to avoid duplicating the function body compilation logic between `Node::Function` and `Node::ImplBlock` methods
- **FieldAccess call handling** (`compiler.rs`): `CallExpression { function: FieldAccess { target, field } }` now emits receiver + args + `Op::CallMethod` instead of erroring
- **Both VM dispatch paths** (`vm.rs`): Match-dispatch and handler-table dispatch both handle `CallMethod` — pop args, pop receiver, extract struct name, form mangled name, push call frame
- **Disassembler** (`disasm.rs`): `CallMethod` formatting added

## Tests

- 4 VM unit tests: `res2542_impl_method_no_args`, `res2542_impl_method_with_arg`, `res2542_impl_multiple_methods`, `res2542_impl_method_chaining`
- All use `assert_both_eq` to verify both dispatch paths produce identical results
- Golden test: `examples/vm_impl_methods.rz` + `.expected.txt`
- Full test suite: 4971+ tests passing, clippy clean, fmt clean

---
*Created by resilient-autopilot*