### PR TITLE
RES-2726: Result == Result and Result != Result now compare structurally

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,8 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-2723-option-equality",
-      "claimed_at": "2026-05-30T14:38:33Z"
+      "branch": "res-2726-result-equality",
+      "claimed_at": "2026-05-30T14:52:59Z"
     }
   }
 }

--- a/resilient/examples/result_equality.expected.txt
+++ b/resilient/examples/result_equality.expected.txt
@@ -1,0 +1,8 @@
+Ok(5) == Ok(5): true
+Ok(5) != Ok(6): true
+Err(fail) == Err(fail): true
+Ok(5) != Err(fail): true
+safe_div(10,2) == safe_div(10,2): true
+Ok(5) != Err(division by zero): true
+error matches expected: true
+Program executed successfully

--- a/resilient/examples/result_equality.rz
+++ b/resilient/examples/result_equality.rz
@@ -1,0 +1,28 @@
+// RES-2726: Result == Result and Result != Result now work correctly.
+// Ok(x) == Ok(x) compares inner values structurally; Err(x) == Err(x) likewise.
+
+let a = Ok(5);
+let b = Ok(5);
+let c = Ok(6);
+let e1 = Err("fail");
+let e2 = Err("fail");
+
+if a == b { println("Ok(5) == Ok(5): true"); }
+if a != c { println("Ok(5) != Ok(6): true"); }
+if e1 == e2 { println("Err(fail) == Err(fail): true"); }
+if a != e1 { println("Ok(5) != Err(fail): true"); }
+
+fn safe_div(int x, int y) -> Result {
+    if y == 0 {
+        return Err("division by zero");
+    }
+    return Ok(x / y);
+}
+
+let r1 = safe_div(10, 2);
+let r2 = safe_div(10, 2);
+let r3 = safe_div(10, 0);
+
+if r1 == r2 { println("safe_div(10,2) == safe_div(10,2): true"); }
+if r1 != r3 { println("Ok(5) != Err(division by zero): true"); }
+if r3 == Err("division by zero") { println("error matches expected: true"); }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -22711,6 +22711,12 @@ fn compound_values_equal(left: &Value, right: &Value) -> Option<bool> {
             (Some(lv), Some(rv)) => values_strict_eq(lv, rv),
             _ => false,
         }),
+        // RES-2726: Result == Result. Ok(x)==Ok(y) iff x==y; Err(x)==Err(y)
+        // iff x==y; Ok(_) != Err(_) always.
+        (
+            Value::Result { ok: lok, payload: lp },
+            Value::Result { ok: rok, payload: rp },
+        ) => Some(lok == rok && values_strict_eq(lp, rp)),
         _ => None,
     }
 }
@@ -22745,6 +22751,10 @@ fn values_strict_eq(left: &Value, right: &Value) -> bool {
             (Some(lv), Some(rv)) => values_strict_eq(lv, rv),
             _ => false,
         },
+        // RES-2726: recursive Result equality. Ok(x)==Ok(y) iff x==y; mismatch variant is false.
+        (Value::Result { ok: lok, payload: lp }, Value::Result { ok: rok, payload: rp }) => {
+            lok == rok && values_strict_eq(lp, rp)
+        }
         _ => false,
     }
 }
@@ -59328,6 +59338,56 @@ mod res2723_option_equality {
     fn nested_option_equality() {
         let r = run("let a = Some(Some(1));\n\
              let b = Some(Some(1));\n\
+             if a == b { println(\"equal\"); } else { println(\"not equal\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("equal"), "got: {}", r.stdout);
+    }
+}
+
+#[cfg(test)]
+mod res2726_result_equality {
+    use super::run_program as run;
+
+    #[test]
+    fn ok_same_value_is_equal() {
+        let r = run("let a = Ok(5);\n\
+             let b = Ok(5);\n\
+             if a == b { println(\"equal\"); } else { println(\"not equal\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("equal"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn ok_different_value_is_not_equal() {
+        let r = run("let a = Ok(5);\n\
+             let b = Ok(6);\n\
+             if a != b { println(\"different\"); } else { println(\"same\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("different"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn err_same_value_is_equal() {
+        let r = run("let a = Err(\"oops\");\n\
+             let b = Err(\"oops\");\n\
+             if a == b { println(\"equal\"); } else { println(\"not equal\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("equal"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn ok_not_equal_to_err() {
+        let r = run("let a = Ok(1);\n\
+             let b = Err(\"no\");\n\
+             if a != b { println(\"different\"); } else { println(\"same\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("different"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn nested_result_equality() {
+        let r = run("let a = Ok(Ok(42));\n\
+             let b = Ok(Ok(42));\n\
              if a == b { println(\"equal\"); } else { println(\"not equal\"); }");
         assert!(r.ok, "errors: {:?}", r.errors);
         assert!(r.stdout.contains("equal"), "got: {}", r.stdout);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -22714,8 +22714,14 @@ fn compound_values_equal(left: &Value, right: &Value) -> Option<bool> {
         // RES-2726: Result == Result. Ok(x)==Ok(y) iff x==y; Err(x)==Err(y)
         // iff x==y; Ok(_) != Err(_) always.
         (
-            Value::Result { ok: lok, payload: lp },
-            Value::Result { ok: rok, payload: rp },
+            Value::Result {
+                ok: lok,
+                payload: lp,
+            },
+            Value::Result {
+                ok: rok,
+                payload: rp,
+            },
         ) => Some(lok == rok && values_strict_eq(lp, rp)),
         _ => None,
     }
@@ -22752,9 +22758,16 @@ fn values_strict_eq(left: &Value, right: &Value) -> bool {
             _ => false,
         },
         // RES-2726: recursive Result equality. Ok(x)==Ok(y) iff x==y; mismatch variant is false.
-        (Value::Result { ok: lok, payload: lp }, Value::Result { ok: rok, payload: rp }) => {
-            lok == rok && values_strict_eq(lp, rp)
-        }
+        (
+            Value::Result {
+                ok: lok,
+                payload: lp,
+            },
+            Value::Result {
+                ok: rok,
+                payload: rp,
+            },
+        ) => lok == rok && values_strict_eq(lp, rp),
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary
- `Ok(x) == Ok(x)` was crashing at runtime with "Type mismatch" because `compound_values_equal` and `values_strict_eq` had no arm for `Value::Result { ok, payload }`
- Same root cause as RES-2723 (Option equality), just applied to `Value::Result`
- Added Result arms to both functions: `Ok(x)==Ok(y)` iff `x==y`, `Err(x)==Err(y)` iff `x==y`, `Ok(_)!=Err(_)` always
- Added 5 unit tests in `res2726_result_equality` module and a golden example `result_equality.rz`

Closes #2726

## Test plan
- [x] `cargo test --manifest-path resilient/Cargo.toml res2726` — 5/5 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Golden example `result_equality.rz` produces expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)