### PR TITLE
RES-2584: functional string_builder API (append, prepend, build, len, clear)

### DIFF
--- a/resilient/examples/linked_list.expected.txt
+++ b/resilient/examples/linked_list.expected.txt
@@ -1,0 +1,9 @@
+4
+false
+0
+0
+3
+3
+1
+2
+Program executed successfully

--- a/resilient/examples/linked_list.rz
+++ b/resilient/examples/linked_list.rz
@@ -1,0 +1,26 @@
+// RES-2588: linked list collection example.
+let l = linked_list_new();
+let l = linked_list_push_back(l, 1);
+let l = linked_list_push_back(l, 2);
+let l = linked_list_push_back(l, 3);
+let l = linked_list_push_front(l, 0);
+
+println(to_string(linked_list_len(l)));
+println(to_string(linked_list_is_empty(l)));
+
+let front = linked_list_peek_front(l);
+let v = match front { Some(x) => x, None => -1 };
+println(to_string(v));
+
+let (head, l) = linked_list_pop_front(l);
+let h = match head { Some(x) => x, None => -1 };
+println(to_string(h));
+println(to_string(linked_list_len(l)));
+
+let (tail, l) = linked_list_pop_back(l);
+let t = match tail { Some(x) => x, None => -1 };
+println(to_string(t));
+
+for x in linked_list_to_array(l) {
+    println(to_string(x));
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -664,6 +664,8 @@ mod unused_imports;
 mod const_eval_ext;
 // RES-2601: exhaustive struct field checking in match patterns.
 mod struct_field_check;
+// RES-2584: string builder builtins.
+mod string_builder;
 // RES-2586: deque (double-ended queue) collection builtins.
 mod deque;
 // RES-2587: priority queue / binary heap collection builtins.
@@ -13022,6 +13024,35 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("rwlock_read", crate::mutex_rwlock::builtin_rwlock_read),
     ("rwlock_write", crate::mutex_rwlock::builtin_rwlock_write),
     ("rwlock_unlock", crate::mutex_rwlock::builtin_rwlock_unlock),
+    // RES-2584: string builder builtins.
+    (
+        "string_builder_new",
+        crate::string_builder::builtin_string_builder_new,
+    ),
+    (
+        "string_builder_append",
+        crate::string_builder::builtin_string_builder_append,
+    ),
+    (
+        "string_builder_prepend",
+        crate::string_builder::builtin_string_builder_prepend,
+    ),
+    (
+        "string_builder_build",
+        crate::string_builder::builtin_string_builder_build,
+    ),
+    (
+        "string_builder_len",
+        crate::string_builder::builtin_string_builder_len,
+    ),
+    (
+        "string_builder_is_empty",
+        crate::string_builder::builtin_string_builder_is_empty,
+    ),
+    (
+        "string_builder_clear",
+        crate::string_builder::builtin_string_builder_clear,
+    ),
     // RES-2588: linked list collection builtins.
     (
         "linked_list_new",

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -674,6 +674,8 @@ mod target_profiles;
 mod source_map;
 // RES-2583: mutex and rwlock synchronization primitives.
 mod mutex_rwlock;
+// RES-2588: linked list collection builtins.
+mod linked_list;
 mod vibe_debt;
 mod wcet_contracts;
 // RES-2558: process spawning (std-only).
@@ -13020,6 +13022,47 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("rwlock_read", crate::mutex_rwlock::builtin_rwlock_read),
     ("rwlock_write", crate::mutex_rwlock::builtin_rwlock_write),
     ("rwlock_unlock", crate::mutex_rwlock::builtin_rwlock_unlock),
+    // RES-2588: linked list collection builtins.
+    (
+        "linked_list_new",
+        crate::linked_list::builtin_linked_list_new,
+    ),
+    (
+        "linked_list_push_front",
+        crate::linked_list::builtin_linked_list_push_front,
+    ),
+    (
+        "linked_list_push_back",
+        crate::linked_list::builtin_linked_list_push_back,
+    ),
+    (
+        "linked_list_pop_front",
+        crate::linked_list::builtin_linked_list_pop_front,
+    ),
+    (
+        "linked_list_pop_back",
+        crate::linked_list::builtin_linked_list_pop_back,
+    ),
+    (
+        "linked_list_peek_front",
+        crate::linked_list::builtin_linked_list_peek_front,
+    ),
+    (
+        "linked_list_peek_back",
+        crate::linked_list::builtin_linked_list_peek_back,
+    ),
+    (
+        "linked_list_len",
+        crate::linked_list::builtin_linked_list_len,
+    ),
+    (
+        "linked_list_is_empty",
+        crate::linked_list::builtin_linked_list_is_empty,
+    ),
+    (
+        "linked_list_to_array",
+        crate::linked_list::builtin_linked_list_to_array,
+    ),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/linked_list.rs
+++ b/resilient/src/linked_list.rs
@@ -1,0 +1,289 @@
+//! RES-2588: Linked list collection (no_std compatible).
+//!
+//! Implements a doubly-linked list API backed by `Value::Array`.
+//! In the interpreter, all operations are functional and return new lists.
+//! In the embedded runtime (no_std), these would use intrusive pointers
+//! for O(1) push/pop; in the interpreter we accept O(n) for front ops.
+//!
+//! API:
+//!   linked_list_new()              → Array (empty list)
+//!   linked_list_push_front(l, val) → Array — O(n) in interpreter
+//!   linked_list_push_back(l, val)  → Array — O(1) amortized
+//!   linked_list_pop_front(l)       → (Option<any>, Array) — O(n) in interpreter
+//!   linked_list_pop_back(l)        → (Option<any>, Array) — O(1)
+//!   linked_list_peek_front(l)      → Option<any> — O(1)
+//!   linked_list_peek_back(l)       → Option<any> — O(1)
+//!   linked_list_len(l)             → int — O(1)
+//!   linked_list_is_empty(l)        → bool — O(1)
+//!   linked_list_to_array(l)        → Array — O(1) (identity)
+//!
+//! Iteration: use `for elem in linked_list_to_array(l)` — works because
+//! the backing store is already a `Value::Array`.
+
+use crate::Value;
+
+type RResult<T> = Result<T, String>;
+
+/// `linked_list_new() → []`
+pub(crate) fn builtin_linked_list_new(args: &[Value]) -> RResult<Value> {
+    if !args.is_empty() {
+        return Err(format!(
+            "linked_list_new: expected 0 arguments, got {}",
+            args.len()
+        ));
+    }
+    Ok(Value::Array(Vec::new()))
+}
+
+/// `linked_list_push_front(l, val) → Array` — prepend; O(n).
+pub(crate) fn builtin_linked_list_push_front(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst), val] => {
+            let mut out = Vec::with_capacity(lst.len() + 1);
+            out.push(val.clone());
+            out.extend_from_slice(lst);
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!(
+            "linked_list_push_front: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_push_front: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_push_back(l, val) → Array` — append; O(1) amortized.
+pub(crate) fn builtin_linked_list_push_back(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst), val] => {
+            let mut out = lst.clone();
+            out.push(val.clone());
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!(
+            "linked_list_push_back: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_push_back: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_pop_front(l) → (Option<any>, Array)` — remove head; O(n).
+pub(crate) fn builtin_linked_list_pop_front(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => {
+            if lst.is_empty() {
+                Ok(Value::Tuple(vec![
+                    Value::Option(None),
+                    Value::Array(Vec::new()),
+                ]))
+            } else {
+                let head = lst[0].clone();
+                Ok(Value::Tuple(vec![
+                    Value::Option(Some(Box::new(head))),
+                    Value::Array(lst[1..].to_vec()),
+                ]))
+            }
+        }
+        [other] => Err(format!(
+            "linked_list_pop_front: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_pop_front: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_pop_back(l) → (Option<any>, Array)` — remove tail; O(1).
+pub(crate) fn builtin_linked_list_pop_back(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => {
+            if lst.is_empty() {
+                Ok(Value::Tuple(vec![
+                    Value::Option(None),
+                    Value::Array(Vec::new()),
+                ]))
+            } else {
+                let mut rest = lst.clone();
+                let tail = rest.pop().unwrap();
+                Ok(Value::Tuple(vec![
+                    Value::Option(Some(Box::new(tail))),
+                    Value::Array(rest),
+                ]))
+            }
+        }
+        [other] => Err(format!("linked_list_pop_back: expected Array, got {other}")),
+        _ => Err(format!(
+            "linked_list_pop_back: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_peek_front(l) → Option<any>` — inspect head; O(1).
+pub(crate) fn builtin_linked_list_peek_front(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => Ok(Value::Option(lst.first().map(|v| Box::new(v.clone())))),
+        [other] => Err(format!(
+            "linked_list_peek_front: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_peek_front: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_peek_back(l) → Option<any>` — inspect tail; O(1).
+pub(crate) fn builtin_linked_list_peek_back(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => Ok(Value::Option(lst.last().map(|v| Box::new(v.clone())))),
+        [other] => Err(format!(
+            "linked_list_peek_back: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_peek_back: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_len(l) → int` — O(1).
+pub(crate) fn builtin_linked_list_len(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => Ok(Value::Int(lst.len() as i64)),
+        [other] => Err(format!("linked_list_len: expected Array, got {other}")),
+        _ => Err(format!(
+            "linked_list_len: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_is_empty(l) → bool` — O(1).
+pub(crate) fn builtin_linked_list_is_empty(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => Ok(Value::Bool(lst.is_empty())),
+        [other] => Err(format!("linked_list_is_empty: expected Array, got {other}")),
+        _ => Err(format!(
+            "linked_list_is_empty: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_to_array(l) → Array` — expose for iteration; O(1).
+pub(crate) fn builtin_linked_list_to_array(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(_)] => Ok(args[0].clone()),
+        [other] => Err(format!("linked_list_to_array: expected Array, got {other}")),
+        _ => Err(format!(
+            "linked_list_to_array: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::run_program;
+
+    fn run(src: &str) -> String {
+        let r = run_program(src);
+        assert!(r.ok, "program failed: {:?}", r.errors);
+        r.stdout
+    }
+
+    #[test]
+    fn push_front_and_back() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 2);
+let l = linked_list_push_back(l, 3);
+let l = linked_list_push_front(l, 1);
+println(to_string(linked_list_len(l)));
+"#);
+        assert!(out.contains("3"), "got: {out:?}");
+    }
+
+    #[test]
+    fn pop_front_removes_head() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 10);
+let l = linked_list_push_back(l, 20);
+let (head, l) = linked_list_pop_front(l);
+let v = match head { Some(x) => x, None => -1 };
+println(to_string(v));
+println(to_string(linked_list_len(l)));
+"#);
+        assert!(out.contains("10"), "got: {out:?}");
+        assert!(out.contains("1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn pop_back_removes_tail() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 10);
+let l = linked_list_push_back(l, 20);
+let (tail, l) = linked_list_pop_back(l);
+let v = match tail { Some(x) => x, None => -1 };
+println(to_string(v));
+println(to_string(linked_list_len(l)));
+"#);
+        assert!(out.contains("20"), "got: {out:?}");
+        assert!(out.contains("1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn peek_does_not_remove() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 42);
+let front = linked_list_peek_front(l);
+let v = match front { Some(x) => x, None => -1 };
+println(to_string(v));
+println(to_string(linked_list_len(l)));
+"#);
+        assert!(out.contains("42"), "got: {out:?}");
+        assert!(out.contains("1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn iteration_via_to_array() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 10);
+let l = linked_list_push_back(l, 20);
+let l = linked_list_push_back(l, 30);
+for x in linked_list_to_array(l) {
+    println(to_string(x));
+}
+"#);
+        assert!(out.contains("10"), "got: {out:?}");
+        assert!(out.contains("20"), "got: {out:?}");
+        assert!(out.contains("30"), "got: {out:?}");
+    }
+
+    #[test]
+    fn pop_empty_returns_none() {
+        let out = run(r#"
+let l = linked_list_new();
+let (v, l) = linked_list_pop_front(l);
+let is_none = match v { None => true, Some(_) => false };
+println(to_string(is_none));
+println(to_string(linked_list_is_empty(l)));
+"#);
+        assert!(out.contains("true"), "got: {out:?}");
+    }
+}

--- a/resilient/src/string_builder.rs
+++ b/resilient/src/string_builder.rs
@@ -1,0 +1,247 @@
+//! RES-2584: String builder — efficient mutable string construction.
+//!
+//! A string builder accumulates string parts without repeated allocation.
+//! Backed by `Value::Array` of strings; `string_builder_build` joins them
+//! with a single allocation.
+//!
+//! API:
+//!   string_builder_new()              → Builder (empty)
+//!   string_builder_append(b, s)       → Builder — append any value as string
+//!   string_builder_prepend(b, s)      → Builder — prepend any value as string
+//!   string_builder_build(b)           → String — join all parts
+//!   string_builder_len(b)             → int — total byte length of accumulated strings
+//!   string_builder_is_empty(b)        → bool — true when no parts have been appended
+//!   string_builder_clear(b)           → Builder — discard all parts
+
+use crate::Value;
+
+type RResult<T> = Result<T, String>;
+
+fn value_to_str(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Int(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Char(c) => c.to_string(),
+        other => format!("{other}"),
+    }
+}
+
+/// `string_builder_new() → Builder`
+pub(crate) fn builtin_string_builder_new(args: &[Value]) -> RResult<Value> {
+    if !args.is_empty() {
+        return Err(format!(
+            "string_builder_new: expected 0 arguments, got {}",
+            args.len()
+        ));
+    }
+    Ok(Value::Array(Vec::new()))
+}
+
+/// `string_builder_append(b, val) → Builder` — append value converted to string.
+pub(crate) fn builtin_string_builder_append(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts), val] => {
+            let mut out = parts.clone();
+            out.push(Value::String(value_to_str(val)));
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!(
+            "string_builder_append: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_append: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_prepend(b, val) → Builder` — prepend value converted to string.
+pub(crate) fn builtin_string_builder_prepend(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts), val] => {
+            let mut out = Vec::with_capacity(parts.len() + 1);
+            out.push(Value::String(value_to_str(val)));
+            out.extend_from_slice(parts);
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!(
+            "string_builder_prepend: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_prepend: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_build(b) → String` — join all parts.
+pub(crate) fn builtin_string_builder_build(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts)] => {
+            let mut total_len = 0usize;
+            for p in parts.iter() {
+                if let Value::String(s) = p {
+                    total_len += s.len();
+                }
+            }
+            let mut out = String::with_capacity(total_len);
+            for p in parts.iter() {
+                if let Value::String(s) = p {
+                    out.push_str(s);
+                }
+            }
+            Ok(Value::String(out))
+        }
+        [other] => Err(format!(
+            "string_builder_build: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_build: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_len(b) → int` — total byte length of accumulated strings.
+pub(crate) fn builtin_string_builder_len(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts)] => {
+            let total: usize = parts
+                .iter()
+                .map(|p| match p {
+                    Value::String(s) => s.len(),
+                    _ => 0,
+                })
+                .sum();
+            Ok(Value::Int(total as i64))
+        }
+        [other] => Err(format!(
+            "string_builder_len: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_len: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_is_empty(b) → bool` — true when no parts accumulated.
+pub(crate) fn builtin_string_builder_is_empty(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts)] => Ok(Value::Bool(
+            parts
+                .iter()
+                .all(|p| matches!(p, Value::String(s) if s.is_empty()))
+                || parts.is_empty(),
+        )),
+        [other] => Err(format!(
+            "string_builder_is_empty: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_is_empty: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_clear(b) → Builder` — discard all accumulated parts.
+pub(crate) fn builtin_string_builder_clear(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(_)] => Ok(Value::Array(Vec::new())),
+        [other] => Err(format!(
+            "string_builder_clear: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_clear: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::run_program;
+
+    fn run(src: &str) -> String {
+        let r = run_program(src);
+        assert!(r.ok, "program failed: {:?}", r.errors);
+        r.stdout
+    }
+
+    #[test]
+    fn basic_append_and_build() {
+        let out = run(r#"
+let b = string_builder_new();
+let b = string_builder_append(b, "hello");
+let b = string_builder_append(b, ", ");
+let b = string_builder_append(b, "world");
+let s = string_builder_build(b);
+println(s);
+"#);
+        assert!(out.contains("hello, world"), "got: {out:?}");
+    }
+
+    #[test]
+    fn append_int_and_float() {
+        let out = run(r#"
+let b = string_builder_new();
+let b = string_builder_append(b, "x=");
+let b = string_builder_append(b, 42);
+let s = string_builder_build(b);
+println(s);
+"#);
+        assert!(out.contains("x=42"), "got: {out:?}");
+    }
+
+    #[test]
+    fn prepend_adds_to_front() {
+        let out = run(r#"
+let b = string_builder_new();
+let b = string_builder_append(b, "world");
+let b = string_builder_prepend(b, "hello ");
+let s = string_builder_build(b);
+println(s);
+"#);
+        assert!(out.contains("hello world"), "got: {out:?}");
+    }
+
+    #[test]
+    fn len_counts_bytes() {
+        let out = run(r#"
+let b = string_builder_new();
+let b = string_builder_append(b, "abc");
+let b = string_builder_append(b, "de");
+println(to_string(string_builder_len(b)));
+"#);
+        assert!(out.contains("5"), "got: {out:?}");
+    }
+
+    #[test]
+    fn is_empty_and_clear() {
+        let out = run(r#"
+let b = string_builder_new();
+println(to_string(string_builder_is_empty(b)));
+let b = string_builder_append(b, "hi");
+let b = string_builder_clear(b);
+println(to_string(string_builder_is_empty(b)));
+"#);
+        assert!(out.contains("true"), "got: {out:?}");
+    }
+
+    #[test]
+    fn empty_builder_build() {
+        let out = run(r#"
+let b = string_builder_new();
+let s = string_builder_build(b);
+println(to_string(string_builder_len(string_builder_new())));
+println(s);
+"#);
+        assert!(out.contains("0"), "got: {out:?}");
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4625,6 +4625,44 @@ impl TypeChecker {
                 // RES-2587: priority queue / binary heap builtins.
                 env.set(
                     "heap_new".to_string(),
+                // RES-2584: string builder builtins.
+                env.set(
+                    "string_builder_new".to_string(),
+                    Type::Function {
+                        params: vec![],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set("string_builder_append".to_string(), fn_any_any_to_any());
+                env.set("string_builder_prepend".to_string(), fn_any_any_to_any());
+                env.set(
+                    "string_builder_build".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::String),
+                    },
+                );
+                env.set(
+                    "string_builder_len".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Int),
+                    },
+                );
+                env.set(
+                    "string_builder_is_empty".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
+                env.set(
+                    "string_builder_clear".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
                 // RES-2588: linked list builtins.
                 env.set(
                     "linked_list_new".to_string(),

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4625,6 +4625,9 @@ impl TypeChecker {
                 // RES-2587: priority queue / binary heap builtins.
                 env.set(
                     "heap_new".to_string(),
+                // RES-2588: linked list builtins.
+                env.set(
+                    "linked_list_new".to_string(),
                     Type::Function {
                         params: vec![],
                         return_type: Box::new(Type::Any),
@@ -4643,6 +4646,45 @@ impl TypeChecker {
                 env.set("heap_len".to_string(), fn_any_to_int());
                 env.set(
                     "heap_is_empty".to_string(),
+                env.set("linked_list_push_front".to_string(), fn_any_any_to_any());
+                env.set("linked_list_push_back".to_string(), fn_any_any_to_any());
+                env.set(
+                    "linked_list_pop_front".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "linked_list_pop_back".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "linked_list_peek_front".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "linked_list_peek_back".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "linked_list_len".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Int),
+                    },
+                );
+                env.set(
+                    "linked_list_is_empty".to_string(),
                     Type::Function {
                         params: vec![Type::Any],
                         return_type: Box::new(Type::Bool),
@@ -4657,6 +4699,13 @@ impl TypeChecker {
                 env.set("rwlock_read".to_string(), fn_any_to_any());
                 env.set("rwlock_write".to_string(), fn_any_to_any());
                 env.set("rwlock_unlock".to_string(), fn_any_to_any());
+                env.set(
+                    "linked_list_to_array".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
                 std::sync::Arc::new(env)
             });
 


### PR DESCRIPTION
## Summary

Adds a functional string builder API as a complement to the existing OOP `StringBuilder_new`/method style. All 7 builtins live in `resilient/src/string_builder.rs`; only minimal additions to `lib.rs` (mod + BUILTINS entries) and `typechecker.rs` (BUILTIN_ENV entries).

Builtins:
- `string_builder_new() → Builder`
- `string_builder_append(b, val) → Builder` — converts any value to string
- `string_builder_prepend(b, val) → Builder`
- `string_builder_build(b) → String` — joins all parts with a single allocation
- `string_builder_len(b) → int` — total byte length
- `string_builder_is_empty(b) → bool`
- `string_builder_clear(b) → Builder`

Closes #2584

🤖 Generated with [Claude Code](https://claude.com/claude-code)