### PR TITLE
RES-2545: Error stack traces with source locations

### DIFF
--- a/resilient/examples/error_stack_traces.expected.txt
+++ b/resilient/examples/error_stack_traces.expected.txt
@@ -1,5 +1,5 @@
 trace length: 3
-outer_trace
-middle_trace
-inner_trace
+outer_trace at error_stack_traces.rz:20:13
+middle_trace at error_stack_traces.rz:17:18
+inner_trace at error_stack_traces.rz:13:17
 Program executed successfully

--- a/resilient/src/error_stack_traces.rs
+++ b/resilient/src/error_stack_traces.rs
@@ -6,6 +6,8 @@
 
 use crate::span::Span;
 
+const DEFAULT_STACKTRACE_DEPTH: usize = 64;
+
 #[derive(Debug, Clone)]
 pub struct StackFrame {
     pub fn_name: String,
@@ -13,11 +15,21 @@ pub struct StackFrame {
 }
 
 pub fn format_stack_trace(frames: &[StackFrame], source_path: &str) -> String {
+    format_stack_trace_with_limit(frames, source_path, stacktrace_depth_limit())
+}
+
+pub(crate) fn format_stack_trace_with_limit(
+    frames: &[StackFrame],
+    source_path: &str,
+    max_depth: usize,
+) -> String {
+    let frames = visible_frames(frames, max_depth);
     if frames.is_empty() {
         return String::new();
     }
     let mut lines = Vec::with_capacity(frames.len() + 1);
     lines.push("stack trace (most recent call last):".to_string());
+    let source_path = display_source_path(source_path);
     for frame in frames {
         let loc = if frame.call_span.start.line > 0 {
             format!(
@@ -33,7 +45,16 @@ pub fn format_stack_trace(frames: &[StackFrame], source_path: &str) -> String {
 }
 
 pub fn builtin_stacktrace(frames: &[StackFrame], source_path: &str) -> Vec<String> {
-    frames
+    builtin_stacktrace_with_limit(frames, source_path, stacktrace_depth_limit())
+}
+
+pub(crate) fn builtin_stacktrace_with_limit(
+    frames: &[StackFrame],
+    source_path: &str,
+    max_depth: usize,
+) -> Vec<String> {
+    let source_path = display_source_path(source_path);
+    visible_frames(frames, max_depth)
         .iter()
         .map(|f| {
             if f.call_span.start.line > 0 {
@@ -46,6 +67,29 @@ pub fn builtin_stacktrace(frames: &[StackFrame], source_path: &str) -> Vec<Strin
             }
         })
         .collect()
+}
+
+fn visible_frames(frames: &[StackFrame], max_depth: usize) -> &[StackFrame] {
+    if frames.len() <= max_depth {
+        frames
+    } else {
+        &frames[frames.len() - max_depth..]
+    }
+}
+
+fn stacktrace_depth_limit() -> usize {
+    std::env::var("RZ_STACKTRACE_DEPTH")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_STACKTRACE_DEPTH)
+}
+
+fn display_source_path(source_path: &str) -> String {
+    std::path::Path::new(source_path)
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_else(|| source_path.to_string())
 }
 
 #[cfg(test)]
@@ -109,6 +153,24 @@ mod tests {
     }
 
     #[test]
+    fn builtin_stacktrace_truncates_to_limit() {
+        let frames = vec![
+            frame("a", 1, 1),
+            frame("b", 2, 2),
+            frame("c", 3, 3),
+            frame("d", 4, 4),
+        ];
+        let result = builtin_stacktrace_with_limit(&frames, "test.rz", 2);
+        assert_eq!(result, vec!["c at test.rz:3:3", "d at test.rz:4:4"]);
+
+        let trace = format_stack_trace_with_limit(&frames, "test.rz", 2);
+        let lines: Vec<&str> = trace.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[1].contains("at c (test.rz:3:3)"));
+        assert!(lines[2].contains("at d (test.rz:4:4)"));
+    }
+
+    #[test]
     fn end_to_end_stack_trace_in_error() {
         let r = crate::run_program(
             r#"
@@ -133,6 +195,45 @@ outer()
             combined.contains("stack trace") || combined.contains("inner"),
             "error should include stack trace, got: {:?}",
             r.errors
+        );
+        assert!(
+            combined.contains("at inner (<input>:") || combined.contains("at middle (<input>:"),
+            "error stack trace should include source locations, got: {:?}",
+            r.errors
+        );
+    }
+
+    #[test]
+    fn builtin_stacktrace_includes_source_locations() {
+        let r = crate::run_program(
+            r#"
+fn inner_trace() {
+    let trace = stacktrace()
+    println("trace length: " + to_string(len(trace)))
+    for frame in trace {
+        println(frame)
+    }
+}
+
+fn middle_trace() {
+    inner_trace()
+}
+
+fn outer_trace() {
+    middle_trace()
+}
+
+outer_trace()
+"#,
+        );
+        assert!(r.ok, "stacktrace example should run successfully");
+        assert!(r.stdout.contains("trace length: 3"), "got: {}", r.stdout);
+        assert!(
+            r.stdout.contains("outer_trace at <input>:")
+                && r.stdout.contains("middle_trace at <input>:")
+                && r.stdout.contains("inner_trace at <input>:"),
+            "stacktrace() should include file:line:col in each frame, got: {}",
+            r.stdout
         );
     }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -24072,8 +24072,9 @@ impl Interpreter {
             Node::CallExpression {
                 function,
                 arguments,
-                ..
+                span,
             } => {
+                let call_span = *span;
                 // RES-2592: tail-call trampoline signal. When this interpreter
                 // is running inside a #[must_tail_call] function body and sees
                 // a self-recursive call in tail position, emit Value::TailCall
@@ -24542,7 +24543,7 @@ impl Interpreter {
                             // Prepend the target as the implicit `self`.
                             let mut args = vec![target_val];
                             args.extend(self.eval_expressions(arguments)?);
-                            return self.apply_function(&method_val, args);
+                            return self.apply_function_at(&method_val, args, call_span);
                         }
                         // No matching method on this struct — fall
                         // through to the regular `FieldAccess` eval
@@ -24557,7 +24558,7 @@ impl Interpreter {
                         if let Some(method_val) = self.env.get(&mangled) {
                             let mut args = vec![target_val];
                             args.extend(self.eval_expressions(arguments)?);
-                            return self.apply_function(&method_val, args);
+                            return self.apply_function_at(&method_val, args, call_span);
                         }
                     }
                     // RES-2553: primitive type method dispatch — `impl int { fn abs(self) }`,
@@ -24576,7 +24577,7 @@ impl Interpreter {
                         if let Some(method_val) = self.env.get(&mangled) {
                             let mut args = vec![target_val];
                             args.extend(self.eval_expressions(arguments)?);
-                            return self.apply_function(&method_val, args);
+                            return self.apply_function_at(&method_val, args, call_span);
                         }
                     }
                 }
@@ -24996,7 +24997,7 @@ impl Interpreter {
                 }
                 let func = self.eval(function)?;
                 let args = self.eval_expressions(arguments)?;
-                self.apply_function(&func, args)
+                self.apply_function_at(&func, args, call_span)
             }
             Node::ArrayLiteral { items, .. } => {
                 let mut out = Vec::with_capacity(items.len());
@@ -27223,6 +27224,15 @@ impl Interpreter {
     }
 
     fn apply_function(&mut self, func: &Value, args: Vec<Value>) -> RResult<Value> {
+        self.apply_function_at(func, args, span::Span::default())
+    }
+
+    fn apply_function_at(
+        &mut self,
+        func: &Value,
+        args: Vec<Value>,
+        call_span: span::Span,
+    ) -> RResult<Value> {
         match func {
             Value::Function(fv) => {
                 let FunctionValue {
@@ -27289,7 +27299,7 @@ impl Interpreter {
                 let mut child_stack = self.call_stack.clone();
                 child_stack.push(crate::error_stack_traces::StackFrame {
                     fn_name: name.clone(),
-                    call_span: crate::span::Span::default(),
+                    call_span,
                 });
 
                 let mut interpreter = Interpreter {


### PR DESCRIPTION
Closes #2545.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-2545-error-stack-traces-with-source-locations`
Worktree: `.claude/worktrees/res-2545`

## Agent claims

(none inferred from issue)