### PR TITLE
RES-2646: --typecheck-strict flag + as-cast for fixed-width integers

### DIFF
--- a/resilient/examples/fixed_width_cast.expected.txt
+++ b/resilient/examples/fixed_width_cast.expected.txt
@@ -1,0 +1,5 @@
+44
+44
+255
+42
+Program executed successfully

--- a/resilient/examples/fixed_width_cast.rz
+++ b/resilient/examples/fixed_width_cast.rz
@@ -1,0 +1,23 @@
+// RES-2646: demonstrate as-cast for fixed-width integer types.
+// `as Int8` / `as u8` / `as i16` etc. all use wrapping truncation.
+
+fn main() -> void {
+    // Wrapping truncation to i8 range (-128..=127)
+    let wide: Int = 300;
+    let narrow = wide as Int8;
+    println(narrow);
+
+    // Wrapping truncation to u8 range (0..=255)
+    let wrapped = wide as u8;
+    println(wrapped);
+
+    // Negative as unsigned wraps at 256
+    let neg = (-1) as u8;
+    println(neg);
+
+    // Lowercase Rust-style alias works identically to PascalCase
+    let same: i8 = 42;
+    println(same);
+}
+
+main();

--- a/resilient/examples/typecheck_strict_mode.expected.txt
+++ b/resilient/examples/typecheck_strict_mode.expected.txt
@@ -1,0 +1,2 @@
+42
+Program executed successfully

--- a/resilient/examples/typecheck_strict_mode.rz
+++ b/resilient/examples/typecheck_strict_mode.rz
@@ -1,0 +1,14 @@
+// RES-2646: demonstrate --typecheck-strict flag.
+// Run with: rz run --typecheck-strict typecheck_strict_mode.rz
+// A program that type-checks cleanly exits 0 in strict mode.
+
+fn add(Int a, Int b) -> Int {
+    return a + b;
+}
+
+fn main() -> void {
+    let result = add(10, 32);
+    println(result);
+}
+
+main();

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -8186,12 +8186,24 @@ impl Parser {
                         }
                     };
                     let builtin = match type_name.as_str() {
-                        "int" | "Int" | "Int64" => "to_int",
+                        "int" | "Int" | "Int64" | "i64" => "to_int",
                         "float" | "Float" => "to_float",
                         "string" | "String" => "to_string",
+                        // RES-2646 / RES-366: pinned-width integer casts.
+                        // Each maps to the corresponding wrapping builtin
+                        // registered in BUILTINS and known to the typechecker.
+                        "Int8" | "i8" => "as_int8",
+                        "Int16" | "i16" => "as_int16",
+                        "Int32" | "i32" => "as_int32",
+                        "UInt8" | "u8" => "as_uint8",
+                        "UInt16" | "u16" => "as_uint16",
+                        "UInt32" | "u32" => "as_uint32",
+                        "UInt64" | "u64" => "as_uint64",
                         other => {
                             self.record_error(format!(
-                                "Cannot cast to `{}` — `as` supports int / float / string",
+                                "Cannot cast to `{}` — `as` supports int / float / string / \
+                                 Int8 / Int16 / Int32 / UInt8 / UInt16 / UInt32 / UInt64 \
+                                 (and their lowercase aliases i8 / u8 / i16 / u16 / i32 / u32 / u64)",
                                 other
                             ));
                             return Some(current_left);
@@ -27682,6 +27694,9 @@ fn execute_file(
     live_log: Option<&Path>,
     #[cfg(feature = "z3")] z3_theory: verifier_z3::Z3Theory,
     no_cache: bool,
+    // RES-2646: `--typecheck-strict` makes any type error fatal (exit 1)
+    // without the verbose status lines that `--typecheck` prints.
+    type_strict: bool,
 ) -> RResult<()> {
     let contents =
         fs::read_to_string(filename).map_err(|e| format!("Error reading file: {}", e))?;
@@ -27880,11 +27895,15 @@ fn execute_file(
     //   execution continues. Exit code follows the program's
     //   runtime exit. Status lines are suppressed so default-mode
     //   stdout matches what users have always seen.
-    let typecheck_strict = type_check || audit || explain_effects || emit_cert_dir.is_some();
+    // `verbose_typecheck`: print "Running type checker…" / "Type check passed".
+    // `typecheck_strict`:  treat any type error as fatal (exit 1).
+    // `--typecheck-strict` sets the latter without the former.
+    let verbose_typecheck = type_check || audit || explain_effects || emit_cert_dir.is_some();
+    let typecheck_strict = verbose_typecheck || type_strict;
     let want_typecheck = !no_typecheck;
     let mut proven_fns: HashSet<String> = HashSet::new();
     if want_typecheck {
-        if typecheck_strict {
+        if verbose_typecheck {
             println!("Running type checker...");
         }
         let tc_base = typechecker::TypeChecker::new()
@@ -27920,7 +27939,7 @@ fn execute_file(
         // are prefixed with `<file>:<line>:<col>:`.
         match tc.check_program_with_source(&program, filename) {
             Ok(_) => {
-                if typecheck_strict {
+                if verbose_typecheck {
                     println!("\x1B[32mType check passed\x1B[0m");
                 }
             }
@@ -29623,6 +29642,10 @@ COMMON FLAGS:\n\
                                  type checker also runs by default in soft\n\
                                  mode — diagnostics print to stderr but the\n\
                                  program still executes (RES-1088).\n\
+        --typecheck-strict       Make any type error fatal (exit 1) without\n\
+                                 the verbose status lines of --typecheck.\n\
+                                 Suitable for CI scripts that want strict\n\
+                                 checking without extra output (RES-2646).\n\
         --no-typecheck           Skip the static type checker entirely\n\
         --audit                  Print the verification audit trail\n\
         --verbose                Print one stderr line per loop\n\
@@ -29873,6 +29896,9 @@ pub fn run_cli() {
     // via `typecheck_strict` below) keep the legacy strict
     // semantics — fail with exit 1 on any type error.
     let mut no_typecheck = false;
+    // RES-2646: `--typecheck-strict` makes type errors fatal without
+    // the verbose status lines that `--typecheck` emits.
+    let mut type_strict = false;
     let mut audit = false;
     // RES-318: --verbose enables one stderr line per loop invariant
     // statically discharged by the Z3 verifier. Off by default so
@@ -29963,6 +29989,10 @@ pub fn run_cli() {
             let arg = &args[i];
             if arg == "--typecheck" || arg == "-t" {
                 type_check = true;
+            } else if arg == "--typecheck-strict" {
+                // RES-2646: make type errors fatal without the verbose
+                // "Running type checker…" / "Type check passed" lines.
+                type_strict = true;
             } else if arg == "--no-typecheck" {
                 // RES-1088: opt out of the default-on type checker.
                 // Mostly for legacy scripts that intentionally feed
@@ -30573,6 +30603,7 @@ pub fn run_cli() {
                     #[cfg(feature = "z3")]
                     z3_theory_snap,
                     no_cache,
+                    type_strict,
                 );
                 match result {
                     Ok(_) => {
@@ -30615,6 +30646,7 @@ pub fn run_cli() {
                 #[cfg(feature = "z3")]
                 z3_theory,
                 no_cache,
+                type_strict,
             );
             // RES-174: print cache stats on exit whenever the
             // flag is set, regardless of whether the run

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -8486,16 +8486,16 @@ impl TypeChecker {
         }
         match name {
             // RES-366: `Int64` is the long-form alias for `Int`.
-            "int" | "Int" | "Int64" => Ok(Type::Int),
-            // RES-366: pinned signed integer widths.
-            "Int8" => Ok(Type::Int8),
-            "Int16" => Ok(Type::Int16),
-            "Int32" => Ok(Type::Int32),
-            // RES-366: pinned unsigned integer widths.
-            "UInt8" => Ok(Type::UInt8),
-            "UInt16" => Ok(Type::UInt16),
-            "UInt32" => Ok(Type::UInt32),
-            "UInt64" => Ok(Type::UInt64),
+            "int" | "Int" | "Int64" | "i64" => Ok(Type::Int),
+            // RES-366: pinned signed integer widths (PascalCase + Rust-style lowercase).
+            "Int8" | "i8" => Ok(Type::Int8),
+            "Int16" | "i16" => Ok(Type::Int16),
+            "Int32" | "i32" => Ok(Type::Int32),
+            // RES-366: pinned unsigned integer widths (PascalCase + Rust-style lowercase).
+            "UInt8" | "u8" => Ok(Type::UInt8),
+            "UInt16" | "u16" => Ok(Type::UInt16),
+            "UInt32" | "u32" => Ok(Type::UInt32),
+            "UInt64" | "u64" => Ok(Type::UInt64),
             "float" => Ok(Type::Float),
             "string" => Ok(Type::String),
             "bool" => Ok(Type::Bool),


### PR DESCRIPTION
## Summary

- Adds `--typecheck-strict` CLI flag: makes type errors fatal (exit 1) without the verbose status lines of `--typecheck`. Closes #2646.
- Wires the existing `as_int8`/`as_uint8`/… runtime builtins to the `as` cast syntax so `x as Int8`, `x as u8`, `x as i32`, etc. now parse and execute correctly.
- Adds Rust-style lowercase type aliases (`i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`) to the typechecker so both `let v: Int8 = …` and `let v: i8 = …` are valid.

## Motivation

**`--typecheck-strict`**: In a safety-critical embedded compiler, a non-exhaustive match on an interrupt handler enum is a real bug. The default soft mode shows the error but lets the program run (exit 0). `--typecheck` makes it fatal but also prints "Running type checker…" / "Type check passed" lines that pollute CI logs. The new `--typecheck-strict` gives CI pipelines a clean strict gate without the extra noise.

**Fixed-width as-cast**: The runtime builtins (`as_int8`, `as_uint8`, …) and typechecker variants (`Type::Int8`, `Type::UInt8`, …) already existed but the `as` syntax parser only accepted `int / float / string`. This made the feature unusable from user code. The fix is a targeted extension of the `as` type-name match arm.

## What changed

| File | Change |
|---|---|
| `resilient/src/lib.rs` | Add `type_strict: bool` to `execute_file`; split `verbose_typecheck` from `typecheck_strict`; wire fixed-width type names in `as` cast parser; add `--typecheck-strict` flag + help text |
| `resilient/src/typechecker.rs` | Add `i8/u8/i16/u16/i32/u32/i64/u64` lowercase aliases in `parse_type_name_inner` |
| `resilient/examples/typecheck_strict_mode.{rz,expected.txt}` | Golden example: clean program, strict mode, exit 0 |
| `resilient/examples/fixed_width_cast.{rz,expected.txt}` | Golden example: wrapping `as Int8 / u8 / i8` casts |

## Test plan

- [x] `cargo test` — 5103+ tests pass, 0 failures
- [x] Golden test suite — 450 golden files match
- [x] `rz run --typecheck-strict <non_exhaustive>.rz` → exit 1 ✓
- [x] `rz run <non_exhaustive>.rz` → exit 0 (soft mode unchanged) ✓
- [x] `300 as Int8` → `44` (wrapping truncation) ✓
- [x] `(-1) as u8` → `255` (wrapping unsigned) ✓
- [x] `let v: i8 = 100` → type-checks correctly ✓
- [x] `cargo clippy -- -D warnings` → clean ✓
- [x] `cargo fmt --check` → clean ✓

🤖 Generated with [Claude Code](https://claude.ai/claude-code)