### PR TITLE
RES-2557: file metadata builtins — file_exists, file_stat, file_is_dir, file_size, dir_list

### DIFF
--- a/resilient/examples/file_meta.expected.txt
+++ b/resilient/examples/file_meta.expected.txt
@@ -1,0 +1,9 @@
+true
+true
+false
+true
+true
+true
+false
+true
+Program executed successfully

--- a/resilient/examples/file_meta.rz
+++ b/resilient/examples/file_meta.rz
@@ -1,0 +1,27 @@
+// RES-2557: file metadata builtins — file_exists, file_stat, file_is_dir,
+// file_is_file, file_size, dir_list.
+
+// Test with the current directory which always exists.
+let dot_exists = file_exists(".");
+println(dot_exists);
+
+let dot_is_dir = file_is_dir(".");
+println(dot_is_dir);
+
+let dot_is_file = file_is_file(".");
+println(dot_is_file);
+
+// Write a temp file, check its size, then stat it.
+file_write("/tmp/rz_file_meta_test.txt", "hello resilient");
+
+let sz = unwrap(file_size("/tmp/rz_file_meta_test.txt"));
+println(sz > 0);
+
+let meta = unwrap(file_stat("/tmp/rz_file_meta_test.txt"));
+println(meta.size > 0);
+println(meta.is_file);
+println(meta.is_dir);
+
+// dir_list returns a sorted array of entry names.
+let listing = unwrap(dir_list("."));
+println(listing != []);

--- a/resilient/src/file_meta.rs
+++ b/resilient/src/file_meta.rs
@@ -1,0 +1,151 @@
+//! RES-2557: File metadata builtins — file_exists, file_stat, file_is_dir,
+//! file_is_file, file_size, dir_list (all std-only).
+
+use crate::Value;
+use std::path::Path;
+
+type RResult<T> = Result<T, String>;
+
+fn ok(v: Value) -> Value {
+    Value::Result {
+        ok: true,
+        payload: Box::new(v),
+    }
+}
+
+fn err(msg: String) -> Value {
+    Value::Result {
+        ok: false,
+        payload: Box::new(Value::String(msg)),
+    }
+}
+
+/// `file_exists(path: string) -> bool`
+///
+/// Returns true if anything (file, directory, symlink) exists at `path`.
+pub(crate) fn builtin_file_exists(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(path)] => Ok(Value::Bool(Path::new(path.as_str()).exists())),
+        [other] => Err(format!(
+            "file_exists: expected string path, got {:?}",
+            other
+        )),
+        _ => Err(format!(
+            "file_exists: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `file_is_dir(path: string) -> bool`
+///
+/// Returns true if `path` exists and is a directory.
+pub(crate) fn builtin_file_is_dir(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(path)] => Ok(Value::Bool(Path::new(path.as_str()).is_dir())),
+        [other] => Err(format!(
+            "file_is_dir: expected string path, got {:?}",
+            other
+        )),
+        _ => Err(format!(
+            "file_is_dir: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `file_is_file(path: string) -> bool`
+///
+/// Returns true if `path` exists and is a regular file.
+pub(crate) fn builtin_file_is_file(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(path)] => Ok(Value::Bool(Path::new(path.as_str()).is_file())),
+        [other] => Err(format!(
+            "file_is_file: expected string path, got {:?}",
+            other
+        )),
+        _ => Err(format!(
+            "file_is_file: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `file_size(path: string) -> Result<int, string>`
+///
+/// Returns `Ok(size_in_bytes)` or `Err(message)`.
+pub(crate) fn builtin_file_size(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(path)] => match std::fs::metadata(path.as_str()) {
+            Ok(meta) => Ok(ok(Value::Int(meta.len() as i64))),
+            Err(e) => Ok(err(format!("file_size: {}: {}", path, e))),
+        },
+        [other] => Err(format!("file_size: expected string path, got {:?}", other)),
+        _ => Err(format!(
+            "file_size: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `file_stat(path: string) -> Result<FileMeta, string>`
+///
+/// Returns a `FileMeta` struct with fields:
+///   - `size: int`       — byte count
+///   - `modified: int`   — seconds since Unix epoch (0 if unavailable)
+///   - `is_dir: bool`    — is directory
+///   - `is_file: bool`   — is regular file
+pub(crate) fn builtin_file_stat(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(path)] => match std::fs::metadata(path.as_str()) {
+            Ok(meta) => {
+                let modified = meta
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0);
+                let file_meta = Value::Struct {
+                    name: "FileMeta".to_string(),
+                    fields: vec![
+                        ("size".to_string(), Value::Int(meta.len() as i64)),
+                        ("modified".to_string(), Value::Int(modified)),
+                        ("is_dir".to_string(), Value::Bool(meta.is_dir())),
+                        ("is_file".to_string(), Value::Bool(meta.is_file())),
+                    ],
+                };
+                Ok(ok(file_meta))
+            }
+            Err(e) => Ok(err(format!("file_stat: {}: {}", path, e))),
+        },
+        [other] => Err(format!("file_stat: expected string path, got {:?}", other)),
+        _ => Err(format!(
+            "file_stat: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `dir_list(path: string) -> Result<[string], string>`
+///
+/// Returns a sorted list of entry names (not full paths) inside `path`.
+pub(crate) fn builtin_dir_list(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(path)] => match std::fs::read_dir(path.as_str()) {
+            Ok(entries) => {
+                let mut names: Vec<String> = entries
+                    .filter_map(|e| {
+                        e.ok()
+                            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                    })
+                    .collect();
+                names.sort();
+                let arr = Value::Array(names.into_iter().map(Value::String).collect());
+                Ok(ok(arr))
+            }
+            Err(e) => Ok(err(format!("dir_list: {}: {}", path, e))),
+        },
+        [other] => Err(format!("dir_list: expected string path, got {:?}", other)),
+        _ => Err(format!("dir_list: expected 1 argument, got {}", args.len())),
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -682,6 +682,8 @@ mod wcet_contracts;
 mod process_exec;
 // RES-2555: TCP/UDP networking (std-only).
 mod tcp_udp;
+// RES-2557: file metadata (std-only).
+mod file_meta;
 
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
@@ -13051,6 +13053,13 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     ("rwlock_read", crate::mutex_rwlock::builtin_rwlock_read),
     ("rwlock_write", crate::mutex_rwlock::builtin_rwlock_write),
     ("rwlock_unlock", crate::mutex_rwlock::builtin_rwlock_unlock),
+    // RES-2557: file metadata builtins (std-only).
+    ("file_exists", crate::file_meta::builtin_file_exists),
+    ("file_is_dir", crate::file_meta::builtin_file_is_dir),
+    ("file_is_file", crate::file_meta::builtin_file_is_file),
+    ("file_size", crate::file_meta::builtin_file_size),
+    ("file_stat", crate::file_meta::builtin_file_stat),
+    ("dir_list", crate::file_meta::builtin_dir_list),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2106,6 +2106,49 @@ impl TypeChecker {
                         return_type: Box::new(Type::Result),
                     },
                 );
+                // RES-2557: file metadata builtins (std-only).
+                env.set(
+                    "file_exists".to_string(),
+                    Type::Function {
+                        params: vec![Type::String],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
+                env.set(
+                    "file_is_dir".to_string(),
+                    Type::Function {
+                        params: vec![Type::String],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
+                env.set(
+                    "file_is_file".to_string(),
+                    Type::Function {
+                        params: vec![Type::String],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
+                env.set(
+                    "file_size".to_string(),
+                    Type::Function {
+                        params: vec![Type::String],
+                        return_type: Box::new(Type::Result),
+                    },
+                );
+                env.set(
+                    "file_stat".to_string(),
+                    Type::Function {
+                        params: vec![Type::String],
+                        return_type: Box::new(Type::Result),
+                    },
+                );
+                env.set(
+                    "dir_list".to_string(),
+                    Type::Function {
+                        params: vec![Type::String],
+                        return_type: Box::new(Type::Result),
+                    },
+                );
                 // RES-2554: JSON serialization builtins.
                 env.set(
                     "to_json".to_string(),


### PR DESCRIPTION
## Summary

Adds six file-metadata builtins to the Resilient stdlib, closing #2557.

All builtins live in `resilient/src/file_meta.rs` (feature-isolation pattern). Minimal additions to `lib.rs` BUILTINS array and `typechecker.rs` env registration block.

## New builtins

| Function | Return type | Description |
|---|---|---|
| `file_exists(path)` | `bool` | true if path exists (any kind) |
| `file_is_dir(path)` | `bool` | true if path is a directory |
| `file_is_file(path)` | `bool` | true if path is a regular file |
| `file_size(path)` | `Result<int, string>` | byte count |
| `file_stat(path)` | `Result<FileMeta, string>` | size, modified (unix epoch), is_dir, is_file |
| `dir_list(path)` | `Result<[string], string>` | sorted entry names |

## Acceptance criteria

- [x] `file_exists(path) -> bool`
- [x] `file_stat(path) -> Result<FileMeta, string>`
- [x] `file_is_dir(path) -> bool`
- [x] `file_is_file(path) -> bool`
- [x] `file_size(path) -> Result<int, string>`
- [x] `dir_list(path) -> Result<[string], string>`
- [x] Golden test (`resilient/examples/file_meta.rz` + `.expected.txt`)
- [x] All 5400 tests pass

Closes #2557

🤖 Generated with [Claude Code](https://claude.com/claude-code)