### PR TITLE
RES-2730: add Value::Char to values_strict_eq and values_cmp

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,8 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-2728-map-set-enum-equality",
-      "claimed_at": "2026-05-30T15:04:20Z"
+      "branch": "res-2730-char-equality-in-compounds",
+      "claimed_at": "2026-05-30T15:13:54Z"
     }
   }
 }

--- a/resilient/examples/char_equality_in_compounds.expected.txt
+++ b/resilient/examples/char_equality_in_compounds.expected.txt
@@ -1,0 +1,7 @@
+char arrays equal: true
+char arrays not equal: true
+Option<char> equal: true
+Option<char> not equal: true
+char tuple equal: true
+char tuple not equal: true
+Program executed successfully

--- a/resilient/examples/char_equality_in_compounds.rz
+++ b/resilient/examples/char_equality_in_compounds.rz
@@ -1,0 +1,24 @@
+// RES-2730: Char equality inside compound types now works correctly.
+// Previously, ['a','b'] == ['a','b'] silently returned false because
+// values_strict_eq had no arm for Value::Char.
+
+let chars1 = ['h', 'i'];
+let chars2 = ['h', 'i'];
+let chars3 = ['h', 'o'];
+
+if chars1 == chars2 { println("char arrays equal: true"); }
+if chars1 != chars3 { println("char arrays not equal: true"); }
+
+let opt1 = Some('x');
+let opt2 = Some('x');
+let opt3 = Some('z');
+
+if opt1 == opt2 { println("Option<char> equal: true"); }
+if opt1 != opt3 { println("Option<char> not equal: true"); }
+
+let t1 = ('a', 1);
+let t2 = ('a', 1);
+let t3 = ('b', 1);
+
+if t1 == t2 { println("char tuple equal: true"); }
+if t1 != t3 { println("char tuple not equal: true"); }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -22767,6 +22767,9 @@ fn values_strict_eq(left: &Value, right: &Value) -> bool {
         (Value::Float(l), Value::Float(r)) => l == r,
         (Value::String(l), Value::String(r)) => l == r,
         (Value::Bool(l), Value::Bool(r)) => l == r,
+        // RES-2730: Char was missing — chars inside compound types (arrays,
+        // Options, tuples, etc.) silently compared as unequal.
+        (Value::Char(l), Value::Char(r)) => l == r,
         (Value::Bytes(l), Value::Bytes(r)) => l == r,
         (Value::Void, Value::Void) => true,
         (Value::Array(l), Value::Array(r)) => slices_strict_eq(l, r),
@@ -22862,6 +22865,9 @@ fn values_cmp(left: &Value, right: &Value) -> Option<std::cmp::Ordering> {
         (Value::Float(l), Value::Float(r)) => l.partial_cmp(r),
         (Value::String(l), Value::String(r)) => Some(l.cmp(r)),
         (Value::Bool(l), Value::Bool(r)) => Some(l.cmp(r)),
+        // RES-2730: Char ordering by Unicode scalar value (same policy as the
+        // `eval_infix_expression` arm added in RES-2683).
+        (Value::Char(l), Value::Char(r)) => Some(l.cmp(r)),
         _ => None,
     }
 }
@@ -59562,5 +59568,55 @@ mod res2728_compound_equality {
              if a != b { println(\"different\"); } else { println(\"same\"); }");
         assert!(r.ok, "errors: {:?}", r.errors);
         assert!(r.stdout.contains("different"), "got: {}", r.stdout);
+    }
+}
+
+#[cfg(test)]
+mod res2730_char_equality {
+    use super::run_program as run;
+
+    #[test]
+    fn char_array_same_equal() {
+        let r = run("let a = ['x', 'y'];\n\
+             let b = ['x', 'y'];\n\
+             if a == b { println(\"equal\"); } else { println(\"not equal\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("equal"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn char_array_different_not_equal() {
+        let r = run("let a = ['x', 'y'];\n\
+             let b = ['x', 'z'];\n\
+             if a != b { println(\"different\"); } else { println(\"same\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("different"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn option_char_some_equal() {
+        let r = run("let a = Some('m');\n\
+             let b = Some('m');\n\
+             if a == b { println(\"equal\"); } else { println(\"not equal\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("equal"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn option_char_different_not_equal() {
+        let r = run("let a = Some('x');\n\
+             let b = Some('y');\n\
+             if a != b { println(\"different\"); } else { println(\"same\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("different"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn char_tuple_equal() {
+        let r = run("let a = ('a', 1);\n\
+             let b = ('a', 1);\n\
+             if a == b { println(\"equal\"); } else { println(\"not equal\"); }");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("equal"), "got: {}", r.stdout);
     }
 }


### PR DESCRIPTION
## Summary
- Chars inside compound types (arrays, tuples, Options, Results, enums) silently compared as unequal because `values_strict_eq` had no `Value::Char` arm and fell through to `_ => false`
- Also added `Value::Char` to `values_cmp` so structs with Char fields can use `#[derive(PartialOrd)]` ordering  
- Direct `'a' == 'a'` comparisons were already correct (RES-2683); this fixes the recursive case
- 5 unit tests + golden example `char_equality_in_compounds.rz`

Closes #2730

## Test plan
- [x] `cargo test res2730` — 5/5 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Golden example produces expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)