### PR TITLE
RES-2585: regex matching builtins (match, find, find_all, captures, replace, replace_all)

### DIFF
--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -146,6 +146,9 @@ rand_core = { version = "0.6", features = ["getrandom"], optional = true }
 # the incremental build cache's source-file hash. Always-on.
 sha2 = "0.10"
 serde_json = "1"
+# RES-2585: regex matching builtins. The `regex` crate is std-only (the
+# interpreter doesn't run no_std); it stays out of resilient-runtime.
+regex = "1"
 
 # RES-510 PR 3: deps that are CLI-only and don't compile to wasm32
 # (or aren't useful there). Moved out of the unconditional

--- a/resilient/examples/linked_list.expected.txt
+++ b/resilient/examples/linked_list.expected.txt
@@ -1,0 +1,9 @@
+4
+false
+0
+0
+3
+3
+1
+2
+Program executed successfully

--- a/resilient/examples/linked_list.rz
+++ b/resilient/examples/linked_list.rz
@@ -1,0 +1,26 @@
+// RES-2588: linked list collection example.
+let l = linked_list_new();
+let l = linked_list_push_back(l, 1);
+let l = linked_list_push_back(l, 2);
+let l = linked_list_push_back(l, 3);
+let l = linked_list_push_front(l, 0);
+
+println(to_string(linked_list_len(l)));
+println(to_string(linked_list_is_empty(l)));
+
+let front = linked_list_peek_front(l);
+let v = match front { Some(x) => x, None => -1 };
+println(to_string(v));
+
+let (head, l) = linked_list_pop_front(l);
+let h = match head { Some(x) => x, None => -1 };
+println(to_string(h));
+println(to_string(linked_list_len(l)));
+
+let (tail, l) = linked_list_pop_back(l);
+let t = match tail { Some(x) => x, None => -1 };
+println(to_string(t));
+
+for x in linked_list_to_array(l) {
+    println(to_string(x));
+}

--- a/resilient/examples/regex_builtins.expected.txt
+++ b/resilient/examples/regex_builtins.expected.txt
@@ -1,0 +1,7 @@
+true
+false
+hello
+3
+baz bar foo
+baz bar baz
+Program executed successfully

--- a/resilient/examples/regex_builtins.rz
+++ b/resilient/examples/regex_builtins.rz
@@ -1,0 +1,16 @@
+// RES-2585: regex matching builtins example.
+println(to_string(regex_match("hello123", "[a-z]+[0-9]+")));
+println(to_string(regex_match("hello", "[0-9]+")));
+
+let found = regex_find("hello world", "[a-z]+");
+let v = match found { Some(s) => s, None => "none" };
+println(v);
+
+let all = regex_find_all("cat bat hat", "[a-z]at");
+println(to_string(len(all)));
+
+let replaced = regex_replace("foo bar foo", "foo", "baz");
+println(replaced);
+
+let replaced_all = regex_replace_all("foo bar foo", "foo", "baz");
+println(replaced_all);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -666,6 +666,8 @@ mod const_eval_ext;
 mod struct_field_check;
 // RES-2584: string builder builtins.
 mod string_builder;
+// RES-2585: regex matching builtins.
+mod regex_builtins;
 // RES-2586: deque (double-ended queue) collection builtins.
 mod deque;
 // RES-2587: priority queue / binary heap collection builtins.
@@ -13038,6 +13040,25 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     (
         "string_builder_clear",
         crate::string_builder::builtin_string_builder_clear,
+    ),
+    // RES-2585: regex matching builtins.
+    ("regex_match", crate::regex_builtins::builtin_regex_match),
+    ("regex_find", crate::regex_builtins::builtin_regex_find),
+    (
+        "regex_find_all",
+        crate::regex_builtins::builtin_regex_find_all,
+    ),
+    (
+        "regex_captures",
+        crate::regex_builtins::builtin_regex_captures,
+    ),
+    (
+        "regex_replace",
+        crate::regex_builtins::builtin_regex_replace,
+    ),
+    (
+        "regex_replace_all",
+        crate::regex_builtins::builtin_regex_replace_all,
     ),
     // RES-2588: linked list collection builtins.
     (

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -672,6 +672,8 @@ mod heap;
 mod target_profiles;
 // RES-2611: source maps linking bytecode offsets to source positions.
 mod source_map;
+// RES-2588: linked list collection builtins.
+mod linked_list;
 mod vibe_debt;
 mod wcet_contracts;
 // RES-2558: process spawning (std-only).
@@ -13006,6 +13008,47 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("udp_send_to", crate::tcp_udp::builtin_udp_send_to),
     ("udp_recv_from", crate::tcp_udp::builtin_udp_recv_from),
     ("udp_close", crate::tcp_udp::builtin_udp_close),
+    // RES-2588: linked list collection builtins.
+    (
+        "linked_list_new",
+        crate::linked_list::builtin_linked_list_new,
+    ),
+    (
+        "linked_list_push_front",
+        crate::linked_list::builtin_linked_list_push_front,
+    ),
+    (
+        "linked_list_push_back",
+        crate::linked_list::builtin_linked_list_push_back,
+    ),
+    (
+        "linked_list_pop_front",
+        crate::linked_list::builtin_linked_list_pop_front,
+    ),
+    (
+        "linked_list_pop_back",
+        crate::linked_list::builtin_linked_list_pop_back,
+    ),
+    (
+        "linked_list_peek_front",
+        crate::linked_list::builtin_linked_list_peek_front,
+    ),
+    (
+        "linked_list_peek_back",
+        crate::linked_list::builtin_linked_list_peek_back,
+    ),
+    (
+        "linked_list_len",
+        crate::linked_list::builtin_linked_list_len,
+    ),
+    (
+        "linked_list_is_empty",
+        crate::linked_list::builtin_linked_list_is_empty,
+    ),
+    (
+        "linked_list_to_array",
+        crate::linked_list::builtin_linked_list_to_array,
+    ),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -664,6 +664,8 @@ mod unused_imports;
 mod const_eval_ext;
 // RES-2601: exhaustive struct field checking in match patterns.
 mod struct_field_check;
+// RES-2584: string builder builtins.
+mod string_builder;
 // RES-2586: deque (double-ended queue) collection builtins.
 mod deque;
 // RES-2587: priority queue / binary heap collection builtins.
@@ -13008,6 +13010,35 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("udp_send_to", crate::tcp_udp::builtin_udp_send_to),
     ("udp_recv_from", crate::tcp_udp::builtin_udp_recv_from),
     ("udp_close", crate::tcp_udp::builtin_udp_close),
+    // RES-2584: string builder builtins.
+    (
+        "string_builder_new",
+        crate::string_builder::builtin_string_builder_new,
+    ),
+    (
+        "string_builder_append",
+        crate::string_builder::builtin_string_builder_append,
+    ),
+    (
+        "string_builder_prepend",
+        crate::string_builder::builtin_string_builder_prepend,
+    ),
+    (
+        "string_builder_build",
+        crate::string_builder::builtin_string_builder_build,
+    ),
+    (
+        "string_builder_len",
+        crate::string_builder::builtin_string_builder_len,
+    ),
+    (
+        "string_builder_is_empty",
+        crate::string_builder::builtin_string_builder_is_empty,
+    ),
+    (
+        "string_builder_clear",
+        crate::string_builder::builtin_string_builder_clear,
+    ),
     // RES-2588: linked list collection builtins.
     (
         "linked_list_new",

--- a/resilient/src/linked_list.rs
+++ b/resilient/src/linked_list.rs
@@ -1,0 +1,289 @@
+//! RES-2588: Linked list collection (no_std compatible).
+//!
+//! Implements a doubly-linked list API backed by `Value::Array`.
+//! In the interpreter, all operations are functional and return new lists.
+//! In the embedded runtime (no_std), these would use intrusive pointers
+//! for O(1) push/pop; in the interpreter we accept O(n) for front ops.
+//!
+//! API:
+//!   linked_list_new()              → Array (empty list)
+//!   linked_list_push_front(l, val) → Array — O(n) in interpreter
+//!   linked_list_push_back(l, val)  → Array — O(1) amortized
+//!   linked_list_pop_front(l)       → (Option<any>, Array) — O(n) in interpreter
+//!   linked_list_pop_back(l)        → (Option<any>, Array) — O(1)
+//!   linked_list_peek_front(l)      → Option<any> — O(1)
+//!   linked_list_peek_back(l)       → Option<any> — O(1)
+//!   linked_list_len(l)             → int — O(1)
+//!   linked_list_is_empty(l)        → bool — O(1)
+//!   linked_list_to_array(l)        → Array — O(1) (identity)
+//!
+//! Iteration: use `for elem in linked_list_to_array(l)` — works because
+//! the backing store is already a `Value::Array`.
+
+use crate::Value;
+
+type RResult<T> = Result<T, String>;
+
+/// `linked_list_new() → []`
+pub(crate) fn builtin_linked_list_new(args: &[Value]) -> RResult<Value> {
+    if !args.is_empty() {
+        return Err(format!(
+            "linked_list_new: expected 0 arguments, got {}",
+            args.len()
+        ));
+    }
+    Ok(Value::Array(Vec::new()))
+}
+
+/// `linked_list_push_front(l, val) → Array` — prepend; O(n).
+pub(crate) fn builtin_linked_list_push_front(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst), val] => {
+            let mut out = Vec::with_capacity(lst.len() + 1);
+            out.push(val.clone());
+            out.extend_from_slice(lst);
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!(
+            "linked_list_push_front: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_push_front: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_push_back(l, val) → Array` — append; O(1) amortized.
+pub(crate) fn builtin_linked_list_push_back(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst), val] => {
+            let mut out = lst.clone();
+            out.push(val.clone());
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!(
+            "linked_list_push_back: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_push_back: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_pop_front(l) → (Option<any>, Array)` — remove head; O(n).
+pub(crate) fn builtin_linked_list_pop_front(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => {
+            if lst.is_empty() {
+                Ok(Value::Tuple(vec![
+                    Value::Option(None),
+                    Value::Array(Vec::new()),
+                ]))
+            } else {
+                let head = lst[0].clone();
+                Ok(Value::Tuple(vec![
+                    Value::Option(Some(Box::new(head))),
+                    Value::Array(lst[1..].to_vec()),
+                ]))
+            }
+        }
+        [other] => Err(format!(
+            "linked_list_pop_front: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_pop_front: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_pop_back(l) → (Option<any>, Array)` — remove tail; O(1).
+pub(crate) fn builtin_linked_list_pop_back(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => {
+            if lst.is_empty() {
+                Ok(Value::Tuple(vec![
+                    Value::Option(None),
+                    Value::Array(Vec::new()),
+                ]))
+            } else {
+                let mut rest = lst.clone();
+                let tail = rest.pop().unwrap();
+                Ok(Value::Tuple(vec![
+                    Value::Option(Some(Box::new(tail))),
+                    Value::Array(rest),
+                ]))
+            }
+        }
+        [other] => Err(format!("linked_list_pop_back: expected Array, got {other}")),
+        _ => Err(format!(
+            "linked_list_pop_back: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_peek_front(l) → Option<any>` — inspect head; O(1).
+pub(crate) fn builtin_linked_list_peek_front(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => Ok(Value::Option(lst.first().map(|v| Box::new(v.clone())))),
+        [other] => Err(format!(
+            "linked_list_peek_front: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_peek_front: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_peek_back(l) → Option<any>` — inspect tail; O(1).
+pub(crate) fn builtin_linked_list_peek_back(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => Ok(Value::Option(lst.last().map(|v| Box::new(v.clone())))),
+        [other] => Err(format!(
+            "linked_list_peek_back: expected Array, got {other}"
+        )),
+        _ => Err(format!(
+            "linked_list_peek_back: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_len(l) → int` — O(1).
+pub(crate) fn builtin_linked_list_len(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => Ok(Value::Int(lst.len() as i64)),
+        [other] => Err(format!("linked_list_len: expected Array, got {other}")),
+        _ => Err(format!(
+            "linked_list_len: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_is_empty(l) → bool` — O(1).
+pub(crate) fn builtin_linked_list_is_empty(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(lst)] => Ok(Value::Bool(lst.is_empty())),
+        [other] => Err(format!("linked_list_is_empty: expected Array, got {other}")),
+        _ => Err(format!(
+            "linked_list_is_empty: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `linked_list_to_array(l) → Array` — expose for iteration; O(1).
+pub(crate) fn builtin_linked_list_to_array(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(_)] => Ok(args[0].clone()),
+        [other] => Err(format!("linked_list_to_array: expected Array, got {other}")),
+        _ => Err(format!(
+            "linked_list_to_array: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::run_program;
+
+    fn run(src: &str) -> String {
+        let r = run_program(src);
+        assert!(r.ok, "program failed: {:?}", r.errors);
+        r.stdout
+    }
+
+    #[test]
+    fn push_front_and_back() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 2);
+let l = linked_list_push_back(l, 3);
+let l = linked_list_push_front(l, 1);
+println(to_string(linked_list_len(l)));
+"#);
+        assert!(out.contains("3"), "got: {out:?}");
+    }
+
+    #[test]
+    fn pop_front_removes_head() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 10);
+let l = linked_list_push_back(l, 20);
+let (head, l) = linked_list_pop_front(l);
+let v = match head { Some(x) => x, None => -1 };
+println(to_string(v));
+println(to_string(linked_list_len(l)));
+"#);
+        assert!(out.contains("10"), "got: {out:?}");
+        assert!(out.contains("1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn pop_back_removes_tail() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 10);
+let l = linked_list_push_back(l, 20);
+let (tail, l) = linked_list_pop_back(l);
+let v = match tail { Some(x) => x, None => -1 };
+println(to_string(v));
+println(to_string(linked_list_len(l)));
+"#);
+        assert!(out.contains("20"), "got: {out:?}");
+        assert!(out.contains("1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn peek_does_not_remove() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 42);
+let front = linked_list_peek_front(l);
+let v = match front { Some(x) => x, None => -1 };
+println(to_string(v));
+println(to_string(linked_list_len(l)));
+"#);
+        assert!(out.contains("42"), "got: {out:?}");
+        assert!(out.contains("1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn iteration_via_to_array() {
+        let out = run(r#"
+let l = linked_list_new();
+let l = linked_list_push_back(l, 10);
+let l = linked_list_push_back(l, 20);
+let l = linked_list_push_back(l, 30);
+for x in linked_list_to_array(l) {
+    println(to_string(x));
+}
+"#);
+        assert!(out.contains("10"), "got: {out:?}");
+        assert!(out.contains("20"), "got: {out:?}");
+        assert!(out.contains("30"), "got: {out:?}");
+    }
+
+    #[test]
+    fn pop_empty_returns_none() {
+        let out = run(r#"
+let l = linked_list_new();
+let (v, l) = linked_list_pop_front(l);
+let is_none = match v { None => true, Some(_) => false };
+println(to_string(is_none));
+println(to_string(linked_list_is_empty(l)));
+"#);
+        assert!(out.contains("true"), "got: {out:?}");
+    }
+}

--- a/resilient/src/regex_builtins.rs
+++ b/resilient/src/regex_builtins.rs
@@ -1,0 +1,214 @@
+//! RES-2585: Regex matching builtins.
+//!
+//! Provides regex operations backed by the `regex` crate (std-only — the
+//! embedded runtime has no regex support). All functions compile the pattern
+//! on each call; for hot paths the caller should cache the result in a let.
+//!
+//! API:
+//!   regex_match(text, pattern)           → bool
+//!   regex_find(text, pattern)            → Option<string>
+//!   regex_find_all(text, pattern)        → [string]
+//!   regex_captures(text, pattern)        → Option<[string]>
+//!   regex_replace(text, pattern, repl)   → string  — replaces first match
+//!   regex_replace_all(text, pattern, repl) → string — replaces all matches
+
+use crate::Value;
+use regex::Regex;
+
+type RResult<T> = Result<T, String>;
+
+fn compile(pattern: &str) -> RResult<Regex> {
+    Regex::new(pattern).map_err(|e| format!("regex_compile: invalid pattern {:?}: {}", pattern, e))
+}
+
+/// `regex_match(text, pattern) → bool`
+pub(crate) fn builtin_regex_match(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(text), Value::String(pattern)] => {
+            let re = compile(pattern)?;
+            Ok(Value::Bool(re.is_match(text)))
+        }
+        [_, _] => Err("regex_match: expected (string, string)".to_string()),
+        _ => Err(format!(
+            "regex_match: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `regex_find(text, pattern) → Option<string>` — first match.
+pub(crate) fn builtin_regex_find(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(text), Value::String(pattern)] => {
+            let re = compile(pattern)?;
+            Ok(Value::Option(
+                re.find(text)
+                    .map(|m| Box::new(Value::String(m.as_str().to_string()))),
+            ))
+        }
+        [_, _] => Err("regex_find: expected (string, string)".to_string()),
+        _ => Err(format!(
+            "regex_find: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `regex_find_all(text, pattern) → [string]` — all non-overlapping matches.
+pub(crate) fn builtin_regex_find_all(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(text), Value::String(pattern)] => {
+            let re = compile(pattern)?;
+            let matches: Vec<Value> = re
+                .find_iter(text)
+                .map(|m| Value::String(m.as_str().to_string()))
+                .collect();
+            Ok(Value::Array(matches))
+        }
+        [_, _] => Err("regex_find_all: expected (string, string)".to_string()),
+        _ => Err(format!(
+            "regex_find_all: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `regex_captures(text, pattern) → Option<[string]>` — capture groups (index 0 = whole match).
+pub(crate) fn builtin_regex_captures(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(text), Value::String(pattern)] => {
+            let re = compile(pattern)?;
+            Ok(Value::Option(re.captures(text).map(|caps| {
+                let groups: Vec<Value> = caps
+                    .iter()
+                    .map(|m| match m {
+                        Some(m) => Value::String(m.as_str().to_string()),
+                        None => Value::Option(None),
+                    })
+                    .collect();
+                Box::new(Value::Array(groups))
+            })))
+        }
+        [_, _] => Err("regex_captures: expected (string, string)".to_string()),
+        _ => Err(format!(
+            "regex_captures: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `regex_replace(text, pattern, replacement) → string` — replace first match.
+pub(crate) fn builtin_regex_replace(args: &[Value]) -> RResult<Value> {
+    match args {
+        [
+            Value::String(text),
+            Value::String(pattern),
+            Value::String(repl),
+        ] => {
+            let re = compile(pattern)?;
+            Ok(Value::String(re.replace(text, repl.as_str()).into_owned()))
+        }
+        [_, _, _] => Err("regex_replace: expected (string, string, string)".to_string()),
+        _ => Err(format!(
+            "regex_replace: expected 3 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `regex_replace_all(text, pattern, replacement) → string` — replace all matches.
+pub(crate) fn builtin_regex_replace_all(args: &[Value]) -> RResult<Value> {
+    match args {
+        [
+            Value::String(text),
+            Value::String(pattern),
+            Value::String(repl),
+        ] => {
+            let re = compile(pattern)?;
+            Ok(Value::String(
+                re.replace_all(text, repl.as_str()).into_owned(),
+            ))
+        }
+        [_, _, _] => Err("regex_replace_all: expected (string, string, string)".to_string()),
+        _ => Err(format!(
+            "regex_replace_all: expected 3 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::run_program;
+
+    fn run(src: &str) -> String {
+        let r = run_program(src);
+        assert!(r.ok, "program failed: {:?}", r.errors);
+        r.stdout
+    }
+
+    #[test]
+    fn regex_match_true_false() {
+        let out = run(r#"
+println(to_string(regex_match("hello123", "[a-z]+[0-9]+")));
+println(to_string(regex_match("hello", "[0-9]+")));
+"#);
+        assert!(out.contains("true"), "got: {out:?}");
+        assert!(out.contains("false"), "got: {out:?}");
+    }
+
+    #[test]
+    fn regex_find_some_and_none() {
+        let out = run(r#"
+let found = regex_find("hello world", "[a-z]+");
+let v = match found { Some(s) => s, None => "none" };
+println(v);
+let not_found = regex_find("hello", "[0-9]+");
+let v2 = match not_found { Some(s) => s, None => "none" };
+println(v2);
+"#);
+        assert!(out.contains("hello"), "got: {out:?}");
+        assert!(out.contains("none"), "got: {out:?}");
+    }
+
+    #[test]
+    fn regex_find_all_returns_array() {
+        let out = run(r#"
+let matches = regex_find_all("cat bat hat", "[a-z]at");
+println(to_string(len(matches)));
+"#);
+        assert!(out.contains("3"), "got: {out:?}");
+    }
+
+    #[test]
+    fn regex_replace_first() {
+        let out = run(r#"
+let result = regex_replace("foo bar foo", "foo", "baz");
+println(result);
+"#);
+        assert!(out.contains("baz bar foo"), "got: {out:?}");
+    }
+
+    #[test]
+    fn regex_replace_all_replaces_all() {
+        let out = run(r#"
+let result = regex_replace_all("foo bar foo", "foo", "baz");
+println(result);
+"#);
+        assert!(out.contains("baz bar baz"), "got: {out:?}");
+    }
+
+    #[test]
+    fn regex_captures_groups() {
+        let out = run(r#"
+let caps = regex_captures("hello world", "(hello) (world)");
+let arr = match caps { Some(a) => a, None => [] };
+println(to_string(len(arr)));
+"#);
+        assert!(out.contains("3"), "got: {out:?}");
+    }
+}

--- a/resilient/src/string_builder.rs
+++ b/resilient/src/string_builder.rs
@@ -1,0 +1,247 @@
+//! RES-2584: String builder — efficient mutable string construction.
+//!
+//! A string builder accumulates string parts without repeated allocation.
+//! Backed by `Value::Array` of strings; `string_builder_build` joins them
+//! with a single allocation.
+//!
+//! API:
+//!   string_builder_new()              → Builder (empty)
+//!   string_builder_append(b, s)       → Builder — append any value as string
+//!   string_builder_prepend(b, s)      → Builder — prepend any value as string
+//!   string_builder_build(b)           → String — join all parts
+//!   string_builder_len(b)             → int — total byte length of accumulated strings
+//!   string_builder_is_empty(b)        → bool — true when no parts have been appended
+//!   string_builder_clear(b)           → Builder — discard all parts
+
+use crate::Value;
+
+type RResult<T> = Result<T, String>;
+
+fn value_to_str(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Int(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Char(c) => c.to_string(),
+        other => format!("{other}"),
+    }
+}
+
+/// `string_builder_new() → Builder`
+pub(crate) fn builtin_string_builder_new(args: &[Value]) -> RResult<Value> {
+    if !args.is_empty() {
+        return Err(format!(
+            "string_builder_new: expected 0 arguments, got {}",
+            args.len()
+        ));
+    }
+    Ok(Value::Array(Vec::new()))
+}
+
+/// `string_builder_append(b, val) → Builder` — append value converted to string.
+pub(crate) fn builtin_string_builder_append(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts), val] => {
+            let mut out = parts.clone();
+            out.push(Value::String(value_to_str(val)));
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!(
+            "string_builder_append: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_append: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_prepend(b, val) → Builder` — prepend value converted to string.
+pub(crate) fn builtin_string_builder_prepend(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts), val] => {
+            let mut out = Vec::with_capacity(parts.len() + 1);
+            out.push(Value::String(value_to_str(val)));
+            out.extend_from_slice(parts);
+            Ok(Value::Array(out))
+        }
+        [other, _] => Err(format!(
+            "string_builder_prepend: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_prepend: expected 2 arguments, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_build(b) → String` — join all parts.
+pub(crate) fn builtin_string_builder_build(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts)] => {
+            let mut total_len = 0usize;
+            for p in parts.iter() {
+                if let Value::String(s) = p {
+                    total_len += s.len();
+                }
+            }
+            let mut out = String::with_capacity(total_len);
+            for p in parts.iter() {
+                if let Value::String(s) = p {
+                    out.push_str(s);
+                }
+            }
+            Ok(Value::String(out))
+        }
+        [other] => Err(format!(
+            "string_builder_build: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_build: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_len(b) → int` — total byte length of accumulated strings.
+pub(crate) fn builtin_string_builder_len(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts)] => {
+            let total: usize = parts
+                .iter()
+                .map(|p| match p {
+                    Value::String(s) => s.len(),
+                    _ => 0,
+                })
+                .sum();
+            Ok(Value::Int(total as i64))
+        }
+        [other] => Err(format!(
+            "string_builder_len: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_len: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_is_empty(b) → bool` — true when no parts accumulated.
+pub(crate) fn builtin_string_builder_is_empty(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(parts)] => Ok(Value::Bool(
+            parts
+                .iter()
+                .all(|p| matches!(p, Value::String(s) if s.is_empty()))
+                || parts.is_empty(),
+        )),
+        [other] => Err(format!(
+            "string_builder_is_empty: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_is_empty: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `string_builder_clear(b) → Builder` — discard all accumulated parts.
+pub(crate) fn builtin_string_builder_clear(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(_)] => Ok(Value::Array(Vec::new())),
+        [other] => Err(format!(
+            "string_builder_clear: expected Builder (Array), got {other}"
+        )),
+        _ => Err(format!(
+            "string_builder_clear: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::run_program;
+
+    fn run(src: &str) -> String {
+        let r = run_program(src);
+        assert!(r.ok, "program failed: {:?}", r.errors);
+        r.stdout
+    }
+
+    #[test]
+    fn basic_append_and_build() {
+        let out = run(r#"
+let b = string_builder_new();
+let b = string_builder_append(b, "hello");
+let b = string_builder_append(b, ", ");
+let b = string_builder_append(b, "world");
+let s = string_builder_build(b);
+println(s);
+"#);
+        assert!(out.contains("hello, world"), "got: {out:?}");
+    }
+
+    #[test]
+    fn append_int_and_float() {
+        let out = run(r#"
+let b = string_builder_new();
+let b = string_builder_append(b, "x=");
+let b = string_builder_append(b, 42);
+let s = string_builder_build(b);
+println(s);
+"#);
+        assert!(out.contains("x=42"), "got: {out:?}");
+    }
+
+    #[test]
+    fn prepend_adds_to_front() {
+        let out = run(r#"
+let b = string_builder_new();
+let b = string_builder_append(b, "world");
+let b = string_builder_prepend(b, "hello ");
+let s = string_builder_build(b);
+println(s);
+"#);
+        assert!(out.contains("hello world"), "got: {out:?}");
+    }
+
+    #[test]
+    fn len_counts_bytes() {
+        let out = run(r#"
+let b = string_builder_new();
+let b = string_builder_append(b, "abc");
+let b = string_builder_append(b, "de");
+println(to_string(string_builder_len(b)));
+"#);
+        assert!(out.contains("5"), "got: {out:?}");
+    }
+
+    #[test]
+    fn is_empty_and_clear() {
+        let out = run(r#"
+let b = string_builder_new();
+println(to_string(string_builder_is_empty(b)));
+let b = string_builder_append(b, "hi");
+let b = string_builder_clear(b);
+println(to_string(string_builder_is_empty(b)));
+"#);
+        assert!(out.contains("true"), "got: {out:?}");
+    }
+
+    #[test]
+    fn empty_builder_build() {
+        let out = run(r#"
+let b = string_builder_new();
+let s = string_builder_build(b);
+println(to_string(string_builder_len(string_builder_new())));
+println(s);
+"#);
+        assert!(out.contains("0"), "got: {out:?}");
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4625,6 +4625,9 @@ impl TypeChecker {
                 // RES-2587: priority queue / binary heap builtins.
                 env.set(
                     "heap_new".to_string(),
+                // RES-2588: linked list builtins.
+                env.set(
+                    "linked_list_new".to_string(),
                     Type::Function {
                         params: vec![],
                         return_type: Box::new(Type::Any),
@@ -4643,9 +4646,55 @@ impl TypeChecker {
                 env.set("heap_len".to_string(), fn_any_to_int());
                 env.set(
                     "heap_is_empty".to_string(),
+                env.set("linked_list_push_front".to_string(), fn_any_any_to_any());
+                env.set("linked_list_push_back".to_string(), fn_any_any_to_any());
+                env.set(
+                    "linked_list_pop_front".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "linked_list_pop_back".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "linked_list_peek_front".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "linked_list_peek_back".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "linked_list_len".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Int),
+                    },
+                );
+                env.set(
+                    "linked_list_is_empty".to_string(),
                     Type::Function {
                         params: vec![Type::Any],
                         return_type: Box::new(Type::Bool),
+                    },
+                );
+                env.set(
+                    "linked_list_to_array".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
                     },
                 );
                 std::sync::Arc::new(env)

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4625,6 +4625,44 @@ impl TypeChecker {
                 // RES-2587: priority queue / binary heap builtins.
                 env.set(
                     "heap_new".to_string(),
+                // RES-2584: string builder builtins.
+                env.set(
+                    "string_builder_new".to_string(),
+                    Type::Function {
+                        params: vec![],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set("string_builder_append".to_string(), fn_any_any_to_any());
+                env.set("string_builder_prepend".to_string(), fn_any_any_to_any());
+                env.set(
+                    "string_builder_build".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::String),
+                    },
+                );
+                env.set(
+                    "string_builder_len".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Int),
+                    },
+                );
+                env.set(
+                    "string_builder_is_empty".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
+                env.set(
+                    "string_builder_clear".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
                 // RES-2588: linked list builtins.
                 env.set(
                     "linked_list_new".to_string(),

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4663,6 +4663,49 @@ impl TypeChecker {
                         return_type: Box::new(Type::Any),
                     },
                 );
+                // RES-2585: regex matching builtins.
+                env.set(
+                    "regex_match".to_string(),
+                    Type::Function {
+                        params: vec![Type::String, Type::String],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
+                env.set(
+                    "regex_find".to_string(),
+                    Type::Function {
+                        params: vec![Type::String, Type::String],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "regex_find_all".to_string(),
+                    Type::Function {
+                        params: vec![Type::String, Type::String],
+                        return_type: Box::new(Type::Array),
+                    },
+                );
+                env.set(
+                    "regex_captures".to_string(),
+                    Type::Function {
+                        params: vec![Type::String, Type::String],
+                        return_type: Box::new(Type::Any),
+                    },
+                );
+                env.set(
+                    "regex_replace".to_string(),
+                    Type::Function {
+                        params: vec![Type::String, Type::String, Type::String],
+                        return_type: Box::new(Type::String),
+                    },
+                );
+                env.set(
+                    "regex_replace_all".to_string(),
+                    Type::Function {
+                        params: vec![Type::String, Type::String, Type::String],
+                        return_type: Box::new(Type::String),
+                    },
+                );
                 // RES-2588: linked list builtins.
                 env.set(
                     "linked_list_new".to_string(),


### PR DESCRIPTION
## Summary

Adds 6 regex builtins backed by the `regex` crate. All logic lives in `resilient/src/regex_builtins.rs`; minimal additions to `lib.rs` (mod + BUILTINS) and `typechecker.rs` (BUILTIN_ENV).

Builtins:
- `regex_match(text, pattern) → bool`
- `regex_find(text, pattern) → Option<string>` — first match
- `regex_find_all(text, pattern) → [string]` — all non-overlapping matches
- `regex_captures(text, pattern) → Option<[string]>` — capture groups (index 0 = whole match)
- `regex_replace(text, pattern, replacement) → string` — replaces first match
- `regex_replace_all(text, pattern, replacement) → string` — replaces all matches

**New dependency**: `regex = "1"` — std-only; not used in `resilient-runtime` (no_std). Required by the issue spec.

Closes #2585

🤖 Generated with [Claude Code](https://claude.com/claude-code)