### PR TITLE
RES-2740/RES-2741: fix Result<T,E> annotation false-positive and struct update trailing spread

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,12 +1,12 @@
 {
   "claims": {
     "resilient/src/lib.rs": {
-      "branch": "res-2738-string-method-dispatch",
-      "claimed_at": "2026-05-30T16:20:34Z"
+      "branch": "res-2740-result-struct-update-fixes",
+      "claimed_at": "2026-05-30T16:38:34Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-2738-string-method-dispatch",
-      "claimed_at": "2026-05-30T16:20:34Z"
+      "branch": "res-2740-result-struct-update-fixes",
+      "claimed_at": "2026-05-30T16:38:34Z"
     }
   }
 }

--- a/resilient/examples/result_parametric_annotation.expected.txt
+++ b/resilient/examples/result_parametric_annotation.expected.txt
@@ -1,0 +1,5 @@
+5
+division by zero
+42
+not positive
+Program executed successfully

--- a/resilient/examples/result_parametric_annotation.rz
+++ b/resilient/examples/result_parametric_annotation.rz
@@ -1,0 +1,41 @@
+// RES-2740: Result<T, E> parametric return-type annotations — previously
+// produced a false-positive "return type mismatch" error. The annotation
+// is now accepted and type-checked as plain Result (params not tracked at MVP).
+
+fn divide(int a, int b) -> Result<int, string> {
+    if b == 0 {
+        return Err("division by zero");
+    }
+    return Ok(a / b);
+}
+
+fn to_positive(int n) -> Result<int, string> {
+    if n < 0 {
+        return Err("not positive");
+    }
+    return Ok(n);
+}
+
+let r1 = divide(10, 2);
+match r1 {
+    Ok(v) => println(v),
+    Err(e) => println(e)
+}
+
+let r2 = divide(10, 0);
+match r2 {
+    Ok(v) => println(v),
+    Err(e) => println(e)
+}
+
+let r3 = to_positive(42);
+match r3 {
+    Ok(v) => println(v),
+    Err(e) => println(e)
+}
+
+let r4 = to_positive(-5);
+match r4 {
+    Ok(v) => println(v),
+    Err(e) => println(e)
+}

--- a/resilient/examples/struct_update_trailing.expected.txt
+++ b/resilient/examples/struct_update_trailing.expected.txt
@@ -1,0 +1,10 @@
+5
+0
+0
+1
+2
+0
+0
+0
+99
+Program executed successfully

--- a/resilient/examples/struct_update_trailing.rz
+++ b/resilient/examples/struct_update_trailing.rz
@@ -1,0 +1,29 @@
+// RES-2741: struct update `..base` at the END of a field list.
+// Previously only `new P { ..base, x: 10 }` worked; the more
+// common Rust-style `new P { x: 10, ..base }` caused a parse error.
+
+struct Point {
+    int x,
+    int y,
+    int z,
+}
+
+let origin = new Point { x: 0, y: 0, z: 0 };
+
+// Trailing ..base (Rust convention — now supported):
+let p1 = new Point { x: 5, ..origin };
+println(p1.x);
+println(p1.y);
+println(p1.z);
+
+// Multiple overrides then ..base:
+let p2 = new Point { x: 1, y: 2, ..origin };
+println(p2.x);
+println(p2.y);
+println(p2.z);
+
+// Leading ..base still works:
+let p3 = new Point { ..origin, z: 99 };
+println(p3.x);
+println(p3.y);
+println(p3.z);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -9156,6 +9156,23 @@ impl Parser {
         }
 
         loop {
+            // RES-2741: `..base` at the END of a field list — Rust-style struct
+            // update syntax. The start-of-list case is handled above; this arm
+            // handles the trailing position: `new P { x: 10, ..base }`.
+            if self.current_token == Token::DotDot {
+                self.next_token(); // skip `..`
+                let base_expr = self.parse_expression(0).unwrap_or(Node::Identifier {
+                    name: String::new(),
+                    span: span::Span::default(),
+                });
+                base = Some(Box::new(base_expr));
+                self.next_token(); // past expression
+                // Skip optional trailing comma then stop — `..base` must be last.
+                if self.current_token == Token::Comma {
+                    self.next_token();
+                }
+                break;
+            }
             // Capture the span of the field-name token so a
             // shorthand expansion's `Identifier` carries the
             // correct source position (the original field name's
@@ -59883,5 +59900,81 @@ mod res2738_string_dot_methods {
         assert!(r.stdout.contains("hi"), "got: {}", r.stdout);
         assert!(r.stdout.contains("HELLO"), "got: {}", r.stdout);
         assert!(r.stdout.contains("world"), "got: {}", r.stdout);
+    }
+}
+
+#[cfg(test)]
+mod res2740_result_parametric_annotation {
+    use super::run_program as run;
+
+    #[test]
+    fn result_parametric_return_ok() {
+        let r = run(r#"fn divide(int a, int b) -> Result<int, string> {
+  if b == 0 { return Err("div by zero"); }
+  return Ok(a / b);
+}
+match divide(10, 2) { Ok(v) => println(v), Err(e) => println(e) }"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains('5'), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn result_parametric_return_err() {
+        let r = run(r#"fn divide(int a, int b) -> Result<int, string> {
+  if b == 0 { return Err("div by zero"); }
+  return Ok(a / b);
+}
+match divide(10, 0) { Ok(v) => println(v), Err(e) => println(e) }"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("div by zero"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn result_parametric_nested_type() {
+        // Result<float, string> should also parse correctly.
+        let r = run(r#"fn f(float x) -> Result<float, string> {
+  if x < 0.0 { return Err("negative"); }
+  return Ok(x);
+}
+match f(3.14) { Ok(v) => println("ok"), Err(e) => println(e) }"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("ok"), "got: {}", r.stdout);
+    }
+}
+
+#[cfg(test)]
+mod res2741_struct_update_trailing {
+    use super::run_program as run;
+
+    #[test]
+    fn spread_at_end_one_override() {
+        let r = run(r#"struct Point { int x, int y, int z, }
+let o = new Point { x: 0, y: 0, z: 0 };
+let p = new Point { x: 5, ..o };
+println(p.x); println(p.y); println(p.z);"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains('5'), "got: {}", r.stdout);
+        assert!(r.stdout.contains('0'), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn spread_at_end_multiple_overrides() {
+        let r = run(r#"struct Point { int x, int y, int z, }
+let o = new Point { x: 0, y: 0, z: 0 };
+let p = new Point { x: 1, y: 2, ..o };
+println(p.x); println(p.y); println(p.z);"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains('1'), "got: {}", r.stdout);
+        assert!(r.stdout.contains('2'), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn spread_at_start_still_works() {
+        let r = run(r#"struct Point { int x, int y, int z, }
+let o = new Point { x: 0, y: 0, z: 0 };
+let p = new Point { ..o, z: 99 };
+println(p.x); println(p.y); println(p.z);"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("99"), "got: {}", r.stdout);
     }
 }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -9027,6 +9027,13 @@ impl TypeChecker {
                 let inner_ty = self.parse_type_name_inner(inner_str.trim(), seen)?;
                 Ok(Type::Option(Box::new(inner_ty)))
             }
+            // RES-2740: `Result<T, E>` with type parameters — Type::Result is
+            // unparameterized at MVP level, so we discard the params and resolve
+            // as plain Type::Result. Without this arm the string falls through to
+            // the alias lookup and becomes Type::Struct("Result<int, string>"),
+            // which never matches Type::Result from Ok()/Err() and produces a
+            // false-positive "return type mismatch" on every annotated function.
+            other if other.starts_with("Result<") && other.ends_with('>') => Ok(Type::Result),
             // RES-426: tuple type `(T1, T2, ...)`. Encoded by the
             // parser as a parenthesised comma-list; at type-check
             // level a tuple is represented as Type::Any (the interpreter


### PR DESCRIPTION
## Summary

Two P0 typechecker/parser correctness fixes:

### RES-2740: `Result<T, E>` parametric return-type annotation produces false-positive type error

**Root cause:** `parse_type_name_inner` had an arm for bare `"Result"` → `Type::Result` and for `"Option<T>"` → `Type::Option(...)`, but no arm for `"Result<T, E>"`. The string `"Result<int, string>"` fell through to the alias lookup and then to `Type::Struct("Result<int, string>")`, which never compared equal to `Type::Result` from `Ok()`/`Err()` checks.

**Fix:** Added `other if other.starts_with("Result<") && other.ends_with('>')` → `Ok(Type::Result)` immediately after the `Option<T>` arm. Since `Type::Result` is unparameterized at MVP level the params are discarded.

### RES-2741: Struct update `..base` only works at the START of a field list

**Root cause:** The struct-literal field loop opened with `match current_token { Token::Identifier(n) => ..., _ => error }`. When a user wrote `new P { x: 10, ..base }`, the parser got to `..` after the comma and hit the wildcard arm, recording an error.

**Fix:** Added a `Token::DotDot` check at the top of each loop iteration. If encountered, parse the base expression, set `base`, and break — exactly mirroring the start-of-list handling already present.

## Test plan
- [x] `fn f() -> Result<int, string> { return Ok(42); }` compiles without error
- [x] `fn f() -> Result<int, string> { return Err("bad"); }` compiles without error
- [x] `new P { x: 5, ..base }` parses and evaluates correctly
- [x] `new P { x: 1, y: 2, ..base }` parses and evaluates correctly
- [x] `new P { ..base, z: 99 }` (leading spread) still works
- [x] All existing tests pass

Closes #2740
Closes #2741

🤖 Generated with [Claude Code](https://claude.com/claude-code)