### PR TITLE
RES-2738: String dot-call methods — replace, chars, reverse, strip_prefix, strip_suffix, lines

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,12 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-2736-map-set-dot-methods",
-      "claimed_at": "2026-05-30T16:06:46Z"
+      "branch": "res-2738-string-method-dispatch",
+      "claimed_at": "2026-05-30T16:20:34Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-2738-string-method-dispatch",
+      "claimed_at": "2026-05-30T16:20:34Z"
     }
   }
 }

--- a/resilient/examples/string_dot_methods.expected.txt
+++ b/resilient/examples/string_dot_methods.expected.txt
@@ -1,0 +1,11 @@
+Hello, Resilient!
+[H, e, l, l, o, ,,  , W, o, r, l, d, !]
+!dlroW ,olleH
+["Hello, World!"]
+hello
+value
+prefix_value
+value
+a | b | c
+["one", "two", "three"]
+Program executed successfully

--- a/resilient/examples/string_dot_methods.rz
+++ b/resilient/examples/string_dot_methods.rz
@@ -1,0 +1,26 @@
+// RES-2738: String dot-call methods — replace, chars, reverse,
+// strip_prefix, strip_suffix, lines. Previously available only as
+// global functions (replace/string_*) or not at all via dot notation.
+
+let s = "Hello, World!";
+println(s.replace("World", "Resilient"));
+println(s.chars());
+println(s.reverse());
+println(s.lines());
+
+let padded = "  hello  ";
+println(padded.trim());
+
+let prefixed = "prefix_value";
+println(prefixed.strip_prefix("prefix_"));
+println(prefixed.strip_prefix("other_"));
+
+let suffixed = "value.txt";
+println(suffixed.strip_suffix(".txt"));
+
+let csv = "a,b,c";
+let parts = csv.split(",");
+println(parts.join(" | "));
+
+let multiline = "one\ntwo\nthree";
+println(multiline.lines());

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -23726,38 +23726,56 @@ impl Interpreter {
                             _ => unreachable!(),
                         }
                     }
-                    // RES-920: method-call sugar on built-in String /
-                    // Array. Forward to the existing builtin with the
-                    // target prepended as the first argument so prefix
-                    // and dot-notation share semantics.
-                    if matches!(target_val, Value::String(_) | Value::Array(_)) {
-                        let allowed = match &target_val {
-                            Value::String(_) => &[
-                                "len",
-                                "trim",
-                                "to_upper",
-                                "to_lower",
-                                "contains",
-                                "starts_with",
-                                "ends_with",
-                                "split",
-                                "repeat",
-                            ][..],
-                            Value::Array(_) => &[
-                                "len",
-                                "push",
-                                "pop",
-                                "slice",
-                                "sort",
-                                "sort_desc",
-                                "reverse",
-                                "join",
-                                "flatten",
-                                "dedup",
-                                "has",
-                            ][..],
-                            _ => unreachable!(),
+                    // RES-920 / RES-2738: method-call sugar on built-in String.
+                    // Uses an explicit short-name → full-builtin-name map so
+                    // `reverse` can route to `string_reverse` without conflicting
+                    // with the Array `reverse` alias that points to `array_reverse`.
+                    if let Value::String(_) = &target_val {
+                        let full_name: &str = match field.as_str() {
+                            "len" => "len",
+                            "trim" => "trim",
+                            "to_upper" => "to_upper",
+                            "to_lower" => "to_lower",
+                            "contains" => "contains",
+                            "starts_with" => "starts_with",
+                            "ends_with" => "ends_with",
+                            "split" => "split",
+                            "repeat" => "repeat",
+                            // RES-2738: additional string methods.
+                            "replace" => "replace",
+                            "chars" => "string_chars",
+                            "reverse" => "string_reverse",
+                            "strip_prefix" => "string_strip_prefix",
+                            "strip_suffix" => "string_strip_suffix",
+                            "lines" => "string_lines",
+                            _ => "",
                         };
+                        if !full_name.is_empty() {
+                            let extra_args = self.eval_expressions(arguments)?;
+                            let mut args = Vec::with_capacity(extra_args.len() + 1);
+                            args.push(target_val);
+                            args.extend(extra_args);
+                            return apply_builtin_by_name(full_name, &args).ok_or_else(|| {
+                                format!("Builtin method `{}` is not registered", field)
+                            })?;
+                        }
+                    }
+                    // RES-920 / RES-2734: method-call sugar on built-in Array.
+                    // All short names correspond to BUILTINS entries exactly.
+                    if let Value::Array(_) = &target_val {
+                        let allowed: &[&str] = &[
+                            "len",
+                            "push",
+                            "pop",
+                            "slice",
+                            "sort",
+                            "sort_desc",
+                            "reverse",
+                            "join",
+                            "flatten",
+                            "dedup",
+                            "has",
+                        ];
                         if allowed.contains(&field.as_str()) {
                             let extra_args = self.eval_expressions(arguments)?;
                             let mut args = Vec::with_capacity(extra_args.len() + 1);
@@ -23767,10 +23785,6 @@ impl Interpreter {
                                 format!("Builtin method `{}` is not registered", field)
                             })?;
                         }
-                        // Fall through to the original "Cannot access
-                        // field on non-struct" error path so misspelled
-                        // methods get the same diagnostic shape as
-                        // before.
                     }
                     // RES-2736: method-call sugar on built-in Map and Set.
                     // Maps the short dot-call name to the underlying
@@ -59796,5 +59810,78 @@ mod res2736_map_set_dot_methods {
         let r = run("let s = #{42}; println(s.items());");
         assert!(r.ok, "errors: {:?}", r.errors);
         assert!(r.stdout.contains("42"), "got: {}", r.stdout);
+    }
+}
+
+#[cfg(test)]
+mod res2738_string_dot_methods {
+    use super::*;
+
+    fn run(src: &str) -> RunResult {
+        run_program(src)
+    }
+
+    #[test]
+    fn string_replace_method() {
+        let r = run(r#"println("hello world".replace("world", "Resilient"));"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("hello Resilient"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn string_chars_method_no_type_error() {
+        // chars() previously caused "Expected 1 arguments, got 0" from typechecker
+        let r = run(r#"fn f() -> array { return "abc".chars(); } println(f());"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains('a'), "got: {}", r.stdout);
+        assert!(r.errors.is_empty(), "type errors: {:?}", r.errors);
+    }
+
+    #[test]
+    fn string_reverse_method() {
+        let r = run(r#"println("abc".reverse());"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("cba"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn string_strip_prefix_method_found() {
+        let r = run(r#"println("prefix_val".strip_prefix("prefix_"));"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("val"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn string_strip_prefix_method_missing() {
+        let r = run(r#"println("hello".strip_prefix("xyz"));"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("hello"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn string_strip_suffix_method() {
+        let r = run(r#"println("file.txt".strip_suffix(".txt"));"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("file"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn string_lines_method() {
+        let r = run("println(\"a\\nb\\nc\".lines());");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("\"a\""), "got: {}", r.stdout);
+        assert!(r.stdout.contains("\"b\""), "got: {}", r.stdout);
+        assert!(r.stdout.contains("\"c\""), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn existing_string_methods_still_work() {
+        let r = run(
+            r#"println("  hi  ".trim()); println("hello".to_upper()); println("WORLD".to_lower());"#,
+        );
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("hi"), "got: {}", r.stdout);
+        assert!(r.stdout.contains("HELLO"), "got: {}", r.stdout);
+        assert!(r.stdout.contains("world"), "got: {}", r.stdout);
     }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -7545,17 +7545,31 @@ impl TypeChecker {
                 }
                 if tgt_ty == Type::String {
                     let ret = match field.as_str() {
-                        "split" | "chars" => Type::Function {
+                        // `split` takes a separator arg; `chars` takes none.
+                        // RES-2738: `chars` was incorrectly grouped with `split`
+                        // (1-param), causing a false arity error on `s.chars()`.
+                        "split" => Type::Function {
                             params: vec![Type::Any],
                             return_type: Box::new(Type::Array),
                         },
-                        "trim" | "to_upper" | "to_lower" => Type::Function {
+                        // RES-2738: zero-arg array-returning string methods.
+                        "chars" | "lines" => Type::Function {
+                            params: vec![],
+                            return_type: Box::new(Type::Array),
+                        },
+                        // Zero-arg string → string methods.
+                        "trim" | "to_upper" | "to_lower" | "reverse" => Type::Function {
                             params: vec![],
                             return_type: Box::new(Type::String),
                         },
                         "replace" => Type::Function {
                             params: vec![Type::String, Type::String],
                             return_type: Box::new(Type::String),
+                        },
+                        // RES-2738: strip_prefix / strip_suffix return Result.
+                        "strip_prefix" | "strip_suffix" => Type::Function {
+                            params: vec![Type::String],
+                            return_type: Box::new(Type::Result),
                         },
                         "contains" | "starts_with" | "ends_with" => Type::Function {
                             params: vec![Type::String],
@@ -9659,6 +9673,12 @@ fn is_known_pure_builtin(name: &str) -> bool {
         "flatten",
         "dedup",
         "has",
+        // RES-2738: string dot-call methods (routed via runtime name mapping).
+        "replace",
+        "chars",
+        "strip_prefix",
+        "strip_suffix",
+        "lines",
         // RES-1859: higher-order array builtins.
         "array_map",
         "array_filter",


### PR DESCRIPTION
## Problem

Several string methods were registered in the typechecker but absent from the runtime dispatch allowlist:
- `s.replace("old", "new")` → \"Cannot access field 'replace' on non-struct String\"
- `s.chars()` → \"Cannot access field 'chars' on non-struct String\"

The typechecker also had a pre-existing arity bug: `chars` was grouped with `split` (1-param), causing a false \"Expected 1 arguments, got 0\" error even though `chars()` takes no extra args.

## Changes

**`resilient/src/lib.rs`**
- Refactored the combined `String | Array` method dispatch into two separate type-specific blocks
- String block now uses an explicit `short_name → full_builtin_name` map (like RES-2736 Map/Set), so `reverse` can route to `string_reverse` without colliding with Array's `reverse` → `array_reverse`
- New String methods: `replace`, `chars`, `reverse`, `strip_prefix`, `strip_suffix`, `lines`
- 8 unit tests in `res2738_string_dot_methods`

**`resilient/src/typechecker.rs`**
- Fixed: `chars` separated from `split` — now correctly has `params: vec![]` (0 extra args)
- Added type registrations: `chars`, `lines` (→ Array), `reverse` (→ String), `strip_prefix`, `strip_suffix` (→ Result)

**`resilient/examples/string_dot_methods.rz` + `.expected.txt`**  
- Golden example exercising all new string methods

## Test changes

Added `res2738_string_dot_methods` tests including `string_chars_method_no_type_error` which specifically verifies the typechecker arity fix (no false error on `s.chars()`).

## Before / After

```
// Before:
let r = replace(s, "old", "new");       // global function only
let cs = string_chars(s);              // global function only
// s.replace(...) and s.chars() both failed at runtime

// After:
let r = s.replace("old", "new");
let cs = s.chars();
let rev = s.reverse();
let lines = s.lines();
```

Closes #2738