### PR TITLE
RES-2599: multi-line string literals and raw strings

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -7,6 +7,10 @@
     "resilient/src/typechecker.rs": {
       "branch": "res-2691-f32-compat-trait-struct-args",
       "claimed_at": "2026-05-30T18:00:00Z"
+    },
+    "resilient/src/lexer_logos.rs": {
+      "branch": "res-2599-multiline-raw-strings",
+      "claimed_at": "2026-05-30T17:31:49Z"
     }
   }
 }

--- a/resilient/examples/multiline_strings.expected.txt
+++ b/resilient/examples/multiline_strings.expected.txt
@@ -1,0 +1,11 @@
+Hello,
+World!
+no \n escape here
+SELECT *
+FROM users
+WHERE active = true
+
+no escape \n processing
+here either
+
+Program executed successfully

--- a/resilient/examples/multiline_strings.rz
+++ b/resilient/examples/multiline_strings.rz
@@ -1,0 +1,24 @@
+// RES-2599: multi-line string literals and raw strings
+// Tests triple-quoted strings and r"..." raw strings.
+
+let greeting = """
+    Hello,
+    World!
+""";
+println(greeting);
+
+let raw = r"no \n escape here";
+println(raw);
+
+let sql = """
+    SELECT *
+    FROM users
+    WHERE active = true
+""";
+println(sql);
+
+let raw_multi = r"""
+no escape \n processing
+here either
+""";
+println(raw_multi);

--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -182,6 +182,22 @@ enum Tok {
     // RES-909: decimal int literals also accept `_` between digits.
     #[regex(r"[0-9][0-9_]*", int_lit)]
     Int(i64),
+    // RES-2599: triple-quoted string `"""..."""`. The regex matches
+    // only the opening `"""`. `triple_str_lit` scans forward via
+    // `lex.bump()` to find the closing `"""`, then strips common
+    // indentation from all lines. Priority 3 > Str (2) so `"""` is
+    // not tokenised as empty-string followed by lone `"`.
+    #[regex(r#"""""#, triple_str_lit, priority = 3)]
+    TripleStr(String),
+    // RES-2599: raw string `r"..."` — no escape processing. Priority
+    // 4 > Str (2) ensures `r"..."` is tokenised as a single token,
+    // not Ident("r") followed by Str("...").
+    #[regex(r#"r"[^"]*""#, raw_str_lit, priority = 4)]
+    RawStr(String),
+    // RES-2599: raw triple-quoted string `r"""..."""`. Priority 6
+    // beats both raw-single (4) and triple-str (3).
+    #[regex(r#"r""""#, raw_triple_str_lit, priority = 6)]
+    RawTripleStr(String),
     // String literal — `"([^"\\]|\\[\s\S])*"` matches any non-quote
     // non-backslash char OR a backslash followed by any char
     // (including newlines). `string_lit` post-processes escapes.
@@ -454,6 +470,62 @@ fn float_lit(lex: &mut logos::Lexer<Tok>) -> Option<f64> {
     } else {
         slice.parse::<f64>().ok()
     }
+}
+
+// RES-2599: strip the common leading indentation from a triple-quoted string
+// body. The algorithm: (1) drop an optional leading newline after `"""`,
+// (2) compute the minimum indentation across non-empty lines, (3) strip
+// that many leading spaces/tabs from each line.
+fn strip_triple_indent(s: &str) -> String {
+    let s = s.strip_prefix('\n').unwrap_or(s);
+    let lines: Vec<&str> = s.lines().collect();
+    let min_indent = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start_matches([' ', '\t']).len())
+        .min()
+        .unwrap_or(0);
+    lines
+        .iter()
+        .map(|l| {
+            if l.len() >= min_indent {
+                &l[min_indent..]
+            } else {
+                l.trim_start()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// RES-2599: `"""..."""` triple-quoted string literal callback. The logos
+// regex matched only the opening `"""`. We scan the remainder for the
+// closing `"""`, bump the cursor, then strip common indentation.
+fn triple_str_lit(lex: &mut logos::Lexer<Tok>) -> Option<String> {
+    let rest = lex.remainder();
+    rest.find("\"\"\"").map(|end| {
+        let content = &rest[..end];
+        lex.bump(end + 3);
+        strip_triple_indent(content)
+    })
+}
+
+// RES-2599: `r"..."` raw string literal — strip the `r"` prefix and
+// trailing `"` with no escape processing at all.
+fn raw_str_lit(lex: &mut logos::Lexer<Tok>) -> String {
+    let slice = lex.slice();
+    slice[2..slice.len().saturating_sub(1)].to_string()
+}
+
+// RES-2599: `r"""..."""` raw triple-quoted string. Logos matched only
+// the opening `r"""`. Scan remainder for the closing `"""`.
+fn raw_triple_str_lit(lex: &mut logos::Lexer<Tok>) -> Option<String> {
+    let rest = lex.remainder();
+    rest.find("\"\"\"").map(|end| {
+        let content = rest[..end].to_string();
+        lex.bump(end + 3);
+        content
+    })
 }
 
 fn bytes_lit(lex: &mut logos::Lexer<Tok>) -> Vec<u8> {
@@ -901,6 +973,9 @@ fn convert(t: Tok) -> Token {
         Tok::BinInt(n) => Token::IntLiteral(n),
         Tok::Int(n) => Token::IntLiteral(n),
         Tok::Float(f) => Token::FloatLiteral(f),
+        Tok::TripleStr(s) => Token::StringLiteral(s),
+        Tok::RawStr(s) => Token::StringLiteral(s),
+        Tok::RawTripleStr(s) => Token::StringLiteral(s),
         Tok::Str(s) => Token::StringLiteral(s),
         Tok::BytesLit(b) => Token::BytesLiteral(b),
         // RES-2619: single-quoted char literal.

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -1052,6 +1052,31 @@ impl Token {
 /// user-facing syntax strings (backtick-quoted punctuation, prose
 /// categories like `identifier`). Single-element slices specialize
 /// to `expected X, got Y` to keep the common case reading
+// RES-2599: strip the common leading indentation from a triple-quoted string
+// body. Leading newline immediately after `"""` is dropped. Then the minimum
+// indentation of all non-empty lines is stripped uniformly.
+fn res2599_strip_indent(s: &str) -> String {
+    let s = s.strip_prefix('\n').unwrap_or(s);
+    let lines: Vec<&str> = s.lines().collect();
+    let min_indent = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start_matches([' ', '\t']).len())
+        .min()
+        .unwrap_or(0);
+    lines
+        .iter()
+        .map(|l| {
+            if l.len() >= min_indent {
+                &l[min_indent..]
+            } else {
+                l.trim_start()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// naturally. Slices longer than 5 entries are truncated with a
 /// trailing `…` so deep FIRST-sets don't balloon the diagnostic.
 pub fn format_expected(expected: &[&str], got_syntax: &str) -> String {
@@ -1188,6 +1213,15 @@ impl Lexer {
             '\0'
         } else {
             self.input[self.read_position]
+        }
+    }
+
+    // RES-2599: look two chars ahead (for `"""` triple-quote detection).
+    fn peek_char2(&self) -> char {
+        if self.read_position + 1 >= self.input.len() {
+            '\0'
+        } else {
+            self.input[self.read_position + 1]
         }
     }
 
@@ -1466,9 +1500,17 @@ impl Lexer {
             // tags the `@` itself.
             '@' => Token::At,
             '"' => {
-                self.read_char();
-                let str_value = self.read_string();
-                Token::StringLiteral(str_value)
+                self.read_char(); // advance past opening `"`; self.ch is now 2nd char
+                // RES-2599: detect `"""..."""` triple-quoted strings.
+                if self.ch == '"' && self.peek_char() == '"' {
+                    self.read_char(); // consume 2nd `"`
+                    self.read_char(); // consume 3rd `"`; self.ch is first content char
+                    let content = self.read_triple_string();
+                    Token::StringLiteral(res2599_strip_indent(&content))
+                } else {
+                    let str_value = self.read_string();
+                    Token::StringLiteral(str_value)
+                }
             }
             // RES-2619: `'...'` char literal.
             '\'' => {
@@ -1476,6 +1518,23 @@ impl Lexer {
                 let inner = self.read_char_inner();
                 // consume closing `'` (read_char_inner leaves self.ch on `'`)
                 Token::CharLiteral(inner)
+            }
+            // RES-2599: `r"..."` raw string (no escape processing) and
+            // `r"""..."""` raw triple-quoted string.
+            'r' if self.peek_char() == '"' => {
+                self.read_char(); // consume `r`; self.ch == `"`
+                self.read_char(); // consume opening `"`; self.ch is first content or 2nd `"`
+                if self.ch == '"' && self.peek_char() == '"' {
+                    // r"""...""" raw triple-quoted
+                    self.read_char(); // consume 2nd `"`
+                    self.read_char(); // consume 3rd `"`; self.ch is first content
+                    let content = self.read_raw_triple_string();
+                    Token::StringLiteral(content)
+                } else {
+                    // r"..." single raw string
+                    let content = self.read_raw_string();
+                    Token::StringLiteral(content)
+                }
             }
             // RES-152: `b"..."` byte-string literal. The guard on
             // the next char distinguishes from a bare identifier
@@ -1783,6 +1842,72 @@ impl Lexer {
             self.read_char();
         }
 
+        result
+    }
+
+    // RES-2599: `"""..."""` triple-quoted string. `self.ch` is the first
+    // content char after the opening `"""`. Reads until `"""` (three
+    // consecutive double-quotes) or EOF. Escape sequences are processed.
+    fn read_triple_string(&mut self) -> String {
+        let mut result = String::new();
+        loop {
+            if self.ch == '\0' {
+                break;
+            }
+            if self.ch == '"' && self.peek_char() == '"' && self.peek_char2() == '"' {
+                self.read_char(); // consume 2nd `"`
+                self.read_char(); // consume 3rd `"`
+                break;
+            }
+            if self.ch == '\\' && self.read_position < self.input.len() {
+                self.read_char();
+                match self.ch {
+                    'n' => result.push('\n'),
+                    't' => result.push('\t'),
+                    'r' => result.push('\r'),
+                    '\\' => result.push('\\'),
+                    '"' => result.push('"'),
+                    '0' => result.push('\0'),
+                    other => {
+                        result.push('\\');
+                        result.push(other);
+                    }
+                }
+            } else {
+                result.push(self.ch);
+            }
+            self.read_char();
+        }
+        result
+    }
+
+    // RES-2599: `r"..."` raw string — no escape processing.
+    // `self.ch` is the first content char after the opening `"`.
+    fn read_raw_string(&mut self) -> String {
+        let mut result = String::new();
+        while self.ch != '"' && self.ch != '\0' {
+            result.push(self.ch);
+            self.read_char();
+        }
+        result
+    }
+
+    // RES-2599: `r"""..."""` raw triple-quoted string — no escape processing.
+    // `self.ch` is the first content char after the opening `r"""`.
+    fn read_raw_triple_string(&mut self) -> String {
+        let mut result = String::new();
+        loop {
+            if self.ch == '\0' {
+                break;
+            }
+            if self.ch == '"' && self.peek_char() == '"' && self.peek_char2() == '"' {
+                self.read_char();
+                self.read_char();
+                break;
+            }
+            result.push(self.ch);
+            self.read_char();
+        }
         result
     }
 
@@ -60021,5 +60146,48 @@ let p = new Point { ..o, z: 99 };
 println(p.x); println(p.y); println(p.z);"#);
         assert!(r.ok, "errors: {:?}", r.errors);
         assert!(r.stdout.contains("99"), "got: {}", r.stdout);
+    }
+}
+
+#[cfg(test)]
+mod res2599_multiline_raw_strings {
+    use super::run_program as run;
+
+    #[test]
+    fn triple_quoted_indent_strip() {
+        let r = run(r#"let s = """
+    hello
+    world
+""";
+println(s);"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("hello"), "got: {}", r.stdout);
+        assert!(r.stdout.contains("world"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn raw_string_no_escape() {
+        let r = run(r#"let s = r"no \n escape";
+println(s);"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains(r"no \n escape"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn raw_triple_string() {
+        let r = run("let s = r\"\"\"\nhello \\n raw\n\"\"\";\nprintln(s);");
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains(r"hello \n raw"), "got: {}", r.stdout);
+    }
+
+    #[test]
+    fn triple_quoted_string_concatenation() {
+        let r = run(r#"let a = """line1
+line2""";
+let b = "suffix";
+println(a + b);"#);
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert!(r.stdout.contains("line1"), "got: {}", r.stdout);
+        assert!(r.stdout.contains("suffix"), "got: {}", r.stdout);
     }
 }


### PR DESCRIPTION
## Summary

Implements triple-quoted and raw string literals (Closes #2599):

- `"""..."""` — triple-quoted strings with automatic indentation stripping
- `r"..."` — raw strings (backslash is literal, no escape processing)
- `r"""..."""` — raw triple-quoted strings

All three produce `Token::StringLiteral` so parser/typechecker are unchanged.

## Implementation

Both the hand-rolled lexer (`lib.rs`) and the logos-based lexer (`lexer_logos.rs`) are updated:

**Hand-rolled lexer:**
- `peek_char2()` helper for lookahead past two chars (for `"""` detection)
- `read_triple_string()` — reads until `"""` with escape processing
- `read_raw_string()` — reads until `"` with no escape processing
- `read_raw_triple_string()` — reads until `"""` with no escape processing
- `res2599_strip_indent()` — strips common leading indentation after `"""`

**Logos lexer:**
- `TripleStr`, `RawStr`, `RawTripleStr` token variants with `bump`-based callbacks
- All map to `Token::StringLiteral` in the conversion function

## Tests

4 unit tests + golden example `multiline_strings.rz`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>