### PR TITLE
RES-2586: deque (double-ended queue) collection builtins

### DIFF
--- a/resilient/examples/deque.expected.txt
+++ b/resilient/examples/deque.expected.txt
@@ -1,0 +1,8 @@
+4
+false
+0
+0
+3
+3
+2
+Program executed successfully

--- a/resilient/examples/deque.rz
+++ b/resilient/examples/deque.rz
@@ -1,0 +1,33 @@
+// RES-2586: Deque (double-ended queue) collection.
+
+let dq = deque_new();
+let dq = deque_push_back(dq, 1);
+let dq = deque_push_back(dq, 2);
+let dq = deque_push_back(dq, 3);
+let dq = deque_push_front(dq, 0);
+
+println(to_string(deque_len(dq)));
+println(to_string(deque_is_empty(dq)));
+
+let front = deque_peek_front(dq);
+let f_val = match front {
+    Some(x) => x,
+    None => -1,
+};
+println(to_string(f_val));
+
+let (popped, dq) = deque_pop_front(dq);
+let pv = match popped {
+    Some(x) => x,
+    None => -1,
+};
+println(to_string(pv));
+println(to_string(deque_len(dq)));
+
+let (last, dq) = deque_pop_back(dq);
+let lv = match last {
+    Some(x) => x,
+    None => -1,
+};
+println(to_string(lv));
+println(to_string(deque_len(dq)));

--- a/resilient/src/deque.rs
+++ b/resilient/src/deque.rs
@@ -1,0 +1,273 @@
+//! RES-2586: Deque (double-ended queue) collection.
+//!
+//! Implements a functional deque backed by `Value::Array` (Vec<Value>).
+//! push_front / pop_front are O(n); push_back / pop_back are O(1) amortized.
+//! All operations return new deque values rather than mutating in place,
+//! consistent with Resilient's functional collection idiom.
+//!
+//! API:
+//!   deque_new()                  → Array (empty deque)
+//!   deque_push_front(dq, val)    → Array
+//!   deque_push_back(dq, val)     → Array
+//!   deque_pop_front(dq)          → (Option<any>, Array)
+//!   deque_pop_back(dq)           → (Option<any>, Array)
+//!   deque_peek_front(dq)         → Option<any>
+//!   deque_peek_back(dq)          → Option<any>
+//!   deque_len(dq)                → int
+//!   deque_is_empty(dq)           → bool
+
+use crate::Value;
+
+type RResult<T> = Result<T, String>;
+
+/// `deque_new() → []` — empty deque.
+pub(crate) fn builtin_deque_new(args: &[Value]) -> RResult<Value> {
+    if !args.is_empty() {
+        return Err(format!(
+            "deque_new: expected 0 arguments, got {}",
+            args.len()
+        ));
+    }
+    Ok(Value::Array(Vec::new()))
+}
+
+/// `deque_push_front(dq, val) → Array` — prepend val; O(n).
+pub(crate) fn builtin_deque_push_front(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(dq), val] => {
+            let mut out = Vec::with_capacity(dq.len() + 1);
+            out.push(val.clone());
+            out.extend_from_slice(dq);
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!("deque_push_front: expected Array, got {other}")),
+        _ => Err(format!(
+            "deque_push_front: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `deque_push_back(dq, val) → Array` — append val; O(1) amortized.
+pub(crate) fn builtin_deque_push_back(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(dq), val] => {
+            let mut out = dq.clone();
+            out.push(val.clone());
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!("deque_push_back: expected Array, got {other}")),
+        _ => Err(format!(
+            "deque_push_back: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `deque_pop_front(dq) → (Option<any>, Array)` — remove front element.
+///
+/// Returns a tuple `(Option<removed>, remaining_dq)`.
+pub(crate) fn builtin_deque_pop_front(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(dq)] => {
+            if dq.is_empty() {
+                Ok(Value::Tuple(vec![
+                    Value::Option(None),
+                    Value::Array(Vec::new()),
+                ]))
+            } else {
+                let front = dq[0].clone();
+                let rest = Value::Array(dq[1..].to_vec());
+                Ok(Value::Tuple(vec![
+                    Value::Option(Some(Box::new(front))),
+                    rest,
+                ]))
+            }
+        }
+        [other] => Err(format!("deque_pop_front: expected Array, got {other}")),
+        _ => Err(format!(
+            "deque_pop_front: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `deque_pop_back(dq) → (Option<any>, Array)` — remove back element.
+pub(crate) fn builtin_deque_pop_back(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(dq)] => {
+            if dq.is_empty() {
+                Ok(Value::Tuple(vec![
+                    Value::Option(None),
+                    Value::Array(Vec::new()),
+                ]))
+            } else {
+                let mut rest = dq.clone();
+                let back = rest.pop().unwrap();
+                Ok(Value::Tuple(vec![
+                    Value::Option(Some(Box::new(back))),
+                    Value::Array(rest),
+                ]))
+            }
+        }
+        [other] => Err(format!("deque_pop_back: expected Array, got {other}")),
+        _ => Err(format!(
+            "deque_pop_back: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `deque_peek_front(dq) → Option<any>` — inspect front without removing.
+pub(crate) fn builtin_deque_peek_front(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(dq)] => Ok(Value::Option(dq.first().map(|v| Box::new(v.clone())))),
+        [other] => Err(format!("deque_peek_front: expected Array, got {other}")),
+        _ => Err(format!(
+            "deque_peek_front: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `deque_peek_back(dq) → Option<any>` — inspect back without removing.
+pub(crate) fn builtin_deque_peek_back(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(dq)] => Ok(Value::Option(dq.last().map(|v| Box::new(v.clone())))),
+        [other] => Err(format!("deque_peek_back: expected Array, got {other}")),
+        _ => Err(format!(
+            "deque_peek_back: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `deque_len(dq) → int`
+pub(crate) fn builtin_deque_len(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(dq)] => Ok(Value::Int(dq.len() as i64)),
+        [other] => Err(format!("deque_len: expected Array, got {other}")),
+        _ => Err(format!(
+            "deque_len: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `deque_is_empty(dq) → bool`
+pub(crate) fn builtin_deque_is_empty(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(dq)] => Ok(Value::Bool(dq.is_empty())),
+        [other] => Err(format!("deque_is_empty: expected Array, got {other}")),
+        _ => Err(format!(
+            "deque_is_empty: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::run_program;
+
+    fn run(src: &str) -> String {
+        let r = run_program(src);
+        assert!(r.ok, "program failed: {:?}", r.errors);
+        r.stdout
+    }
+
+    #[test]
+    fn deque_basic_push_pop() {
+        let out = run(r#"
+let dq = deque_new();
+let dq = deque_push_back(dq, 1);
+let dq = deque_push_back(dq, 2);
+let dq = deque_push_front(dq, 0);
+println(to_string(deque_len(dq)));
+"#);
+        assert!(out.contains("3"), "got: {out:?}");
+    }
+
+    #[test]
+    fn deque_pop_front_removes_first() {
+        let out = run(r#"
+let dq = deque_new();
+let dq = deque_push_back(dq, 10);
+let dq = deque_push_back(dq, 20);
+let (front, dq) = deque_pop_front(dq);
+let val = match front {
+    Some(x) => x,
+    None => -1,
+};
+println(to_string(val));
+println(to_string(deque_len(dq)));
+"#);
+        assert!(out.contains("10"), "got: {out:?}");
+        assert!(out.contains("1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn deque_pop_back_removes_last() {
+        let out = run(r#"
+let dq = deque_new();
+let dq = deque_push_back(dq, 10);
+let dq = deque_push_back(dq, 20);
+let (back, dq) = deque_pop_back(dq);
+let val = match back {
+    Some(x) => x,
+    None => -1,
+};
+println(to_string(val));
+println(to_string(deque_len(dq)));
+"#);
+        assert!(out.contains("20"), "got: {out:?}");
+        assert!(out.contains("1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn deque_peek_does_not_remove() {
+        let out = run(r#"
+let dq = deque_new();
+let dq = deque_push_back(dq, 42);
+let front = deque_peek_front(dq);
+let val = match front {
+    Some(x) => x,
+    None => -1,
+};
+println(to_string(val));
+println(to_string(deque_len(dq)));
+"#);
+        assert!(out.contains("42"), "got: {out:?}");
+        assert!(out.contains("1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn deque_pop_empty_returns_none() {
+        let out = run(r#"
+let dq = deque_new();
+let (front, dq) = deque_pop_front(dq);
+let is_none = match front {
+    None => true,
+    Some(_) => false,
+};
+println(to_string(is_none));
+println(to_string(deque_is_empty(dq)));
+"#);
+        assert!(out.contains("true"), "got: {out:?}");
+    }
+
+    #[test]
+    fn deque_is_empty_on_new() {
+        let out = run(r#"
+let dq = deque_new();
+println(to_string(deque_is_empty(dq)));
+println(to_string(deque_len(dq)));
+"#);
+        assert!(out.contains("true"), "got: {out:?}");
+        assert!(out.contains("0"), "got: {out:?}");
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -658,6 +658,8 @@ mod unused_imports;
 mod const_eval_ext;
 // RES-2601: exhaustive struct field checking in match patterns.
 mod struct_field_check;
+// RES-2586: deque (double-ended queue) collection builtins.
+mod deque;
 mod vibe_debt;
 mod wcet_contracts;
 
@@ -12788,6 +12790,16 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("char_to_int", crate::char_type::builtin_char_to_int),
     ("int_to_char", crate::char_type::builtin_int_to_char),
     ("char_to_string", crate::char_type::builtin_char_to_string),
+    // RES-2586: deque (double-ended queue) collection builtins.
+    ("deque_new", crate::deque::builtin_deque_new),
+    ("deque_push_front", crate::deque::builtin_deque_push_front),
+    ("deque_push_back", crate::deque::builtin_deque_push_back),
+    ("deque_pop_front", crate::deque::builtin_deque_pop_front),
+    ("deque_pop_back", crate::deque::builtin_deque_pop_back),
+    ("deque_peek_front", crate::deque::builtin_deque_peek_front),
+    ("deque_peek_back", crate::deque::builtin_deque_peek_back),
+    ("deque_len", crate::deque::builtin_deque_len),
+    ("deque_is_empty", crate::deque::builtin_deque_is_empty),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4419,6 +4419,29 @@ impl TypeChecker {
                 // `.set` rebinds the inner value, and the inner value's
                 // dynamic type flows through `Type::Any`.
                 env.set("cell".to_string(), fn_any_to_any());
+
+                // RES-2586: deque builtins.
+                env.set(
+                    "deque_new".to_string(),
+                    Type::Function {
+                        params: vec![],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set("deque_push_front".to_string(), fn_any_any_to_any());
+                env.set("deque_push_back".to_string(), fn_any_any_to_any());
+                env.set("deque_pop_front".to_string(), fn_any_to_any());
+                env.set("deque_pop_back".to_string(), fn_any_to_any());
+                env.set("deque_peek_front".to_string(), fn_any_to_any());
+                env.set("deque_peek_back".to_string(), fn_any_to_any());
+                env.set("deque_len".to_string(), fn_any_to_int());
+                env.set(
+                    "deque_is_empty".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
                 std::sync::Arc::new(env)
             });
 


### PR DESCRIPTION
## Summary

- **New module** `resilient/src/deque.rs`: 9 functional deque builtins backed by `Value::Array`.
- `deque_new()` → empty array; `deque_push_back` / `deque_pop_back` are O(1) amortized; `deque_push_front` / `deque_pop_front` are O(n).
- `pop_front` / `pop_back` return `(Option<element>, remaining_deque)` tuples for safe empty-deque handling.
- Typechecker `BUILTIN_ENV` updated so all 9 functions type-check cleanly.
- 6 unit tests + golden example.

## API

| Function | Signature | Notes |
|---|---|---|
| `deque_new()` | `→ Array` | empty deque |
| `deque_push_front(dq, val)` | `→ Array` | O(n) |
| `deque_push_back(dq, val)` | `→ Array` | O(1) amortized |
| `deque_pop_front(dq)` | `→ (Option, Array)` | O(n) |
| `deque_pop_back(dq)` | `→ (Option, Array)` | O(1) |
| `deque_peek_front(dq)` | `→ Option` | O(1) |
| `deque_peek_back(dq)` | `→ Option` | O(1) |
| `deque_len(dq)` | `→ int` | O(1) |
| `deque_is_empty(dq)` | `→ bool` | O(1) |

Closes #2586