### PR TITLE
RES-2666: fix compiler panic on i64::MIN/MAX literals

### DIFF
--- a/resilient/src/mutation_testing.rs
+++ b/resilient/src/mutation_testing.rs
@@ -146,18 +146,26 @@ fn generate_in<'a>(node: &'a Node, fn_name: &'a str, out: &mut Vec<Mutation<'a>>
                 push(out, fn_name, "literal", "swap `0` -> `1`");
             } else {
                 push(out, fn_name, "literal", format!("swap `{value}` -> `0`"));
-                push(
-                    out,
-                    fn_name,
-                    "literal",
-                    format!("off-by-one `{value}` -> `{}`", value - 1),
-                );
-                push(
-                    out,
-                    fn_name,
-                    "literal",
-                    format!("off-by-one `{value}` -> `{}`", value + 1),
-                );
+                // Off-by-one mutants use checked arithmetic: `i64::MIN`
+                // has no `-1` mutant and `i64::MAX` has no `+1` mutant,
+                // so skip the direction that would overflow rather than
+                // panicking the compiler on extremal literals.
+                if let Some(dec) = value.checked_sub(1) {
+                    push(
+                        out,
+                        fn_name,
+                        "literal",
+                        format!("off-by-one `{value}` -> `{dec}`"),
+                    );
+                }
+                if let Some(inc) = value.checked_add(1) {
+                    push(
+                        out,
+                        fn_name,
+                        "literal",
+                        format!("off-by-one `{value}` -> `{inc}`"),
+                    );
+                }
             }
         }
         Node::BooleanLiteral { value, .. } => {


### PR DESCRIPTION
Closes #2666

## Problem

The mutation-testing analysis pass generated "off-by-one" mutant
descriptions for every integer literal with unchecked arithmetic:

```rust
format!("off-by-one `{value}` -> `{}`", value - 1)
format!("off-by-one `{value}` -> `{}`", value + 1)
```

For `i64::MAX` literals, `value + 1` overflows and panics the compiler;
for `i64::MIN`, `value - 1` overflows. Because resilience scoring runs
this pass on every `rz run`/`rz check`/`rz test`, any program containing
an extremal integer literal crashed the toolchain:

```
fn main() { let a = 9223372036854775807; println(a + 1); }
```
```
thread '<unnamed>' panicked at resilient/src/mutation_testing.rs:159:61:
attempt to add with overflow
```

## Fix

Use `checked_sub`/`checked_add` and skip the direction that would
overflow. `i64::MAX` keeps its `-1` mutant, `i64::MIN` keeps its `+1`
mutant, and every non-extremal literal is unchanged. This mirrors the
discipline already used by the const-fold pass.

## Tests

- `extremal_int_literals_do_not_panic` — an `i64::MAX` literal generates
  mutants without panicking and still emits its in-range `-1` mutant.
- `ordinary_literal_off_by_one_unchanged` — both off-by-one mutants are
  still emitted for ordinary literals.

Full suite: 2167 passed, 0 failed. fmt + clippy clean.