### PR TITLE
RES-2709: string s[i] returns char; fix to_string and concat for chars

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,8 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-2707-array-method-chains",
-      "claimed_at": "2026-05-30T12:23:54Z"
-    },
-    "resilient/src/typechecker.rs": {
-      "branch": "res-2707-array-method-chains",
-      "claimed_at": "2026-05-30T12:26:50Z"
+      "branch": "res-2709-char-string-indexing",
+      "claimed_at": "2026-05-30T12:36:31Z"
     }
   }
 }

--- a/resilient/examples/char_string_index.expected.txt
+++ b/resilient/examples/char_string_index.expected.txt
@@ -1,0 +1,5 @@
+h
+matched h
+got: h
+w
+Program executed successfully

--- a/resilient/examples/char_string_index.rz
+++ b/resilient/examples/char_string_index.rz
@@ -1,0 +1,19 @@
+let s = "hello";
+
+// String indexing now returns char, not single-char string
+let c = s[0];
+println(to_string(c));
+
+// Char literal patterns in match work
+match c {
+  'h' => println("matched h"),
+  _ => println("no match"),
+}
+
+// Char participates in string concatenation
+let greeting = "got: " + c;
+println(greeting);
+
+// to_string works on char literals directly
+let x = 'w';
+println(to_string(x));

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -11115,7 +11115,9 @@ fn format_contract_expr(node: &Node) -> String {
 fn can_stringify_for_concat(v: &Value) -> bool {
     matches!(
         v,
-        Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_)
+        // RES-2709: Char is now returned by string indexing s[i] so it
+        // must participate in `+` concatenation alongside the existing scalars.
+        Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) | Value::Char(_)
     )
 }
 
@@ -11125,6 +11127,7 @@ fn stringify_for_concat_owned(v: Value) -> String {
         Value::Int(i) => i.to_string(),
         Value::Float(f) => f.to_string(),
         Value::Bool(b) => b.to_string(),
+        Value::Char(c) => c.to_string(),
         _ => unreachable!(),
     }
 }
@@ -15972,6 +15975,8 @@ fn builtin_to_string(args: &[Value]) -> RResult<Value> {
         [Value::Int(n)] => Ok(Value::String(n.to_string())),
         [Value::Float(f)] => Ok(Value::String(f.to_string())),
         [Value::Bool(b)] => Ok(Value::String(b.to_string())),
+        // RES-2709: char is a scalar; convert to its one-character string form.
+        [Value::Char(c)] => Ok(Value::String(c.to_string())),
         [other] => Err(format!("to_string: expected scalar value, got {}", other)),
         _ => Err(format!(
             "to_string: expected 1 argument, got {}",
@@ -24594,9 +24599,11 @@ impl Interpreter {
                         m.remove(&mk)
                             .ok_or_else(|| format!("Key not found in map: {}", key_val))
                     }
-                    // RES-427: string subscript on a string yields a
-                    // one-character substring (`s["0"]` is not useful; the
-                    // useful form is integer subscript `s[i]`).
+                    // RES-427 / RES-2709: string subscript `s[i]` yields
+                    // the i-th Unicode scalar as a `Value::Char` so that
+                    // char literal patterns in `match` and `==` comparisons
+                    // can match the result. String concat via `+` accepts
+                    // Char (see `can_stringify_for_concat`).
                     (Value::String(s), Value::Int(i)) => {
                         let chars: Vec<char> = s.chars().collect();
                         let len = chars.len() as i64;
@@ -24608,7 +24615,7 @@ impl Interpreter {
                                 chars.len()
                             ))
                         } else {
-                            Ok(Value::String(chars[resolved as usize].to_string()))
+                            Ok(Value::Char(chars[resolved as usize]))
                         }
                     }
                     (other, _) => Err(format!("Cannot index {:?}", other)),


### PR DESCRIPTION
## Problem

Three gaps in `Value::Char` support (added by RES-2619) caused char operations to fail:

1. `to_string('a')` → "to_string: expected scalar value"
2. `"prefix" + s[0]` → type error when the result of string indexing is used in concat
3. `match s[0] { 'h' => ..., _ => ... }` always fell to the wildcard arm — because `s[i]` returned `Value::String("h")` but the pattern `'h'` is `Value::Char('h')`

## Fix

**`builtin_to_string`**: add `Value::Char(c) => Ok(Value::String(c.to_string()))` arm.

**`can_stringify_for_concat` / `stringify_for_concat_owned`**: include `Value::Char` so char values coerce in string `+` concatenation.

**String subscript `s[i]`**: change `Ok(Value::String(chars[i].to_string()))` to `Ok(Value::Char(chars[i]))`. This is the primary fix — it aligns what string indexing produces with what char literal patterns expect.

## Example (now works)

```resilient
let s = "hello";
let c = s[0];
println(to_string(c));      // "h"
match c {
  'h' => println("matched h"),  // now reached
  _ => println("other"),
}
let greeting = "got: " + c; // "got: h"
```

## Tests

All existing tests pass. Golden example `char_string_index.rz` covers all three behaviors.

Closes #2709

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>