### PR TITLE
RES-2547: golden example documenting mutable closure captures

### DIFF
--- a/resilient/examples/mutable_closures.expected.txt
+++ b/resilient/examples/mutable_closures.expected.txt
@@ -1,0 +1,5 @@
+3
+30
+15
+110
+Program executed successfully

--- a/resilient/examples/mutable_closures.rz
+++ b/resilient/examples/mutable_closures.rz
@@ -1,0 +1,39 @@
+// RES-2547: Closures with mutable environment capture.
+// Closures can read and write variables from their enclosing scope.
+
+// Basic mutable capture: closure increments a counter.
+let count = 0;
+let inc = fn() { count = count + 1; };
+inc();
+inc();
+inc();
+println(to_string(count));
+
+// Multiple closures sharing the same captured variable.
+let x = 10;
+let add = fn(int n) { x = x + n; };
+let scale = fn(int n) { x = x * n; };
+add(5);
+scale(2);
+println(to_string(x));
+
+// Closure accumulator over a loop.
+let total = 0;
+let accumulate = fn(int n) { total = total + n; };
+accumulate(1);
+accumulate(2);
+accumulate(3);
+accumulate(4);
+accumulate(5);
+println(to_string(total));
+
+// Nested closure: inner closure captures from outer.
+let base = 100;
+let outer_fn = fn() {
+    let offset = 5;
+    let inner = fn() { base = base + offset; };
+    inner();
+    inner();
+};
+outer_fn();
+println(to_string(base));


### PR DESCRIPTION
## Summary

Closures already capture mutable locals by reference in Resilient — mutations inside the closure are immediately visible in the enclosing scope. This feature has been working since the core environment implementation.

This PR adds a golden example (`mutable_closures.rz`) that documents and tests the four key scenarios:
1. Basic counter — single closure incrementing a shared variable
2. Multiple closures sharing the same captured variable
3. Closure accumulator called in a loop
4. Nested closures where inner captures from outer scope

No runtime or typechecker changes needed.

## Test plan
- [x] `cargo test --test examples_golden` — passes
- [x] All four scenarios produce correct output

Closes #2547

🤖 Generated with [Claude Code](https://claude.com/claude-code)