### PR TITLE
RES-2631: rz --version --verbose with build metadata

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -3,6 +3,14 @@
     "resilient/src/typechecker.rs": {
       "branch": "res-2622-did-you-mean-fields",
       "claimed_at": "2026-05-29T04:14:06Z"
+    },
+    "resilient/build.rs": {
+      "branch": "res-2631-version-metadata",
+      "claimed_at": "2026-05-29T04:23:30Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "res-2631-version-metadata",
+      "claimed_at": "2026-05-29T04:23:30Z"
     }
   }
 }

--- a/resilient/build.rs
+++ b/resilient/build.rs
@@ -28,6 +28,19 @@ fn main() {
     println!("cargo:rerun-if-changed=tests/ffi/lib_testhelper.c");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_FFI");
 
+    // RES-2631: embed build metadata into the compiler binary so
+    // `rz --version --verbose` can report the exact build a user is
+    // running. This matters for safety-critical embedded engineering
+    // where a bug report needs to pin the exact compiler commit.
+    //
+    // All values fall back to "unknown" when the build environment
+    // does not provide them (e.g. a tarball release without `.git`,
+    // a sandboxed builder, or a target where `rustc -vV` is not on
+    // PATH). The runtime printer must tolerate "unknown" gracefully.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/heads");
+    emit_build_metadata();
+
     // Only compile the FFI test helper when the `ffi` feature is active.
     if std::env::var("CARGO_FEATURE_FFI").is_err() {
         return;
@@ -61,4 +74,68 @@ fn main() {
         "cargo:rustc-env=RESILIENT_FFI_TESTHELPER_PATH={}",
         lib_path.display()
     );
+}
+
+/// RES-2631: emit build-metadata env vars consumed by `--version --verbose`.
+///
+/// Best-effort: every value falls back to the string `"unknown"` rather
+/// than panicking, so a build without `.git` (release tarball, sandbox)
+/// still produces a working binary. The runtime is responsible for
+/// hiding the "unknown" lines from the verbose printout.
+fn emit_build_metadata() {
+    let git_hash = run_capture(&["git", "rev-parse", "--short=12", "HEAD"]);
+    let git_dirty = run_capture(&["git", "status", "--porcelain"])
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    let git_hash_display = match (git_hash.as_deref(), git_dirty) {
+        (Some(h), true) => format!("{}-dirty", h),
+        (Some(h), false) => h.to_string(),
+        (None, _) => "unknown".to_string(),
+    };
+    let date = run_capture(&["date", "-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .unwrap_or_else(|| "unknown".to_string());
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
+    let rustc_version = run_capture(&["rustc", "--version"])
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!(
+        "cargo:rustc-env=RESILIENT_BUILD_GIT_HASH={}",
+        git_hash_display
+    );
+    println!("cargo:rustc-env=RESILIENT_BUILD_DATE={}", date);
+    println!("cargo:rustc-env=RESILIENT_BUILD_TARGET={}", target);
+    println!("cargo:rustc-env=RESILIENT_BUILD_PROFILE={}", profile);
+    println!(
+        "cargo:rustc-env=RESILIENT_BUILD_RUSTC_VERSION={}",
+        rustc_version
+    );
+
+    // Enabled cargo features show up in env as CARGO_FEATURE_<UPPER>=1.
+    // We translate that back to lower-snake names for the user.
+    let mut features: Vec<String> = std::env::vars()
+        .filter_map(|(k, _)| {
+            k.strip_prefix("CARGO_FEATURE_")
+                .map(|f| f.to_ascii_lowercase().replace('_', "-"))
+        })
+        .collect();
+    features.sort();
+    println!(
+        "cargo:rustc-env=RESILIENT_BUILD_FEATURES={}",
+        if features.is_empty() {
+            "none".to_string()
+        } else {
+            features.join(",")
+        }
+    );
+}
+
+fn run_capture(argv: &[&str]) -> Option<String> {
+    let out = Command::new(argv[0]).args(&argv[1..]).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -322,6 +322,10 @@ mod type_aliases;
 // helper consumed by the typechecker; no parser / lexer surface.
 mod did_you_mean;
 
+// RES-2631: build-metadata version banner consumed by the CLI driver
+// when the user invokes `rz --version [--verbose]`.
+mod version_info;
+
 // RES-307: parser error recovery — sync-point predicates and the
 // per-run diagnostic cap. The recovery loops live on `Parser` in
 // this file (they need `next_token` and the lexer's mutable state);
@@ -29767,11 +29771,21 @@ pub fn run_cli() {
     // RES-209: `--version` / `-V` prints the compiler version plus a
     // pre-1.0 stability notice and exits. See STABILITY.md at the
     // repo root for the policy this notice points to.
+    //
+    // RES-2631: `--verbose` (when paired with `--version`) prints
+    // the build metadata embedded by `build.rs` — git commit, build
+    // date, target triple, profile, rustc version, and enabled
+    // feature flags. Useful when filing safety-critical bug reports
+    // because two binaries built from the same source can produce
+    // different bytecode under different feature combinations.
     if args.iter().any(|a| a == "--version" || a == "-V") {
-        println!(
-            "rz {}: pre-1.0 — breaking changes possible (see STABILITY.md)",
-            env!("CARGO_PKG_VERSION")
-        );
+        let verbose = args.iter().any(|a| a == "--verbose" || a == "-vv");
+        let banner = if verbose {
+            version_info::verbose()
+        } else {
+            version_info::short()
+        };
+        print!("{}", banner);
         std::process::exit(0);
     }
 

--- a/resilient/src/version_info.rs
+++ b/resilient/src/version_info.rs
@@ -1,0 +1,106 @@
+//! RES-2631: build-metadata version banner.
+//!
+//! Two-form `--version` output for the `rz` CLI driver:
+//!
+//! - **Short** (`rz --version`) — single line, version + pre-1.0
+//!   stability notice, identical to the historical `--version` line
+//!   so existing CI scrapers do not need to change.
+//! - **Verbose** (`rz --version --verbose`) — appends the
+//!   commit hash, build date, target triple, profile, rustc
+//!   version, and enabled compile-time features. Useful for
+//!   reproducible-build verification and bug-report attachment in
+//!   safety-critical contexts where the exact compiler bytes matter.
+//!
+//! All metadata is read from `RESILIENT_BUILD_*` env vars set by
+//! `build.rs`. Any value equal to the literal string `"unknown"`
+//! (the fallback when the build environment cannot supply it — for
+//! instance a release tarball without `.git`) is suppressed from the
+//! verbose printout rather than echoed back as a useless line.
+
+/// RES-2631: the short single-line banner.
+pub fn short() -> String {
+    format!(
+        "rz {}: pre-1.0 — breaking changes possible (see STABILITY.md)\n",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+/// RES-2631: the full multi-line `--version --verbose` banner.
+///
+/// Lines whose metadata value is `"unknown"` are suppressed so a
+/// build outside a git tree does not print useless `commit: unknown`
+/// noise.
+pub fn verbose() -> String {
+    let mut out = short();
+    let lines = [
+        ("commit", env!("RESILIENT_BUILD_GIT_HASH")),
+        ("built", env!("RESILIENT_BUILD_DATE")),
+        ("target", env!("RESILIENT_BUILD_TARGET")),
+        ("profile", env!("RESILIENT_BUILD_PROFILE")),
+        ("rustc", env!("RESILIENT_BUILD_RUSTC_VERSION")),
+        ("features", env!("RESILIENT_BUILD_FEATURES")),
+    ];
+    for (label, value) in lines {
+        if value != "unknown" {
+            out.push_str(&format!("  {}: {}\n", label, value));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_form_starts_with_rz_and_version() {
+        let s = short();
+        assert!(s.starts_with("rz "), "got: {:?}", s);
+        assert!(s.contains(env!("CARGO_PKG_VERSION")));
+        assert!(s.contains("pre-1.0"));
+        assert!(s.ends_with('\n'));
+    }
+
+    #[test]
+    fn verbose_form_contains_short_prefix() {
+        let v = verbose();
+        let s = short();
+        assert!(v.starts_with(&s), "verbose must start with short banner");
+    }
+
+    #[test]
+    fn verbose_form_omits_unknown_values() {
+        let v = verbose();
+        // The verbose banner never prints `: unknown` because the
+        // formatter is supposed to drop those entries entirely.
+        assert!(
+            !v.contains(": unknown"),
+            "unknown-value line leaked into verbose output: {:?}",
+            v
+        );
+    }
+
+    #[test]
+    fn verbose_form_includes_known_labels_when_available() {
+        let v = verbose();
+        // Target triple is always set by Cargo even without git, so
+        // it must be present in any verbose build.
+        let target = env!("RESILIENT_BUILD_TARGET");
+        if target != "unknown" {
+            assert!(
+                v.contains(&format!("target: {}", target)),
+                "target line missing: {:?}",
+                v
+            );
+        }
+        // Profile likewise — set by Cargo.
+        let profile = env!("RESILIENT_BUILD_PROFILE");
+        if profile != "unknown" {
+            assert!(
+                v.contains(&format!("profile: {}", profile)),
+                "profile line missing: {:?}",
+                v
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #2631.

## Problem

\`rz --version\` printed one line — package version + stability notice — with no way to tell which build a user was running. For safety-critical embedded work, identifying the exact compiler bytes behind a firmware binary is a real question: two builds from the same \`Cargo.toml\` differ when feature flags like \`z3\`, \`lsp\`, or \`jit\` flip.

## Solution

Add a \`--verbose\` form to \`--version\` that appends six lines of metadata:

\`\`\`
rz 0.2.0: pre-1.0 — breaking changes possible (see STABILITY.md)
  commit: d67274e947ea-dirty
  built: 2026-05-29T04:24:57Z
  target: aarch64-apple-darwin
  profile: debug
  rustc: rustc 1.91.1 (ed61e7d7e 2025-11-07)
  features: default,jit,lsp,z3
\`\`\`

The short form is byte-identical to today's output so existing CI scrapers don't need to change.

### How it works

\`resilient/build.rs\` (\`emit_build_metadata\`) shells out to \`git\`, \`date\`, and \`rustc\`, plus reads \`TARGET\` / \`PROFILE\` / \`CARGO_FEATURE_*\` from the build environment, and emits each value as \`RESILIENT_BUILD_*\` env vars via \`cargo:rustc-env\`. The new \`version_info\` module reads them at runtime with \`env!()\`.

Every value is best-effort. When the build cannot resolve a piece (release tarball without \`.git\`, sandboxed builder, \`rustc\` not on PATH), the build script stores the literal \`"unknown"\` and the runtime printer silently omits the line rather than echoing \`commit: unknown\` back. \`build.rs\` also re-declares its dependencies (\`.git/HEAD\`, \`.git/refs/heads\`) so Cargo invalidates the cache only when the commit actually changes.

## Test changes

Adds four \`version_info\` unit tests covering: short form shape, verbose ⊃ short, suppression of "unknown" lines, and presence of always-set labels (\`target\`, \`profile\`). No existing tests change — the \`rz_version()\` builtin still returns \`CARGO_PKG_VERSION\` exactly as before.

## Impact

Bug reports against \`rz\` can now pin the exact commit / profile / feature set. Embedded users who reproducibly build the toolchain get a single canonical place to verify their build matches a known-good reference. Closes a long-standing agent-ready ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)