### PR TITLE
RES-2583: mutex and rwlock synchronization primitives

### DIFF
--- a/resilient/examples/mutex_rwlock.expected.txt
+++ b/resilient/examples/mutex_rwlock.expected.txt
@@ -1,0 +1,3 @@
+0
+shared
+Program executed successfully

--- a/resilient/examples/mutex_rwlock.rz
+++ b/resilient/examples/mutex_rwlock.rz
@@ -1,0 +1,9 @@
+let counter = mutex_new(0);
+let v = mutex_lock(counter);
+println(to_string(v));
+mutex_unlock(counter);
+
+let data = rwlock_new("shared");
+let r = rwlock_read(data);
+println(r);
+rwlock_unlock(data);

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -672,6 +672,8 @@ mod heap;
 mod target_profiles;
 // RES-2611: source maps linking bytecode offsets to source positions.
 mod source_map;
+// RES-2583: mutex and rwlock synchronization primitives.
+mod mutex_rwlock;
 mod vibe_debt;
 mod wcet_contracts;
 // RES-2558: process spawning (std-only).
@@ -13006,6 +13008,18 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("udp_send_to", crate::tcp_udp::builtin_udp_send_to),
     ("udp_recv_from", crate::tcp_udp::builtin_udp_recv_from),
     ("udp_close", crate::tcp_udp::builtin_udp_close),
+    // RES-2583: mutex and rwlock synchronization primitives.
+    ("mutex_new", crate::mutex_rwlock::builtin_mutex_new),
+    ("mutex_lock", crate::mutex_rwlock::builtin_mutex_lock),
+    ("mutex_unlock", crate::mutex_rwlock::builtin_mutex_unlock),
+    (
+        "mutex_try_lock",
+        crate::mutex_rwlock::builtin_mutex_try_lock,
+    ),
+    ("rwlock_new", crate::mutex_rwlock::builtin_rwlock_new),
+    ("rwlock_read", crate::mutex_rwlock::builtin_rwlock_read),
+    ("rwlock_write", crate::mutex_rwlock::builtin_rwlock_write),
+    ("rwlock_unlock", crate::mutex_rwlock::builtin_rwlock_unlock),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/mutex_rwlock.rs
+++ b/resilient/src/mutex_rwlock.rs
@@ -1,0 +1,206 @@
+//! RES-2583: Mutex and RwLock synchronization primitives.
+//!
+//! Provides interpreter-level wrappers around shared-state concurrency
+//! primitives. In the single-threaded interpreter these are value containers
+//! with explicit lock/unlock; compiled backends map them to real OS primitives.
+//!
+//! ## API
+//!
+//!   mutex_new(v)          → Mutex  — create a mutex wrapping value `v`
+//!   mutex_lock(m)         → value  — acquire lock, return wrapped value
+//!   mutex_unlock(m)       → void   — release lock (no-op in interpreter)
+//!   mutex_try_lock(m)     → Option — non-blocking; always Some in interpreter
+//!   rwlock_new(v)         → RwLock — create an RwLock wrapping value `v`
+//!   rwlock_read(l)        → value  — acquire shared read, return value
+//!   rwlock_write(l)       → value  — acquire exclusive write, return value
+//!   rwlock_unlock(l)      → void   — release lock (no-op in interpreter)
+//!
+//! ## Notes
+//!
+//! Both `Mutex` and `RwLock` are backed by a single-element `Value::Array`.
+//! The lock/unlock operations are no-ops in the interpreter; the API matches
+//! what a compiled backend would use with real OS primitives.
+
+use crate::Value;
+
+type RResult<T> = Result<T, String>;
+
+// ---------------------------------------------------------------------------
+// Mutex builtins
+// ---------------------------------------------------------------------------
+
+/// `mutex_new(v) → Mutex` — wrap `v` in a new mutex.
+pub(crate) fn builtin_mutex_new(args: &[Value]) -> RResult<Value> {
+    match args {
+        [v] => Ok(Value::Array(vec![v.clone()])),
+        _ => Err(format!(
+            "mutex_new: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `mutex_lock(m) → value` — acquire the mutex and return the wrapped value.
+/// In the interpreter this always succeeds immediately.
+pub(crate) fn builtin_mutex_lock(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(cells)] if !cells.is_empty() => Ok(cells[0].clone()),
+        [_] => Err("mutex_lock: argument is not a mutex".to_string()),
+        _ => Err(format!(
+            "mutex_lock: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `mutex_unlock(m) → void` — release the mutex. No-op in the interpreter.
+pub(crate) fn builtin_mutex_unlock(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(_)] => Ok(Value::Void),
+        [_] => Err("mutex_unlock: argument is not a mutex".to_string()),
+        _ => Err(format!(
+            "mutex_unlock: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `mutex_try_lock(m) → Option<value>` — non-blocking acquire.
+/// In the interpreter this always returns `Some(value)`.
+pub(crate) fn builtin_mutex_try_lock(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(cells)] if !cells.is_empty() => {
+            Ok(Value::Option(Some(Box::new(cells[0].clone()))))
+        }
+        [Value::Array(_)] => Ok(Value::Option(None)),
+        [_] => Err("mutex_try_lock: argument is not a mutex".to_string()),
+        _ => Err(format!(
+            "mutex_try_lock: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RwLock builtins
+// ---------------------------------------------------------------------------
+
+/// `rwlock_new(v) → RwLock` — wrap `v` in a new read-write lock.
+pub(crate) fn builtin_rwlock_new(args: &[Value]) -> RResult<Value> {
+    match args {
+        [v] => Ok(Value::Array(vec![v.clone()])),
+        _ => Err(format!(
+            "rwlock_new: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `rwlock_read(l) → value` — acquire a shared read guard.
+pub(crate) fn builtin_rwlock_read(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(cells)] if !cells.is_empty() => Ok(cells[0].clone()),
+        [_] => Err("rwlock_read: argument is not an rwlock".to_string()),
+        _ => Err(format!(
+            "rwlock_read: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `rwlock_write(l) → value` — acquire an exclusive write guard.
+pub(crate) fn builtin_rwlock_write(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(cells)] if !cells.is_empty() => Ok(cells[0].clone()),
+        [_] => Err("rwlock_write: argument is not an rwlock".to_string()),
+        _ => Err(format!(
+            "rwlock_write: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `rwlock_unlock(l) → void` — release a read or write guard. No-op in interpreter.
+pub(crate) fn builtin_rwlock_unlock(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::Array(_)] => Ok(Value::Void),
+        [_] => Err("rwlock_unlock: argument is not an rwlock".to_string()),
+        _ => Err(format!(
+            "rwlock_unlock: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Advisory type-check pass
+// ---------------------------------------------------------------------------
+
+/// No-op check: static analysis for mutex usage is handled by the existing
+/// `deadlock_freedom` and `lock_priority` modules.
+pub(crate) fn check(_program: &crate::Node, _source_path: &str) -> Result<(), String> {
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::run_program;
+
+    fn run(src: &str) -> String {
+        let r = run_program(src);
+        assert!(r.ok, "program failed: {:?}", r.errors);
+        r.stdout
+    }
+
+    #[test]
+    fn mutex_new_and_lock() {
+        let out = run(r#"
+let m = mutex_new(42);
+let v = mutex_lock(m);
+println(to_string(v));
+mutex_unlock(m);
+"#);
+        assert!(out.contains("42"), "got: {out:?}");
+    }
+
+    #[test]
+    fn mutex_try_lock_returns_some() {
+        let out = run(r#"
+let m = mutex_new("hello");
+let opt = mutex_try_lock(m);
+println(to_string(is_some(opt)));
+"#);
+        assert!(out.contains("true"), "got: {out:?}");
+    }
+
+    #[test]
+    fn rwlock_read_and_write() {
+        let out = run(r#"
+let l = rwlock_new(100);
+let r = rwlock_read(l);
+println(to_string(r));
+let w = rwlock_write(l);
+println(to_string(w));
+rwlock_unlock(l);
+"#);
+        assert!(out.contains("100"), "got: {out:?}");
+    }
+
+    #[test]
+    fn mutex_wraps_different_types() {
+        let out = run(r#"
+let m1 = mutex_new(true);
+let m2 = mutex_new("world");
+let v1 = mutex_lock(m1);
+let v2 = mutex_lock(m2);
+println(to_string(v1));
+println(v2);
+"#);
+        assert!(out.contains("true"), "got: {out:?}");
+        assert!(out.contains("world"), "got: {out:?}");
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -4648,6 +4648,15 @@ impl TypeChecker {
                         return_type: Box::new(Type::Bool),
                     },
                 );
+                // RES-2583: mutex and rwlock synchronization primitives.
+                env.set("mutex_new".to_string(), fn_any_to_any());
+                env.set("mutex_lock".to_string(), fn_any_to_any());
+                env.set("mutex_unlock".to_string(), fn_any_to_any());
+                env.set("mutex_try_lock".to_string(), fn_any_to_any());
+                env.set("rwlock_new".to_string(), fn_any_to_any());
+                env.set("rwlock_read".to_string(), fn_any_to_any());
+                env.set("rwlock_write".to_string(), fn_any_to_any());
+                env.set("rwlock_unlock".to_string(), fn_any_to_any());
                 std::sync::Arc::new(env)
             });
 
@@ -5747,6 +5756,8 @@ impl TypeChecker {
                 crate::trait_inheritance::check(program, source_path)?;
                 // RES-2575: validate generic enum type parameters.
                 crate::generic_enums::check(program, source_path)?;
+                // RES-2583: mutex/rwlock advisory check (no-op; real analysis in deadlock_freedom).
+                crate::mutex_rwlock::check(program, source_path)?;
                 // </EXTENSION_PASSES>
 
                 // RES-192: IO-effect inference. Binary lattice


### PR DESCRIPTION
## Summary

- Adds 4 mutex builtins: `mutex_new(v)`, `mutex_lock(m)`, `mutex_unlock(m)`, `mutex_try_lock(m) → Option`
- Adds 4 rwlock builtins: `rwlock_new(v)`, `rwlock_read(l)`, `rwlock_write(l)`, `rwlock_unlock(l)`
- Both backed by `Value::Array` in the interpreter (single-threaded, locking is no-op)
- `mutex_try_lock` returns `Option<value>` — always `Some` in the interpreter
- Advisory `check()` no-ops; real deadlock analysis is handled by the existing `deadlock_freedom` and `lock_priority` modules

## Test plan

- [x] `mutex_new_and_lock` — basic round-trip
- [x] `mutex_try_lock_returns_some` — non-blocking acquire returns Some
- [x] `rwlock_read_and_write` — read/write both return value
- [x] `mutex_wraps_different_types` — works with int, bool, string
- [x] Golden example: `resilient/examples/mutex_rwlock.rz`
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #2583

🤖 Generated with [Claude Code](https://claude.com/claude-code)