### PR TITLE
RES-2834: harden Ralph loop and live ticket flow

### DIFF
--- a/.board/prompts/README.md
+++ b/.board/prompts/README.md
@@ -1,0 +1,26 @@
+# Prompt Library
+
+Reusable prompt artifacts for Codex and related agent loops.
+
+## Available prompts
+
+- `manager.md` — the legacy board manager loop that keeps `.board/` healthy.
+- `ralph-loop.md` — the open-ended high-leverage improvement loop for
+  language, workflow, CI, docs, and automation.
+
+## How to invoke
+
+In a future Codex turn, reference the prompt file directly, for example:
+
+```text
+Use the Ralph Loop prompt at `.board/prompts/ralph-loop.md`.
+```
+
+Or launch it through the helper script:
+
+```bash
+agent-scripts/ralph-loop.sh
+```
+
+The prompt files are intentionally plain Markdown so they can be read,
+copied, and reused without any extra tooling.

--- a/.board/prompts/ralph-loop.md
+++ b/.board/prompts/ralph-loop.md
@@ -1,0 +1,84 @@
+# Ralph Loop
+
+Reusable Codex prompt for continuous, high-leverage improvement passes on
+Resilient.
+
+## How to reuse
+
+Ask Codex to use this prompt again by referencing the file directly:
+
+> Use the Ralph Loop prompt at `.board/prompts/ralph-loop.md`.
+
+You can also paste the prompt body below into a fresh Codex turn if you
+want the behavior inline.
+
+## Operating stance
+
+You are running an open-ended improvement loop for the Resilient
+repository.
+
+Do not optimize for tiny, isolated fixes. Prefer improvements that remove
+an entire class of bugs, collapse repeated manual work, unify duplicated
+flows, or unlock a larger chunk of the roadmap.
+
+If a small issue is the highest-leverage way to unblock a bigger
+improvement, fix it immediately. Otherwise, aim for the largest safe
+change you can land end-to-end in the current pass.
+
+Treat language features, workflow automation, CI, documentation, ticket
+flow, release mechanics, and developer ergonomics as equally valid
+targets. If the repo has a mismatch between docs and scripts, fix the
+source of truth first.
+
+## Loop contract
+
+For each pass:
+
+1. Inspect the current state.
+2. Identify the highest-leverage improvement available.
+3. Implement it end-to-end.
+4. Verify it with the strongest practical checks.
+5. Record the result and the next improvement target.
+6. Immediately continue to the next pass unless you are blocked by an
+   external dependency or the user explicitly stops the loop.
+
+## What counts as a good pass
+
+Favor changes that:
+
+- remove a correctness hole,
+- eliminate repeated manual steps,
+- unify competing sources of truth,
+- improve claim / PR / issue / branch automation,
+- increase the size or quality of a future ticket stream,
+- or make the next iteration materially easier.
+
+Prefer compound improvements over cosmetic tweaks. If the current pass can
+solve a workflow inconsistency and harden the related CI or orchestration
+path at the same time, do both.
+
+## Guardrails
+
+Follow the repository rules in `AGENTS.md`, `CLAUDE.md`, and
+`CONTRIBUTING.md`.
+
+- Do not weaken tests to make a pass look good.
+- Do not bypass CI or guardrails.
+- Do not introduce `unsafe` without a soundness rationale.
+- Do not create a second canonical source of truth for tickets or
+  workflow state.
+
+## Suggested working rhythm
+
+1. Read `agent-scripts/README.md`, `docs/AGENT_PLAYBOOK.md`,
+   `docs/agent-orchestration.md`, `README.md`, `ROADMAP.md`, and the live
+   issue / PR state.
+2. Pick the biggest leverage gap, not the easiest cosmetic issue.
+3. Ship the fix with tests, docs, or workflow updates as needed.
+4. Re-run the loop and look for the next high-value improvement.
+
+## Exit condition
+
+This prompt is designed to be reused. Keep looping until the user says
+stop, the repo state is genuinely blocked by an external dependency, or no
+meaningful improvement remains in scope for the current pass.

--- a/.github/ISSUE_TEMPLATE/agent-ready-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/agent-ready-ticket.yml
@@ -21,6 +21,26 @@ body:
       description: What should exist or work after this ticket is done? One paragraph.
     validations:
       required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How urgent is this work?
+      options:
+        - P0 — blocks shipping or safety
+        - P1 — high leverage
+        - P2 — standard
+        - P3 — backlog / nice to have
+    validations:
+      required: true
+  - type: input
+    id: roadmap-goal
+    attributes:
+      label: Roadmap goal
+      description: Which current ROADMAP.md goal or milestone does this serve? Use `G#` when applicable, or `Infra / tooling` for work that does not map cleanly to a goalpost.
+      placeholder: "G7 — Real type checker"
+    validations:
+      required: true
   - type: textarea
     id: files-to-touch
     attributes:
@@ -45,31 +65,3 @@ body:
     attributes:
       label: Out of scope
       description: Explicitly name things NOT to do in this ticket
-  - type: dropdown
-    id: roadmap-goal
-    attributes:
-      label: Roadmap goal
-      description: Which roadmap goalpost does this serve? (see ROADMAP.md)
-      options:
-        - G1 — Hello World
-        - G2 — Arithmetic
-        - G3 — Control flow
-        - G4 — Functions
-        - G5 — Strings
-        - G6 — Structs
-        - G7 — Pattern matching
-        - G8 — Modules
-        - G9 — Effect system
-        - G10 — Type inference
-        - G11 — LSP
-        - G12 — Verifier
-        - G13 — Package manager
-        - G14 — Embedded runtime
-        - G15 — JIT
-        - G16 — FFI
-        - G17 — Concurrency
-        - G18 — Self-hosting
-        - G19 — Stability
-        - G20 — Release
-        - G21+ — Future
-        - Infra / tooling (no roadmap goal)

--- a/.github/workflows/release-file-claims.yml
+++ b/.github/workflows/release-file-claims.yml
@@ -79,5 +79,5 @@ jobs:
           else
             git add agent-scripts/file-claims.json
             git commit -m "chore: release file claims (+ sweep stale) for ${{ github.event.pull_request.head.ref }}"
-            git push
+            git push origin HEAD:refs/heads/main
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,14 +48,13 @@ Welcome! Resilient is an open project for safety-critical embedded systems. Cont
 ## Picking and Claiming a Ticket
 
 1. Browse [GitHub Issues](https://github.com/EricSpencer00/Resilient/issues)
-2. Look for issues labeled `agent-ready` or without any assignment
-3. Comment on the issue: `"I'll take this"` (or similar)
-4. Create a branch named `res-NNN-short-title` (e.g., `res-376-contributing-guide`)
+2. Look for issues labeled `agent-ready`
+3. Create a branch named `res-NNN-short-title` (e.g., `res-376-contributing-guide`)
    - `NNN` is the issue number
    - Use lowercase with hyphens for multi-word titles
-5. Open a **draft PR** early with `Closes #NNN` in the description
-   - This signals that the ticket is taken and prevents duplicate work
-   - Convert to ready-for-review when you're done
+4. Open a **draft PR** immediately with `Closes #NNN` in the description
+   - The draft PR is the canonical claim signal
+   - Convert to ready-for-review with `agent-scripts/ready-or-bail.sh --pr <number>` when you're done
 
 ---
 
@@ -326,55 +325,33 @@ When you modify golden files:
 
 ## Agent Contributors
 
-### Ticket Lifecycle
+### Live Ticket Flow
 
-The issue board uses a simple workflow:
+Resilient tracks active work in GitHub Issues and pull requests. The
+`agent-ready` issue template is the live queue.
 
 - **OPEN**: Ticket is available; nobody is actively working on it
-- **IN_PROGRESS**: An agent or human has claimed it (comment + draft PR)
-- **DONE**: PR is merged; the issue closes automatically when you add `Closes #NNN` in the PR body
+- **CLAIMED**: An agent has opened a draft PR with `Closes #NNN`
+- **DONE**: PR is merged; the issue closes automatically when you add
+  `Closes #NNN` in the PR body
 
 ### Workflow
 
-1. **Claim** the ticket by commenting with intent
-2. **Create a draft PR** immediately with `Closes #NNN` in the body
-3. **Push after every commit** — don't accumulate local commits
-4. **Mark ready for review** once all CI is green and the implementation is complete
-5. **Monitor for feedback** via the PR comment subscription
-6. Merge is automatic once approved; the issue closes
+1. **Pick** an `agent-ready` issue.
+2. **Create a branch** named `res-NNN-short-title`.
+3. **Open a draft PR** immediately with `Closes #NNN` in the body.
+4. **Push after every commit** — don't accumulate local commits.
+5. **Mark ready for review** with `agent-scripts/ready-or-bail.sh --pr <number>` once the implementation and CI are green.
+6. **Monitor for feedback** via the PR comment subscription.
+7. Merge is automatic once CI is green and the PR has been synced; the issue closes.
 
-### Creating New Tickets
+### Legacy Local Ledger
 
-Always use `scripts/new-ticket.sh` to create new board tickets. It automatically assigns the next unused `RES-NNN` id and places the file in `.board/tickets/OPEN/`:
-
-```bash
-scripts/new-ticket.sh "Short imperative title"
-```
-
-This prevents ID collisions that arise from manually chosen numbers.
-
-### Pre-commit Hook — Ticket ID Collision Guard
-
-A pre-commit hook prevents commits that introduce duplicate ticket IDs. Install it once per clone:
-
-```bash
-scripts/install-hooks.sh
-```
-
-Or install manually:
-
-```bash
-cp scripts/pre-commit .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
-```
-
-The hook runs `scripts/check-ticket-ids.sh`, which scans `.board/tickets/OPEN/`, `IN_PROGRESS/`, and `DONE/` for `id: RES-NNN` front-matter and aborts the commit when a collision is found.
-
-You can also run the check independently (useful in CI):
-
-```bash
-scripts/check-ticket-ids.sh
-```
+The `.board/` tree and the `scripts/new-ticket.sh` /
+`scripts/check-ticket-ids.sh` helpers remain in-tree for archive
+maintenance and historical migration work. They are not the live queue
+and should not be used to start new work unless you are explicitly
+auditing or migrating historical tickets.
 
 ### Special Notes
 

--- a/README.md
+++ b/README.md
@@ -802,8 +802,9 @@ See the [SYNTAX.md](SYNTAX.md) file for detailed syntax requirements and example
 ## Project Status
 
 Active development happens one ticket at a time. See [ROADMAP.md](ROADMAP.md)
-for the goalpost ladder and [GitHub Issues (closed)](https://github.com/EricSpencer00/Resilient/issues?q=is%3Aissue+is%3Aclosed) for
-the full ledger. Each commit of the form `RES-NNN: summary` closes one ticket.
+for the goalpost ladder and [GitHub Issues](https://github.com/EricSpencer00/Resilient/issues)
+for the live queue; closed issues are the historical ledger. Each commit
+of the form `RES-NNN: summary` closes one ticket.
 
 ### What works today
 

--- a/agent-scripts/README.md
+++ b/agent-scripts/README.md
@@ -10,13 +10,14 @@ file-claims + extension-point system introduced in PR #230.
 | `check-overlaps.sh` | Pre-dispatch: verify files don't conflict with open PRs or active claims |
 | `claim-files.sh` | Register files owned by a branch |
 | `release-claims.sh` | Release claims (called by CI on PR merge) |
-| `pick-ticket.sh` | Select the next `agent-ready` ticket not already in an open PR |
+| `pick-ticket.sh` | Select the next `agent-ready` ticket by priority / roadmap order, skipping open PR claims |
 | `dispatch-agent.sh` | Create worktree + branch + draft PR for a ticket, then record inferred file claims |
 | `agent-handoff.sh` | Post resumable PR handoff comments when model context is lost |
 | `agent-status.sh` | One-screen or JSON view of worktrees, open PRs, claims, and the next ticket |
 | **`verify-scope.sh`** | Guardrail: diff-shape + fmt + clippy + test + overlap, writes JSON report |
 | **`ready-or-bail.sh`** | Runs `verify-scope.sh`; marks PR ready on green, posts failure comment on red |
 | **`orchestrator.sh`** | The grand loop: pick → dispatch → sub-agent → ready-or-bail |
+| **`ralph-loop.sh`** | The reusable open-ended improvement loop, preloaded with the Ralph prompt |
 
 ## Four-layer guardrail architecture
 
@@ -54,10 +55,13 @@ agent-scripts/orchestrator.sh --n 3 --parallel 3
 # Drain the queue.
 agent-scripts/orchestrator.sh --loop
 
+# Drain the queue with the reusable high-leverage prompt.
+agent-scripts/ralph-loop.sh
+
 # Plan without mutating anything.
 agent-scripts/orchestrator.sh --dry-run
 
-# Feed a visual board or monitor.
+# Feed the status dashboard or monitor.
 agent-scripts/agent-status.sh --json
 ```
 
@@ -97,6 +101,11 @@ own pipeline) with `--skip tests --skip clippy --skip fmt`.
   `RES-NNN` in the title/body/branch, or a `res-NNN-*` branch name.
 - It's assigned to a human (non-bot). The Copilot and Claude bot
   accounts are treated as non-human and don't block the pick.
+- When multiple issues are eligible, it prefers explicit `Priority`
+  values first (`P0` before `P1`, etc.), then the lowest numbered
+  roadmap goal (`G7` before `G22`), then the oldest ticket. Legacy
+  issues without those fields fall back to the default `P2` / no-goal
+  ordering.
 
 ## Dispatch rules
 

--- a/agent-scripts/claim-files.sh
+++ b/agent-scripts/claim-files.sh
@@ -8,12 +8,10 @@
 # from being dispatched to the same files.
 #
 # RES-2670: as a side-effect, every claim sweeps the file for stale
-# entries whose branch no longer exists on `origin`. The bot-driven
-# `release-file-claims` workflow has been failing for days because
-# branch protection rejects its direct push to `main` (the chore
-# commit cannot satisfy required status checks). Local sweep here
-# is the primary cleanup mechanism — the workflow remains as a
-# best-effort safety net.
+# entries whose branch no longer exists on `origin`. The local sweep
+# here is the primary cleanup mechanism — the merge-time
+# `release-file-claims` workflow is best-effort only, so stale claims
+# never block a fresh dispatch.
 
 set -euo pipefail
 

--- a/agent-scripts/orchestrator.sh
+++ b/agent-scripts/orchestrator.sh
@@ -22,6 +22,9 @@
 #   AGENT_CMD — command used to run the sub-agent inside each worktree.
 #     Default: `claude -p --permission-mode acceptEdits`. Override to plug in
 #     other CLIs (e.g. `codex` or a mock for testing).
+#   AGENT_LOOP_PROMPT_FILE — optional Markdown file whose contents are
+#     prepended to the per-ticket prompt. Use this to steer the loop toward
+#     a reusable operating mode such as the Ralph improvement loop.
 
 set -euo pipefail
 
@@ -33,6 +36,7 @@ UNBOUNDED=0
 PARALLEL=1
 DRY_RUN=0
 AGENT_CMD="${AGENT_CMD:-claude -p --permission-mode acceptEdits}"
+LOOP_PROMPT_FILE="${AGENT_LOOP_PROMPT_FILE:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -76,7 +80,12 @@ run_one() {
   gh issue view "$issue" --json title,body -q '.title + "\n\n" + .body' > "$body_file"
 
   local prompt_file="/tmp/agent-prompt-${issue}.md"
-  cat > "$prompt_file" <<EOF
+  {
+    if [ -n "$LOOP_PROMPT_FILE" ] && [ -f "$LOOP_PROMPT_FILE" ]; then
+      cat "$LOOP_PROMPT_FILE"
+      printf '\n\n---\n\n'
+    fi
+    cat <<EOF
 You are working on Resilient. A worktree is prepared at:
   ${worktree}
 Branch is pushed and tracks origin. Draft PR is #${pr} with 'Closes #${issue}'.
@@ -103,6 +112,7 @@ Work in this order:
 
 When you're finished (guardrail green OR exhausted — don't loop forever on a stuck ticket), exit. Report under 300 words what you shipped and whether the PR is ready or left draft.
 EOF
+  } > "$prompt_file"
 
   log "launching sub-agent for #${issue}"
   (cd "$worktree" && $AGENT_CMD < "$prompt_file") || log "agent exited non-zero for #${issue}"
@@ -122,10 +132,16 @@ EOF
 }
 
 pick_next() {
-  local excl=("$@")
   local flags=()
-  for e in "${excl[@]}"; do flags+=(--exclude "$e"); done
-  bash "$SCRIPT_DIR/pick-ticket.sh" "${flags[@]}" 2>/dev/null | cut -f1
+  if (($# > 0)); then
+    local e
+    for e in "$@"; do flags+=(--exclude "$e"); done
+  fi
+  if ((${#flags[@]} > 0)); then
+    bash "$SCRIPT_DIR/pick-ticket.sh" "${flags[@]}" 2>/dev/null | cut -f1
+  else
+    bash "$SCRIPT_DIR/pick-ticket.sh" 2>/dev/null | cut -f1
+  fi
 }
 
 EXCLUDED=()
@@ -137,7 +153,11 @@ while true; do
     PIDS=()
     BATCH=()
     for ((k=0; k<PARALLEL; k++)); do
-      issue="$(pick_next "${EXCLUDED[@]}")"
+      if (( ${#EXCLUDED[@]} > 0 )); then
+        issue="$(pick_next "${EXCLUDED[@]}")"
+      else
+        issue="$(pick_next)"
+      fi
       [ -z "$issue" ] && break
       EXCLUDED+=("$issue")
       BATCH+=("$issue")
@@ -151,7 +171,11 @@ while true; do
     for pid in "${PIDS[@]}"; do wait "$pid" || true; done
     COUNT=$(( COUNT + ${#BATCH[@]} ))
   else
-    issue="$(pick_next "${EXCLUDED[@]}")"
+    if (( ${#EXCLUDED[@]} > 0 )); then
+      issue="$(pick_next "${EXCLUDED[@]}")"
+    else
+      issue="$(pick_next)"
+    fi
     [ -z "$issue" ] && { log "no more tickets"; break; }
     EXCLUDED+=("$issue")
     run_one "$issue" || true

--- a/agent-scripts/pick-ticket.sh
+++ b/agent-scripts/pick-ticket.sh
@@ -7,6 +7,11 @@
 #   - no open PR whose body or branch references `#<number>`
 #   - not assigned (or only the agent bots)
 #
+# Ordering:
+#   - explicit Priority field first (P0 → P3)
+#   - then Roadmap goal (lower `G#` first, Infra/tooling last)
+#   - then oldest created issue
+#
 # Output:
 #   Prints `<number>\t<title>` for the first eligible ticket, or
 #   exits 1 if none.
@@ -35,7 +40,7 @@ ISSUES_JSON="$(gh issue list \
   --state open \
   --label agent-ready \
   --limit 100 \
-  --json number,title,body,assignees,labels 2>/dev/null || echo '[]')"
+  --json number,title,body,assignees,labels,createdAt 2>/dev/null || echo '[]')"
 
 PRS_JSON="$(gh pr list --state open --limit 100 --json number,title,body,headRefName 2>/dev/null || echo '[]')"
 
@@ -76,8 +81,69 @@ for pr in prs:
         if res_num in res_to_issue:
             pr_refs.add(res_to_issue[res_num])
 
+heading_re = re.compile(r"^#{1,6}\s+(.+?)\s*$")
+
+
+def normalize_heading(text):
+    return re.sub(r"\s+", " ", text.strip().lower().replace("-", " "))
+
+
+def sections(body):
+    data = {}
+    current = None
+    buf = []
+    for raw in (body or "").splitlines():
+        line = raw.strip()
+        match = heading_re.match(line)
+        if match:
+            if current is not None:
+                data[current] = "\n".join(buf).strip()
+            current = normalize_heading(match.group(1))
+            buf = []
+            continue
+        if current is not None:
+            buf.append(raw)
+    if current is not None:
+        data[current] = "\n".join(buf).strip()
+    return data
+
+
+def section_text(issue, *names):
+    sec = sections(issue.get("body") or "")
+    return " ".join(sec.get(name, "") for name in names).strip()
+
+
+def priority_rank(issue):
+    text = section_text(issue, "priority")
+    match = re.search(r"\bP([0-3])\b", text, re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+    return 2
+
+
+def roadmap_rank(issue):
+    text = section_text(issue, "roadmap goal")
+    match = re.search(r"\bG(\d{1,2})\b", text, re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+    lowered = text.lower()
+    if "infra" in lowered or "tooling" in lowered:
+        return 1000
+    return 999
+
+
+def sort_key(issue):
+    return (
+        priority_rank(issue),
+        roadmap_rank(issue),
+        issue.get("createdAt") or "9999-12-31T23:59:59Z",
+        issue["number"],
+    )
+
+
 allowed_bots = {"Copilot", "Claude", "claude", "copilot-swe-agent", "anthropic-code-agent"}
 
+eligible = []
 for issue in issues:
     n = issue["number"]
     if n in excluded or n in pr_refs:
@@ -86,11 +152,18 @@ for issue in issues:
     non_bot = [a for a in assignees if a.get("login", "") not in allowed_bots]
     if non_bot:
         continue
-    if os.environ.get("WANT_JSON") == "1":
-        print(json.dumps(issue))
-    else:
-        print(f"{n}\t{issue['title']}")
-    sys.exit(0)
+    eligible.append(issue)
 
-sys.exit(1)
+if not eligible:
+    sys.exit(1)
+
+eligible.sort(key=sort_key)
+selected = eligible[0]
+
+if os.environ.get("WANT_JSON") == "1":
+    print(json.dumps(selected))
+else:
+    print(f"{selected['number']}\t{selected['title']}")
+
+sys.exit(0)
 PYEOF

--- a/agent-scripts/ralph-loop.sh
+++ b/agent-scripts/ralph-loop.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# ralph-loop.sh — launch the high-leverage improvement loop.
+#
+# This is a thin wrapper around orchestrator.sh that prepends the reusable
+# Ralph prompt to each ticket prompt and defaults to an unbounded loop.
+#
+# Usage:
+#   agent-scripts/ralph-loop.sh                # continuous loop
+#   agent-scripts/ralph-loop.sh --n 1          # one iteration
+#   agent-scripts/ralph-loop.sh --dry-run      # plan only
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+if [[ $# -eq 0 ]]; then
+  set -- --loop
+fi
+
+export AGENT_LOOP_PROMPT_FILE="${AGENT_LOOP_PROMPT_FILE:-$REPO_ROOT/.board/prompts/ralph-loop.md}"
+exec "$SCRIPT_DIR/orchestrator.sh" "$@"

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -28,11 +28,11 @@ safely re-converges.
 
 | Stage | Mechanism | Output |
 |---|---|---|
-| Pick | `pick-ticket.sh` | `<issue-number>\t<title>\tagent-ready` |
+| Pick | `pick-ticket.sh` | `<issue-number>\t<title>` from the highest-priority eligible issue |
 | Dispatch | `dispatch-agent.sh --issue N` | Worktree at `.claude/worktrees/res-N/`, draft PR with `Closes #N` |
 | Implement | (agent free-form) | Follow feature-isolation pattern in CLAUDE.md |
 | Verify | `ready-or-bail.sh --pr P` | Runs `verify-scope.sh` + `sync-integration.sh`; marks PR ready on green |
-| Sync | `sync-integration.sh` (called by ready-or-bail) | Rebases branch onto `origin/agents/integration`, fast-forwards integration, stamps PR with `integration-synced` label |
+| Sync | `sync-integration.sh` (called by ready-or-bail) | Rebases branch onto `origin/main`, fast-forwards `agents/integration`, stamps PR with `integration-synced` label |
 | Auto-merge | `agent-auto-merge.yml` (CI) | Enables `gh pr merge --auto` when every check is green AND PR is labeled `integration-synced` |
 | Follow-main | `integration-follow-main.yml` (CI) | Fast-forwards `agents/integration` to `main` after every merge |
 | Release | `release-file-claims.yml` (CI) | `agent-scripts/file-claims.json` cleared for the branch |
@@ -59,10 +59,10 @@ Claims are automatically released by
 on PR merge, and by `agent-scripts/release-claims.sh` locally when a
 branch is abandoned.
 
-**Stale-claim rule**: any claim older than 30 minutes (measured by the
-commit timestamp on the claim-adding commit on `main`) is treated as
-abandoned. A new dispatcher may overwrite it. This is enforced by
-`check-overlaps.sh` treating stale entries as absent.
+**Stale-claim rule**: a claim is stale when its branch no longer has an
+open PR. `check-overlaps.sh` treats stale entries as informational only,
+so they do not block a fresh dispatch. The local claim sweep clears them
+opportunistically when a new claim is recorded.
 
 ### 2b. Append-only extension points
 
@@ -104,7 +104,7 @@ first, then `sync-integration.sh`. If either fails, the PR stays draft.
 `sync-integration.sh` does:
 
 1. `git fetch origin` and rebase the current branch onto
-   `origin/agents/integration`.
+   `origin/main`.
 2. If the rebase hits conflicts, check each file against the
    append-only allowlist (main.rs, typechecker.rs, lexer_logos.rs,
    file-claims.json). If all conflict files are in the allowlist, run
@@ -222,6 +222,12 @@ One command to drain the queue:
 
 ```bash
 agent-scripts/orchestrator.sh --loop
+```
+
+One command to run the reusable high-leverage loop:
+
+```bash
+agent-scripts/ralph-loop.sh
 ```
 
 One command to land the already-done work:

--- a/docs/community.md
+++ b/docs/community.md
@@ -65,7 +65,7 @@ The repository contains:
 |------|----------|
 | `resilient/` | Compiler and runtime source (Rust) |
 | `docs/` | This documentation site (Jekyll) |
-| `.board/` | Plain-text ticket ledger |
+| `.board/` | Legacy ticket archive and prompt artifacts |
 | `examples/` | Example `.rz` programs |
 | `resilient-runtime/` | `#![no_std]` runtime crate |
 
@@ -96,25 +96,24 @@ workflow — fork, clone, `cargo test`, open PR.
 
 The short version:
 - All contributions go through GitHub pull requests
+- The live queue lives in GitHub Issues with the `agent-ready` label
 - The CI workflow (tests + fmt + clippy + perf gate) is the
   acceptance bar
-- Work is tracked through the
-  [`.board/`](https://github.com/EricSpencer00/Resilient/tree/main/.board)
-  ticket system with `RES-NNN` identifiers
 
 ---
 
 ## AI agents welcome
 
-Resilient is designed with automated contributors in mind. The
-ticket system is machine-readable plain text, the test suite
-gives a deterministic pass/fail signal, and the contribution
-workflow requires no human-only interaction beyond opening a PR.
+Resilient is designed with automated contributors in mind. The live
+ticket queue is machine-readable through GitHub Issues and PR
+metadata, the test suite gives a deterministic pass/fail signal,
+and the contribution workflow requires no human-only interaction
+beyond opening a PR.
 
 Agents of any kind — code generation assistants, autonomous
 coding agents, or CI bots — are welcome to:
 
-- Pick up a `good first issue` or `.board/` ticket
+- Pick up a `good first issue` or `agent-ready` issue
 - Submit a PR that passes `cargo test && cargo fmt --check && cargo clippy`
 - Report bugs by opening a GitHub issue with a reproducible example
 
@@ -134,5 +133,6 @@ The current focus is on:
 - Improving the LSP experience
 
 Follow along in
-[`.board/`](https://github.com/EricSpencer00/Resilient/tree/main/.board)
-or watch the repository on GitHub to stay current.
+[ROADMAP.md](https://github.com/EricSpencer00/Resilient/blob/main/ROADMAP.md)
+and the live GitHub Issues queue, or watch the repository on GitHub to
+stay current.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -77,11 +77,12 @@ the perf gate automatically.
 ## The ticket system
 
 Resilient tracks work in [GitHub Issues](https://github.com/EricSpencer00/Resilient/issues).
-Each issue carries a unique `RES-NNN` identifier, a clear goal, and
-concrete acceptance criteria.
+Each issue carries a unique `RES-NNN` identifier, a clear goal,
+priority, roadmap goal, and concrete acceptance criteria.
 
-- **Claiming a ticket**: comment on the issue, then create a branch
-  named `res-NNN-short-title`.
+- **Claiming a ticket**: create a branch named `res-NNN-short-title`
+  and open a draft PR with `Closes #N` in the body. Commenting on the
+  issue is optional.
 - **Landing a ticket**: open a PR with `Closes #N` in the body; the
   commit message should reference the ticket ID
   (e.g. `RES-042: add float division`).


### PR DESCRIPTION
Closes #2834.

## What changed
- Added a reusable Ralph loop launcher with prompt injection.
- Made ticket selection priority-aware and roadmap-aware.
- Reconciled the agent docs with the live GitHub issue/PR flow.
- Hardened the loop harness against empty-array nounset crashes.
- Tightened claim-release documentation and workflow behavior.

## Verification
- `bash -n` on touched shell scripts
- `git diff --check`
- YAML parse of the updated issue template and workflow
- `agent-scripts/ralph-loop.sh --n 1 --dry-run`

## Notes
- Existing untracked workspace artifacts were left untouched.