### PR TITLE
RES-2689: VM: add BlanketImpl to compile_stmt no-op list

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,8 @@
 {
   "claims": {
-    "resilient/src/lib.rs": {
-      "branch": "res-2687-string-chars-returns-char",
-      "claimed_at": "2026-05-30T09:12:49Z"
-    },
-    "resilient/src/string_array_misc.rs": {
-      "branch": "res-2687-string-chars-returns-char",
-      "claimed_at": "2026-05-30T09:12:49Z"
+    "resilient/src/compiler.rs": {
+      "branch": "res-2689-vm-blanket-impl-noop",
+      "claimed_at": "2026-05-30T09:24:53Z"
     }
   }
 }

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -873,6 +873,9 @@ fn compile_stmt(
         Node::StructDecl { .. }
         | Node::TraitDecl { .. }
         | Node::ImplBlock { .. }
+        // RES-2689: BlanketImpl is declaration-only; lower_program already
+        // injected the concrete ImplBlocks before compilation reaches here.
+        | Node::BlanketImpl { .. }
         | Node::TypeAlias { .. }
         | Node::NewtypeDecl { .. }
         | Node::RegionDecl { .. }
@@ -1725,6 +1728,9 @@ fn compile_stmt_in_fn(
         Node::StructDecl { .. }
         | Node::TraitDecl { .. }
         | Node::ImplBlock { .. }
+        // RES-2689: BlanketImpl is declaration-only; concrete ImplBlocks were
+        // already injected by lower_program before compilation.
+        | Node::BlanketImpl { .. }
         | Node::TypeAlias { .. }
         | Node::NewtypeDecl { .. }
         | Node::RegionDecl { .. }


### PR DESCRIPTION
## Summary

`--vm` crashed on any program containing `impl<T: Bound> Trait for T` with:
```
Error: VM compile error: bytecode compile: unsupported construct: <other>
```

`Node::BlanketImpl` was missing from the declaration-only no-op pattern arms in both `compile_stmt` and `compile_stmt_in_fn`. All other declaration-level nodes (`StructDecl`, `TraitDecl`, `ImplBlock`, etc.) were already handled as no-ops. Since `blanket_impl::lower_program` injects concrete `ImplBlock` nodes before bytecode compilation, `BlanketImpl` itself needs only a no-op in the compiler.

## Changes

- `compiler.rs`: add `Node::BlanketImpl { .. }` to the no-op arm in `compile_stmt` (~line 873) and `compile_stmt_in_fn` (~line 1725).

## Test plan

- Programs with `impl<T: Bound> Trait for T` now execute correctly under `--vm`.
- 5157 tests pass, clippy clean.

Closes #2689