### PR TITLE
RES-2807: Float32 type gaps + panic elimination in production code

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,16 @@
 {
   "claims": {
     "resilient/src/typechecker.rs": {
-      "branch": "res-2805-generic-return-type-inference",
-      "claimed_at": "2026-05-31T12:50:20Z"
+      "branch": "res-2807-float32-gaps-panic-elimination",
+      "claimed_at": "2026-05-31T13:05:00Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "res-2807-float32-gaps-panic-elimination",
+      "claimed_at": "2026-05-31T13:05:00Z"
+    },
+    "resilient/src/mcp_tool_registry.rs": {
+      "branch": "res-2807-float32-gaps-panic-elimination",
+      "claimed_at": "2026-05-31T13:05:00Z"
     }
   }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -19141,7 +19141,7 @@ fn builtin_array_min(args: &[Value]) -> RResult<Value> {
                     }
                 }
             }
-            Ok(Value::Int(best.unwrap()))
+            Ok(Value::Int(best.unwrap_or(0)))
         }
         [other] => Err(format!("array_min: expected array, got {}", other)),
         _ => Err(format!(
@@ -19173,7 +19173,7 @@ fn builtin_array_max(args: &[Value]) -> RResult<Value> {
                     }
                 }
             }
-            Ok(Value::Int(best.unwrap()))
+            Ok(Value::Int(best.unwrap_or(0)))
         }
         [other] => Err(format!("array_max: expected array, got {}", other)),
         _ => Err(format!(
@@ -19207,7 +19207,7 @@ fn builtin_array_max_or(args: &[Value]) -> RResult<Value> {
                     }
                 }
             }
-            Ok(Value::Int(best.unwrap()))
+            Ok(Value::Int(best.unwrap_or(0)))
         }
         [a, b] => Err(format!(
             "array_max_or: expected (array, int), got ({}, {})",
@@ -19243,7 +19243,7 @@ fn builtin_array_min_or(args: &[Value]) -> RResult<Value> {
                     }
                 }
             }
-            Ok(Value::Int(best.unwrap()))
+            Ok(Value::Int(best.unwrap_or(0)))
         }
         [a, b] => Err(format!(
             "array_min_or: expected (array, int), got ({}, {})",

--- a/resilient/src/mcp_tool_registry.rs
+++ b/resilient/src/mcp_tool_registry.rs
@@ -190,7 +190,7 @@ impl McpBridgeRegistry {
 
     /// Register a new bridged tool.  Duplicate names are silently replaced.
     pub fn register(&self, tool: BridgedTool) {
-        let mut tools = self.tools.write().expect("registry lock poisoned");
+        let mut tools = self.tools.write().unwrap_or_else(|p| p.into_inner());
         if let Some(pos) = tools.iter().position(|t| t.name == tool.name) {
             tools[pos] = tool;
         } else {
@@ -200,7 +200,7 @@ impl McpBridgeRegistry {
 
     /// Return all registered tools.
     pub fn all_tools(&self) -> Vec<BridgedTool> {
-        self.tools.read().expect("registry lock poisoned").clone()
+        self.tools.read().unwrap_or_else(|p| p.into_inner()).clone()
     }
 
     /// Return only tools that are currently available.
@@ -223,7 +223,7 @@ impl McpBridgeRegistry {
     pub fn get(&self, name: &str) -> Option<BridgedTool> {
         self.tools
             .read()
-            .expect("registry lock poisoned")
+            .unwrap_or_else(|p| p.into_inner())
             .iter()
             .find(|t| t.name == name)
             .cloned()

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -8882,6 +8882,7 @@ impl TypeChecker {
                     "-" => {
                         if right_type != Type::Int
                             && right_type != Type::Float
+                            && right_type != Type::Float32
                             && right_type != Type::Any
                             && !is_pinned_int(&right_type)
                         {
@@ -8924,6 +8925,7 @@ impl TypeChecker {
                                 Type::String
                                     | Type::Int
                                     | Type::Float
+                                    | Type::Float32
                                     | Type::Bool
                                     | Type::Char
                                     | Type::Any
@@ -15891,5 +15893,29 @@ mod res2801_generic_struct_type_validation {
     #[test]
     fn char_concat_with_string_accepted() {
         check_ok("let c: char = 'x'\nlet s = \"hello\" + c\n");
+    }
+}
+
+#[cfg(test)]
+mod res2807_float32_gaps {
+    use crate::parse;
+    use crate::typechecker::TypeChecker;
+
+    fn check_ok(src: &str) {
+        let (prog, errs) = parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        TypeChecker::new()
+            .check_program(&prog)
+            .unwrap_or_else(|e| panic!("unexpected type error: {e}"));
+    }
+
+    #[test]
+    fn f32_string_concat_accepted() {
+        check_ok("let x: f32 = 3.14\nlet s = \"val: \" + x\n");
+    }
+
+    #[test]
+    fn f32_unary_minus_accepted() {
+        check_ok("let x: f32 = 3.14\nlet y: f32 = -x\n");
     }
 }


### PR DESCRIPTION
## Summary

- **Float32 string coercion**: `"value: " + f32_val` now accepted — was a false-positive type error
- **Float32 unary minus**: `-f32_val` now accepted — was a false-positive type error  
- **MCP registry panics**: replace 3x `.expect("poisoned")` on RwLock with `.unwrap_or_else(|p| p.into_inner())` matching existing codebase pattern
- **array_min/max panics**: replace 4x `.unwrap()` with `.unwrap_or(0)` to eliminate latent panic risk
- 2 new typechecker tests for Float32 gaps

## Test plan

- [x] `let s = "val: " + f32_val` now typechecks (was rejected)
- [x] `let y: f32 = -x` now typechecks (was rejected)
- [x] All 5550 tests pass (0 failures, 2 new)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #2807

🤖 Generated with [Claude Code](https://claude.com/claude-code)