### PR TITLE
RES-2541: Re-export support: pub use

### DIFF
--- a/resilient/examples/pub_use_internal_parser.rz
+++ b/resilient/examples/pub_use_internal_parser.rz
@@ -1,0 +1,5 @@
+// RES-2541: helper module for `pub use` re-export coverage.
+// Imported via `pub use "pub_use_internal_parser.rz" as parser;`.
+fn greet() {
+    println("parser");
+}

--- a/resilient/examples/pub_use_internal_types.rz
+++ b/resilient/examples/pub_use_internal_types.rz
@@ -1,0 +1,9 @@
+// RES-2541: helper module for selective `pub use` re-exports.
+// Imported via `pub use "pub_use_internal_types.rz" { Type, TypeKind };`.
+fn Type() {
+    println("Type");
+}
+
+fn TypeKind() {
+    println("TypeKind");
+}

--- a/resilient/examples/pub_use_lib.rz
+++ b/resilient/examples/pub_use_lib.rz
@@ -1,0 +1,3 @@
+// RES-2541: library surface that re-exports internal helpers.
+pub use "pub_use_internal_parser.rz" as parser;
+pub use "pub_use_internal_types.rz" { Type, TypeKind };

--- a/resilient/examples/pub_use_main.expected.txt
+++ b/resilient/examples/pub_use_main.expected.txt
@@ -1,0 +1,4 @@
+parser
+Type
+TypeKind
+Program executed successfully

--- a/resilient/examples/pub_use_main.rz
+++ b/resilient/examples/pub_use_main.rz
@@ -1,0 +1,8 @@
+// RES-2541: golden test for `pub use`.
+// Importers of this module should see both the namespace re-export
+// and the selective symbol re-exports.
+use "pub_use_lib.rz";
+
+parser::greet();
+Type();
+TypeKind();

--- a/resilient/src/formatter.rs
+++ b/resilient/src/formatter.rs
@@ -158,12 +158,30 @@ impl Formatter {
 
     fn fmt_stmt(&mut self, node: &Node) {
         match node {
-            Node::Use { path, alias, .. } => {
-                if let Some(ns) = alias {
-                    self.write_args(format_args!("use \"{}\" as {};", path, ns));
-                } else {
-                    self.write_args(format_args!("use \"{}\";", path));
+            Node::Use {
+                path,
+                alias,
+                selectors,
+                is_pub,
+                ..
+            } => {
+                if *is_pub {
+                    self.write("pub ");
                 }
+                self.write_args(format_args!("use \"{}\"", path));
+                if let Some(ns) = alias {
+                    self.write_args(format_args!(" as {}", ns));
+                } else if let Some(selectors) = selectors {
+                    self.write(" { ");
+                    for (i, selector) in selectors.iter().enumerate() {
+                        if i > 0 {
+                            self.write(", ");
+                        }
+                        self.write(selector);
+                    }
+                    self.write(" }");
+                }
+                self.write(";");
                 self.newline();
             }
             Node::Function {

--- a/resilient/src/imports.rs
+++ b/resilient/src/imports.rs
@@ -10,7 +10,11 @@
 //! 2. **Namespaced file imports**: `use "path" as name;` — like above but
 //!    declarations are scoped under `name::`.
 //!
-//! 3. **Standard library imports**: `use std::http;` / `use std::json as j;`
+//! 3. **Selective / public re-exports**: `use "path" { A, B };` imports
+//!    only the named declarations, while `pub use "path"` marks imported
+//!    declarations public so the current module can re-export them.
+//!
+//! 4. **Standard library imports**: `use std::http;` / `use std::json as j;`
 //!    — imports a built-in standard library module.
 //!
 //! Cycles are detected via an in-flight stack: before expanding a file,
@@ -84,8 +88,17 @@ fn expand_recursive(
 
     let mut expanded: Vec<Spanned<Node>> = Vec::with_capacity(stmts.len());
     for stmt in stmts.drain(..) {
-        if let Node::Use { path, alias, .. } = &stmt.node {
+        if let Node::Use {
+            path,
+            alias,
+            selectors,
+            is_pub,
+            ..
+        } = &stmt.node
+        {
             let alias = alias.clone();
+            let selectors = selectors.clone();
+            let is_pub = *is_pub;
 
             // Check for standard library import: `use std::module;`
             if let Some(module_name) = path.strip_prefix("std::") {
@@ -128,18 +141,14 @@ fn expand_recursive(
                 )?;
                 in_flight.pop();
                 if let Node::Program(imported_stmts) = imported_program {
-                    let has_any_pub = imported_stmts.iter().any(|s| is_pub_decl(&s.node));
-                    let ns = alias.clone().unwrap_or_else(|| dep_name.to_string());
-                    for s in imported_stmts {
-                        if matches!(s.node, Node::Use { .. }) {
-                            continue;
-                        }
-                        if has_any_pub && is_exportable_decl(&s.node) && !is_pub_decl(&s.node) {
-                            continue;
-                        }
-                        let renamed = rename_decl(s, &ns);
-                        expanded.push(renamed);
-                    }
+                    let ns = alias.as_deref().unwrap_or(dep_name);
+                    append_imported_stmts(
+                        imported_stmts,
+                        &mut expanded,
+                        selectors.as_deref(),
+                        is_pub,
+                        Some(ns),
+                    );
                 }
                 continue;
             }
@@ -175,24 +184,13 @@ fn expand_recursive(
             in_flight.pop();
 
             if let Node::Program(imported_stmts) = imported_program {
-                let has_any_pub = imported_stmts.iter().any(|s| is_pub_decl(&s.node));
-
-                for s in imported_stmts {
-                    if matches!(s.node, Node::Use { .. }) {
-                        continue;
-                    }
-
-                    if has_any_pub && is_exportable_decl(&s.node) && !is_pub_decl(&s.node) {
-                        continue;
-                    }
-
-                    if let Some(ref ns) = alias {
-                        let renamed = rename_decl(s, ns);
-                        expanded.push(renamed);
-                    } else {
-                        expanded.push(s);
-                    }
-                }
+                append_imported_stmts(
+                    imported_stmts,
+                    &mut expanded,
+                    selectors.as_deref(),
+                    is_pub,
+                    alias.as_deref(),
+                );
             }
         } else {
             expanded.push(stmt);
@@ -242,6 +240,24 @@ fn is_exportable_decl(node: &Node) -> bool {
     matches!(node, Node::Function { .. } | Node::StructDecl { .. })
 }
 
+/// Return the declaration name for items that can be re-exported.
+fn decl_name(node: &Node) -> Option<&str> {
+    match node {
+        Node::Function { name, .. } | Node::StructDecl { name, .. } => Some(name.as_str()),
+        _ => None,
+    }
+}
+
+/// Mark a declaration as public when it is re-exported via `pub use`.
+fn mark_pub_decl(node: &mut Node) {
+    match node {
+        Node::Function { is_pub, .. } | Node::StructDecl { is_pub, .. } => {
+            *is_pub = true;
+        }
+        _ => {}
+    }
+}
+
 /// Rename an imported declaration by prepending `ns::` to its name.
 fn rename_decl(mut s: Spanned<Node>, ns: &str) -> Spanned<Node> {
     match &mut s.node {
@@ -254,6 +270,45 @@ fn rename_decl(mut s: Spanned<Node>, ns: &str) -> Spanned<Node> {
         _ => {}
     }
     s
+}
+
+/// Apply import/export filtering and push the surviving declarations
+/// into `expanded`.
+fn append_imported_stmts(
+    imported_stmts: Vec<Spanned<Node>>,
+    expanded: &mut Vec<Spanned<Node>>,
+    selectors: Option<&[String]>,
+    make_pub: bool,
+    namespace: Option<&str>,
+) {
+    let has_any_pub = imported_stmts.iter().any(|s| is_pub_decl(&s.node));
+
+    for mut s in imported_stmts {
+        if matches!(s.node, Node::Use { .. }) {
+            continue;
+        }
+
+        if has_any_pub && is_exportable_decl(&s.node) && !is_pub_decl(&s.node) {
+            continue;
+        }
+
+        if let Some(selector_names) = selectors {
+            let Some(name) = decl_name(&s.node) else {
+                continue;
+            };
+            if !selector_names.iter().any(|selector| selector == name) {
+                continue;
+            }
+        }
+
+        if let Some(ns) = namespace {
+            s = rename_decl(s, ns);
+        }
+        if make_pub {
+            mark_pub_decl(&mut s.node);
+        }
+        expanded.push(s);
+    }
 }
 
 fn resolve_use_path(base_dir: &Path, path: &str) -> Result<PathBuf, String> {

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -2364,11 +2364,23 @@ enum Node {
     /// RES-360: optional `as NAME` suffix creates a namespace alias.
     /// Declarations imported from the file are bound as `NAME::decl`
     /// instead of being merged directly into the current scope.
+    ///
+    /// RES-2541: `pub use` marks the imported declarations public so
+    /// the current module can re-export them. A selective form,
+    /// `use "file" { A, B }`, imports only the named declarations.
     Use {
         path: String,
         /// RES-360: namespace alias from `use "file" as name;`.
         /// `None` preserves the original unqualified-import behaviour.
         alias: Option<String>,
+        /// RES-2541: optional selective import / re-export list from
+        /// `use "file" { A, B };`. `None` preserves flat import
+        /// behaviour. The selector names are matched against the
+        /// imported declaration names before any namespace rename.
+        selectors: Option<Vec<String>>,
+        /// RES-2541: `pub use` re-exports the imported declarations to
+        /// downstream importers of the current module.
+        is_pub: bool,
         /// RES-088: span of the `use` keyword. Consumed in follow-ups.
         #[allow(dead_code)]
         span: span::Span,
@@ -3972,8 +3984,14 @@ impl Parser {
                 }
                 node
             }
+            Token::Use => self
+                .parse_use_statement_with_visibility(true)
+                .unwrap_or_else(|| Node::Block {
+                    stmts: Vec::new(),
+                    span: self.span_at_current(),
+                }),
             _ => {
-                self.record_error("`pub` must be followed by `fn` or `struct`".to_string());
+                self.record_error("`pub` must be followed by `fn`, `struct`, or `use`".to_string());
                 Node::Block {
                     stmts: Vec::new(),
                     span: self.span_at_current(),
@@ -7021,10 +7039,17 @@ impl Parser {
         }
     }
 
-    /// RES-073: `use "path/to/file.rz";` — emits `Node::Use { path, alias, span }`.
+    /// RES-073: `use "path/to/file.rz";` — emits `Node::Use { path, alias, selectors, is_pub, span }`.
     /// RES-360: `use "path" as name;` — namespaced import.
+    /// RES-2541: `pub use "path";` marks the imported declarations
+    /// public; `use "path" { A, B };` selectively imports only the
+    /// named declarations.
     /// Also supports `use std::module;` and `use std::module as alias;`.
     fn parse_use_statement(&mut self) -> Option<Node> {
+        self.parse_use_statement_with_visibility(false)
+    }
+
+    fn parse_use_statement_with_visibility(&mut self, is_pub: bool) -> Option<Node> {
         self.next_token(); // consume 'use'
         let path = match &self.current_token {
             Token::StringLiteral(s) => s.clone(),
@@ -7070,12 +7095,50 @@ impl Parser {
         } else {
             None
         };
+        let selectors = if self.peek_token == Token::LeftBrace {
+            self.next_token();
+            self.next_token();
+            let mut selectors = Vec::new();
+            while self.current_token != Token::RightBrace && self.current_token != Token::Eof {
+                match &self.current_token {
+                    Token::Identifier(name) => selectors.push(name.clone()),
+                    _ => {
+                        let tok = self.current_token.clone();
+                        self.record_error(format!(
+                            "Expected identifier inside selective `use`, found {}",
+                            tok
+                        ));
+                        return None;
+                    }
+                }
+                self.next_token();
+                if self.current_token == Token::Comma {
+                    self.next_token();
+                } else if self.current_token != Token::RightBrace {
+                    let tok = self.current_token.clone();
+                    self.record_error(format!(
+                        "Expected `,` or `}}` in selective `use`, found {}",
+                        tok
+                    ));
+                    return None;
+                }
+            }
+            if selectors.is_empty() {
+                self.record_error("Selective `use` requires at least one name".to_string());
+                return None;
+            }
+            Some(selectors)
+        } else {
+            None
+        };
         if self.peek_token == Token::Semicolon {
             self.next_token();
         }
         Some(Node::Use {
             path,
             alias,
+            selectors,
+            is_pub,
             span: self.span_at_current(),
         })
     }

--- a/resilient/src/unused_imports.rs
+++ b/resilient/src/unused_imports.rs
@@ -12,6 +12,7 @@
 //! use "util.rz";           ← skipped (conservative; flat merge)
 //! use std::http;           ← skipped (stdlib)
 //! use std::http as h;      ← skipped (stdlib)
+//! pub use "lib.rz" as h;   ← skipped (intentional re-export)
 //! ```
 //!
 //! For `use "path"` without an alias, the imported declarations are
@@ -60,7 +61,17 @@ pub(crate) fn check(program: &Node, source_path: &str) {
     // stdlib (`std::`) imports are always skipped.
     let mut candidates: Vec<ImportInfo<'_>> = Vec::new();
     for stmt in stmts {
-        if let Node::Use { path, alias, span } = &stmt.node {
+        if let Node::Use {
+            path,
+            alias,
+            span,
+            is_pub,
+            ..
+        } = &stmt.node
+        {
+            if *is_pub {
+                continue;
+            }
             if path.starts_with("std::") {
                 continue;
             }
@@ -486,7 +497,17 @@ mod tests {
         // Collect candidates.
         let mut candidates: Vec<(String, String, crate::span::Span)> = Vec::new();
         for stmt in stmts {
-            if let crate::Node::Use { path, alias, span } = &stmt.node {
+            if let crate::Node::Use {
+                path,
+                alias,
+                span,
+                is_pub,
+                ..
+            } = &stmt.node
+            {
+                if *is_pub {
+                    continue;
+                }
                 if path.starts_with("std::") {
                     continue;
                 }
@@ -599,5 +620,15 @@ mod tests {
         let src = "use std::json; let x = 1; x;";
         let warnings = warnings_for(src);
         assert!(warnings.is_empty(), "stdlib import should not warn");
+    }
+
+    #[test]
+    fn pub_use_alias_unused_is_not_warned() {
+        let src = "pub use \"util.rz\" as util; let x = 1; x;";
+        let warnings = warnings_for(src);
+        assert!(
+            warnings.is_empty(),
+            "pub re-export should not warn even when alias is unused"
+        );
     }
 }


### PR DESCRIPTION
Closes #2541.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-2541-re-export-support-pub-use`
Worktree: `.claude/worktrees/res-2541`

## Agent claims

(none inferred from issue)