### PR TITLE
RES-2590: warn on unused aliased use imports

### DIFF
--- a/resilient/examples/unused_import_warn.expected.txt
+++ b/resilient/examples/unused_import_warn.expected.txt
@@ -1,0 +1,2 @@
+hello from A
+Program executed successfully

--- a/resilient/examples/unused_import_warn.rz
+++ b/resilient/examples/unused_import_warn.rz
@@ -1,0 +1,4 @@
+// RES-2590: Demonstrates that a used aliased import does NOT produce a warning.
+// `use "scoped_imports_a.rz" as helper;` is referenced via `helper::greet()`.
+use "scoped_imports_a.rz" as helper;
+helper::greet();


### PR DESCRIPTION
Closes #2590

## Summary

Adds a new `unused_imports` analysis pass that emits a `warning:` diagnostic to stderr when a `use "file.rz" as alias;` import declares an alias that is never referenced anywhere in the program.

## What was added

- `resilient/src/unused_imports.rs` — new pass with `check()` function and `collect_namespaces()` AST walker
- `resilient/src/lib.rs` — added `mod unused_imports;` and `unused_imports::check(&program, filename)` call before `expand_uses_with_std`
- `resilient/examples/unused_import_warn.rz` + `.expected.txt` — golden test showing used alias → no warning

## Design

**Conservative by design:**

- Only **aliased** file imports (`use "path" as alias;`) are checked. Plain `use "path"` imports splice their symbols flat into the current scope, making them indistinguishable from locally-defined names without resolving the file — those are skipped to avoid false positives.
- **Stdlib imports** (`use std::*`) are always skipped.
- The check must run **before** `imports::expand_uses_with_std` because that function replaces `Node::Use` nodes with the imported content. After expansion, no `Node::Use` nodes remain in the AST.

**Warning format:**
```
warning: path/to/file.rz:2:1: unused import: "util.rz" (alias `util`)
```

## Test plan

- [x] 7 unit tests in `unused_imports::tests` covering: no-use programs, used alias, unused alias, plain import skip, stdlib skip, partial usage, stdlib plain skip
- [x] Golden example `unused_import_warn.rz` demonstrates no spurious warning for used import
- [x] `cargo test` — 5309 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)