### PR TITLE
RES-2853: add manual CI workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -11,6 +11,7 @@
 name: embedded
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/size_gate.yml
+++ b/.github/workflows/size_gate.yml
@@ -14,6 +14,7 @@
 name: size-gate
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` to the required `CI`, `embedded`, and `size-gate` workflows
- preserve existing `push` and `pull_request` behavior
- give us a safe manual recovery path when `push` workflows do not attach to `main`

## Why
The merge commit for #2853 reached `main`, but GitHub Actions did not create any `push` runs for that SHA. This keeps `main` from getting fresh required-check evidence even though the PR checks passed.

## Verification
- `git diff --check`
- PR checks on this branch
