### PR TITLE
RES-2734: Array dot-call methods — sort, join, reverse, flatten, dedup, has, slice

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,8 @@
 {
   "claims": {
-    "resilient/src/typechecker.rs": {
-      "branch": "res-2731-negative-index-false-positive",
-      "claimed_at": "2026-05-30T15:37:55Z"
+    "resilient/src/lib.rs": {
+      "branch": "res-2733-array-method-dispatch",
+      "claimed_at": "2026-05-30T15:49:47Z"
     }
   }
 }

--- a/resilient/examples/array_dot_methods.expected.txt
+++ b/resilient/examples/array_dot_methods.expected.txt
@@ -1,0 +1,10 @@
+[1, 1, 2, 3, 4, 5, 6, 9]
+[9, 6, 5, 4, 3, 2, 1, 1]
+[6, 2, 9, 5, 1, 4, 1, 3]
+hello, world, foo
+[1, 2, 3, 4, 5, 6]
+[1, 2, 3]
+true
+false
+[20, 30]
+Program executed successfully

--- a/resilient/examples/array_dot_methods.rz
+++ b/resilient/examples/array_dot_methods.rz
@@ -1,0 +1,23 @@
+// RES-2734: array dot-call methods — sort, join, reverse, flatten, dedup, has, slice.
+// These were previously only available as global functions (array_sort, array_join, …);
+// dot-notation now works for all of them.
+
+let nums = [3, 1, 4, 1, 5, 9, 2, 6];
+println(nums.sort());
+println(nums.sort_desc());
+println(nums.reverse());
+
+let words = ["hello", "world", "foo"];
+println(words.join(", "));
+
+let nested = [[1, 2], [3, 4], [5, 6]];
+println(nested.flatten());
+
+let dupes = [1, 1, 2, 2, 3, 3];
+println(dupes.dedup());
+
+let haystack = [10, 20, 30];
+println(haystack.has(20));
+println(haystack.has(99));
+
+println(haystack.slice(1, 3));

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -11645,6 +11645,18 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("array_flatten", builtin_array_flatten),
     // RES-424: join a string array with a separator.
     ("array_join", builtin_array_join),
+    // RES-2734: short-name aliases so `arr.sort()`, `arr.join(sep)`, etc.
+    // work as dot-call methods via the Array method dispatch allowlist.
+    // These also serve as convenient global function aliases.
+    ("sort", builtin_array_sort),
+    ("sort_desc", builtin_array_sort_desc),
+    ("reverse", builtin_array_reverse),
+    ("join", builtin_array_join),
+    ("flatten", builtin_array_flatten),
+    ("dedup", builtin_array_dedup),
+    // "has" avoids collision with string `contains` while providing
+    // element membership testing as a dot-call: `arr.has(x)`.
+    ("has", builtin_array_contains),
     // RES-425: explicit scalar-to-string conversion.
     ("to_string", builtin_to_string),
     // RES-426: first-occurrence dedupe over scalar elements.
@@ -23731,7 +23743,19 @@ impl Interpreter {
                                 "split",
                                 "repeat",
                             ][..],
-                            Value::Array(_) => &["len", "push", "pop"][..],
+                            Value::Array(_) => &[
+                                "len",
+                                "push",
+                                "pop",
+                                "slice",
+                                "sort",
+                                "sort_desc",
+                                "reverse",
+                                "join",
+                                "flatten",
+                                "dedup",
+                                "has",
+                            ][..],
                             _ => unreachable!(),
                         };
                         if allowed.contains(&field.as_str()) {

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -7487,9 +7487,18 @@ impl TypeChecker {
                 // Function type here lets the call site infer the correct return.
                 if tgt_ty == Type::Array {
                     let ret = match field.as_str() {
-                        "map" | "filter" | "push" | "pop" | "sort" | "reverse" | "flat_map" => {
+                        // HOF methods: take a callback / element as the extra arg.
+                        "map" | "filter" | "push" | "flat_map" => Type::Function {
+                            params: vec![Type::Any],
+                            return_type: Box::new(Type::Array),
+                        },
+                        // RES-2734: zero-extra-arg array transformations. `pop`,
+                        // `sort`, `reverse` etc. were previously grouped with the
+                        // HOF methods (1 param), causing a false arity error when
+                        // called without arguments. Fixed here.
+                        "pop" | "sort" | "sort_desc" | "reverse" | "flatten" | "dedup" => {
                             Type::Function {
-                                params: vec![Type::Any],
+                                params: vec![],
                                 return_type: Box::new(Type::Array),
                             }
                         }
@@ -7513,13 +7522,20 @@ impl TypeChecker {
                             params: vec![],
                             return_type: Box::new(Type::Int),
                         },
-                        "contains" => Type::Function {
+                        // RES-2734: `has` is the array-element membership method;
+                        // `contains` is kept for backward compat.
+                        "contains" | "has" => Type::Function {
                             params: vec![Type::Any],
                             return_type: Box::new(Type::Bool),
                         },
                         "join" => Type::Function {
                             params: vec![Type::String],
                             return_type: Box::new(Type::String),
+                        },
+                        // RES-2734: slice(start, end) — sub-array extraction.
+                        "slice" => Type::Function {
+                            params: vec![Type::Int, Type::Int],
+                            return_type: Box::new(Type::Array),
                         },
                         _ => Type::Any,
                     };
@@ -9635,6 +9651,14 @@ fn is_known_pure_builtin(name: &str) -> bool {
         // RES-412: reverse string/array.
         "string_reverse",
         "array_reverse",
+        // RES-2734: short-name aliases for array dot-call methods.
+        "sort",
+        "sort_desc",
+        "reverse",
+        "join",
+        "flatten",
+        "dedup",
+        "has",
         // RES-1859: higher-order array builtins.
         "array_map",
         "array_filter",
@@ -13491,6 +13515,47 @@ mod res412_method_return_types {
     #[test]
     fn array_join_returns_string() {
         check_ok(r#"fn f() -> string { let arr = ["a", "b"]; return arr.join(", "); }"#);
+    }
+
+    // RES-2734: zero-extra-arg methods were incorrectly registered with 1 param.
+    #[test]
+    fn array_sort_accepts_no_args() {
+        check_ok(r#"fn f() -> array { let arr = [3, 1, 2]; return arr.sort(); }"#);
+    }
+
+    #[test]
+    fn array_sort_desc_accepts_no_args() {
+        check_ok(r#"fn f() -> array { let arr = [1, 3, 2]; return arr.sort_desc(); }"#);
+    }
+
+    #[test]
+    fn array_reverse_accepts_no_args() {
+        check_ok(r#"fn f() -> array { let arr = [1, 2, 3]; return arr.reverse(); }"#);
+    }
+
+    #[test]
+    fn array_pop_accepts_no_args() {
+        check_ok(r#"fn f() -> array { let arr = [1, 2, 3]; return arr.pop(); }"#);
+    }
+
+    #[test]
+    fn array_flatten_accepts_no_args() {
+        check_ok(r#"fn f() -> array { let arr = [[1, 2], [3]]; return arr.flatten(); }"#);
+    }
+
+    #[test]
+    fn array_dedup_accepts_no_args() {
+        check_ok(r#"fn f() -> array { let arr = [1, 1, 2]; return arr.dedup(); }"#);
+    }
+
+    #[test]
+    fn array_has_returns_bool() {
+        check_ok(r#"fn f() -> bool { let arr = [1, 2, 3]; return arr.has(2); }"#);
+    }
+
+    #[test]
+    fn array_slice_returns_array() {
+        check_ok(r#"fn f() -> array { let arr = [1, 2, 3, 4]; return arr.slice(1, 3); }"#);
     }
 }
 


### PR DESCRIPTION
## Problem

Arrays in Resilient had only three dot-call methods: `len`, `push`, `pop`. Rich array builtins like `array_sort`, `array_join`, `array_reverse`, `array_flatten`, `array_dedup` existed but required verbose global-function syntax.

Additionally, a pre-existing bug in the typechecker grouped `pop`, `sort`, and `reverse` with HOF methods (1-param callback slot), causing a false type error when calling `arr.sort()`, `arr.pop()`, or `arr.reverse()` with no arguments.

## Changes

**`resilient/src/lib.rs`**
- Added 7 short-name aliases to the BUILTINS table: `sort`, `sort_desc`, `reverse`, `join`, `flatten`, `dedup`, `has` (array element membership — distinct name avoids collision with string `contains`)
- Extended the Array method dispatch allowlist from `["len", "push", "pop"]` to include all new methods plus `slice`

**`resilient/src/typechecker.rs`**
- Fixed: moved `pop`, `sort`, `reverse` out of the 1-param HOF group into a 0-param group (`params: vec![]`), ending the false "Expected 1 arguments, got 0" arity error
- Added type registrations for `sort_desc`, `flatten`, `dedup` (→ Array), `has` (→ Bool), `slice` (→ Array, 2 Int params)
- Added 8 new unit tests covering each new method

**`resilient/examples/array_dot_methods.rz` + `.expected.txt`**
- Golden example exercising all new methods

## Test changes

Added `res412_method_return_types` tests: `array_sort_accepts_no_args`, `array_sort_desc_accepts_no_args`, `array_reverse_accepts_no_args`, `array_pop_accepts_no_args`, `array_flatten_accepts_no_args`, `array_dedup_accepts_no_args`, `array_has_returns_bool`, `array_slice_returns_array`. These test that the typechecker correctly accepts zero-arg calls on methods that were previously incorrectly gated.

## Before / After

```
// Before — type error + runtime-only workaround:
let sorted = array_sort(nums);         // ← had to use global syntax
let joined = array_join(words, ", "); 

// After — natural dot-notation:
let sorted = nums.sort();
let joined = words.join(", ");
let rev    = nums.reverse();
let flat   = nested.flatten();
let unique = dupes.dedup();
let found  = haystack.has(20);
let sub    = haystack.slice(1, 3);
```

Closes #2734