### PR TITLE
RES-2551: break with value from loop expressions

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -11,6 +11,8 @@
     "resilient/src/typechecker.rs": {
       "branch": "res-2554-json-builtins",
       "claimed_at": "2026-05-31T01:05:24Z"
+      "branch": "res-2551-break-with-value",
+      "claimed_at": "2026-05-31T00:09:37Z"
     }
   }
 }

--- a/resilient/examples/break_with_value.expected.txt
+++ b/resilient/examples/break_with_value.expected.txt
@@ -1,0 +1,4 @@
+50
+done
+true
+Program executed successfully

--- a/resilient/examples/break_with_value.rz
+++ b/resilient/examples/break_with_value.rz
@@ -1,0 +1,33 @@
+// RES-2551: break with value from loop expressions.
+// Note: `break identifier;` is a labeled break (backward-compat).
+// Use `break (expr);` or a compound expression to carry a value.
+
+// Break with an arithmetic expression.
+let mut i = 0;
+let result = loop {
+    i = i + 1;
+    if i >= 5 {
+        break i * 10;
+    }
+};
+println(to_string(result));
+
+// Break with a string expression.
+let mut n = 0;
+let msg = loop {
+    n = n + 1;
+    if n >= 3 {
+        break "done";
+    }
+};
+println(msg);
+
+// Break with a boolean expression.
+let mut x = 0;
+let ok = loop {
+    x = x + 1;
+    if x >= 4 {
+        break x > 2;
+    }
+};
+println(to_string(ok));

--- a/resilient/src/compiler.rs
+++ b/resilient/src/compiler.rs
@@ -4575,6 +4575,7 @@ fn node_line(n: &Node) -> Option<u32> {
         | Node::Assignment { span, .. }
         | Node::ReturnStatement { span, .. }
         | Node::Break { span, .. }
+        | Node::BreakWith { span, .. }
         | Node::Continue { span, .. }
         | Node::BreakLabel { span, .. }
         | Node::ContinueLabel { span, .. }

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -508,6 +508,13 @@ impl Formatter {
                 self.write("break;");
                 self.newline();
             }
+            // RES-2551: `break expr;` formatter.
+            Node::BreakWith { value, .. } => {
+                self.write("break ");
+                self.fmt_expr(value);
+                self.write(";");
+                self.newline();
+            }
             Node::Continue { .. } => {
                 self.write("continue;");
                 self.newline();
@@ -1223,6 +1230,7 @@ impl Formatter {
             | Node::Assignment { .. }
             | Node::ReturnStatement { .. }
             | Node::Break { .. }
+            | Node::BreakWith { .. }
             | Node::Continue { .. }
             | Node::BreakLabel { .. }
             | Node::ContinueLabel { .. }

--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -99,6 +99,8 @@ fn walk(node: &Node, bound: &mut BTreeSet<String>, free: &mut BTreeSet<String>) 
         // RES-2653: labeled variants likewise.
         | Node::BreakLabel { .. }
         | Node::ContinueLabel { .. } => {}
+        // RES-2551: `break expr;` — walk the value expression.
+        Node::BreakWith { value, .. } => walk(value, bound, free),
         // RES-911: slicing — walk the target plus both endpoints; binds
         // no names of its own.
         Node::Slice { target, lo, hi, .. } => {

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -2563,6 +2563,13 @@ enum Node {
         #[allow(dead_code)]
         span: span::Span,
     },
+    /// RES-2551: `break expr;` — exit the innermost `loop` with a value.
+    /// The loop expression evaluates to that value.
+    BreakWith {
+        value: Box<Node>,
+        #[allow(dead_code)]
+        span: span::Span,
+    },
     /// RES-910: `continue;` — skip to the next iteration of the
     /// innermost enclosing loop. Typechecker rejects outside a loop.
     Continue {
@@ -7278,23 +7285,35 @@ impl Parser {
     fn parse_break_statement(&mut self) -> Node {
         let stmt_span = self.span_at_current();
         self.next_token(); // skip `break`
-        // RES-2653: `break label;` — if current token is an identifier
-        // (not a semicolon or EOF), treat it as a label name.
-        if let Token::Identifier(label) = &self.current_token.clone() {
+        // Plain `break;` — no value or label.
+        if self.current_token == Token::Semicolon || self.current_token == Token::Eof {
+            return Node::Break { span: stmt_span };
+        }
+        // RES-2653: `break label;` — a lone identifier followed by `;`.
+        // Must check peek FIRST: `break foo;` is a label, `break foo + 1;` is
+        // an expression.  The label form keeps backward compatibility.
+        if let Token::Identifier(label) = &self.current_token.clone()
+            && (self.peek_token == Token::Semicolon || self.peek_token == Token::Eof)
+        {
             let label = label.clone();
-            // Consume the label identifier.
-            if self.peek_token == Token::Semicolon {
-                self.next_token(); // move to `;`
-            }
+            self.next_token(); // skip the label identifier
             return Node::BreakLabel {
                 label,
                 span: stmt_span,
             };
         }
-        if self.peek_token == Token::Semicolon {
-            self.next_token();
+        // RES-2551: `break expr;` — parse the expression as a break value.
+        let Some(value) = self.parse_expression(0) else {
+            self.record_error("Expected expression after `break`".to_string());
+            return Node::Break { span: stmt_span };
+        };
+        if self.current_token == Token::Semicolon {
+            self.next_token(); // consume `;`
         }
-        Node::Break { span: stmt_span }
+        Node::BreakWith {
+            value: Box::new(value),
+            span: stmt_span,
+        }
     }
 
     /// RES-910: parse `continue;` or `continue label;` (RES-2653).
@@ -8304,6 +8323,10 @@ impl Parser {
             // the consequence / alternative blocks, a trailing bare
             // expression statement is what carries the block's value.
             Token::If => Some(self.parse_if_statement()),
+            // RES-2551: `loop { }` and `while cond { }` as expressions.
+            // This enables `let x = loop { break value; }`.
+            Token::Loop => Some(self.parse_loop_statement()),
+            Token::While => Some(self.parse_while_statement()),
             Token::Function => Some(self.parse_function_literal()),
             // RES-330: quantifier expressions delegate parsing entirely
             // to the quantifiers module so the prefix dispatch stays
@@ -10527,6 +10550,10 @@ enum Value {
     /// `eval_block_statement` like `Return`, but is intercepted by the
     /// nearest `WhileStatement` / `ForInStatement` evaluator.
     Break,
+    /// RES-2551: control-flow sentinel for `break expr;`. Carries the
+    /// break value; the enclosing `loop` evaluator returns it as the
+    /// loop expression value.
+    BreakWith(Box<Value>),
     /// RES-910: control-flow sentinel for `continue`. Same propagation
     /// rule as `Break`; the loop evaluator consumes it and starts the
     /// next iteration instead of exiting.
@@ -10774,6 +10801,7 @@ impl std::fmt::Debug for Value {
             },
             Value::Return(v) => write!(f, "Return({:?})", v),
             Value::Break => write!(f, "Break"),
+            Value::BreakWith(v) => write!(f, "BreakWith({:?})", v),
             Value::Continue => write!(f, "Continue"),
             Value::BreakLabel(l) => write!(f, "BreakLabel({l})"),
             Value::ContinueLabel(l) => write!(f, "ContinueLabel({l})"),
@@ -10909,6 +10937,7 @@ impl std::fmt::Display for Value {
             },
             Value::Return(v) => write!(f, "{}", v),
             Value::Break => write!(f, "<break>"),
+            Value::BreakWith(v) => write!(f, "<break {v}>"),
             Value::Continue => write!(f, "<continue>"),
             Value::BreakLabel(l) => write!(f, "<break {l}>"),
             Value::ContinueLabel(l) => write!(f, "<continue {l}>"),
@@ -23585,6 +23614,11 @@ impl Interpreter {
             // loop evaluator consumes it.
             Node::Break { .. } => Ok(Value::Break),
             Node::Continue { .. } => Ok(Value::Continue),
+            // RES-2651: `break expr;` — evaluate and wrap in BreakWith.
+            Node::BreakWith { value, .. } => {
+                let v = self.eval(value)?;
+                Ok(Value::BreakWith(Box::new(v)))
+            }
             // RES-2653: labeled break/continue sentinels.
             Node::BreakLabel { label, .. } => Ok(Value::BreakLabel(label.clone())),
             Node::ContinueLabel { label, .. } => Ok(Value::ContinueLabel(label.clone())),
@@ -23637,6 +23671,13 @@ impl Interpreter {
                     // iteration.
                     if matches!(result, Value::Break) {
                         break;
+                    }
+                    // RES-2551: `break expr;` — exit with a value.
+                    if matches!(result, Value::BreakWith(_)) {
+                        return Ok(match result {
+                            Value::BreakWith(v) => *v,
+                            _ => unreachable!(),
+                        });
                     }
                     // RES-2653: labeled break — consume only if the label
                     // matches this loop; otherwise propagate upward.
@@ -25762,6 +25803,10 @@ impl Interpreter {
                 if matches!(result, Value::Break) {
                     return Ok(Value::Void);
                 }
+                // RES-2551: break with value.
+                if let Value::BreakWith(v) = result {
+                    return Ok(*v);
+                }
                 // RES-2653: labeled break/continue.
                 if let Value::BreakLabel(ref lbl) = result {
                     if label == Some(lbl.as_str()) {
@@ -25813,6 +25858,10 @@ impl Interpreter {
             // fast-path above.
             if matches!(result, Value::Break) {
                 return Ok(Value::Void);
+            }
+            // RES-2551: break with value.
+            if let Value::BreakWith(v) = result {
+                return Ok(*v);
             }
             // RES-2653: labeled break/continue.
             if let Value::BreakLabel(ref lbl) = result {
@@ -25941,6 +25990,7 @@ impl Interpreter {
                         result,
                         Value::Return(_)
                             | Value::Break
+                            | Value::BreakWith(_)
                             | Value::Continue
                             | Value::BreakLabel(_)
                             | Value::ContinueLabel(_)

--- a/resilient/src/type_builtins.rs
+++ b/resilient/src/type_builtins.rs
@@ -50,6 +50,7 @@ pub(crate) fn builtin_type_of(args: &[Value]) -> RResult<Value> {
                 // Control-flow sentinels — not user-visible.
                 Value::Return(_)
                 | Value::Break
+                | Value::BreakWith(_)
                 | Value::Continue
                 | Value::BreakLabel(_)
                 | Value::ContinueLabel(_) => "void",

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -194,7 +194,10 @@ impl std::fmt::Display for Type {
 /// so any positive diagnosis is a real bug rather than a guess.
 pub(crate) fn node_terminates(node: &Node) -> bool {
     match node {
-        Node::ReturnStatement { .. } | Node::Break { .. } | Node::Continue { .. } => true,
+        Node::ReturnStatement { .. }
+        | Node::Break { .. }
+        | Node::BreakWith { .. }
+        | Node::Continue { .. } => true,
         Node::Block { stmts, .. } => stmts.iter().any(node_terminates),
         Node::IfStatement {
             consequence,
@@ -6739,7 +6742,12 @@ impl TypeChecker {
                 // is always a bug. The `_`-prefixed discard convention is the
                 // expected pattern; bare `let x = void_fn()` produces a variable
                 // that can never be used in a typed context.
-                if value_type == Type::Void && !name.starts_with('_') {
+                // RES-2551 exception: `loop { break expr; }` and `while cond { break expr; }`
+                // are loop expressions whose type comes from the break value at runtime.
+                // The typechecker conservatively types WhileStatement as Void; skip the
+                // void-binding check here so `let x = loop { break 42; }` is accepted.
+                let rhs_is_loop = matches!(value.as_ref(), Node::WhileStatement { .. });
+                if value_type == Type::Void && !name.starts_with('_') && !rhs_is_loop {
                     return Err(format!(
                         "cannot bind void value to `{}` — the right-hand side expression has type void; \
                          use `let _ = expr;` to explicitly discard it",
@@ -8171,6 +8179,17 @@ impl TypeChecker {
                          inside a `while` or `for-in` body"
                         .to_string());
                 }
+                Ok(Type::Void)
+            }
+            // RES-2551: `break expr;` — validates the expression; loop type
+            // inference is done at use-site, not here.
+            Node::BreakWith { value, .. } => {
+                if self.loop_depth == 0 {
+                    return Err("'break' outside of a loop — `break` is only valid \
+                         inside a `while` or `for-in` body"
+                        .to_string());
+                }
+                self.check_node(value)?;
                 Ok(Type::Void)
             }
             Node::Continue { .. } => {

--- a/resilient/src/unused_imports.rs
+++ b/resilient/src/unused_imports.rs
@@ -460,6 +460,8 @@ fn collect_namespaces<'a>(node: &'a Node, out: &mut HashSet<&'a str>) {
         | Node::Continue { .. }
         | Node::BreakLabel { .. }
         | Node::ContinueLabel { .. } => {}
+        // RES-2551: walk the expression inside `break expr;`.
+        Node::BreakWith { value, .. } => collect_namespaces(value, out),
     }
 }
 


### PR DESCRIPTION
## Summary

Enables `break expr;` to carry a value out of any loop, making `loop { }` and
`while` blocks usable as expressions:

```resilient
let result = loop {
    i = i + 1;
    if i >= 5 { break i * 10; }
};
// result == 50
```

## Design

- **Disambiguation**: `break identifier;` (lone identifier + semicolon) remains a
  labeled break for backward compatibility with RES-2653. Any other expression
  after `break` produces a value break.
- **Loop expressions**: `loop {}` and `while cond {}` are now parseable in
  expression position so `let x = loop { break val; }` is syntactically valid.
- **Typechecker**: `let x = loop { ... }` is exempt from the void-binding check;
  the actual break type is tracked at runtime.

## Changes

| File | Change |
|---|---|
| `lib.rs` | `Node::BreakWith` AST node; `Value::BreakWith` runtime sentinel; parser and evaluator |
| `typechecker.rs` | `BreakWith` check; loop-expression exemption in void-binding check |
| `compiler.rs` / `formatter.rs` / `free_vars.rs` / `unused_imports.rs` / `type_builtins.rs` | Exhaustive match arms |

## Test

Golden file `break_with_value.rz` covers arithmetic, string, and boolean break values.

Closes #2551