### PR TITLE
RES-2573: enum methods — impl blocks on EnumVariant receivers

### DIFF
--- a/resilient/examples/enum_methods.expected.txt
+++ b/resilient/examples/enum_methods.expected.txt
@@ -1,0 +1,5 @@
+north
+south
+true
+false
+Program executed successfully

--- a/resilient/examples/enum_methods.rz
+++ b/resilient/examples/enum_methods.rz
@@ -1,0 +1,42 @@
+// RES-2573: impl blocks for enum types.
+enum Direction {
+    North,
+    South,
+    East,
+    West,
+}
+
+impl Direction {
+    fn label(self) -> string {
+        match self {
+            Direction::North => "north",
+            Direction::South => "south",
+            Direction::East => "east",
+            Direction::West => "west",
+        }
+    }
+
+    fn opposite_label(self) -> string {
+        match self {
+            Direction::North => "south",
+            Direction::South => "north",
+            Direction::East => "west",
+            Direction::West => "east",
+        }
+    }
+
+    fn is_vertical(self) -> bool {
+        match self {
+            Direction::North => true,
+            Direction::South => true,
+            Direction::East => false,
+            Direction::West => false,
+        }
+    }
+}
+
+let d = Direction::North;
+println(d.label());
+println(d.opposite_label());
+println(to_string(d.is_vertical()));
+println(to_string(Direction::East.is_vertical()));

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -24107,6 +24107,18 @@ impl Interpreter {
                         // through to the regular `FieldAccess` eval
                         // (which will itself raise a clean error).
                     }
+                    // RES-2573: enum method dispatch — look up `TypeName$method`
+                    // in the environment, exactly like struct method dispatch.
+                    // `impl Color { fn foo(self) }` registers `Color$foo`; we
+                    // find it here when the receiver is an EnumVariant.
+                    if let Value::EnumVariant { type_name, .. } = &target_val {
+                        let mangled = format!("{}${}", type_name, field);
+                        if let Some(method_val) = self.env.get(&mangled) {
+                            let mut args = vec![target_val];
+                            args.extend(self.eval_expressions(arguments)?);
+                            return self.apply_function(&method_val, args);
+                        }
+                    }
                 }
                 // RES-1859: standalone array_map / array_filter / array_reduce
                 // must be handled inline — they accept user callbacks that


### PR DESCRIPTION
## Summary

Adds enum method dispatch to the interpreter's `CallExpression` handler.

When a dot-call target evaluates to `Value::EnumVariant { type_name, .. }`, the runtime now looks up `TypeName$method` in the environment — the same mangled name that `ImplBlock` parsing registers. This 12-line change makes `impl MyEnum { fn foo(self) }` fully functional at runtime.

The parser and typechecker already accepted `impl Enum { ... }` and registered methods correctly. Only the runtime dispatch was missing.

## Example

```rz
enum Direction { North, South, East, West }

impl Direction {
    fn is_vertical(self) -> bool {
        match self {
            Direction::North => true,  Direction::South => true,
            Direction::East  => false, Direction::West  => false,
        }
    }
}

println(to_string(Direction::North.is_vertical())); // true
```

## Test plan

- [x] `cargo test --manifest-path resilient/Cargo.toml` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] Golden example `enum_methods.rz` matches expected output

Closes #2573

🤖 Generated with [Claude Code](https://claude.ai/claude-code)