### PR TITLE
RES-2555: TCP/UDP socket builtins

### DIFF
--- a/resilient/examples/tcp_udp.expected.txt
+++ b/resilient/examples/tcp_udp.expected.txt
@@ -1,0 +1,13 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+Program executed successfully

--- a/resilient/examples/tcp_udp.rz
+++ b/resilient/examples/tcp_udp.rz
@@ -1,0 +1,36 @@
+// RES-2555: TCP/UDP networking builtins.
+// This example uses loopback sockets to test the API without external servers.
+
+// Test 1: TCP echo (listen, connect, write, read, close).
+let listener = unwrap(tcp_listen("127.0.0.1", 19555));
+println(listener.id > 0);
+
+let conn = unwrap(tcp_connect("127.0.0.1", 19555));
+println(conn.id > 0);
+
+let accepted = unwrap(tcp_accept(listener));
+println(accepted.id > 0);
+
+// Write from conn side, read from accepted side.
+let written = unwrap(tcp_write(conn, "hello"));
+println(written == 5);
+
+let received = unwrap(tcp_read(accepted, 16));
+println(received == "hello");
+
+println(tcp_close(conn));
+println(tcp_close(accepted));
+
+// Test 2: UDP loopback.
+let sender = unwrap(udp_bind("127.0.0.1", 19556));
+let recver = unwrap(udp_bind("127.0.0.1", 19557));
+println(sender.id > 0);
+
+let sent = unwrap(udp_send_to(sender, "ping", "127.0.0.1", 19557));
+println(sent == 4);
+
+let msg = unwrap(udp_recv_from(recver, 64));
+println(msg == "ping");
+
+println(udp_close(sender));
+println(udp_close(recver));

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -673,6 +673,8 @@ mod vibe_debt;
 mod wcet_contracts;
 // RES-2558: process spawning (std-only).
 mod process_exec;
+// RES-2555: TCP/UDP networking (std-only).
+mod tcp_udp;
 
 #[allow(unused_imports)]
 use span::{Pos, Span, Spanned};
@@ -12875,6 +12877,18 @@ const BUILTINS: &[(&str, BuiltinFn)] = &[
     // RES-2558: process spawning builtins (std-only).
     ("exec", crate::process_exec::builtin_exec),
     ("exec_shell", crate::process_exec::builtin_exec_shell),
+    // RES-2555: TCP/UDP networking builtins (std-only).
+    ("tcp_connect", crate::tcp_udp::builtin_tcp_connect),
+    ("tcp_listen", crate::tcp_udp::builtin_tcp_listen),
+    ("tcp_accept", crate::tcp_udp::builtin_tcp_accept),
+    ("tcp_read", crate::tcp_udp::builtin_tcp_read),
+    ("tcp_write", crate::tcp_udp::builtin_tcp_write),
+    ("tcp_close", crate::tcp_udp::builtin_tcp_close),
+    ("tcp_set_timeout", crate::tcp_udp::builtin_tcp_set_timeout),
+    ("udp_bind", crate::tcp_udp::builtin_udp_bind),
+    ("udp_send_to", crate::tcp_udp::builtin_udp_send_to),
+    ("udp_recv_from", crate::tcp_udp::builtin_udp_recv_from),
+    ("udp_close", crate::tcp_udp::builtin_udp_close),
 ];
 
 /// Print the single argument followed by a newline and return `Void`.

--- a/resilient/src/tcp_udp.rs
+++ b/resilient/src/tcp_udp.rs
@@ -1,0 +1,400 @@
+//! RES-2555: TCP/UDP socket builtins (std-only).
+//!
+//! TCP connections are represented as `Value::Struct { name: "TcpConn", fields: [("id", Int(N))] }`.
+//! TCP listeners are `Value::Struct { name: "TcpListener", fields: [("id", Int(N))] }`.
+//! UDP sockets are `Value::Struct { name: "UdpSocket", fields: [("id", Int(N))] }`.
+//!
+//! Handle ids are minted by monotonic counters and stored in thread-local registries
+//! keyed by id. Closing a handle removes it from the registry so stale handles
+//! surface `unknown handle` errors.
+
+use crate::Value;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream, UdpSocket};
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::Duration;
+
+type RResult<T> = Result<T, String>;
+
+// ---------------------------------------------------------------------------
+// Handle registries
+// ---------------------------------------------------------------------------
+
+static NEXT_TCP_CONN: AtomicI64 = AtomicI64::new(1);
+static NEXT_TCP_LISTENER: AtomicI64 = AtomicI64::new(1);
+static NEXT_UDP: AtomicI64 = AtomicI64::new(1);
+
+thread_local! {
+    static TCP_CONNS: RefCell<HashMap<i64, TcpStream>> = RefCell::new(HashMap::new());
+    static TCP_LISTENERS: RefCell<HashMap<i64, TcpListener>> = RefCell::new(HashMap::new());
+    static UDP_SOCKETS: RefCell<HashMap<i64, UdpSocket>> = RefCell::new(HashMap::new());
+}
+
+fn ok(v: Value) -> Value {
+    Value::Result {
+        ok: true,
+        payload: Box::new(v),
+    }
+}
+
+fn err(msg: String) -> Value {
+    Value::Result {
+        ok: false,
+        payload: Box::new(Value::String(msg)),
+    }
+}
+
+fn tcp_conn_handle(id: i64) -> Value {
+    Value::Struct {
+        name: "TcpConn".to_string(),
+        fields: vec![("id".to_string(), Value::Int(id))],
+    }
+}
+
+fn tcp_listener_handle(id: i64) -> Value {
+    Value::Struct {
+        name: "TcpListener".to_string(),
+        fields: vec![("id".to_string(), Value::Int(id))],
+    }
+}
+
+fn udp_socket_handle(id: i64) -> Value {
+    Value::Struct {
+        name: "UdpSocket".to_string(),
+        fields: vec![("id".to_string(), Value::Int(id))],
+    }
+}
+
+fn extract_handle_id(v: &Value, kind: &str) -> RResult<i64> {
+    match v {
+        Value::Struct { name, fields } => {
+            for (k, val) in fields {
+                if k == "id" {
+                    return match val {
+                        Value::Int(i) => Ok(*i),
+                        _ => Err(format!("{}: invalid handle id", kind)),
+                    };
+                }
+            }
+            Err(format!(
+                "{}: expected {} handle, got struct '{}'",
+                kind, kind, name
+            ))
+        }
+        _ => Err(format!("{}: expected {} handle, got {:?}", kind, kind, v)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TCP builtins
+// ---------------------------------------------------------------------------
+
+/// `tcp_connect(host: string, port: int) -> Result<TcpConn, string>`
+///
+/// Opens a TCP connection to `host:port`. Returns `Ok(TcpConn)` or `Err(msg)`.
+pub(crate) fn builtin_tcp_connect(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(host), Value::Int(port)] => {
+            let addr = format!("{}:{}", host, port);
+            match TcpStream::connect(addr.as_str()) {
+                Ok(stream) => {
+                    let id = NEXT_TCP_CONN.fetch_add(1, Ordering::Relaxed);
+                    TCP_CONNS.with(|r| r.borrow_mut().insert(id, stream));
+                    Ok(ok(tcp_conn_handle(id)))
+                }
+                Err(e) => Ok(err(format!("tcp_connect: {}: {}", addr, e))),
+            }
+        }
+        _ => Err(format!(
+            "tcp_connect: expected (string host, int port), got {} arg(s)",
+            args.len()
+        )),
+    }
+}
+
+/// `tcp_listen(host: string, port: int) -> Result<TcpListener, string>`
+///
+/// Binds a TCP listener on `host:port`. Returns `Ok(TcpListener)` or `Err(msg)`.
+pub(crate) fn builtin_tcp_listen(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(host), Value::Int(port)] => {
+            let addr = format!("{}:{}", host, port);
+            match TcpListener::bind(addr.as_str()) {
+                Ok(listener) => {
+                    let id = NEXT_TCP_LISTENER.fetch_add(1, Ordering::Relaxed);
+                    TCP_LISTENERS.with(|r| r.borrow_mut().insert(id, listener));
+                    Ok(ok(tcp_listener_handle(id)))
+                }
+                Err(e) => Ok(err(format!("tcp_listen: {}: {}", addr, e))),
+            }
+        }
+        _ => Err(format!(
+            "tcp_listen: expected (string host, int port), got {} arg(s)",
+            args.len()
+        )),
+    }
+}
+
+/// `tcp_accept(listener: TcpListener) -> Result<TcpConn, string>`
+///
+/// Accepts the next incoming connection on `listener`. Blocks until
+/// a connection arrives. Returns `Ok(TcpConn)` or `Err(msg)`.
+pub(crate) fn builtin_tcp_accept(args: &[Value]) -> RResult<Value> {
+    match args {
+        [handle] => {
+            let id = extract_handle_id(handle, "tcp_accept")?;
+            let result = TCP_LISTENERS.with(|r| {
+                let borrow = r.borrow();
+                match borrow.get(&id) {
+                    Some(listener) => listener.accept().map_err(|e| format!("tcp_accept: {}", e)),
+                    None => Err(format!(
+                        "tcp_accept: unknown or closed listener handle {}",
+                        id
+                    )),
+                }
+            });
+            match result {
+                Ok((stream, _addr)) => {
+                    let conn_id = NEXT_TCP_CONN.fetch_add(1, Ordering::Relaxed);
+                    TCP_CONNS.with(|r| r.borrow_mut().insert(conn_id, stream));
+                    Ok(ok(tcp_conn_handle(conn_id)))
+                }
+                Err(e) => Ok(err(e)),
+            }
+        }
+        _ => Err(format!(
+            "tcp_accept: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `tcp_read(conn: TcpConn, max_bytes: int) -> Result<string, string>`
+///
+/// Reads up to `max_bytes` from the connection. Returns the data as a
+/// UTF-8 string (invalid bytes are replaced with U+FFFD). `Err` on
+/// connection error.
+pub(crate) fn builtin_tcp_read(args: &[Value]) -> RResult<Value> {
+    match args {
+        [handle, Value::Int(max_bytes)] => {
+            let id = extract_handle_id(handle, "tcp_read")?;
+            let cap = (*max_bytes).max(0) as usize;
+            let result = TCP_CONNS.with(|r| {
+                let mut borrow = r.borrow_mut();
+                match borrow.get_mut(&id) {
+                    Some(stream) => {
+                        let mut buf = vec![0u8; cap];
+                        stream
+                            .read(&mut buf)
+                            .map(|n| buf[..n].to_vec())
+                            .map_err(|e| format!("tcp_read: {}", e))
+                    }
+                    None => Err(format!("tcp_read: unknown or closed connection {}", id)),
+                }
+            });
+            match result {
+                Ok(bytes) => Ok(ok(Value::String(
+                    String::from_utf8_lossy(&bytes).into_owned(),
+                ))),
+                Err(e) => Ok(err(e)),
+            }
+        }
+        _ => Err(format!(
+            "tcp_read: expected (TcpConn, int max_bytes), got {} arg(s)",
+            args.len()
+        )),
+    }
+}
+
+/// `tcp_write(conn: TcpConn, data: string) -> Result<int, string>`
+///
+/// Writes `data` to the connection. Returns `Ok(bytes_written)` or `Err(msg)`.
+pub(crate) fn builtin_tcp_write(args: &[Value]) -> RResult<Value> {
+    match args {
+        [handle, Value::String(data)] => {
+            let id = extract_handle_id(handle, "tcp_write")?;
+            let result = TCP_CONNS.with(|r| {
+                let mut borrow = r.borrow_mut();
+                match borrow.get_mut(&id) {
+                    Some(stream) => stream
+                        .write_all(data.as_bytes())
+                        .map(|_| data.len())
+                        .map_err(|e| format!("tcp_write: {}", e)),
+                    None => Err(format!("tcp_write: unknown or closed connection {}", id)),
+                }
+            });
+            match result {
+                Ok(n) => Ok(ok(Value::Int(n as i64))),
+                Err(e) => Ok(err(e)),
+            }
+        }
+        _ => Err(format!(
+            "tcp_write: expected (TcpConn, string data), got {} arg(s)",
+            args.len()
+        )),
+    }
+}
+
+/// `tcp_close(conn: TcpConn) -> bool`
+///
+/// Closes the connection and removes it from the registry. Returns `true`
+/// if the handle existed, `false` if it was already closed.
+pub(crate) fn builtin_tcp_close(args: &[Value]) -> RResult<Value> {
+    match args {
+        [handle] => {
+            let id = extract_handle_id(handle, "tcp_close")?;
+            let existed = TCP_CONNS.with(|r| r.borrow_mut().remove(&id).is_some());
+            Ok(Value::Bool(existed))
+        }
+        _ => Err(format!(
+            "tcp_close: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}
+
+/// `tcp_set_timeout(conn: TcpConn, ms: int) -> bool`
+///
+/// Sets read/write timeout in milliseconds. `0` means no timeout.
+pub(crate) fn builtin_tcp_set_timeout(args: &[Value]) -> RResult<Value> {
+    match args {
+        [handle, Value::Int(ms)] => {
+            let id = extract_handle_id(handle, "tcp_set_timeout")?;
+            let timeout = if *ms <= 0 {
+                None
+            } else {
+                Some(Duration::from_millis(*ms as u64))
+            };
+            let ok = TCP_CONNS.with(|r| {
+                let borrow = r.borrow();
+                if let Some(stream) = borrow.get(&id) {
+                    stream.set_read_timeout(timeout).is_ok()
+                        && stream.set_write_timeout(timeout).is_ok()
+                } else {
+                    false
+                }
+            });
+            Ok(Value::Bool(ok))
+        }
+        _ => Err(format!(
+            "tcp_set_timeout: expected (TcpConn, int ms), got {} arg(s)",
+            args.len()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// UDP builtins
+// ---------------------------------------------------------------------------
+
+/// `udp_bind(host: string, port: int) -> Result<UdpSocket, string>`
+///
+/// Binds a UDP socket on `host:port`. Returns `Ok(UdpSocket)` or `Err(msg)`.
+pub(crate) fn builtin_udp_bind(args: &[Value]) -> RResult<Value> {
+    match args {
+        [Value::String(host), Value::Int(port)] => {
+            let addr = format!("{}:{}", host, port);
+            match UdpSocket::bind(addr.as_str()) {
+                Ok(socket) => {
+                    let id = NEXT_UDP.fetch_add(1, Ordering::Relaxed);
+                    UDP_SOCKETS.with(|r| r.borrow_mut().insert(id, socket));
+                    Ok(ok(udp_socket_handle(id)))
+                }
+                Err(e) => Ok(err(format!("udp_bind: {}: {}", addr, e))),
+            }
+        }
+        _ => Err(format!(
+            "udp_bind: expected (string host, int port), got {} arg(s)",
+            args.len()
+        )),
+    }
+}
+
+/// `udp_send_to(sock: UdpSocket, data: string, host: string, port: int) -> Result<int, string>`
+///
+/// Sends `data` to `host:port`. Returns `Ok(bytes_sent)` or `Err(msg)`.
+pub(crate) fn builtin_udp_send_to(args: &[Value]) -> RResult<Value> {
+    match args {
+        [
+            handle,
+            Value::String(data),
+            Value::String(host),
+            Value::Int(port),
+        ] => {
+            let id = extract_handle_id(handle, "udp_send_to")?;
+            let addr = format!("{}:{}", host, port);
+            let result = UDP_SOCKETS.with(|r| {
+                let borrow = r.borrow();
+                match borrow.get(&id) {
+                    Some(socket) => socket
+                        .send_to(data.as_bytes(), addr.as_str())
+                        .map_err(|e| format!("udp_send_to: {}", e)),
+                    None => Err(format!("udp_send_to: unknown or closed socket {}", id)),
+                }
+            });
+            match result {
+                Ok(n) => Ok(ok(Value::Int(n as i64))),
+                Err(e) => Ok(err(e)),
+            }
+        }
+        _ => Err(format!(
+            "udp_send_to: expected (UdpSocket, string data, string host, int port), got {} arg(s)",
+            args.len()
+        )),
+    }
+}
+
+/// `udp_recv_from(sock: UdpSocket, max_bytes: int) -> Result<string, string>`
+///
+/// Receives up to `max_bytes`. Returns `Ok(data)` — the sender address
+/// is not currently returned (add as a follow-up if needed).
+pub(crate) fn builtin_udp_recv_from(args: &[Value]) -> RResult<Value> {
+    match args {
+        [handle, Value::Int(max_bytes)] => {
+            let id = extract_handle_id(handle, "udp_recv_from")?;
+            let cap = (*max_bytes).max(0) as usize;
+            let result = UDP_SOCKETS.with(|r| {
+                let borrow = r.borrow();
+                match borrow.get(&id) {
+                    Some(socket) => {
+                        let mut buf = vec![0u8; cap];
+                        socket
+                            .recv_from(&mut buf)
+                            .map(|(n, _src)| buf[..n].to_vec())
+                            .map_err(|e| format!("udp_recv_from: {}", e))
+                    }
+                    None => Err(format!("udp_recv_from: unknown or closed socket {}", id)),
+                }
+            });
+            match result {
+                Ok(bytes) => Ok(ok(Value::String(
+                    String::from_utf8_lossy(&bytes).into_owned(),
+                ))),
+                Err(e) => Ok(err(e)),
+            }
+        }
+        _ => Err(format!(
+            "udp_recv_from: expected (UdpSocket, int max_bytes), got {} arg(s)",
+            args.len()
+        )),
+    }
+}
+
+/// `udp_close(sock: UdpSocket) -> bool`
+///
+/// Closes the UDP socket. Returns `true` if it existed.
+pub(crate) fn builtin_udp_close(args: &[Value]) -> RResult<Value> {
+    match args {
+        [handle] => {
+            let id = extract_handle_id(handle, "udp_close")?;
+            let existed = UDP_SOCKETS.with(|r| r.borrow_mut().remove(&id).is_some());
+            Ok(Value::Bool(existed))
+        }
+        _ => Err(format!(
+            "udp_close: expected 1 argument, got {}",
+            args.len()
+        )),
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -2029,6 +2029,65 @@ impl TypeChecker {
                         return_type: Box::new(Type::Int),
                     },
                 );
+                // RES-2555: TCP/UDP networking builtins (std-only).
+                for name in &["tcp_connect", "tcp_listen", "tcp_read", "tcp_write"] {
+                    env.set(
+                        (*name).to_string(),
+                        Type::Function {
+                            params: vec![Type::Any, Type::Any],
+                            return_type: Box::new(Type::Result),
+                        },
+                    );
+                }
+                env.set(
+                    "tcp_accept".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Result),
+                    },
+                );
+                env.set(
+                    "tcp_close".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
+                env.set(
+                    "tcp_set_timeout".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any, Type::Int],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
+                env.set(
+                    "udp_bind".to_string(),
+                    Type::Function {
+                        params: vec![Type::String, Type::Int],
+                        return_type: Box::new(Type::Result),
+                    },
+                );
+                env.set(
+                    "udp_send_to".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any, Type::String, Type::String, Type::Int],
+                        return_type: Box::new(Type::Result),
+                    },
+                );
+                env.set(
+                    "udp_recv_from".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any, Type::Int],
+                        return_type: Box::new(Type::Result),
+                    },
+                );
+                env.set(
+                    "udp_close".to_string(),
+                    Type::Function {
+                        params: vec![Type::Any],
+                        return_type: Box::new(Type::Bool),
+                    },
+                );
                 // RES-2558: process execution builtins (std-only). Return Result<Struct>.
                 env.set(
                     "exec".to_string(),


### PR DESCRIPTION
## Summary

- Adds `src/tcp_udp.rs` with full TCP and UDP networking builtins backed by thread-local handle registries (same pattern as `file_io.rs`)
- TCP: `tcp_listen`, `tcp_connect`, `tcp_accept`, `tcp_read`, `tcp_write`, `tcp_close`, `tcp_set_timeout`
- UDP: `udp_bind`, `udp_send_to`, `udp_recv_from`, `udp_close`
- Handles represented as `Value::Struct { name: "TcpConn" | "TcpListener" | "UdpSocket", fields: [("id", Int(N))] }`
- Minimal `lib.rs` + `typechecker.rs` additions following feature-isolation pattern
- Golden example `examples/tcp_udp.rz` tests loopback TCP echo + UDP round-trip

## Test plan

- [x] `cargo test` — all 501 golden tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `resilient/examples/tcp_udp.rz` runs end-to-end with all 12 expected `true` outputs

Closes #2555

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>