### PR TITLE
RES-2544: compile try-catch structured failure handlers in VM bytecode

### DIFF
--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -255,6 +255,27 @@ pub enum Op {
     /// RES-2532: pop TOS and store into `locals[idx]` in the main frame.
     /// Lets function bodies write top-level `let mut` bindings.
     StoreGlobal(u16),
+    /// RES-2544: enter a try-catch block. Pushes a try-handler frame
+    /// onto the handler stack. `handler_table` indexes the chunk's
+    /// `try_handlers` side table.
+    EnterTry(u16),
+    /// RES-2544: exit a try-catch block (normal completion of try body).
+    /// Pops the topmost try-handler frame from the handler stack.
+    ExitTry,
+}
+
+/// RES-2544: one catch arm in a try-catch handler table.
+#[derive(Debug, Clone)]
+pub struct CatchArm {
+    pub variant: String,
+    pub handler_pc: usize,
+}
+
+/// RES-2544: try-catch handler table entry. Stored in `Chunk::try_handlers`
+/// and referenced by `Op::EnterTry(idx)`.
+#[derive(Debug, Clone)]
+pub struct TryHandlerEntry {
+    pub arms: Vec<CatchArm>,
 }
 
 /// One compiled chunk of bytecode. `code` is the instruction stream;
@@ -293,6 +314,8 @@ pub struct Chunk {
     /// path skips any allocation; `add_string_constant` already
     /// avoided the up-front clone for hits since RES-1419).
     pub(crate) string_idx: HashMap<String, u16>,
+    /// RES-2544: try-catch handler table. `EnterTry(idx)` indexes this.
+    pub try_handlers: Vec<TryHandlerEntry>,
 }
 
 /// RES-081: a compiled function. Parameters occupy the first `arity`
@@ -309,6 +332,10 @@ pub struct Function {
     /// was captured from. `source_slots[i]` is the caller-frame slot
     /// for upvalue `i`. Empty for non-closure functions.
     pub upvalue_source_slots: Box<[u16]>,
+    /// RES-2544: declared `fails` variant names. When the function is
+    /// called inside a `try` block, the VM injects a checked failure
+    /// for the first variant instead of running the body.
+    pub fails: Box<[String]>,
 }
 
 /// RES-081: top-level compile output. `main` is the entrypoint
@@ -365,6 +392,7 @@ impl Chunk {
             bool_idx: [None; 2],
             void_idx: None,
             string_idx: HashMap::with_capacity(cap / 4),
+            try_handlers: Vec::new(),
         }
     }
 
@@ -492,6 +520,24 @@ impl Chunk {
         self.string_idx.insert(owned.clone(), idx);
         self.constants.push(Value::String(owned));
         Ok(idx)
+    }
+
+    /// RES-2544: register a try-catch handler table. Returns the index
+    /// for `Op::EnterTry(idx)`. Handler PCs are set to 0 initially and
+    /// must be patched via `patch_try_handler` after compiling handlers.
+    pub fn add_try_handler(&mut self, arms: Vec<CatchArm>) -> Result<u16, CompileError> {
+        let idx = self.try_handlers.len();
+        if idx > u16::MAX as usize {
+            return Err(CompileError::InternalError("too many try-catch blocks"));
+        }
+        self.try_handlers.push(TryHandlerEntry { arms });
+        Ok(idx as u16)
+    }
+
+    /// RES-2544: patch a catch arm's handler PC after the handler body
+    /// has been compiled and its start PC is known.
+    pub fn patch_try_handler(&mut self, table_idx: u16, arm_idx: usize, handler_pc: usize) {
+        self.try_handlers[table_idx as usize].arms[arm_idx].handler_pc = handler_pc;
     }
 }
 

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -11,7 +11,7 @@
 
 #![allow(dead_code)]
 
-use crate::bytecode::{Chunk, CompileError, Function, Op, Program};
+use crate::bytecode::{CatchArm, Chunk, CompileError, Function, Op, Program};
 use crate::{Node, Value};
 use std::collections::HashMap;
 
@@ -316,6 +316,7 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
         chunk: Chunk::with_capacity(0),
         local_count: 0,
         upvalue_source_slots: Box::default(),
+        fails: Box::default(),
     };
     for _ in 0..fn_count {
         functions.push(placeholder());
@@ -325,6 +326,7 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
                                parameters: &[(String, String)],
                                body: &Node,
                                fn_line: u32,
+                               fails: Box<[String]>,
                                functions: &mut Vec<Function>,
                                next_fn_idx: &mut u16|
      -> Result<(), CompileError> {
@@ -373,6 +375,7 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
             chunk,
             local_count: next_local,
             upvalue_source_slots: Box::default(),
+            fails,
         };
         top_idx += 1;
         Ok(())
@@ -383,6 +386,7 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
                 name,
                 parameters,
                 body,
+                fails,
                 ..
             } => {
                 compile_fn_body(
@@ -390,6 +394,7 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
                     parameters,
                     body,
                     spanned.span.start.line as u32,
+                    fails.clone().into_boxed_slice(),
                     &mut functions,
                     &mut next_fn_idx,
                 )?;
@@ -409,6 +414,7 @@ pub fn compile(program: &Node) -> Result<Program, CompileError> {
                             parameters,
                             body,
                             line,
+                            Box::default(),
                             &mut functions,
                             &mut next_fn_idx,
                         )?;
@@ -854,8 +860,126 @@ fn compile_stmt(
         | Node::ModuleDecl { .. }
         | Node::Use { .. }
         | Node::UnsafeBlock { .. } => Ok(()),
+        Node::TryCatch { body, handlers, .. } => compile_try_catch(
+            body,
+            handlers,
+            chunk,
+            locals,
+            next_local,
+            fn_index,
+            ffi_index,
+            fns,
+            next_fn_idx,
+            line,
+            loop_stack,
+            false,
+        ),
         other => Err(CompileError::Unsupported(node_kind(other))),
     }
+}
+
+/// RES-2544: compile a `try { body } catch Variant { handler }` block.
+#[allow(clippy::too_many_arguments)]
+fn compile_try_catch(
+    body: &[Node],
+    handlers: &[(String, Vec<Node>)],
+    chunk: &mut Chunk,
+    locals: &mut HashMap<String, u16>,
+    next_local: &mut u16,
+    fn_index: &HashMap<String, u16>,
+    ffi_index: &HashMap<String, u16>,
+    fns: &mut Vec<Function>,
+    next_fn_idx: &mut u16,
+    line: u32,
+    loop_stack: &mut Vec<LoopState>,
+    in_fn: bool,
+) -> Result<(), CompileError> {
+    let arms: Vec<CatchArm> = handlers
+        .iter()
+        .map(|(variant, _)| CatchArm {
+            variant: variant.clone(),
+            handler_pc: 0,
+        })
+        .collect();
+    let handler_idx = chunk.add_try_handler(arms)?;
+    chunk.emit(Op::EnterTry(handler_idx), line);
+
+    for stmt in body {
+        let stmt_line = node_line(stmt).unwrap_or(line);
+        if in_fn {
+            compile_stmt_in_fn(
+                stmt,
+                chunk,
+                locals,
+                next_local,
+                fn_index,
+                ffi_index,
+                fns,
+                next_fn_idx,
+                stmt_line,
+                loop_stack,
+            )?;
+        } else {
+            compile_stmt(
+                stmt,
+                chunk,
+                locals,
+                next_local,
+                fn_index,
+                ffi_index,
+                fns,
+                next_fn_idx,
+                stmt_line,
+                loop_stack,
+            )?;
+        }
+    }
+    chunk.emit(Op::ExitTry, line);
+    let jmp_end = chunk.emit(Op::Jump(0), line);
+
+    let mut end_jumps = vec![jmp_end];
+    for (arm_idx, (_, handler_body)) in handlers.iter().enumerate() {
+        let handler_pc = chunk.code.len();
+        chunk.patch_try_handler(handler_idx, arm_idx, handler_pc);
+        for stmt in handler_body {
+            let stmt_line = node_line(stmt).unwrap_or(line);
+            if in_fn {
+                compile_stmt_in_fn(
+                    stmt,
+                    chunk,
+                    locals,
+                    next_local,
+                    fn_index,
+                    ffi_index,
+                    fns,
+                    next_fn_idx,
+                    stmt_line,
+                    loop_stack,
+                )?;
+            } else {
+                compile_stmt(
+                    stmt,
+                    chunk,
+                    locals,
+                    next_local,
+                    fn_index,
+                    ffi_index,
+                    fns,
+                    next_fn_idx,
+                    stmt_line,
+                    loop_stack,
+                )?;
+            }
+        }
+        let jmp = chunk.emit(Op::Jump(0), line);
+        end_jumps.push(jmp);
+    }
+
+    let end_pc = chunk.code.len();
+    for jmp in end_jumps {
+        chunk.patch_jump(jmp, end_pc)?;
+    }
+    Ok(())
 }
 
 /// Shared assert-lowering logic used by both `compile_stmt` and
@@ -1210,6 +1334,7 @@ fn compile_nested_fn(
         chunk: Chunk::with_capacity(0),
         local_count: 0,
         upvalue_source_slots: Box::default(),
+        fails: Box::default(),
     });
     let mut inner_fn_index = fn_index.clone();
     inner_fn_index.insert(name.to_string(), fn_idx);
@@ -1245,6 +1370,7 @@ fn compile_nested_fn(
         chunk,
         local_count: next_local,
         upvalue_source_slots: Box::default(),
+        fails: Box::default(),
     };
     outer_chunk.emit(
         Op::MakeClosure {
@@ -1603,6 +1729,20 @@ fn compile_stmt_in_fn(
             fns,
             next_fn_idx,
             line,
+        ),
+        Node::TryCatch { body, handlers, .. } => compile_try_catch(
+            body,
+            handlers,
+            chunk,
+            locals,
+            next_local,
+            fn_index,
+            ffi_index,
+            fns,
+            next_fn_idx,
+            line,
+            loop_stack,
+            true,
         ),
         Node::Extern { .. } => Err(CompileError::Unsupported("nested extern decl")),
         other => Err(CompileError::Unsupported(node_kind(other))),
@@ -3056,6 +3196,7 @@ fn compile_expr(
                     chunk: Chunk::with_capacity(0),
                     local_count: 0,
                     upvalue_source_slots: Box::default(),
+                    fails: Box::default(),
                 });
             }
             fns[fn_idx as usize] = Function {
@@ -3064,6 +3205,7 @@ fn compile_expr(
                 chunk: fn_chunk,
                 local_count,
                 upvalue_source_slots: source_slots,
+                fails: Box::default(),
             };
 
             // Emit: push each captured value onto the stack, then MakeClosure.

--- a/resilient/src/const_fold.rs
+++ b/resilient/src/const_fold.rs
@@ -309,6 +309,13 @@ fn fold_pass(chunk: &mut Chunk) -> Result<bool, FoldError> {
         }
     }
 
+    // RES-2544: remap try_handler PCs through old_to_new.
+    for entry in &mut chunk.try_handlers {
+        for arm in &mut entry.arms {
+            arm.handler_pc = old_to_new[arm.handler_pc];
+        }
+    }
+
     chunk.code = new_code;
     chunk.line_info = new_line_info;
     Ok(true)

--- a/resilient/src/dce.rs
+++ b/resilient/src/dce.rs
@@ -69,6 +69,17 @@ fn remove_unreachable(chunk: &mut Chunk) {
             reachable[t] = true;
             worklist.push(t);
         }
+        // RES-2544: EnterTry handler PCs are reachable via exception dispatch.
+        if let Op::EnterTry(handler_idx) = op
+            && let Some(entry) = chunk.try_handlers.get(handler_idx as usize)
+        {
+            for arm in &entry.arms {
+                if arm.handler_pc < n && !reachable[arm.handler_pc] {
+                    reachable[arm.handler_pc] = true;
+                    worklist.push(arm.handler_pc);
+                }
+            }
+        }
         // Fall-through: everything except unconditional terminators.
         // RES-2514: TailCall and AssertFail are also terminators that
         // never fall through to the next instruction.
@@ -135,6 +146,13 @@ fn remove_unreachable(chunk: &mut Chunk) {
             Op::JumpIfFalse(o) => *o = offset,
             Op::JumpIfTrue(o) => *o = offset,
             _ => unreachable!("is_jump_op guards the match"),
+        }
+    }
+
+    // RES-2544: remap try_handler PCs through old_to_new.
+    for entry in &mut chunk.try_handlers {
+        for arm in &mut entry.arms {
+            arm.handler_pc = old_to_new[arm.handler_pc];
         }
     }
 

--- a/resilient/src/disasm.rs
+++ b/resilient/src/disasm.rs
@@ -245,6 +245,8 @@ fn write_op(
             method_const,
             arity,
         } => write!(out, "CallMethod method={} arity={}", method_const, arity)?,
+        Op::EnterTry(idx) => write!(out, "EnterTry handler_table={}", idx)?,
+        Op::ExitTry => write!(out, "ExitTry")?,
     }
     Ok(())
 }
@@ -333,6 +335,7 @@ mod tests {
                 chunk: mk_chunk(vec![Op::Return], vec![], vec![1]),
                 local_count: 0,
                 upvalue_source_slots: Box::default(),
+                fails: Box::default(),
             }],
             #[cfg(feature = "ffi")]
             foreign_syms: Vec::new(),
@@ -361,6 +364,7 @@ mod tests {
                     ),
                     local_count: 1,
                     upvalue_source_slots: Box::default(),
+                    fails: Box::default(),
                 },
                 Function {
                     name: "beta".to_string(),
@@ -368,6 +372,7 @@ mod tests {
                     chunk: mk_chunk(vec![Op::Return], vec![], vec![1]),
                     local_count: 2,
                     upvalue_source_slots: Box::default(),
+                    fails: Box::default(),
                 },
             ],
             #[cfg(feature = "ffi")]
@@ -422,6 +427,7 @@ mod tests {
                 ),
                 local_count: 1,
                 upvalue_source_slots: Box::default(),
+                fails: Box::default(),
             }],
             #[cfg(feature = "ffi")]
             foreign_syms: Vec::new(),
@@ -500,6 +506,7 @@ mod tests {
                 chunk: Chunk::new(),
                 local_count: 0,
                 upvalue_source_slots: Box::default(),
+                fails: Box::default(),
             }],
             #[cfg(feature = "ffi")]
             foreign_syms: Vec::new(),

--- a/resilient/src/inline.rs
+++ b/resilient/src/inline.rs
@@ -497,6 +497,13 @@ fn inline_into_chunk(
         }
     }
 
+    // RES-2544: remap try_handler PCs through old_to_new.
+    for entry in &mut chunk.try_handlers {
+        for arm in &mut entry.arms {
+            arm.handler_pc = old_to_new[arm.handler_pc];
+        }
+    }
+
     chunk.code = new_code;
     chunk.line_info = new_lines;
     Ok(true)
@@ -658,6 +665,7 @@ mod tests {
             arity: 1,
             local_count: 1,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(
                 vec![Op::LoadLocal(0), Op::ReturnFromCall, Op::ReturnFromCall],
                 vec![],
@@ -673,6 +681,7 @@ mod tests {
             arity: 1,
             local_count: 1,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(
                 vec![
                     Op::LoadLocal(0),
@@ -694,6 +703,7 @@ mod tests {
             arity: 0,
             local_count: 0,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(vec![Op::Call(0), Op::ReturnFromCall], vec![], vec![1, 1]),
         }
     }
@@ -717,6 +727,7 @@ mod tests {
             arity: 1,
             local_count: 1,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(code, vec![Value::Int(0)], lines),
         }
     }
@@ -764,6 +775,7 @@ mod tests {
             arity: 1,
             local_count: 1,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(code, vec![], lines),
         };
         let funcs = vec![func];
@@ -783,6 +795,7 @@ mod tests {
             arity: 1,
             local_count: 1,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(code, vec![], lines),
         };
         let funcs = vec![func];
@@ -796,6 +809,7 @@ mod tests {
             arity: 0,
             local_count: 0,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(vec![Op::TailCall(0), Op::Return], vec![], vec![1, 1]),
         };
         let funcs = vec![func];
@@ -809,6 +823,7 @@ mod tests {
             arity: 0,
             local_count: 0,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(
                 vec![Op::CallForeign(0), Op::ReturnFromCall],
                 vec![],
@@ -826,6 +841,7 @@ mod tests {
             arity: 0,
             local_count: 0,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(
                 vec![
                     Op::MakeClosure {
@@ -952,6 +968,7 @@ mod tests {
             arity: 0,
             local_count: 0,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
             chunk: mk_chunk(
                 vec![Op::Const(0), Op::ReturnFromCall, Op::ReturnFromCall],
                 vec![Value::Int(0)],

--- a/resilient/src/peephole.rs
+++ b/resilient/src/peephole.rs
@@ -379,6 +379,13 @@ pub fn optimize(chunk: &mut Chunk) -> Result<(), OptimizeError> {
         }
     }
 
+    // RES-2544: remap try_handler PCs through old_to_new.
+    for entry in &mut chunk.try_handlers {
+        for arm in &mut entry.arms {
+            arm.handler_pc = old_to_new[arm.handler_pc];
+        }
+    }
+
     chunk.code = new_code;
     chunk.line_info = new_line_info;
     Ok(())

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -88,6 +88,8 @@ pub enum VmError {
     /// RES-169c: `LoadUpvalue(idx)` with `idx` outside the current
     /// frame's upvalue slab.
     UpvalueOutOfBounds(u16),
+    /// RES-2544: a function with `fails` was called inside a try block.
+    CheckedFailure(String),
 }
 
 impl VmError {
@@ -138,6 +140,9 @@ impl std::fmt::Display for VmError {
             }
             VmError::UpvalueOutOfBounds(idx) => {
                 write!(f, "vm: upvalue index {} out of bounds", idx)
+            }
+            VmError::CheckedFailure(variant) => {
+                write!(f, "vm: checked failure: {}", variant)
             }
         }
     }
@@ -370,6 +375,17 @@ struct CallFrame {
     source_slots: Box<[u16]>,
 }
 
+/// RES-2544: active try-catch handler frame. Pushed by `EnterTry`,
+/// popped by `ExitTry`. When a `CheckedFailure` error fires during
+/// a function call, the VM searches this stack for a matching handler.
+#[derive(Debug, Clone)]
+struct TryFrame {
+    handler_table_idx: u16,
+    chunk_idx: usize,
+    call_depth: usize,
+    stack_depth: usize,
+}
+
 /// RES-329: dispatch strategy. The default match-based loop and the
 /// direct-threaded function-pointer table produce byte-identical
 /// results; the threaded path is selected with `RESILIENT_DISPATCH=direct`.
@@ -476,6 +492,7 @@ fn run_inner(
         closure_home: None,
         source_slots: Box::default(),
     });
+    let mut try_stack: Vec<TryFrame> = Vec::new();
 
     loop {
         // SAFETY: frames is non-empty for the duration of the main
@@ -645,15 +662,42 @@ fn run_inner(
                 locals[abs] = v;
             }
             Op::Call(idx) => {
-                // RES-081: set up a fresh call frame. Pop `arity`
-                // values as args (leftmost arg is the deepest push),
-                // reserve `local_count` slots in the locals slab
-                // (params plus body-local bindings), copy args into
-                // slots 0..arity.
                 let func = program
                     .functions
                     .get(idx as usize)
                     .ok_or(VmError::FunctionOutOfBounds(idx))?;
+                if !try_stack.is_empty() && !func.fails.is_empty() {
+                    let variant = &func.fails[0];
+                    let arity = func.arity as usize;
+                    for _ in 0..arity {
+                        stack.pop();
+                    }
+                    let mut dispatched = false;
+                    while let Some(try_frame) = try_stack.pop() {
+                        let handler_chunk = if try_frame.chunk_idx == usize::MAX {
+                            &program.main
+                        } else {
+                            &program.functions[try_frame.chunk_idx].chunk
+                        };
+                        let entry =
+                            &handler_chunk.try_handlers[try_frame.handler_table_idx as usize];
+                        if let Some(arm) = entry.arms.iter().find(|a| a.variant == *variant) {
+                            while frames.len() > try_frame.call_depth {
+                                let popped = frames.pop().ok_or(VmError::CallStackUnderflow)?;
+                                locals.truncate(popped.locals_base);
+                            }
+                            stack.truncate(try_frame.stack_depth);
+                            let fi = frames.len() - 1;
+                            frames[fi].pc = arm.handler_pc;
+                            dispatched = true;
+                            break;
+                        }
+                    }
+                    if dispatched {
+                        continue;
+                    }
+                    return Err(VmError::CheckedFailure(variant.clone()));
+                }
                 let arity = func.arity as usize;
                 if stack.len() < arity {
                     return Err(VmError::EmptyStack);
@@ -1173,6 +1217,17 @@ fn run_inner(
                 }
                 locals[abs] = v;
             }
+            Op::EnterTry(handler_idx) => {
+                try_stack.push(TryFrame {
+                    handler_table_idx: handler_idx,
+                    chunk_idx: frames[frames.len() - 1].chunk_idx,
+                    call_depth: frames.len(),
+                    stack_depth: stack.len(),
+                });
+            }
+            Op::ExitTry => {
+                try_stack.pop();
+            }
             Op::LoadIndex => {
                 let idx_val = stack.pop().ok_or(VmError::EmptyStack)?;
                 let target = stack.pop().ok_or(VmError::EmptyStack)?;
@@ -1543,6 +1598,9 @@ enum Step {
     /// Halt execution and yield the supplied value as the program's result.
     /// Emitted by `Op::Return` and by implicit-return-from-main.
     Halt(Value),
+    /// RES-2544: a checked failure was injected. The dispatch loop
+    /// unwinds to the matching try-catch handler.
+    CatchDispatch(String),
 }
 
 /// Mutable VM state threaded through every direct-dispatch handler.
@@ -1555,6 +1613,7 @@ struct VmState<'p> {
     locals: Vec<Value>,
     frames: Vec<CallFrame>,
     overflow_mode: OverflowMode,
+    try_stack: Vec<TryFrame>,
 }
 
 impl<'p> VmState<'p> {
@@ -1646,6 +1705,8 @@ fn op_to_index(op: Op) -> usize {
         Op::StoreGlobal(_) => OP_KIND_STORE_GLOBAL,
         Op::StoreUpvalue { .. } => OP_KIND_STORE_UPVALUE,
         Op::CallMethod { .. } => OP_KIND_CALL_METHOD,
+        Op::EnterTry(_) => OP_KIND_ENTER_TRY,
+        Op::ExitTry => OP_KIND_EXIT_TRY,
     }
 }
 
@@ -1667,7 +1728,9 @@ const OP_KIND_LOAD_GLOBAL: usize = 45;
 const OP_KIND_STORE_GLOBAL: usize = 46;
 const OP_KIND_STORE_UPVALUE: usize = 47;
 const OP_KIND_CALL_METHOD: usize = 48;
-const HANDLER_TABLE_LEN: usize = 49;
+const OP_KIND_ENTER_TRY: usize = 49;
+const OP_KIND_EXIT_TRY: usize = 50;
+const HANDLER_TABLE_LEN: usize = 51;
 
 /// The dispatch table. Each entry is a handler keyed by the index
 /// returned from `op_to_index`. Built once at compile time.
@@ -1722,6 +1785,8 @@ static HANDLERS: [Handler; HANDLER_TABLE_LEN] = {
     table[OP_KIND_STORE_GLOBAL] = h_store_global;
     table[OP_KIND_STORE_UPVALUE] = h_store_upvalue;
     table[OP_KIND_CALL_METHOD] = h_call_method;
+    table[OP_KIND_ENTER_TRY] = h_enter_try;
+    table[OP_KIND_EXIT_TRY] = h_exit_try;
     table
 };
 
@@ -1743,6 +1808,7 @@ fn run_direct(
         locals: Vec::with_capacity(32),
         frames: Vec::with_capacity(16),
         overflow_mode,
+        try_stack: Vec::new(),
     };
     state.frames.push(CallFrame {
         chunk_idx: usize::MAX,
@@ -1792,6 +1858,32 @@ fn run_direct(
         match handler(&mut state, op)? {
             Step::Continue => continue,
             Step::Halt(v) => return Ok(v),
+            Step::CatchDispatch(variant) => {
+                let mut dispatched = false;
+                while let Some(try_frame) = state.try_stack.pop() {
+                    let handler_chunk = if try_frame.chunk_idx == usize::MAX {
+                        &state.program.main
+                    } else {
+                        &state.program.functions[try_frame.chunk_idx].chunk
+                    };
+                    let entry = &handler_chunk.try_handlers[try_frame.handler_table_idx as usize];
+                    if let Some(arm) = entry.arms.iter().find(|a| a.variant == variant) {
+                        while state.frames.len() > try_frame.call_depth {
+                            let popped = state.frames.pop().ok_or(VmError::CallStackUnderflow)?;
+                            state.locals.truncate(popped.locals_base);
+                        }
+                        state.stack.truncate(try_frame.stack_depth);
+                        let fi = state.frame_idx();
+                        state.frames[fi].pc = arm.handler_pc;
+                        dispatched = true;
+                        break;
+                    }
+                }
+                if dispatched {
+                    continue;
+                }
+                return Err(VmError::CheckedFailure(variant));
+            }
         }
     }
 }
@@ -1999,6 +2091,14 @@ fn h_call(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
         .functions
         .get(idx as usize)
         .ok_or(VmError::FunctionOutOfBounds(idx))?;
+    if !state.try_stack.is_empty() && !func.fails.is_empty() {
+        let variant = func.fails[0].clone();
+        let arity = func.arity as usize;
+        for _ in 0..arity {
+            state.stack.pop();
+        }
+        return Ok(Step::CatchDispatch(variant));
+    }
     let arity = func.arity as usize;
     if state.stack.len() < arity {
         return Err(VmError::EmptyStack);
@@ -2879,6 +2979,27 @@ fn h_call_method(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
     Ok(Step::Continue)
 }
 
+#[inline(never)]
+fn h_enter_try(state: &mut VmState<'_>, op: Op) -> Result<Step, VmError> {
+    let Op::EnterTry(handler_idx) = op else {
+        unreachable!()
+    };
+    let frame_idx = state.frame_idx();
+    state.try_stack.push(TryFrame {
+        handler_table_idx: handler_idx,
+        chunk_idx: state.frames[frame_idx].chunk_idx,
+        call_depth: state.frames.len(),
+        stack_depth: state.stack.len(),
+    });
+    Ok(Step::Continue)
+}
+
+#[inline(never)]
+fn h_exit_try(state: &mut VmState<'_>, _op: Op) -> Result<Step, VmError> {
+    state.try_stack.pop();
+    Ok(Step::Continue)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3119,6 +3240,7 @@ mod tests {
             chunk: body,
             local_count: 0,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
         };
         let mut main = Chunk::new();
         main.code.push(Op::Call(0));
@@ -3386,6 +3508,7 @@ mod tests {
                 arity: 0,
                 local_count: 0,
                 upvalue_source_slots: Box::default(),
+                fails: Box::default(),
                 chunk: body,
             }],
             #[cfg(feature = "ffi")]
@@ -4290,6 +4413,7 @@ mod tests {
             chunk: body,
             local_count: 0,
             upvalue_source_slots: Box::default(),
+            fails: Box::default(),
         };
         let mut main = Chunk::new();
         main.code.push(Op::Call(0));
@@ -4328,6 +4452,7 @@ mod tests {
                 arity: 0,
                 local_count: 0,
                 upvalue_source_slots: Box::default(),
+                fails: Box::default(),
                 chunk: body,
             }],
             #[cfg(feature = "ffi")]
@@ -5920,5 +6045,90 @@ let b = new Val { n: a.doubled() };
 b.doubled()"#;
         assert_both_eq(src);
         assert_int(compile_run(src).unwrap(), 20);
+    }
+
+    #[test]
+    fn res2544_try_catch_dispatches_to_handler() {
+        let src = r#"fn read_sensor(int addr)
+    requires addr >= 0
+    fails Timeout
+{
+    return addr;
+}
+
+let result = 0;
+try {
+    let v = read_sensor(42);
+    result = v;
+} catch Timeout {
+    result = -1;
+}
+result;"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), -1);
+    }
+
+    #[test]
+    fn res2544_try_catch_nested_propagation() {
+        let src = r#"fn read_sensor(int addr)
+    requires addr >= 0
+    fails Timeout, HardwareFault
+{
+    return addr;
+}
+
+let result = 0;
+try {
+    try {
+        let v = read_sensor(42);
+        result = v;
+    } catch HardwareFault {
+        result = -2;
+    }
+} catch Timeout {
+    result = -1;
+}
+result;"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), -1);
+    }
+
+    #[test]
+    fn res2544_try_catch_no_failure_runs_body() {
+        let src = r#"fn safe_fn(int x)
+    requires x >= 0
+{
+    return x * 2;
+}
+
+let result = 0;
+try {
+    result = safe_fn(21);
+} catch Timeout {
+    result = -1;
+}
+result;"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 42);
+    }
+
+    #[test]
+    fn res2544_try_exit_cleans_try_stack() {
+        let src = r#"fn safe_fn(int x)
+    requires x >= 0
+{
+    return x + 1;
+}
+
+let a = 0;
+try {
+    a = safe_fn(10);
+} catch Timeout {
+    a = -1;
+}
+let b = safe_fn(20);
+a + b;"#;
+        assert_both_eq(src);
+        assert_int(compile_run(src).unwrap(), 32);
     }
 }


### PR DESCRIPTION
## Summary
- Add `EnterTry`/`ExitTry` opcodes and `TryHandlerEntry` side table to bytecode for structured try-catch compilation
- Implement `compile_try_catch` in the compiler that emits handler tables with catch arm dispatch PCs
- Add `TryFrame` and `try_stack` to both VM dispatch paths (match-based and handler-table) with catch dispatch logic that walks the try stack for nested propagation
- Fix all four optimizer passes (DCE, peephole, const_fold, inline) to remap `try_handler` PCs through `old_to_new` fixup tables during instruction renumbering
- Fix DCE reachability analysis to mark `EnterTry` handler PCs as reachable BFS roots (prevents handler body elimination)

## Impact
This is a tier-2 (missing language feature) improvement. Try-catch was already parsed and interpreted but had no VM bytecode compilation. Functions with `fails` declarations now work in compiled mode — the VM injects checked failures when calling a failing function inside a try block, and dispatches to the matching catch handler. Nested try blocks correctly propagate unmatched failures to outer handlers.

## Test plan
- [x] `res2544_try_catch_dispatches_to_handler` — basic try-catch dispatches to handler (both dispatch paths via `assert_both_eq`)
- [x] `res2544_try_catch_nested_propagation` — nested try with inner miss propagates to outer handler
- [x] `res2544_try_catch_no_failure_runs_body` — function without `fails` runs body normally inside try
- [x] `res2544_try_exit_cleans_try_stack` — ExitTry cleans try stack so subsequent calls aren't intercepted
- [x] Existing `try_catch_runtime` integration tests pass (CLI-level end-to-end)
- [x] Full test suite (4871 tests) green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

Closes #2527

🤖 Generated with [Claude Code](https://claude.com/claude-code)