### PR TITLE
RES-2824: precise info-flow taint + #[declassify] laundering

### DIFF
--- a/resilient/examples/info_flow_declassify.expected.txt
+++ b/resilient/examples/info_flow_declassify.expected.txt
@@ -1,0 +1,3 @@
+1
+0
+Program executed successfully

--- a/resilient/examples/info_flow_declassify.rz
+++ b/resilient/examples/info_flow_declassify.rz
@@ -1,0 +1,35 @@
+// RES-2824: information-flow declassification demo.
+//
+// `read_secret` is a `#[secret]` source — every value it returns is
+// classified. `publish` is a `#[public]` sink — its return value is
+// observable. Returning the secret directly would be rejected by the
+// info-flow pass (see info_flow_leak.rz), but routing it through the
+// `#[declassify]` function `redact` launders it, so `publish` compiles
+// and runs.
+
+#[secret]
+fn read_secret(int seed) -> int {
+    return seed * 7 + 3;
+}
+
+#[declassify]
+fn redact(int classified) -> int {
+    // Audited downgrade: collapse the secret to a coarse, non-sensitive
+    // bucket — here, just its sign — before publishing.
+    if classified > 0 {
+        return 1;
+    }
+    return 0;
+}
+
+#[public]
+fn publish(int seed) -> int {
+    return redact(read_secret(seed));
+}
+
+fn main() {
+    println(publish(5));
+    println(publish(-1));
+}
+
+main();

--- a/resilient/examples/info_flow_leak.rz
+++ b/resilient/examples/info_flow_leak.rz
@@ -1,0 +1,26 @@
+// RES-2824: information-flow leak — this example is REJECTED at compile
+// time, on purpose. `publish` is a `#[public]` sink that returns the
+// value of the `#[secret]` source `read_secret` directly, without
+// routing it through a `#[declassify]` function. The info-flow pass
+// reports the explicit flow and `rz check` exits non-zero.
+//
+// Compare with info_flow_declassify.rz, which launders the value and
+// therefore compiles. This file carries a sibling `.interactive` marker
+// so the stdout golden harness skips it; the rejection is asserted by
+// tests/info_flow_smoke.rs instead.
+
+#[secret]
+fn read_secret(int seed) -> int {
+    return seed * 7 + 3;
+}
+
+#[public]
+fn publish(int seed) -> int {
+    return read_secret(seed);
+}
+
+fn main() {
+    println(publish(5));
+}
+
+main();

--- a/resilient/src/feature_attrs.rs
+++ b/resilient/src/feature_attrs.rs
@@ -32,7 +32,7 @@
 //! | `#[property_test]` | `property_tests` | Auto-generated property tests |
 //! | `#[const_fn]` | `const_fn` | Compile-time evaluation |
 //! | `#[async_fn]` | `async_await` | Async function |
-//! | `#[secret]` / `#[public]` | `info_flow` | Information-flow tags |
+//! | `#[secret]` / `#[public]` / `#[declassify]` | `info_flow` | Information-flow tags |
 //! | `#[phantom]` | `phantom_types` | Type-erased marker |
 //! | `#[atomic]` | `atomic_types` | Lock-free primitive |
 //! | `#[lock_priority(N)]` | `lock_priority` | Static lock ordering |
@@ -268,6 +268,8 @@ pub fn is_known_attribute(name: &str) -> bool {
             | "async_fn"
             | "secret"
             | "public"
+            // RES-2824: information-flow laundering boundary.
+            | "declassify"
             | "phantom"
             | "atomic"
             | "lock_priority"

--- a/resilient/src/info_flow.rs
+++ b/resilient/src/info_flow.rs
@@ -1,18 +1,46 @@
 //! Feature 16/50 — Information Flow / Non-Interference Types.
 //!
-//! `#[secret]` marks a value or parameter as classified; `#[public]`
-//! marks one as observable. The compiler enforces that no `#[secret]`
-//! value reaches a `#[public]` sink without going through a
-//! declassification function tagged `#[declassify]`.
+//! `#[secret]` marks a function as a *source* of classified data: any
+//! value it returns is secret. `#[public]` marks a function as an
+//! *observable sink*: the value it returns is visible to an attacker.
+//! `#[declassify]` marks a *laundering boundary*: the value a
+//! declassify-tagged function returns is treated as public regardless of
+//! its arguments — the deliberate, audited downgrade point.
 //!
-//! This first slice tracks the secret/public classification on
-//! parameters and return types, builds the data-flow approximation
-//! at call sites, and reports any direct secret→public propagation.
+//! The non-interference property this pass enforces is the explicit-flow
+//! fragment of *"a `#[public]` function's output must not depend on
+//! `#[secret]` data"*: it propagates a **taint set** — the secret
+//! sources a value is derived from — through the body of every public
+//! function and rejects the function if any value it *returns* is still
+//! tainted.
+//!
+//! ### What counts as a flow
+//! - calling a `#[secret]` fn taints the result;
+//! - calling a `#[declassify]` fn launders it (the result is public);
+//! - calling any other fn passes taint through from its arguments;
+//! - `let` / assignment bind a variable to its initializer's taint;
+//! - infix / prefix operators, field / index access, and array / tuple
+//!   literals propagate taint from their operands;
+//! - `if` / `while` / `for` union-merge the taint a branch may assign.
+//!
+//! A secret value that is *computed and discarded* (never returned) is
+//! **not** a leak — that is the precision win over the original
+//! call-graph approximation (RES-2824), which flagged any transitive
+//! secret call even when the result never reached the public output.
+//!
+//! ### Out of scope (tracked follow-ups)
+//! - **Implicit flows**: a secret-derived branch condition that taints
+//!   what the branch assigns or returns. Sound handling needs
+//!   program-counter labels.
+//! - **Semantic non-interference** via self-composition + Z3
+//!   (`#[noninterference(low = …, high = …)]`), the rigorous companion
+//!   that *proves* output-independence rather than approximating
+//!   explicit flow.
 
 #![allow(clippy::collapsible_if, clippy::doc_lazy_continuation, dead_code)]
 
 use crate::Node;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Label {
@@ -21,6 +49,8 @@ pub enum Label {
     Unknown,
 }
 
+/// Legacy per-item label view, retained for external callers. The taint
+/// analysis below reads the function sets directly via [`collect_fns`].
 pub fn collect_param_labels() -> HashMap<String, Label> {
     let mut out = HashMap::new();
     for (item, _rec) in crate::feature_attrs::find_kind("secret") {
@@ -32,94 +62,204 @@ pub fn collect_param_labels() -> HashMap<String, Label> {
     out
 }
 
-pub fn check_program(program: &Node) -> Vec<String> {
-    let labels = collect_param_labels();
-    let mut errors = Vec::new();
-    if labels.is_empty() {
-        return errors;
-    }
-    // RES-1439: store `&str` borrows into the `labels` map rather
-    // than `&String` references. Then `walk_calls` can collect
-    // `&str` borrows of identifier names (skipping the per-callee
-    // `String::clone` it used to do), and the set membership check
-    // `secret_fns.contains(callee)` works directly on `&str`.
-    let secret_fns: HashSet<&str> = labels
-        .iter()
-        .filter(|(_, l)| **l == Label::Secret)
-        .map(|(k, _)| k.as_str())
-        .collect();
-    let public_fns: HashSet<&str> = labels
-        .iter()
-        .filter(|(_, l)| **l == Label::Public)
-        .map(|(k, _)| k.as_str())
-        .collect();
-
-    // RES-1527: skip the program walk when no public fn exists — the
-    // leak diagnostic only fires inside public-tagged fn bodies, so
-    // without any public fn the walk produces nothing.
-    if public_fns.is_empty() {
-        return errors;
-    }
-
-    let Node::Program(stmts) = program else {
-        return errors;
-    };
-    for s in stmts {
-        if let Node::Function { name, body, .. } = &s.node {
-            if public_fns.contains(name.as_str()) {
-                // walk body: any call to a secret-tagged fn is a leak.
-                let mut leaks: Vec<&str> = Vec::new();
-                walk_calls(body, &mut leaks);
-                for callee in leaks {
-                    if secret_fns.contains(callee) {
-                        errors.push(format!(
-                            "info-flow: `{}` is `#[public]` but transitively calls `#[secret]` fn `{}`",
-                            name, callee
-                        ));
-                    }
-                }
-            }
-        }
-    }
-    errors
+/// All function names carrying the attribute `kind` (`secret`, `public`,
+/// or `declassify`).
+fn collect_fns(kind: &str) -> HashSet<String> {
+    crate::feature_attrs::find_kind(kind)
+        .into_iter()
+        .map(|(item, _)| item)
+        .collect()
 }
 
-fn walk_calls<'a>(node: &'a Node, out: &mut Vec<&'a str>) {
+/// The set of `#[secret]` sources a value is derived from. Empty == the
+/// value is public. A `BTreeSet` keeps the diagnostic's source list
+/// deterministic.
+type Taint = BTreeSet<String>;
+
+/// The information-flow classification of every tagged function.
+struct Classes {
+    secret: HashSet<String>,
+    declassify: HashSet<String>,
+}
+
+/// Taint of an expression's *value*, given the current variable env.
+fn expr_taint(node: &Node, env: &HashMap<String, Taint>, cls: &Classes) -> Taint {
     match node {
+        Node::Identifier { name, .. } => env.get(name).cloned().unwrap_or_default(),
         Node::CallExpression {
             function,
             arguments,
             ..
         } => {
             if let Node::Identifier { name, .. } = function.as_ref() {
-                out.push(name.as_str());
+                if cls.declassify.contains(name) {
+                    // Laundered at the audited downgrade point: the result
+                    // is public no matter how secret the arguments were.
+                    return Taint::new();
+                }
+                if cls.secret.contains(name) {
+                    // Secret source: its result is classified regardless
+                    // of the arguments.
+                    let mut t = Taint::new();
+                    t.insert(name.clone());
+                    return t;
+                }
             }
+            // Ordinary callee (user fn, builtin, or a closure held in a
+            // variable): conservatively pass taint through from the
+            // arguments and the callee expression itself.
+            let mut t = expr_taint(function, env, cls);
             for a in arguments {
-                walk_calls(a, out);
+                t.extend(expr_taint(a, env, cls));
             }
+            t
         }
+        Node::InfixExpression { left, right, .. } => {
+            let mut t = expr_taint(left, env, cls);
+            t.extend(expr_taint(right, env, cls));
+            t
+        }
+        Node::PrefixExpression { right, .. } => expr_taint(right, env, cls),
+        Node::FieldAccess { target, .. } => expr_taint(target, env, cls),
+        Node::IndexExpression { target, index, .. } => {
+            let mut t = expr_taint(target, env, cls);
+            t.extend(expr_taint(index, env, cls));
+            t
+        }
+        Node::TryExpression { expr, .. } => expr_taint(expr, env, cls),
+        Node::ArrayLiteral { items, .. } | Node::TupleLiteral { items, .. } => {
+            let mut t = Taint::new();
+            for it in items {
+                t.extend(expr_taint(it, env, cls));
+            }
+            t
+        }
+        // Literals and constructs that do not carry a secret-derived
+        // scalar contribute no taint in this explicit-flow slice.
+        _ => Taint::new(),
+    }
+}
+
+/// Union the taint of every binding in `from` into `into`. Used to merge
+/// the environments of conditionally-executed branches back into the
+/// surrounding scope (sound over-approximation).
+fn merge_env(into: &mut HashMap<String, Taint>, from: &HashMap<String, Taint>) {
+    for (k, v) in from {
+        into.entry(k.clone()).or_default().extend(v.iter().cloned());
+    }
+}
+
+/// Walk a statement, updating `env` and pushing the taint of every
+/// returned value into `returns`.
+fn walk_stmt(
+    node: &Node,
+    env: &mut HashMap<String, Taint>,
+    cls: &Classes,
+    returns: &mut Vec<Taint>,
+) {
+    match node {
         Node::Block { stmts, .. } => {
             for s in stmts {
-                walk_calls(s, out);
+                walk_stmt(s, env, cls, returns);
             }
         }
-        Node::ReturnStatement { value: Some(e), .. } => walk_calls(e, out),
-        Node::LetStatement { value, .. } => walk_calls(value, out),
-        Node::ExpressionStatement { expr, .. } => walk_calls(expr, out),
+        Node::LetStatement { name, value, .. } | Node::Assignment { name, value, .. } => {
+            let t = expr_taint(value, env, cls);
+            env.insert(name.clone(), t);
+        }
+        Node::ReturnStatement { value: Some(e), .. } => {
+            returns.push(expr_taint(e, env, cls));
+        }
+        Node::ExpressionStatement { expr, .. } => {
+            // Evaluated for effect; the value is discarded, so it cannot
+            // reach the public output. (Implicit / side-channel flows are
+            // out of scope for this slice.)
+            let _ = expr_taint(expr, env, cls);
+        }
         Node::IfStatement {
-            condition,
             consequence,
             alternative,
             ..
         } => {
-            walk_calls(condition, out);
-            walk_calls(consequence, out);
-            if let Some(e) = alternative {
-                walk_calls(e, out);
+            let mut then_env = env.clone();
+            walk_stmt(consequence, &mut then_env, cls, returns);
+            if let Some(alt) = alternative {
+                let mut else_env = env.clone();
+                walk_stmt(alt, &mut else_env, cls, returns);
+                merge_env(env, &else_env);
             }
+            merge_env(env, &then_env);
+        }
+        Node::WhileStatement { body, .. } => {
+            let mut body_env = env.clone();
+            walk_stmt(body, &mut body_env, cls, returns);
+            merge_env(env, &body_env);
+        }
+        Node::ForInStatement {
+            name,
+            iterable,
+            body,
+            ..
+        } => {
+            let it = expr_taint(iterable, env, cls);
+            let mut body_env = env.clone();
+            body_env.insert(name.clone(), it);
+            walk_stmt(body, &mut body_env, cls, returns);
+            merge_env(env, &body_env);
         }
         _ => {}
     }
+}
+
+/// Return one diagnostic per `#[public]` function whose returned value is
+/// secret-derived (an explicit-flow leak). Empty when there is no leak.
+pub fn check_program(program: &Node) -> Vec<String> {
+    let secret = collect_fns("secret");
+    let public = collect_fns("public");
+    // Fast-reject: a leak can only fire inside a public-fn body that can
+    // reach a secret source.
+    if secret.is_empty() || public.is_empty() {
+        return Vec::new();
+    }
+    let cls = Classes {
+        secret,
+        declassify: collect_fns("declassify"),
+    };
+    let Node::Program(stmts) = program else {
+        return Vec::new();
+    };
+    let mut errors = Vec::new();
+    for s in stmts {
+        if let Node::Function {
+            name,
+            parameters,
+            body,
+            ..
+        } = &s.node
+        {
+            if !public.contains(name) {
+                continue;
+            }
+            // A public function's parameters are public inputs: untainted.
+            let mut env: HashMap<String, Taint> = parameters
+                .iter()
+                .map(|(_ty, pname)| (pname.clone(), Taint::new()))
+                .collect();
+            let mut returns = Vec::new();
+            walk_stmt(body, &mut env, &cls, &mut returns);
+            let mut leaked = Taint::new();
+            for r in returns {
+                leaked.extend(r);
+            }
+            if !leaked.is_empty() {
+                let srcs = leaked.into_iter().collect::<Vec<_>>().join("`, `");
+                errors.push(format!(
+                    "info-flow: `{name}` is `#[public]` but returns secret data from `#[secret]` fn `{srcs}` — route it through a `#[declassify]` fn to launder it"
+                ));
+            }
+        }
+    }
+    errors
 }
 
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
@@ -135,26 +275,24 @@ mod tests {
     use super::*;
     use crate::parse;
 
+    /// Tag `item` with attribute `kind` in the shared registry.
+    fn tag(item: &str, kind: &str) {
+        crate::feature_attrs::record(
+            item,
+            crate::feature_attrs::AttrRecord {
+                name: kind.into(),
+                args: String::new(),
+                line: 0,
+            },
+        );
+    }
+
     #[test]
     fn secret_to_public_is_blocked() {
         let _g = crate::feature_attrs::lock_for_test();
         crate::feature_attrs::reset();
-        crate::feature_attrs::record(
-            "leak",
-            crate::feature_attrs::AttrRecord {
-                name: "secret".into(),
-                args: String::new(),
-                line: 0,
-            },
-        );
-        crate::feature_attrs::record(
-            "log",
-            crate::feature_attrs::AttrRecord {
-                name: "public".into(),
-                args: String::new(),
-                line: 0,
-            },
-        );
+        tag("leak", "secret");
+        tag("log", "public");
         let src = r#"
             fn leak(int x) -> int { return x; }
             fn log(int x) -> int { return leak(x); }
@@ -163,6 +301,113 @@ mod tests {
         assert!(!check_program(&prog).is_empty());
         crate::feature_attrs::reset();
     }
+
+    #[test]
+    fn discarded_secret_is_not_a_leak() {
+        // RES-2824: the precision win. Calling a secret fn and discarding
+        // the result does not leak it to the public output.
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        tag("leak", "secret");
+        tag("log", "public");
+        let src = r#"
+            fn leak(int x) -> int { return x; }
+            fn log(int x) -> int { leak(x); return 0; }
+        "#;
+        let (prog, _) = parse(src);
+        assert!(
+            check_program(&prog).is_empty(),
+            "discarded secret value must not be flagged"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn declassified_secret_is_clean() {
+        // RES-2824: routing the secret through a #[declassify] fn launders
+        // it, so the public sink may return it.
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        tag("leak", "secret");
+        tag("redact", "declassify");
+        tag("log", "public");
+        let src = r#"
+            fn leak(int x) -> int { return x; }
+            fn redact(int x) -> int { return 0; }
+            fn log(int x) -> int { return redact(leak(x)); }
+        "#;
+        let (prog, _) = parse(src);
+        assert!(
+            check_program(&prog).is_empty(),
+            "declassified value must be clean"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn taint_through_let_leaks() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        tag("leak", "secret");
+        tag("log", "public");
+        let src = r#"
+            fn leak(int x) -> int { return x; }
+            fn log(int x) -> int { let s = leak(x); return s; }
+        "#;
+        let (prog, _) = parse(src);
+        assert!(!check_program(&prog).is_empty());
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn taint_through_operator_leaks() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        tag("leak", "secret");
+        tag("log", "public");
+        let src = r#"
+            fn leak(int x) -> int { return x; }
+            fn log(int x) -> int { return leak(x) + 1; }
+        "#;
+        let (prog, _) = parse(src);
+        assert!(!check_program(&prog).is_empty());
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn declassify_through_let_is_clean() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        tag("leak", "secret");
+        tag("redact", "declassify");
+        tag("log", "public");
+        let src = r#"
+            fn leak(int x) -> int { return x; }
+            fn redact(int x) -> int { return 0; }
+            fn log(int x) -> int { let s = leak(x); let p = redact(s); return p; }
+        "#;
+        let (prog, _) = parse(src);
+        assert!(check_program(&prog).is_empty());
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn diagnostic_names_the_secret_source() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        tag("leak", "secret");
+        tag("log", "public");
+        let src = r#"
+            fn leak(int x) -> int { return x; }
+            fn log(int x) -> int { return leak(x); }
+        "#;
+        let (prog, _) = parse(src);
+        let errs = check_program(&prog);
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("`log`") && errs[0].contains("`leak`"));
+        crate::feature_attrs::reset();
+    }
+
     #[test]
     fn check_ok_without_attributes() {
         let _g = crate::feature_attrs::lock_for_test();

--- a/resilient/tests/info_flow_smoke.rs
+++ b/resilient/tests/info_flow_smoke.rs
@@ -1,0 +1,81 @@
+//! RES-2824: end-to-end smoke tests for the information-flow /
+//! non-interference pass. Unlike the in-module unit tests (which inject
+//! `#[secret]` / `#[public]` / `#[declassify]` straight into the shared
+//! attribute registry), these drive the *full* pipeline through the
+//! compiled `rz` binary: real attribute syntax → `cfg_attr` parser →
+//! `feature_attrs` registry → `info_flow::check`.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn run_check(example: &str) -> (String, String, Option<i32>) {
+    let output = Command::new(bin())
+        .arg("check")
+        .arg(format!("examples/{example}"))
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("failed to spawn rz");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+#[test]
+fn leak_example_is_rejected() {
+    // `publish` (#[public]) returns the value of `read_secret`
+    // (#[secret]) directly — an explicit flow that must be rejected.
+    let (stdout, stderr, code) = run_check("info_flow_leak.rz");
+    assert_eq!(
+        code,
+        Some(1),
+        "leak example must fail `rz check`; stdout={stdout} stderr={stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("info-flow"),
+        "expected an info-flow diagnostic; got:\n{combined}"
+    );
+    assert!(
+        combined.contains("publish") && combined.contains("read_secret"),
+        "diagnostic should name the public sink and the secret source; got:\n{combined}"
+    );
+}
+
+#[test]
+fn declassify_example_is_accepted() {
+    // Routing the same secret through the #[declassify] `redact` launders
+    // it, so the public sink type-checks.
+    let (stdout, stderr, code) = run_check("info_flow_declassify.rz");
+    assert_eq!(
+        code,
+        Some(0),
+        "declassified flow must pass `rz check`; stdout={stdout} stderr={stderr}"
+    );
+}
+
+#[test]
+fn declassify_example_runs_and_launders() {
+    let output = Command::new(bin())
+        .arg("examples/info_flow_declassify.rz")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("failed to spawn rz");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "declassify example must run; stdout={stdout} stderr={stderr}"
+    );
+    // publish(5)  -> redact(38) -> 1
+    // publish(-1) -> redact(-4) -> 0
+    assert!(
+        stdout.contains('1') && stdout.contains('0'),
+        "expected laundered outputs 1 and 0; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Closes #2824.

## What & why

The "hardest property a trace-property logic (LTL/TLA⁺) can't express" is a **hyperproperty** — a statement about *pairs* of executions. The cleanest case is **non-interference**: a `#[public]` output must not depend on `#[secret]` input. `info_flow.rs` already had the attribute surface, but only a **coarse call-graph** approximation that (a) raised false positives on discarded secret values and (b) never implemented the `#[declassify]` laundering boundary its own doc-comment promised.

This PR replaces that with **expression-level taint propagation**:

- a call to a `#[secret]` fn is a *source* (tainted result);
- a call to a `#[declassify]` fn *launders* (public result, regardless of args);
- ordinary calls pass taint through from arguments; `let`/assignment, infix/prefix ops, field/index access and array/tuple literals propagate it; `if`/`while`/`for` union-merge branch environments;
- a `#[public]` fn leaks **iff a value it returns is secret-derived**.

A secret value that is computed and **discarded** is no longer flagged — that is the precision win, and it is exactly the non-interference semantics (the *output* must not depend on the secret).

## Behavior

```
#[secret] fn read_secret(int s) -> int { return s * 7 + 3; }
#[public] fn publish(int s) -> int { return read_secret(s); }        // REJECTED
#[public] fn publish(int s) -> int { return redact(read_secret(s)); } // OK via #[declassify] redact
```

```
$ rz check examples/info_flow_leak.rz
examples/info_flow_leak.rz:0:0: error: info-flow: `publish` is `#[public]` but returns secret data
  from `#[secret]` fn `read_secret` — route it through a `#[declassify]` fn to launder it   (exit 1)
$ rz check examples/info_flow_declassify.rz        # exit 0
```

## Tests
- 9 in-module unit cases (discarded-secret clean, returned-secret leaks, declassify-launders, taint through `let`/operators, diagnostic names the source, plus the preserved `secret_to_public_is_blocked`).
- `tests/info_flow_smoke.rs`: 3 end-to-end cases driving the real `#[…]` parse → `cfg_attr` → `feature_attrs` → `info_flow` pipeline.
- `info_flow_declassify.expected.txt` golden; `info_flow_leak.rz` marked `.interactive` so the stdout golden skips the (intentionally) compile-failing example.

Local gates: `cargo fmt --check`, `cargo clippy -p resilient --all-targets -- -D warnings`, and the unit/smoke/golden tests all pass.

## Scope note
Explicit flows only. **Implicit flows** (a secret-derived branch condition) are a documented follow-up (#2826). The rigorous **semantic** companion — non-interference via self-composition + Z3 (`#[noninterference(low=…, high=…)]`) — is #2825 and builds on this. Sibling families: probabilistic (#2827), continuous/hybrid (#2828).