### PR TITLE
RES-2672: rebase sync-integration.sh against main (not agents/integration)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,7 +424,7 @@ workflow file.
 - **Preconditions** (all must hold):
   1. PR is **not draft** (set by `ready-or-bail.sh`).
   2. PR has the **`integration-synced` label** (applied by
-     `sync-integration.sh` when the rebase onto `agents/integration`
+     `sync-integration.sh` when the rebase onto `origin/main`
      succeeds without conflicts outside the append-only allowlist).
   3. PR base is **`main`**.
   4. **Every required status check is `SUCCESS`** (the diff-shape

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,12 @@
 {
   "claims": {
-    "agent-scripts/claim-files.sh": {
-      "branch": "res-2670-claim-sweep",
-      "claimed_at": "2026-05-29T04:30:54Z"
+    "agent-scripts/sync-integration.sh": {
+      "branch": "res-2672-fix-integration-branch-drift",
+      "claimed_at": "2026-05-30T02:21:34Z"
+    },
+    "CLAUDE.md": {
+      "branch": "res-2672-fix-integration-branch-drift",
+      "claimed_at": "2026-05-30T02:21:34Z"
     }
   }
 }

--- a/agent-scripts/sync-integration.sh
+++ b/agent-scripts/sync-integration.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # sync-integration.sh
 #
-# Rebase the current branch onto `origin/agents/integration` (the shared
-# live branch that tracks all in-flight agent work), then push that
-# rebased branch back into `agents/integration` via a fast-forward.
+# Rebase the current branch onto `origin/main`, then push that rebased
+# branch back into `agents/integration` via a fast-forward (keeping the
+# tracking branch in sync with shipped work).
 #
 # Workflow:
 #   1. fetch origin.
-#   2. rebase current branch onto origin/agents/integration.
+#   2. rebase current branch onto origin/main.
 #   3. if the rebase hits conflicts only in the append-only extension
 #      allowlist, run auto-resolve-extensions.sh and continue.
 #      Otherwise abort the rebase and exit nonzero — that needs a human.
@@ -59,7 +59,7 @@ if [[ -z "$PR" ]]; then
     PR="$(gh pr list --head "$branch" --state open --json number -q '.[0].number' 2>/dev/null || true)"
 fi
 
-echo "Syncing $branch against origin/$INTEGRATION_REF"
+echo "Syncing $branch against origin/main (tracking via $INTEGRATION_REF)"
 
 git fetch origin "$INTEGRATION_REF" main 2>&1 | tail -3
 
@@ -69,8 +69,8 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
     exit 3
 fi
 
-# Rebase.
-if git rebase "origin/$INTEGRATION_REF"; then
+# Rebase against main — not agents/integration, which can drift far behind.
+if git rebase "origin/main"; then
     echo "rebase: clean"
 else
     unresolved="$(git diff --name-only --diff-filter=U)"
@@ -153,8 +153,8 @@ for attempt in 1 2 3; do
         break
     fi
     echo "integration push failed (attempt $attempt), refetching and retrying..."
-    git fetch origin "$INTEGRATION_REF" 2>&1 | tail -1
-    git rebase "origin/$INTEGRATION_REF" || {
+    git fetch origin "$INTEGRATION_REF" main 2>&1 | tail -1
+    git rebase "origin/main" || {
         echo "integration: concurrent conflicting change landed — re-run sync-integration" >&2
         exit 6
     }


### PR DESCRIPTION
## Problem

`agents/integration` was **757 commits behind main** and 30 ahead, causing `sync-integration.sh` to explode with merge conflicts on every PR. The 30 unique commits on the branch are old intermediate sync states (PRs 748–763) whose work is already on `main` via squash merges — they're safe to discard.

Every PR for the last several weeks had to use the manual workaround:
```bash
gh pr ready N
gh pr edit N --add-label integration-synced
```
instead of the documented `agent-scripts/ready-or-bail.sh` path.

## Fix

**`sync-integration.sh`**: change the rebase target from `origin/agents/integration` to `origin/main`.

- The fast-forward push to `agents/integration` is preserved — the branch stays as a lightweight tracking ref.
- No changes to the `integration-synced` label, `agent-auto-merge.yml`, or any other machinery.
- **`agents/integration` reset to `main`** (done manually alongside this PR) so the branch is no longer divergent.

**`CLAUDE.md`**: update the auto-merge preconditions section to say "rebase onto `origin/main`" (was `agents/integration`).

## Why this is safe

The append-only extension blocks in `lib.rs`/`typechecker.rs`/`lexer_logos.rs` exist specifically to make rebasing onto any green base trivial. The conflict-resolution machinery (`auto-resolve-extensions.sh`, the allowlist) still works identically — it just triggers on a much smaller diff now.

## Acceptance criteria

- [x] `sync-integration.sh` rebases against `origin/main`
- [x] Fast-forward push to `agents/integration` preserved (tracking only)
- [x] `CLAUDE.md` updated to match
- [x] `agents/integration` branch reset to `main`
- [ ] Verify next PR ships via `ready-or-bail.sh` without manual fallback

Closes #2672