### PR TITLE
RES-2831: reject indexing of non-indexable types at compile time

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -638,6 +638,39 @@ fn is_pinned_int(t: &Type) -> bool {
     )
 }
 
+/// RES-2831: is `t` a type that the `[]` index operator can never apply
+/// to? The runtime only indexes arrays, strings, and maps (maps carry
+/// `Type::Any`), so anything that resolves to a concrete non-sequence
+/// type is an unsound index at compile time. `Array`, `String`, `Any`,
+/// and unresolved inference variables (`Var`) are deliberately *not*
+/// listed: they are either indexable or still-unknown, and rejecting
+/// them would produce false positives on generic / inferred targets.
+fn is_non_indexable(t: &Type) -> bool {
+    matches!(
+        t,
+        Type::Int
+            | Type::Int8
+            | Type::Int16
+            | Type::Int32
+            | Type::UInt8
+            | Type::UInt16
+            | Type::UInt32
+            | Type::UInt64
+            | Type::Float
+            | Type::Float32
+            | Type::Bool
+            | Type::Char
+            | Type::Bytes
+            | Type::Void
+            | Type::Function { .. }
+            | Type::Range
+            | Type::Result
+            | Type::Option(_)
+            | Type::Struct(_)
+            | Type::Tuple(_)
+    )
+}
+
 fn check_numeric_same_type(op: &str, left: &Type, right: &Type) -> Result<Type, String> {
     match (left, right) {
         (Type::Int, Type::Int) => Ok(Type::Int),
@@ -8696,6 +8729,16 @@ impl TypeChecker {
             Node::IndexExpression { target, index, .. } => {
                 let tgt_ty = self.check_node(target)?;
                 let idx_ty = self.check_node(index)?;
+                // RES-2831: the target must be indexable at all. The
+                // runtime only indexes arrays, strings, and maps; `[]`
+                // on any other concrete type faults at runtime
+                // ("Cannot index ..."), so reject it at compile time.
+                if is_non_indexable(&tgt_ty) {
+                    return Err(format!(
+                        "cannot index a value of type {} — only arrays, strings, and maps support `[]` indexing",
+                        tgt_ty
+                    ));
+                }
                 // RES-405: array/string indexing must use an integer
                 // index. Reject obvious type errors like `arr["key"]`
                 // while keeping Map targets permissive (Any index).
@@ -8762,6 +8805,14 @@ impl TypeChecker {
                 // RES-406: validate index type for array/string targets.
                 let tgt_ty = self.check_node(target)?;
                 let idx_ty = self.check_node(index)?;
+                // RES-2831: reject index-assignment to a non-indexable
+                // target (mirrors the IndexExpression check).
+                if is_non_indexable(&tgt_ty) {
+                    return Err(format!(
+                        "cannot index a value of type {} — only arrays, strings, and maps support `[]` indexing",
+                        tgt_ty
+                    ));
+                }
                 if matches!(tgt_ty, Type::Array | Type::String)
                     && !matches!(idx_ty, Type::Int | Type::Any)
                     && !is_pinned_int(&idx_ty)

--- a/resilient/tests/index_typecheck_smoke.rs
+++ b/resilient/tests/index_typecheck_smoke.rs
@@ -1,0 +1,91 @@
+//! RES-2831: the typechecker must reject `[]` indexing of a
+//! non-indexable target at compile time, instead of deferring to a
+//! runtime "Cannot index ..." fault. Arrays, strings, and maps stay
+//! indexable; everything else is a static type error.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn check_src(src: &str) -> (String, Option<i32>) {
+    static CTR: AtomicUsize = AtomicUsize::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let path: PathBuf =
+        std::env::temp_dir().join(format!("res_2831_{}_{}.rz", std::process::id(), n));
+    std::fs::write(&path, src).expect("write tmp");
+    let out = Command::new(bin())
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("spawn rz check");
+    let _ = std::fs::remove_file(&path);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (combined, out.status.code())
+}
+
+#[test]
+fn index_int_target_is_rejected() {
+    let (out, code) = check_src("let x = 5;\nlet z = x[0];\nprintln(z);\n");
+    assert_eq!(
+        code,
+        Some(1),
+        "indexing an int must fail typecheck; got:\n{out}"
+    );
+    assert!(
+        out.contains("cannot index"),
+        "expected a 'cannot index' diagnostic; got:\n{out}"
+    );
+}
+
+#[test]
+fn index_struct_target_is_rejected() {
+    let (out, code) =
+        check_src("struct P { int a }\nlet p = new P { a: 1 };\nlet z = p[0];\nprintln(z);\n");
+    assert_eq!(
+        code,
+        Some(1),
+        "indexing a struct must fail typecheck; got:\n{out}"
+    );
+    assert!(
+        out.contains("cannot index"),
+        "expected diagnostic; got:\n{out}"
+    );
+}
+
+#[test]
+fn index_assignment_to_int_target_is_rejected() {
+    let (out, code) = check_src("let x = 5;\nx[0] = 9;\nprintln(x);\n");
+    assert_eq!(
+        code,
+        Some(1),
+        "index-assignment to an int must fail typecheck; got:\n{out}"
+    );
+    assert!(
+        out.contains("cannot index"),
+        "expected diagnostic; got:\n{out}"
+    );
+}
+
+#[test]
+fn array_index_still_accepted() {
+    let (out, code) = check_src("let xs = [1, 2, 3];\nlet z = xs[0];\nprintln(z);\n");
+    assert_eq!(code, Some(0), "array indexing must still pass; got:\n{out}");
+}
+
+#[test]
+fn string_index_still_accepted() {
+    let (out, code) = check_src("let s = \"hi\";\nlet z = s[0];\nprintln(z);\n");
+    assert_eq!(
+        code,
+        Some(0),
+        "string indexing must still pass; got:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #2831.

## Problem

The index typecheck validated the **index** type (`arr["k"]` is rejected) but never the **target** type. So indexing a non-indexable value passed `rz check` and only faulted at runtime:

```
let x = 5; let z = x[0];     // rz check: OK → runtime: "Cannot index Int(5)"
let x = 5; x[0] = 9;         // same, for index-assignment
```

Accepted today, all should be compile errors: indexing `int` / pinned int+uint / `float` / `f32` / `bool` / `char` / `bytes` / structs / tuples / options / results / ranges / functions. For a statically-typed safety-critical language this is an **unsound acceptance** — a class of type errors silently deferred to a runtime fault.

## Fix

Add `is_non_indexable(&Type)` and reject non-indexable targets in both `IndexExpression` and `IndexAssignment`. It **mirrors the runtime exactly** — the interpreter only indexes arrays, strings, and maps (maps type as `Type::Any`) — so the allow-set is `Array`, `String`, `Any`, and inference variables (`Var`). Everything concrete and non-indexable is rejected; `Any`/`Var` stay permissive so generic / not-yet-resolved targets can't produce a false positive.

```
cannot index a value of type int — only arrays, strings, and maps support `[]` indexing
```

## Why no false positives
The allow-set is exactly the runtime-indexable set plus permissive unknowns. Any currently-working `x[i]` has `x: Array | String | Any` (maps are `Any`), none of which are rejected. Anything newly rejected (e.g. `5[0]`) was already a guaranteed runtime error, so no working program changes behavior.

## Tests
`tests/index_typecheck_smoke.rs` — 5 cases: int / struct / index-assignment-to-int rejected with the new diagnostic; array and string indexing still pass.

Local gates: `cargo fmt --check` ✓, `cargo clippy --all-targets -- -D warnings` ✓, and the regression-sensitive suite (`examples_golden` — every example — plus `examples_smoke`, `check_smoke`, `differential`, `roundtrip`, and the new smoke) all green. Full `cargo test` runs via the guardrail.