### PR TITLE
RES-2549: Iterator protocol: for-in over custom types

### DIFF
--- a/resilient/src/iterator_protocol.rs
+++ b/resilient/src/iterator_protocol.rs
@@ -185,6 +185,37 @@ println("done")
     }
 
     #[test]
+    fn for_in_trait_iterator_works_without_typecheck() {
+        let r = crate::run_program(
+            r#"
+struct Counter { Cell current, int end }
+
+fn make_counter(int end) -> Counter {
+    let current = cell(0)
+    return new Counter { current, end }
+}
+
+impl Iterator for Counter {
+    type Item = int;
+    fn next(self) -> Option<int> {
+        if self.current.get() >= self.end { return None }
+        let value = self.current.get()
+        self.current.set(value + 1)
+        return Some(value)
+    }
+}
+
+for x in make_counter(4) {
+    println(x)
+}
+"#,
+        );
+        assert!(r.ok, "errors: {:?}", r.errors);
+        let lines: Vec<&str> = r.stdout.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines, vec!["0", "1", "2", "3"]);
+    }
+
+    #[test]
     fn non_option_iterator_errors() {
         let r = crate::run_program(
             r#"
@@ -198,5 +229,38 @@ for x in bad_iter() {
 "#,
         );
         assert!(!r.ok, "should error when next() returns non-Option");
+    }
+
+    #[test]
+    fn iterator_trait_collect_and_adapters_work() {
+        let r = crate::run_program(
+            r#"
+struct Counter { Cell current, int end }
+
+fn make_counter(int end) -> Counter {
+    let current = cell(0)
+    return new Counter { current, end }
+}
+
+impl Iterator for Counter {
+    type Item = int;
+    fn next(self) -> Option<int> {
+        if self.current.get() >= self.end { return None }
+        let value = self.current.get()
+        self.current.set(value + 1)
+        return Some(value)
+    }
+}
+
+println(len(make_counter(5).collect()))
+println(len(make_counter(6).map(fn(int x) -> int { return x * 2; }).collect()))
+println(len(make_counter(6).filter(fn(int x) -> bool { return x % 2 == 0; }).collect()))
+println(len(make_counter(6).take(2).collect()))
+println(len(make_counter(6).skip(4).collect()))
+"#,
+        );
+        assert!(r.ok, "errors: {:?}", r.errors);
+        let lines: Vec<&str> = r.stdout.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines, vec!["5", "6", "3", "2", "2"]);
     }
 }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -24509,6 +24509,16 @@ impl Interpreter {
                     // RES-920 / RES-2734: method-call sugar on built-in Array.
                     // All short names correspond to BUILTINS entries exactly.
                     if let Value::Array(_) = &target_val {
+                        if field == "collect" {
+                            let extra_args = self.eval_expressions(arguments)?;
+                            if !extra_args.is_empty() {
+                                return Err(format!(
+                                    "collect: expected 0 arguments, got {}",
+                                    extra_args.len()
+                                ));
+                            }
+                            return Ok(target_val.clone());
+                        }
                         let allowed: &[&str] = &[
                             "len",
                             "push",
@@ -24606,6 +24616,123 @@ impl Interpreter {
                             let mut args = vec![target_val];
                             args.extend(self.eval_expressions(arguments)?);
                             return self.apply_function(&method_val, args);
+                        }
+                        let next_mangled = format!("{}${}", sname, "next");
+                        if let Some(next_method) = self.env.get(&next_mangled) {
+                            match field.as_str() {
+                                "collect" => {
+                                    let extra_args = self.eval_expressions(arguments)?;
+                                    if !extra_args.is_empty() {
+                                        return Err(format!(
+                                            "collect: expected 0 arguments, got {}",
+                                            extra_args.len()
+                                        ));
+                                    }
+                                    let items = self.collect_iterator_items(
+                                        target_val.clone(),
+                                        next_method.clone(),
+                                    )?;
+                                    return Ok(Value::Array(items));
+                                }
+                                "map" => {
+                                    let mut extra_args = self.eval_expressions(arguments)?;
+                                    if extra_args.len() != 1 {
+                                        return Err(format!(
+                                            "map: expected 1 callback argument, got {}",
+                                            extra_args.len()
+                                        ));
+                                    }
+                                    let callback = extra_args.pop().unwrap();
+                                    let items = self.collect_iterator_items(
+                                        target_val.clone(),
+                                        next_method.clone(),
+                                    )?;
+                                    let mut out = Vec::with_capacity(items.len());
+                                    for item in items {
+                                        out.push(self.apply_function(&callback, vec![item])?);
+                                    }
+                                    return Ok(Value::Array(out));
+                                }
+                                "filter" => {
+                                    let mut extra_args = self.eval_expressions(arguments)?;
+                                    if extra_args.len() != 1 {
+                                        return Err(format!(
+                                            "filter: expected 1 predicate argument, got {}",
+                                            extra_args.len()
+                                        ));
+                                    }
+                                    let predicate = extra_args.pop().unwrap();
+                                    let items = self.collect_iterator_items(
+                                        target_val.clone(),
+                                        next_method.clone(),
+                                    )?;
+                                    let mut out = Vec::new();
+                                    for item in items {
+                                        match self.apply_function(&predicate, vec![item.clone()])? {
+                                            Value::Bool(true) => out.push(item),
+                                            Value::Bool(false) => {}
+                                            other => {
+                                                return Err(format!(
+                                                    "filter: predicate must return bool, got {}",
+                                                    other
+                                                ));
+                                            }
+                                        }
+                                    }
+                                    return Ok(Value::Array(out));
+                                }
+                                "take" => {
+                                    let mut extra_args = self.eval_expressions(arguments)?;
+                                    if extra_args.len() != 1 {
+                                        return Err(format!(
+                                            "take: expected 1 count argument, got {}",
+                                            extra_args.len()
+                                        ));
+                                    }
+                                    let count = match extra_args.pop().unwrap() {
+                                        Value::Int(n) if n >= 0 => n as usize,
+                                        other => {
+                                            return Err(format!(
+                                                "take: count must be non-negative, got {}",
+                                                other
+                                            ));
+                                        }
+                                    };
+                                    let items = self.collect_iterator_items(
+                                        target_val.clone(),
+                                        next_method.clone(),
+                                    )?;
+                                    return Ok(Value::Array(
+                                        items.into_iter().take(count).collect(),
+                                    ));
+                                }
+                                "skip" => {
+                                    let mut extra_args = self.eval_expressions(arguments)?;
+                                    if extra_args.len() != 1 {
+                                        return Err(format!(
+                                            "skip: expected 1 count argument, got {}",
+                                            extra_args.len()
+                                        ));
+                                    }
+                                    let count = match extra_args.pop().unwrap() {
+                                        Value::Int(n) if n >= 0 => n as usize,
+                                        other => {
+                                            return Err(format!(
+                                                "skip: count must be non-negative, got {}",
+                                                other
+                                            ));
+                                        }
+                                    };
+                                    let items = self.collect_iterator_items(
+                                        target_val.clone(),
+                                        next_method.clone(),
+                                    )?;
+                                    return Ok(Value::Array(
+                                        items.into_iter().skip(count).collect(),
+                                    ));
+                                }
+                                _ => {}
+                            }
                         }
                         // No matching method on this struct — fall
                         // through to the regular `FieldAccess` eval
@@ -26210,14 +26337,20 @@ impl Interpreter {
             }
             Value::Struct {
                 name: ref sname, ..
-            } if crate::iterator_protocol::is_iterator(sname) => {
+            } => {
                 let mangled = format!("{}$next", sname);
                 if let Some(method_val) = self.env.get(&mangled) {
                     let iter_fn = method_val;
                     return self.eval_for_in_iterator_method(iter_val, iter_fn, name, body, label);
                 }
+                if crate::iterator_protocol::is_iterator(sname) {
+                    return Err(format!(
+                        "type `{}` implements Iterator but has no `next` method",
+                        sname
+                    ));
+                }
                 return Err(format!(
-                    "type `{}` implements Iterator but has no `next` method",
+                    "`for` iterable must be an array, map, or iterator, got struct `{}`",
                     sname
                 ));
             }
@@ -26321,6 +26454,39 @@ impl Interpreter {
             }
         }
         Ok(Value::Void)
+    }
+
+    /// Eagerly materialize every item produced by a custom iterator.
+    /// The iterator protocol in this slice is intentionally array-backed
+    /// once a consumer asks for adapters like `collect`, `map`, or `take`.
+    fn collect_iterator_items(
+        &mut self,
+        iterable: Value,
+        method_val: Value,
+    ) -> RResult<Vec<Value>> {
+        const MAX_ITERS: usize = 1_000_000;
+        let mut iters = 0usize;
+        let mut items = Vec::new();
+        loop {
+            iters += 1;
+            if iters > MAX_ITERS {
+                return Err(format!(
+                    "iterator exceeded {MAX_ITERS} calls to next() (runaway?)"
+                ));
+            }
+            let next_result = self.apply_function(&method_val, vec![iterable.clone()])?;
+            match next_result {
+                Value::Option(None) => break,
+                Value::Option(Some(inner)) => items.push(*inner),
+                other => {
+                    return Err(format!(
+                        "iterator next() must return Option (Some/None), got {}",
+                        other
+                    ));
+                }
+            }
+        }
+        Ok(items)
     }
 
     /// Extract `Some(v)` from an Option enum variant and bind it as the loop

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -8516,6 +8516,36 @@ impl TypeChecker {
                             }
                         }
                     }
+                    let next_mangled = format!("{}$next", sname);
+                    let implements_iterator = self.env.get(&next_mangled).is_some()
+                        || self
+                            .trait_impls
+                            .get(sname.as_str())
+                            .is_some_and(|traits| traits.contains("Iterator"))
+                        || crate::iterator_protocol::is_iterator(sname.as_str());
+                    if implements_iterator {
+                        match field.as_str() {
+                            "collect" => {
+                                return Ok(Type::Function {
+                                    params: vec![],
+                                    return_type: Box::new(Type::Array),
+                                });
+                            }
+                            "map" | "filter" => {
+                                return Ok(Type::Function {
+                                    params: vec![Type::Any],
+                                    return_type: Box::new(Type::Array),
+                                });
+                            }
+                            "take" | "skip" => {
+                                return Ok(Type::Function {
+                                    params: vec![Type::Int],
+                                    return_type: Box::new(Type::Array),
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
                     // RES-407: struct is known, field not found, and no
                     // impl method or default trait method — report a clear diagnostic.
                     let avail: Vec<&str> = declared.iter().map(|(n, _)| n.as_str()).collect();
@@ -8574,6 +8604,10 @@ impl TypeChecker {
                         "len" => Type::Function {
                             params: vec![],
                             return_type: Box::new(Type::Int),
+                        },
+                        "collect" => Type::Function {
+                            params: vec![],
+                            return_type: Box::new(Type::Array),
                         },
                         // RES-2734: `has` is the array-element membership method;
                         // `contains` is kept for backward compat.
@@ -8669,6 +8703,12 @@ impl TypeChecker {
                             return Ok(Type::Function {
                                 params: vec![Type::Any],
                                 return_type: Box::new(Type::Bool),
+                            });
+                        }
+                        "collect" => {
+                            return Ok(Type::Function {
+                                params: vec![],
+                                return_type: Box::new(Type::Array),
                             });
                         }
                         _ => {}


### PR DESCRIPTION
Closes #2549.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-2549-iterator-protocol-for-in-over-custom-typ`
Worktree: `.claude/worktrees/res-2549`

## Agent claims

(none inferred from issue)