### PR TITLE
RES-2731: remove false-positive negative-index check from typechecker

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,8 @@
 {
   "claims": {
-    "resilient/src/lib.rs": {
-      "branch": "res-2730-char-equality-in-compounds",
-      "claimed_at": "2026-05-30T15:13:54Z"
+    "resilient/src/typechecker.rs": {
+      "branch": "res-2731-negative-index-false-positive",
+      "claimed_at": "2026-05-30T15:37:55Z"
     }
   }
 }

--- a/resilient/examples/negative_index.expected.txt
+++ b/resilient/examples/negative_index.expected.txt
@@ -1,0 +1,6 @@
+50
+40
+10
+o
+l
+Program executed successfully

--- a/resilient/examples/negative_index.rz
+++ b/resilient/examples/negative_index.rz
@@ -1,0 +1,13 @@
+// RES-2731: negative array and string indices work without a false-positive
+// type error. RES-921 added Python-style negative indexing to the runtime;
+// this removes the compile-time rejection that predated that feature.
+
+let arr = [10, 20, 30, 40, 50];
+
+println(arr[-1]);
+println(arr[-2]);
+println(arr[-5]);
+
+let s = "hello";
+println(s[-1]);
+println(s[-3]);

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -7658,16 +7658,11 @@ impl TypeChecker {
                         idx_ty
                     ));
                 }
-                // RES-415: negative constant index is always out-of-bounds.
-                if matches!(tgt_ty, Type::Array | Type::String)
-                    && let Some(idx_val) = fold_const_i64(index, &self.const_bindings)
-                    && idx_val < 0
-                {
-                    return Err(format!(
-                        "index {} is always out of bounds — array/string indices must be non-negative",
-                        idx_val
-                    ));
-                }
+                // RES-921 added Python-style negative indexing to the runtime: arr[-1]
+                // is the last element, arr[-2] is second-to-last, etc. The RES-415
+                // compile-time rejection of negative constant indices is therefore a
+                // false positive and is removed. Out-of-range access (including
+                // out-of-range negative indices) is caught at runtime.
                 // String indexing returns a char (RES-2709 + RES-2711):
                 // runtime yields Value::Char; typechecker mirrors that here.
                 // Array indexing returns Any (no element-type tracking yet).
@@ -13672,12 +13667,11 @@ mod res415_collection_type_checks {
     }
 
     #[test]
-    fn negative_constant_index_errors() {
-        let e = check_err(r#"fn f() -> void { let arr = [1, 2, 3]; let x = arr[-1]; }"#);
-        assert!(
-            e.contains("out of bounds") || e.contains("negative"),
-            "expected negative-index error; got: {e}"
-        );
+    fn negative_constant_index_is_valid() {
+        // RES-921 added Python-style negative indexing (arr[-1] = last element).
+        // RES-2731 removed the false-positive compile-time rejection of negative
+        // constant indices — the runtime handles them correctly.
+        check_ok(r#"fn f() -> void { let arr = [1, 2, 3]; let x = arr[-1]; }"#);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `arr[-1]` and `s[-1]` produced spurious type errors ("index -1 is always out of bounds") even though RES-921 added Python-style negative indexing to the runtime
- Removed the stale RES-415 compile-time check from `typechecker.rs` (9 lines deleted)
- Updated the test that previously expected the rejection to now verify acceptance
- Added golden example `negative_index.rz` demonstrating negative array and string indexing

Closes #2732

## Test plan
- [x] `cargo test collection_type_checks` — all 7 tests pass (including renamed `negative_constant_index_is_valid`)
- [x] `cargo test negative` — runtime negative-index tests from RES-921 still pass
- [x] Golden example produces correct output: `arr[-1]=50`, `s[-1]='o'`
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)