### PR TITLE
RES-2556: HTTP client stdlib (std-only)

### DIFF
--- a/resilient/src/http_client.rs
+++ b/resilient/src/http_client.rs
@@ -1,17 +1,21 @@
 //! RES-2556: minimal HTTP/1.1 client builtins (std-only).
 //!
 //! Provides `http_get` and `http_post` built on raw TCP sockets.
-//! Handles chunked transfer encoding, Content-Length, and header
-//! parsing. No TLS — HTTP only.
+//! Handles chunked transfer encoding, Content-Length, request
+//! headers, response headers, and configurable timeouts. No TLS —
+//! HTTP only.
 
 #![allow(clippy::collapsible_if, clippy::doc_lazy_continuation)]
 
-use crate::{Node, Value};
+use crate::{MapKey, Node, Value};
+use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
 
 type RResult<T> = Result<T, String>;
+
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
 fn ok(v: Value) -> Value {
     Value::Result {
@@ -31,6 +35,21 @@ struct ParsedUrl {
     host: String,
     port: u16,
     path: String,
+}
+
+#[derive(Debug)]
+struct RequestOptions {
+    headers: HashMap<String, String>,
+    timeout: Duration,
+}
+
+impl Default for RequestOptions {
+    fn default() -> Self {
+        Self {
+            headers: HashMap::new(),
+            timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+        }
+    }
 }
 
 fn parse_url(url: &str) -> Result<ParsedUrl, String> {
@@ -65,57 +84,162 @@ fn parse_url(url: &str) -> Result<ParsedUrl, String> {
     })
 }
 
+fn response_headers_to_map(headers: Vec<(String, String)>) -> Value {
+    let mut map = HashMap::with_capacity(headers.len());
+    for (key, value) in headers {
+        map.insert(MapKey::Str(key), Value::String(value));
+    }
+    Value::Map(map)
+}
+
 fn make_response(status: i64, body: String, headers: Vec<(String, String)>) -> Value {
-    let header_values: Vec<Value> = headers
-        .into_iter()
-        .map(|(k, v)| Value::Tuple(vec![Value::String(k), Value::String(v)]))
-        .collect();
     Value::Struct {
-        name: "HttpResponse".to_string(),
+        name: "Response".to_string(),
         fields: vec![
             ("status".to_string(), Value::Int(status)),
             ("body".to_string(), Value::String(body)),
-            ("headers".to_string(), Value::Array(header_values)),
+            ("headers".to_string(), response_headers_to_map(headers)),
         ],
     }
 }
 
-fn send_request(
-    method: &str,
-    url: &str,
-    body: Option<&str>,
-    extra_headers: &[(String, String)],
-) -> Value {
+fn timeout_from_ms(ms: i64, builtin: &str) -> RResult<Duration> {
+    if ms <= 0 {
+        return Err(format!(
+            "{builtin}: timeout must be a positive integer number of milliseconds"
+        ));
+    }
+    Ok(Duration::from_millis(ms as u64))
+}
+
+fn request_headers_from_map(
+    headers: &HashMap<MapKey, Value>,
+    builtin: &str,
+) -> RResult<HashMap<String, String>> {
+    let mut out = HashMap::with_capacity(headers.len());
+    for (key, value) in headers {
+        let key = match key {
+            MapKey::Str(s) => s.clone(),
+            other => {
+                return Err(format!(
+                    "{builtin}: header names must be strings, got {}",
+                    other
+                ));
+            }
+        };
+        let val = match value {
+            Value::String(s) => s.clone(),
+            other => {
+                return Err(format!(
+                    "{builtin}: header `{}` must be a string value, got {}",
+                    key, other
+                ));
+            }
+        };
+        out.insert(key, val);
+    }
+    Ok(out)
+}
+
+fn parse_request_options(args: &[Value], start: usize, builtin: &str) -> RResult<RequestOptions> {
+    let mut options = RequestOptions::default();
+    let mut saw_headers = false;
+    let mut saw_timeout = false;
+    for arg in &args[start..] {
+        match arg {
+            Value::Map(map) => {
+                if saw_headers {
+                    return Err(format!(
+                        "{builtin}: request headers specified more than once"
+                    ));
+                }
+                options.headers = request_headers_from_map(map, builtin)?;
+                saw_headers = true;
+            }
+            Value::Int(ms) => {
+                if saw_timeout {
+                    return Err(format!("{builtin}: timeout specified more than once"));
+                }
+                options.timeout = timeout_from_ms(*ms, builtin)?;
+                saw_timeout = true;
+            }
+            other => {
+                return Err(format!(
+                    "{builtin}: expected an optional headers map or timeout integer, got {}",
+                    other
+                ));
+            }
+        }
+    }
+    Ok(options)
+}
+
+fn connect_with_timeout(parsed: &ParsedUrl, timeout: Duration) -> Result<TcpStream, String> {
+    let addr = format!("{}:{}", parsed.host, parsed.port);
+    let mut last_err: Option<String> = None;
+    let addrs = addr
+        .to_socket_addrs()
+        .map_err(|e| format!("connection failed: could not resolve {}: {}", addr, e))?;
+    for socket_addr in addrs {
+        match TcpStream::connect_timeout(&socket_addr, timeout) {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last_err = Some(e.to_string()),
+        }
+    }
+    Err(match last_err {
+        Some(e) => format!("connection failed: {}", e),
+        None => format!(
+            "connection failed: no socket addresses resolved for {}",
+            addr
+        ),
+    })
+}
+
+fn host_header(parsed: &ParsedUrl) -> String {
+    if parsed.port == 80 {
+        parsed.host.clone()
+    } else {
+        format!("{}:{}", parsed.host, parsed.port)
+    }
+}
+
+fn send_request(method: &str, url: &str, body: Option<&str>, options: RequestOptions) -> Value {
     let parsed = match parse_url(url) {
         Ok(p) => p,
         Err(e) => return err_val(e),
     };
 
-    let mut stream = match TcpStream::connect(format!("{}:{}", parsed.host, parsed.port)) {
+    let mut stream = match connect_with_timeout(&parsed, options.timeout) {
         Ok(s) => s,
-        Err(e) => return err_val(format!("connection failed: {e}")),
+        Err(e) => return err_val(e),
     };
 
     if stream
-        .set_read_timeout(Some(Duration::from_secs(30)))
+        .set_read_timeout(Some(options.timeout))
+        .and_then(|_| stream.set_write_timeout(Some(options.timeout)))
         .is_err()
     {
-        return err_val("failed to set read timeout".to_string());
+        return err_val("failed to set socket timeout".to_string());
     }
 
-    let mut request = format!(
-        "{} {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n",
-        method, parsed.path, parsed.host
-    );
-
+    let mut headers = HashMap::with_capacity(options.headers.len() + 4);
+    headers.insert("User-Agent".to_string(), "Resilient/1.0".to_string());
+    for (k, v) in options.headers {
+        headers.insert(k, v);
+    }
+    headers.insert("Host".to_string(), host_header(&parsed));
+    headers.insert("Connection".to_string(), "close".to_string());
     if let Some(b) = body {
-        request.push_str(&format!("Content-Length: {}\r\n", b.len()));
+        headers.insert("Content-Length".to_string(), b.len().to_string());
+        headers
+            .entry("Content-Type".to_string())
+            .or_insert_with(|| "application/json".to_string());
     }
 
-    for (k, v) in extra_headers {
+    let mut request = format!("{} {} HTTP/1.1\r\n", method, parsed.path);
+    for (k, v) in headers {
         request.push_str(&format!("{}: {}\r\n", k, v));
     }
-
     request.push_str("\r\n");
 
     if let Some(b) = body {
@@ -218,25 +342,46 @@ fn decode_chunked(data: &str) -> String {
 // ---------------------------------------------------------------------------
 
 pub(crate) fn builtin_http_get(args: &[Value]) -> RResult<Value> {
-    match args {
-        [Value::String(url)] => Ok(send_request("GET", url, None, &[])),
-        [other] => Err(format!("http_get: expected string URL, got {}", other)),
-        _ => Err(format!("http_get: expected 1 argument, got {}", args.len())),
+    if args.is_empty() {
+        return Err("http_get: expected at least 1 argument, got 0".to_string());
     }
+    let url = match &args[0] {
+        Value::String(url) => url,
+        other => return Err(format!("http_get: expected string URL, got {}", other)),
+    };
+    if args.len() > 3 {
+        return Err(format!(
+            "http_get: expected 1 to 3 arguments, got {}",
+            args.len()
+        ));
+    }
+    let options = parse_request_options(args, 1, "http_get")?;
+    Ok(send_request("GET", url, None, options))
 }
 
 pub(crate) fn builtin_http_post(args: &[Value]) -> RResult<Value> {
-    match args {
-        [Value::String(url), Value::String(body)] => Ok(send_request("POST", url, Some(body), &[])),
-        [a, b] => Err(format!(
-            "http_post: expected (string, string), got ({}, {})",
-            a, b
-        )),
-        _ => Err(format!(
-            "http_post: expected 2 arguments, got {}",
+    if args.len() < 2 {
+        return Err(format!(
+            "http_post: expected at least 2 arguments, got {}",
             args.len()
-        )),
+        ));
     }
+    let url = match &args[0] {
+        Value::String(url) => url,
+        other => return Err(format!("http_post: expected string URL, got {}", other)),
+    };
+    let body = match &args[1] {
+        Value::String(body) => body,
+        other => return Err(format!("http_post: expected string body, got {}", other)),
+    };
+    if args.len() > 4 {
+        return Err(format!(
+            "http_post: expected 2 to 4 arguments, got {}",
+            args.len()
+        ));
+    }
+    let options = parse_request_options(args, 2, "http_post")?;
+    Ok(send_request("POST", url, Some(body), options))
 }
 
 // ---------------------------------------------------------------------------
@@ -254,9 +399,50 @@ pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::typechecker::TypeChecker;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Instant;
 
     fn s(v: &str) -> Value {
         Value::String(v.to_string())
+    }
+
+    fn typechecks(src: &str) {
+        let (prog, errs) = crate::parse(src);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        TypeChecker::new()
+            .check_program(&prog)
+            .expect("program should typecheck");
+    }
+
+    fn headers_map(pairs: &[(&str, &str)]) -> Value {
+        let mut map = HashMap::with_capacity(pairs.len());
+        for (k, v) in pairs {
+            map.insert(
+                MapKey::Str((*k).to_string()),
+                Value::String((*v).to_string()),
+            );
+        }
+        Value::Map(map)
+    }
+
+    fn read_request_text(stream: &mut std::net::TcpStream, needle: &str) -> String {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut chunk).unwrap();
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            let text = String::from_utf8_lossy(&buf);
+            if text.contains(needle) {
+                break;
+            }
+        }
+        String::from_utf8(buf).unwrap()
     }
 
     #[test]
@@ -327,13 +513,28 @@ mod tests {
             Value::Result {
                 ok: true, payload, ..
             } => match *payload {
-                Value::Struct { ref fields, .. } => {
+                Value::Struct {
+                    ref name,
+                    ref fields,
+                    ..
+                } => {
+                    assert_eq!(name, "Response");
                     let status = fields.iter().find(|(k, _)| k == "status");
                     assert!(matches!(status, Some((_, Value::Int(200)))));
                     let body = fields.iter().find(|(k, _)| k == "body");
                     match body {
                         Some((_, Value::String(s))) => assert_eq!(s, "hello world"),
                         _ => panic!("expected body string"),
+                    }
+                    let headers = fields.iter().find(|(k, _)| k == "headers");
+                    match headers {
+                        Some((_, Value::Map(headers))) => {
+                            assert!(matches!(
+                                headers.get(&MapKey::Str("content-type".to_string())),
+                                Some(Value::String(s)) if s == "text/plain"
+                            ));
+                        }
+                        _ => panic!("expected headers map"),
                     }
                 }
                 _ => panic!("expected struct"),
@@ -350,11 +551,26 @@ mod tests {
             Value::Result {
                 ok: true, payload, ..
             } => match *payload {
-                Value::Struct { ref fields, .. } => {
+                Value::Struct {
+                    ref name,
+                    ref fields,
+                    ..
+                } => {
+                    assert_eq!(name, "Response");
                     let body = fields.iter().find(|(k, _)| k == "body");
                     match body {
                         Some((_, Value::String(s))) => assert_eq!(s, "hello"),
                         _ => panic!("expected body string"),
+                    }
+                    let headers = fields.iter().find(|(k, _)| k == "headers");
+                    match headers {
+                        Some((_, Value::Map(headers))) => {
+                            assert!(matches!(
+                                headers.get(&MapKey::Str("transfer-encoding".to_string())),
+                                Some(Value::String(s)) if s == "chunked"
+                            ));
+                        }
+                        _ => panic!("expected headers map"),
                     }
                 }
                 _ => panic!("expected struct"),
@@ -385,6 +601,136 @@ mod tests {
     fn http_get_connection_refused() {
         let result = builtin_http_get(&[s("http://127.0.0.1:1/test")]).unwrap();
         assert!(matches!(result, Value::Result { ok: false, .. }));
+    }
+
+    #[test]
+    fn http_get_round_trip_supports_headers_and_response_map() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request = read_request_text(&mut stream, "\r\n\r\n");
+            assert!(request.contains("GET /data HTTP/1.1"));
+            assert!(request.contains("X-Test: one"));
+            assert!(request.contains("Connection: close"));
+            let response = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nX-Trace: abc\r\nContent-Length: 5\r\n\r\nhello";
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let url = format!("http://127.0.0.1:{}/data", port);
+        let result = builtin_http_get(&[s(&url), headers_map(&[("X-Test", "one")])]).unwrap();
+        match result {
+            Value::Result { ok: true, payload } => match *payload {
+                Value::Struct { name, fields } => {
+                    assert_eq!(name, "Response");
+                    let body = fields.iter().find(|(k, _)| k == "body");
+                    match body {
+                        Some((_, Value::String(s))) => assert_eq!(s, "hello"),
+                        _ => panic!("expected body string"),
+                    }
+                    let headers = fields.iter().find(|(k, _)| k == "headers");
+                    match headers {
+                        Some((_, Value::Map(map))) => {
+                            assert!(matches!(
+                                map.get(&MapKey::Str("content-type".to_string())),
+                                Some(Value::String(s)) if s == "text/plain"
+                            ));
+                            assert!(matches!(
+                                map.get(&MapKey::Str("x-trace".to_string())),
+                                Some(Value::String(s)) if s == "abc"
+                            ));
+                        }
+                        _ => panic!("expected response headers map"),
+                    }
+                }
+                other => panic!("expected response struct, got {:?}", other),
+            },
+            other => panic!("expected Ok result, got {:?}", other),
+        }
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn http_post_round_trip_supports_body_headers_and_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request = read_request_text(&mut stream, "{\"ping\":true}");
+            assert!(request.contains("POST /submit HTTP/1.1"));
+            assert!(request.contains("Content-Type: application/json"));
+            assert!(request.contains("X-Token: abc123"));
+            assert!(request.contains("{\"ping\":true}"));
+            let response = "HTTP/1.1 201 Created\r\nX-Reply: yes\r\nContent-Length: 2\r\n\r\nok";
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let url = format!("http://127.0.0.1:{}/submit", port);
+        let result = builtin_http_post(&[
+            s(&url),
+            s("{\"ping\":true}"),
+            headers_map(&[("X-Token", "abc123")]),
+            Value::Int(250),
+        ])
+        .unwrap();
+        match result {
+            Value::Result { ok: true, payload } => match *payload {
+                Value::Struct { name, fields } => {
+                    assert_eq!(name, "Response");
+                    let status = fields.iter().find(|(k, _)| k == "status");
+                    assert!(matches!(status, Some((_, Value::Int(201)))));
+                    let headers = fields.iter().find(|(k, _)| k == "headers");
+                    match headers {
+                        Some((_, Value::Map(map))) => {
+                            assert!(matches!(
+                                map.get(&MapKey::Str("x-reply".to_string())),
+                                Some(Value::String(s)) if s == "yes"
+                            ));
+                        }
+                        _ => panic!("expected response headers map"),
+                    }
+                }
+                other => panic!("expected response struct, got {:?}", other),
+            },
+            other => panic!("expected Ok result, got {:?}", other),
+        }
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn http_get_honors_timeout_parameter() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let _request = read_request_text(&mut stream, "\r\n\r\n");
+            std::thread::sleep(std::time::Duration::from_millis(250));
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+        });
+
+        let url = format!("http://127.0.0.1:{}/slow", port);
+        let start = Instant::now();
+        let result = builtin_http_get(&[s(&url), Value::Int(50)]).unwrap();
+        let elapsed = start.elapsed();
+        assert!(matches!(result, Value::Result { ok: false, .. }));
+        assert!(
+            elapsed < std::time::Duration::from_millis(200),
+            "timeout should fire quickly, elapsed: {:?}",
+            elapsed
+        );
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn http_get_accepts_optional_headers_and_timeout_in_typechecker() {
+        typechecks(
+            r#"
+let headers = {"X-Test" -> "one"};
+let resp = http_get("http://example.com/data", headers, 50);
+"#,
+        );
     }
 
     #[test]

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -9757,6 +9757,57 @@ impl TypeChecker {
                     return Ok(Type::Option(Box::new(arg_type)));
                 }
 
+                // RES-2556: HTTP builtins accept optional request
+                // headers and timeout arguments. The type system only
+                // tracks the required string parameters; the optional
+                // request options are validated at runtime because the
+                // language does not yet model `map<string, string>` as
+                // a first-class type.
+                if let Node::Identifier {
+                    name: callee_name, ..
+                } = function.as_ref()
+                    && matches!(callee_name.as_str(), "http_get" | "http_post")
+                {
+                    let (required_count, max_count) = if callee_name == "http_get" {
+                        (1, 3)
+                    } else {
+                        (2, 4)
+                    };
+                    if arguments.len() < required_count || arguments.len() > max_count {
+                        return Err(format!(
+                            "{} expects between {} and {} argument(s), got {}",
+                            callee_name,
+                            required_count,
+                            max_count,
+                            arguments.len()
+                        ));
+                    }
+                    let url_ty = self.check_node(&arguments[0])?;
+                    if !compatible(&url_ty, &Type::String) {
+                        return Err(format!(
+                            "{} URL must be a string, got {}",
+                            callee_name, url_ty
+                        ));
+                    }
+                    if callee_name == "http_post" {
+                        let body_ty = self.check_node(&arguments[1])?;
+                        if !compatible(&body_ty, &Type::String) {
+                            return Err(format!(
+                                "{} body must be a string, got {}",
+                                callee_name, body_ty
+                            ));
+                        }
+                        for arg in arguments.iter().skip(2) {
+                            self.check_node(arg)?;
+                        }
+                    } else {
+                        for arg in arguments.iter().skip(1) {
+                            self.check_node(arg)?;
+                        }
+                    }
+                    return Ok(Type::Result);
+                }
+
                 // RES-410: call-site type inference for numeric polymorphic
                 // builtins registered as (Any, Any) -> Any. When all
                 // arguments agree on the same concrete numeric type,


### PR DESCRIPTION
Closes #2556.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-2556-http-client-stdlib-std-only`
Worktree: `.claude/worktrees/res-2556`

## Agent claims

(none inferred from issue)