### PR TITLE
RES-2800: iterator protocol — for-in over custom iterator functions

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,3 +1,16 @@
 {
-  "claims": {}
+  "claims": {
+    "resilient/src/lib.rs": {
+      "branch": "res-2800-iterator-protocol",
+      "claimed_at": "2026-05-31T08:54:26Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-2800-iterator-protocol",
+      "claimed_at": "2026-05-31T08:54:26Z"
+    },
+    "resilient/src/lexer_logos.rs": {
+      "branch": "res-2800-iterator-protocol",
+      "claimed_at": "2026-05-31T08:54:26Z"
+    }
+  }
 }

--- a/resilient/examples/iterator_protocol.expected.txt
+++ b/resilient/examples/iterator_protocol.expected.txt
@@ -1,0 +1,10 @@
+0
+1
+2
+3
+4
+10
+11
+12
+done
+Program executed successfully

--- a/resilient/examples/iterator_protocol.rz
+++ b/resilient/examples/iterator_protocol.rz
@@ -1,0 +1,42 @@
+// RES-2800: iterator protocol — for-in over custom iterator functions.
+// A function returning Option<T> can be used as a for-in iterable.
+
+fn make_counter(int max) {
+    let count = 0
+    fn next() {
+        if count >= max {
+            return None
+        }
+        let val = count
+        count = count + 1
+        return Some(val)
+    }
+    return next
+}
+
+// Basic iteration
+let counter = make_counter(5)
+for x in counter {
+    println(x)
+}
+
+// Iterator with break
+fn make_range(int start, int end_val) {
+    let current = start
+    fn next() {
+        if current >= end_val {
+            return None
+        }
+        let val = current
+        current = current + 1
+        return Some(val)
+    }
+    return next
+}
+
+let r = make_range(10, 20)
+for x in r {
+    if x >= 13 { break; }
+    println(x)
+}
+println("done")

--- a/resilient/src/iterator_protocol.rs
+++ b/resilient/src/iterator_protocol.rs
@@ -116,4 +116,87 @@ mod tests {
         assert!(check(&prog, "test").is_ok());
         crate::feature_attrs::reset();
     }
+
+    #[test]
+    fn for_in_closure_iterator() {
+        let r = crate::run_program(
+            r#"
+fn counter(int max) {
+    let n = 0
+    fn next() {
+        if n >= max { return None }
+        let v = n
+        n = n + 1
+        return Some(v)
+    }
+    return next
+}
+for x in counter(4) {
+    println(x)
+}
+"#,
+        );
+        assert!(r.ok, "errors: {:?}", r.errors);
+        let lines: Vec<&str> = r.stdout.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines, vec!["0", "1", "2", "3"]);
+    }
+
+    #[test]
+    fn for_in_iterator_with_break() {
+        let r = crate::run_program(
+            r#"
+fn counter(int max) {
+    let n = 0
+    fn next() {
+        if n >= max { return None }
+        let v = n
+        n = n + 1
+        return Some(v)
+    }
+    return next
+}
+for x in counter(100) {
+    if x >= 3 { break; }
+    println(x)
+}
+"#,
+        );
+        assert!(r.ok, "errors: {:?}", r.errors);
+        let lines: Vec<&str> = r.stdout.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines, vec!["0", "1", "2"]);
+    }
+
+    #[test]
+    fn for_in_empty_iterator() {
+        let r = crate::run_program(
+            r#"
+fn empty() {
+    fn next() { return None }
+    return next
+}
+for x in empty() {
+    println(x)
+}
+println("done")
+"#,
+        );
+        assert!(r.ok, "errors: {:?}", r.errors);
+        assert_eq!(r.stdout.trim(), "done");
+    }
+
+    #[test]
+    fn non_option_iterator_errors() {
+        let r = crate::run_program(
+            r#"
+fn bad_iter() {
+    fn next() { return 42 }
+    return next
+}
+for x in bad_iter() {
+    println(x)
+}
+"#,
+        );
+        assert!(!r.ok, "should error when next() returns non-Option");
+    }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -26094,9 +26094,25 @@ impl Interpreter {
                 keys.sort_unstable_by(|a, b| crate::map_entries_merge::cmp_map_keys(a, b));
                 keys.into_iter().map(|k| k.to_value()).collect()
             }
+            Value::Function(_) | Value::Builtin { .. } => {
+                return self.eval_for_in_iterator(iter_val, name, body, label);
+            }
+            Value::Struct {
+                name: ref sname, ..
+            } if crate::iterator_protocol::is_iterator(sname) => {
+                let mangled = format!("{}$next", sname);
+                if let Some(method_val) = self.env.get(&mangled) {
+                    let iter_fn = method_val;
+                    return self.eval_for_in_iterator_method(iter_val, iter_fn, name, body, label);
+                }
+                return Err(format!(
+                    "type `{}` implements Iterator but has no `next` method",
+                    sname
+                ));
+            }
             other => {
                 return Err(format!(
-                    "`for` iterable must be an array or map, got {}",
+                    "`for` iterable must be an array, map, or iterator, got {}",
                     other
                 ));
             }
@@ -26133,6 +26149,110 @@ impl Interpreter {
             }
         }
         Ok(Value::Void)
+    }
+
+    /// RES-2800: for-in loop over a custom iterator. Calls `next()` on the
+    /// struct until it returns `None`. `Some(v)` unwraps to the loop variable.
+    /// RES-2800: for-in over a callable iterator. Calls the function/closure
+    /// with zero arguments until it returns `None`.
+    fn eval_for_in_iterator(
+        &mut self,
+        iter_fn: Value,
+        var_name: &str,
+        body: &Node,
+        label: Option<&str>,
+    ) -> RResult<Value> {
+        const MAX_ITERS: usize = 1_000_000;
+        let mut iters = 0usize;
+        loop {
+            iters += 1;
+            if iters > MAX_ITERS {
+                return Err(format!(
+                    "iterator exceeded {MAX_ITERS} calls to next() (runaway?)"
+                ));
+            }
+            let next_result = self.apply_function(&iter_fn, vec![])?;
+            if !Self::bind_iterator_value(&next_result, var_name, &mut self.env)? {
+                break;
+            }
+            if let Some(v) = self.eval_loop_body(body, label)? {
+                return Ok(v);
+            }
+        }
+        Ok(Value::Void)
+    }
+
+    /// RES-2800: for-in over a struct implementing Iterator. Calls `next(self)`
+    /// passing the struct value each iteration.
+    fn eval_for_in_iterator_method(
+        &mut self,
+        iterable: Value,
+        method_val: Value,
+        var_name: &str,
+        body: &Node,
+        label: Option<&str>,
+    ) -> RResult<Value> {
+        const MAX_ITERS: usize = 1_000_000;
+        let mut iters = 0usize;
+        loop {
+            iters += 1;
+            if iters > MAX_ITERS {
+                return Err(format!(
+                    "iterator exceeded {MAX_ITERS} calls to next() (runaway?)"
+                ));
+            }
+            let next_result = self.apply_function(&method_val, vec![iterable.clone()])?;
+            if !Self::bind_iterator_value(&next_result, var_name, &mut self.env)? {
+                break;
+            }
+            if let Some(v) = self.eval_loop_body(body, label)? {
+                return Ok(v);
+            }
+        }
+        Ok(Value::Void)
+    }
+
+    /// Extract `Some(v)` from an Option enum variant and bind it as the loop
+    /// variable. Returns `false` when `None` is encountered (loop should stop).
+    fn bind_iterator_value(result: &Value, var_name: &str, env: &mut Environment) -> RResult<bool> {
+        match result {
+            Value::Option(None) => Ok(false),
+            Value::Option(Some(inner)) => {
+                env.set(var_name.to_string(), inner.as_ref().clone());
+                Ok(true)
+            }
+            other => Err(format!(
+                "iterator next() must return Option (Some/None), got {}",
+                other
+            )),
+        }
+    }
+
+    /// Evaluate a loop body and handle break/continue/return signals.
+    /// Returns `Some(value)` when the loop should exit, `None` to continue.
+    fn eval_loop_body(&mut self, body: &Node, label: Option<&str>) -> RResult<Option<Value>> {
+        let result = self.eval(body)?;
+        if let Value::Return(_) = result {
+            return Ok(Some(result));
+        }
+        if matches!(result, Value::Break) {
+            return Ok(Some(Value::Void));
+        }
+        if let Value::BreakWith(v) = result {
+            return Ok(Some(*v));
+        }
+        if let Value::BreakLabel(ref lbl) = result {
+            if label == Some(lbl.as_str()) {
+                return Ok(Some(Value::Void));
+            }
+            return Ok(Some(result));
+        }
+        if let Value::ContinueLabel(ref lbl) = result
+            && label != Some(lbl.as_str())
+        {
+            return Ok(Some(result));
+        }
+        Ok(None)
     }
 
     /// RES-291 / RES-2548: helper for `Node::Range` evaluation as a value

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -8172,10 +8172,11 @@ impl TypeChecker {
                 // RES-2548: Range is also iterable.
                 if !matches!(
                     iter_ty,
-                    Type::Array | Type::String | Type::Any | Type::Range
-                ) {
+                    Type::Array | Type::String | Type::Any | Type::Range | Type::Function { .. }
+                ) && !matches!(iter_ty, Type::Struct(_))
+                {
                     return Err(format!(
-                        "cannot iterate over type {} — for-in requires an array, range, or string",
+                        "cannot iterate over type {} — for-in requires an array, range, string, or iterator",
                         iter_ty
                     ));
                 }


### PR DESCRIPTION
Closes #2796

## Summary

- Enable `for x in iterator_fn { ... }` loops over closure-based iterators that return `Option<T>` (`Some(val)` to yield, `None` to stop)
- Support struct types implementing Iterator with a `next()` method via the existing iterator registry
- Handle `break`, `continue`, labeled loops, and `return` inside iterator for-in bodies
- Accept `Function`, `Builtin`, and Iterator-implementing `Struct` types in the typechecker's for-in validation

## Changes

- **`lib.rs`**: Added `eval_for_in_iterator()`, `eval_for_in_iterator_method()`, `bind_iterator_value()`, and `eval_loop_body()` methods; dispatch from `eval_for_in_in_scope` for Function/Builtin/Struct iterators
- **`typechecker.rs`**: Extended for-in type validation to accept `Function` and `Struct` types
- **`iterator_protocol.rs`**: Added 4 end-to-end tests (closure iteration, break, empty iterator, non-Option error)
- **`examples/iterator_protocol.rz`** + `.expected.txt`**: Golden test for closure-based iterators

## Test plan

- [x] All 4 new iterator tests pass
- [x] Full test suite passes (no regressions)
- [x] Clippy clean
- [x] Golden test output verified manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)