### PR TITLE
RES-2705: fix false-positive type error for capitalised Array annotation

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,8 @@
 {
   "claims": {
     "resilient/src/typechecker.rs": {
-      "branch": "res-2703-result-exhaustiveness",
-      "claimed_at": "2026-05-30T11:46:20Z"
+      "branch": "res-2705-array-type-annotation",
+      "claimed_at": "2026-05-30T12:11:00Z"
     }
   }
 }

--- a/resilient/examples/array_capitalised_annotation.expected.txt
+++ b/resilient/examples/array_capitalised_annotation.expected.txt
@@ -1,0 +1,3 @@
+15
+30
+Program executed successfully

--- a/resilient/examples/array_capitalised_annotation.rz
+++ b/resilient/examples/array_capitalised_annotation.rz
@@ -1,0 +1,19 @@
+fn total(Array nums) -> int {
+    let s = 0;
+    let i = 0;
+    while i < len(nums) {
+        s = s + nums[i];
+        i = i + 1;
+    }
+    return s;
+}
+
+struct Bag {
+    Array items
+}
+
+let xs = [1, 2, 3, 4, 5];
+println(to_string(total(xs)));
+
+let b = new Bag { items: [10, 20] };
+println(to_string(total(b.items)));

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -8760,7 +8760,11 @@ impl TypeChecker {
             "Result" => Ok(Type::Result),
             // RES-2651: bare `Option` or `Option<T>`.
             "Option" => Ok(Type::Option(Box::new(Type::Any))),
-            "array" => Ok(Type::Array),
+            // RES-2705: accept both `array` (canonical) and `Array` (capitalised)
+            // so that struct fields and fn params written as `Array foo` resolve
+            // to Type::Array instead of Type::Struct("Array"), which previously
+            // caused false-positive type-mismatch errors against array literals.
+            "array" | "Array" => Ok(Type::Array),
             // RES-408: `any` as a written type annotation maps to Type::Any
             // (the unresolved/wildcard type). Without this arm the identifier
             // falls through to `other => Type::Struct("any")`, which caused
@@ -14358,6 +14362,73 @@ mod res2703_result_exhaustiveness {
                Err(e) => { println(e); },\n\
              }\n\
              }\n",
+        );
+    }
+}
+
+#[cfg(test)]
+mod res2705_array_type_annotation {
+    use super::*;
+
+    fn check_ok(src: &str) {
+        let (prog, errs) = crate::parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        TypeChecker::new()
+            .check_program(&prog)
+            .unwrap_or_else(|e| panic!("unexpected type error: {e}"));
+    }
+
+    fn check_err(src: &str, fragment: &str) {
+        let (prog, errs) = crate::parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let e = TypeChecker::new()
+            .check_program(&prog)
+            .expect_err("expected a type error but got Ok");
+        assert!(
+            e.contains(fragment),
+            "expected {:?} in error: {e}",
+            fragment
+        );
+    }
+
+    #[test]
+    fn capitalised_array_param_accepts_array_literal() {
+        check_ok(
+            "fn sum(Array items) -> int { return 0; }\n\
+             sum([1, 2, 3]);\n",
+        );
+    }
+
+    #[test]
+    fn lowercase_array_param_still_accepted() {
+        check_ok(
+            "fn sum(array items) -> int { return 0; }\n\
+             sum([1, 2, 3]);\n",
+        );
+    }
+
+    #[test]
+    fn capitalised_array_struct_field_accepts_array_literal() {
+        check_ok(
+            "struct Bag { Array items }\n\
+             let b = new Bag { items: [1, 2, 3] };\n",
+        );
+    }
+
+    #[test]
+    fn capitalised_array_return_type_accepted() {
+        check_ok(
+            "fn make() -> Array { return [1, 2]; }\n\
+             let xs = make();\n",
+        );
+    }
+
+    #[test]
+    fn wrong_type_still_errors_for_array_param() {
+        check_err(
+            "fn sum(Array items) -> int { return 0; }\n\
+             sum(42);\n",
+            "Type mismatch",
         );
     }
 }


### PR DESCRIPTION
## Problem

`Array` written as a type annotation (struct fields, fn parameters, return types)
was resolving to `Type::Struct("Array")` via the fallthrough arm in
`parse_type_name_inner`, while array literals `[1, 2, 3]` produce `Type::Array`.
`compatible(Type::Array, Type::Struct("Array"))` returns false, so any program
using `Array foo` as a parameter or struct field produced a false-positive
type-mismatch error.

## Solution

Extend the `"array"` match arm in `parse_type_name_inner` to also accept
`"Array"`, parallel to the existing `"float" | "Float"` and `"any" | "Any"` pattern:

```rust
"array" | "Array" => Ok(Type::Array),
```

## Tests

5 unit tests in `mod res2705_array_type_annotation`:
- `capitalised_array_param_accepts_array_literal` — fn param typed `Array` accepts `[...]`
- `lowercase_array_param_still_accepted` — regression: `array` still works
- `capitalised_array_struct_field_accepts_array_literal` — struct field typed `Array`
- `capitalised_array_return_type_accepted` — `-> Array` return annotation
- `wrong_type_still_errors_for_array_param` — type mismatch still reported for `int` → `Array`

Golden example: `array_capitalised_annotation.rz` — sums an `Array nums` param and accesses an `Array items` struct field.

Closes #2705

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>