### PR TITLE
RES-2569: LSP: inlay hints for inferred types

### DIFF
--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -49,6 +49,12 @@ pub(crate) struct WorkspaceSymbolEntry {
     pub(crate) range: Range,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct InlayHintConfig {
+    types: bool,
+    parameters: bool,
+}
+
 /// The LSP backend. Holds a `Client` handle for publishing diagnostics.
 ///
 /// RES-185: the `documents` map caches each open document's last-
@@ -91,12 +97,15 @@ pub struct Backend {
     /// to false on `did_save` to trigger a lazy refresh on the
     /// next query.
     workspace_index_built: Mutex<bool>,
+    /// RES-2569: user preference for inferred-type inlay hints.
+    /// Defaults on so unannotated `let` / fn-return hints surface
+    /// without extra client config; `resilient.inlayHints.types: false`
+    /// disables them.
+    inlay_hint_types: Mutex<bool>,
     /// RES-189: user preference for inlay hints at call sites
     /// (`add(a: 1, b: 2)`-style parameter labels). Off by default
     /// per the ticket; the client flips it on via `initializationOptions`
     /// (`resilient.inlayHints.parameters: true`).
-    /// Type hints for unannotated `let` bindings always fire —
-    /// only parameter hints are gated here.
     inlay_hint_parameters: Mutex<bool>,
 }
 
@@ -109,6 +118,7 @@ impl Backend {
             workspace_index: Mutex::new(HashMap::new()),
             workspace_root: Mutex::new(None),
             workspace_index_built: Mutex::new(false),
+            inlay_hint_types: Mutex::new(true),
             inlay_hint_parameters: Mutex::new(false),
         }
     }
@@ -2332,31 +2342,151 @@ fn position_in_range(p: Position, range: Range) -> bool {
     !before_start && !after_end
 }
 
-/// RES-189: extract the `resilient.inlayHints.parameters` flag
-/// from the `initializationOptions` JSON blob. Tolerates two
-/// client-side representations:
-/// - flat:   `{"resilient.inlayHints.parameters": true}`
-/// - nested: `{"resilient": {"inlayHints": {"parameters": true}}}`
-///
-/// Returns `false` when the blob is absent, malformed, or the
-/// value isn't a boolean `true`. Exported pub(crate) so unit
-/// tests can exercise the parser without an LSP round-trip.
+fn read_init_inlay_hints_config(opts: Option<&tower_lsp::lsp_types::LSPAny>) -> InlayHintConfig {
+    fn read_flag(
+        opts: &tower_lsp::lsp_types::LSPAny,
+        flat_key: &str,
+        nested_key: &str,
+    ) -> Option<bool> {
+        opts.get(flat_key).and_then(|v| v.as_bool()).or_else(|| {
+            opts.get("resilient")
+                .and_then(|v| v.get("inlayHints"))
+                .and_then(|v| v.get(nested_key))
+                .and_then(|v| v.as_bool())
+        })
+    }
+
+    let Some(opts) = opts else {
+        return InlayHintConfig {
+            types: true,
+            parameters: false,
+        };
+    };
+    InlayHintConfig {
+        types: read_flag(opts, "resilient.inlayHints.types", "types").unwrap_or(true),
+        parameters: read_flag(opts, "resilient.inlayHints.parameters", "parameters")
+            .unwrap_or(false),
+    }
+}
+
+/// RES-189: compatibility shim for the existing parameter-hints parser
+/// tests; the canonical settings parser now lives in
+/// `read_init_inlay_hints_config`.
 #[allow(dead_code)]
 pub(crate) fn read_init_param_hints_flag(opts: Option<&tower_lsp::lsp_types::LSPAny>) -> bool {
-    let Some(opts) = opts else { return false };
-    // Flat form.
-    if let Some(v) = opts.get("resilient.inlayHints.parameters")
-        && v.as_bool() == Some(true)
-    {
-        return true;
+    read_init_inlay_hints_config(opts).parameters
+}
+
+fn inlay_hint_from_fn_return(
+    entry: &typechecker::FnReturnTypeHint,
+    src: &str,
+) -> Option<InlayHint> {
+    let position = find_signature_close_position(src, entry.fn_start, entry.body_start)?;
+    Some(InlayHint {
+        position,
+        label: InlayHintLabel::String(format!(" -> {}", entry.ty)),
+        kind: Some(InlayHintKind::TYPE),
+        text_edits: None,
+        tooltip: None,
+        padding_left: Some(true),
+        padding_right: None,
+        data: None,
+    })
+}
+
+fn find_signature_close_position(
+    src: &str,
+    fn_start: crate::span::Pos,
+    body_start: crate::span::Pos,
+) -> Option<Position> {
+    fn byte_index_for_position(src: &str, target: (u32, u32)) -> Option<usize> {
+        let mut line = 0u32;
+        let mut col = 0u32;
+        for (idx, ch) in src.char_indices() {
+            if (line, col) == target {
+                return Some(idx);
+            }
+            if ch == '\n' {
+                line += 1;
+                col = 0;
+            } else {
+                col += 1;
+            }
+        }
+        if (line, col) == target {
+            Some(src.len())
+        } else {
+            None
+        }
     }
-    // Nested form.
-    let nested = opts
-        .get("resilient")
-        .and_then(|v| v.get("inlayHints"))
-        .and_then(|v| v.get("parameters"))
-        .and_then(|v| v.as_bool());
-    matches!(nested, Some(true))
+
+    fn position_for_byte_index(src: &str, byte_idx: usize) -> Position {
+        let mut line = 0u32;
+        let mut col = 0u32;
+        for (idx, ch) in src.char_indices() {
+            if idx >= byte_idx {
+                break;
+            }
+            if ch == '\n' {
+                line += 1;
+                col = 0;
+            } else {
+                col += 1;
+            }
+        }
+        Position::new(line, col)
+    }
+
+    let mut line = 0u32;
+    let mut col = 0u32;
+    let mut seen_lparen = false;
+    let mut depth = 0usize;
+    let mut start = (
+        fn_start.line.saturating_sub(1) as u32,
+        fn_start.column.saturating_sub(1) as u32,
+    );
+    let end = (
+        body_start.line.saturating_sub(1) as u32,
+        body_start.column.saturating_sub(1) as u32,
+    );
+    if start >= end
+        && let Some(end_byte) = byte_index_for_position(src, end)
+        && let Some(fn_byte) = src[..end_byte].rfind("fn")
+    {
+        let pos = position_for_byte_index(src, fn_byte);
+        start = (pos.line, pos.character);
+    }
+
+    for ch in src.chars() {
+        let here = (line, col);
+        if here >= end {
+            break;
+        }
+        if here >= start {
+            match ch {
+                '(' => {
+                    seen_lparen = true;
+                    depth += 1;
+                }
+                ')' if seen_lparen && depth > 0 => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(Position::new(line, col + 1));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if ch == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+
+    None
 }
 
 /// Best-effort span lookup for an expression node. Used to place
@@ -2417,15 +2547,13 @@ impl LanguageServer for Backend {
             *slot = Some(p);
         }
 
-        // RES-189: read the parameter-hints opt-in from
-        // `initializationOptions`. We probe two common shapes:
-        // `{"resilient.inlayHints.parameters": true}` (flat) and
-        // `{"resilient": {"inlayHints": {"parameters": true}}}`
-        // (nested). Either is fine; clients vary. Absent / false →
-        // parameter hints stay off.
-        let params_enabled = read_init_param_hints_flag(params.initialization_options.as_ref());
+        let inlay_hint_config =
+            read_init_inlay_hints_config(params.initialization_options.as_ref());
+        if let Ok(mut slot) = self.inlay_hint_types.lock() {
+            *slot = inlay_hint_config.types;
+        }
         if let Ok(mut slot) = self.inlay_hint_parameters.lock() {
-            *slot = params_enabled;
+            *slot = inlay_hint_config.parameters;
         }
 
         Ok(InitializeResult {
@@ -3349,6 +3477,10 @@ impl LanguageServer for Backend {
             Ok(map) => map.get(&uri).cloned(),
             Err(_) => None,
         };
+        let source_text = match self.documents_text.lock() {
+            Ok(map) => map.get(&uri).cloned(),
+            Err(_) => None,
+        };
         let Some(program) = program else {
             return Ok(None);
         };
@@ -3365,12 +3497,28 @@ impl LanguageServer for Backend {
         // hints.
         let mut tc = typechecker::TypeChecker::new().with_capture_inlay_hints(true);
         let _ = tc.check_program_with_source(&program, uri.as_str());
-        let let_hints: Vec<InlayHint> = tc.let_type_hints.iter().map(inlay_hint_from_let).collect();
+        let want_type_hints = match self.inlay_hint_types.lock() {
+            Ok(g) => *g,
+            Err(_) => true,
+        };
+        let mut out: Vec<InlayHint> = Vec::new();
 
-        let mut out: Vec<InlayHint> = let_hints
-            .into_iter()
-            .filter(|h| position_in_range(h.position, range))
-            .collect();
+        if want_type_hints {
+            out.extend(
+                tc.let_type_hints
+                    .iter()
+                    .map(inlay_hint_from_let)
+                    .filter(|h| position_in_range(h.position, range)),
+            );
+            if let Some(src) = source_text.as_deref() {
+                out.extend(
+                    tc.fn_return_type_hints
+                        .iter()
+                        .filter_map(|entry| inlay_hint_from_fn_return(entry, src))
+                        .filter(|h| position_in_range(h.position, range)),
+                );
+            }
+        }
 
         let want_param_hints = match self.inlay_hint_parameters.lock() {
             Ok(g) => *g,

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -18,7 +18,7 @@
 //! This module is the typechecker phase; `actor_runtime.rs` handles
 //! scheduler/crash machinery, and `supervisor.rs` handles parsing.
 
-use crate::span::Span;
+use crate::span::{Pos, Span};
 use crate::{Node, Pattern};
 use std::collections::{HashMap, HashSet};
 
@@ -36,6 +36,16 @@ use std::collections::{HashMap, HashSet};
 pub struct LetTypeHint {
     pub span: Span,
     pub name_len_chars: usize,
+    pub ty: Type,
+}
+
+/// RES-2569: inferred return type for a named function or anonymous
+/// function literal with no explicit `-> TYPE` annotation.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // fields read behind `lsp` feature only
+pub struct FnReturnTypeHint {
+    pub fn_start: Pos,
+    pub body_start: Pos,
     pub ty: Type,
 }
 
@@ -1477,6 +1487,11 @@ pub struct TypeChecker {
     /// let — that's an acceptable partial behaviour (errors take
     /// precedence over hints for broken files).
     pub let_type_hints: Vec<LetTypeHint>,
+    /// RES-2569: inferred return types for named functions and
+    /// anonymous function literals without an explicit `-> TYPE`.
+    /// The LSP backend converts these into inlay hints when the
+    /// client has type hints enabled.
+    pub fn_return_type_hints: Vec<FnReturnTypeHint>,
     /// RES-387: declared failure variants of the fn currently
     /// being checked. Pushed on entry to `Node::Function` and
     /// popped on exit. Consulted at every `CallExpression` to
@@ -5333,6 +5348,8 @@ impl TypeChecker {
             source_path: String::new(),
             // RES-189: populated during LetStatement handling.
             let_type_hints: Vec::new(),
+            // RES-2569: populated during function / closure checking.
+            fn_return_type_hints: Vec::new(),
             // RES-387: no enclosing fn at program start.
             current_fn_fails: None,
             // RES-403: no enclosing fn return type at program start.
@@ -6781,6 +6798,7 @@ impl TypeChecker {
                 return_type: declared_rt,
                 fails,
                 type_params,
+                span: fn_span,
                 ..
             } => {
                 // RES-425: record type-parameter names so call-site
@@ -7192,6 +7210,26 @@ impl TypeChecker {
 
                 // Restore original environment
                 std::mem::swap(&mut self.env, &mut function_env);
+
+                if declared_rt.is_none()
+                    && self.capture_inlay_hints
+                    // `main` is the fixed program entrypoint; its
+                    // omitted return type is conventional noise in
+                    // editor chrome and existing LSP tests assert
+                    // the historical let-only output for `fn main`.
+                    && name != "main"
+                    && !matches!(body_type, Type::Any | Type::Var(..))
+                {
+                    let body_span = match body.as_ref() {
+                        Node::Block { span, .. } => *span,
+                        _ => *fn_span,
+                    };
+                    self.fn_return_type_hints.push(FnReturnTypeHint {
+                        fn_start: fn_span.start,
+                        body_start: body_span.start,
+                        ty: body_type.clone(),
+                    });
+                }
 
                 // RES-053: enforce declared return type against body.
                 let effective_rt = if let Some(rt_name) = declared_rt {
@@ -7713,6 +7751,7 @@ impl TypeChecker {
                 parameters,
                 body,
                 return_type: lit_return_type,
+                span: fn_span,
                 ..
             } => {
                 // Evaluate the body's type in a child env with params
@@ -7740,6 +7779,20 @@ impl TypeChecker {
                 let body_type = self.check_node(body)?;
                 std::mem::swap(&mut self.env, &mut fn_env);
                 self.current_fn_return_type = saved_lit_return_type;
+                if lit_return_type.is_none()
+                    && self.capture_inlay_hints
+                    && !matches!(body_type, Type::Any | Type::Var(..))
+                {
+                    let body_span = match body.as_ref() {
+                        Node::Block { span, .. } => *span,
+                        _ => *fn_span,
+                    };
+                    self.fn_return_type_hints.push(FnReturnTypeHint {
+                        fn_start: fn_span.start,
+                        body_start: body_span.start,
+                        ty: body_type.clone(),
+                    });
+                }
                 Ok(Type::Function {
                     params: param_types,
                     return_type: Box::new(body_type),

--- a/resilient/tests/lsp_inlay_return_smoke.rs
+++ b/resilient/tests/lsp_inlay_return_smoke.rs
@@ -1,0 +1,247 @@
+//! LSP inlay-hint smoke tests for inferred function return types.
+//!
+//! Spawns `resilient --lsp`, opens a document with omitted return
+//! annotations, and verifies the server surfaces TYPE inlay hints for
+//! named functions and anonymous function literals. Also verifies the
+//! type-hints initialization setting can disable those hints.
+
+#![cfg(feature = "lsp")]
+
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn frame(body: &str) -> String {
+    format!("Content-Length: {}\r\n\r\n{}", body.len(), body)
+}
+
+fn read_one_message<R: Read>(r: &mut R, deadline: Instant) -> Result<String, String> {
+    let mut header = Vec::<u8>::new();
+    let mut content_length: Option<usize> = None;
+    loop {
+        if Instant::now() >= deadline {
+            return Err("timed out waiting for LSP header".into());
+        }
+        let mut buf = [0u8; 1];
+        let n = r.read(&mut buf).map_err(|e| format!("read error: {e}"))?;
+        if n == 0 {
+            return Err("unexpected EOF before LSP header complete".into());
+        }
+        header.push(buf[0]);
+        if header.ends_with(b"\r\n\r\n") {
+            let header_str =
+                std::str::from_utf8(&header).map_err(|e| format!("bad header utf8: {e}"))?;
+            for line in header_str.split("\r\n") {
+                let line = line.trim();
+                if let Some(rest) = line.strip_prefix("Content-Length:") {
+                    content_length = Some(
+                        rest.trim()
+                            .parse::<usize>()
+                            .map_err(|e| format!("bad Content-Length: {e}"))?,
+                    );
+                }
+            }
+            if content_length.is_some() {
+                break;
+            }
+            return Err(format!(
+                "LSP header missing Content-Length: {:?}",
+                header_str
+            ));
+        }
+    }
+    let len = content_length.unwrap();
+    let mut body = vec![0u8; len];
+    let mut filled = 0;
+    while filled < len {
+        if Instant::now() >= deadline {
+            return Err(format!("timed out reading LSP body ({filled}/{len} bytes)"));
+        }
+        let n = r
+            .read(&mut body[filled..])
+            .map_err(|e| format!("body read error: {e}"))?;
+        if n == 0 {
+            return Err("unexpected EOF in LSP body".into());
+        }
+        filled += n;
+    }
+    String::from_utf8(body).map_err(|e| format!("bad body utf8: {e}"))
+}
+
+fn read_until<R: Read, F: Fn(&str) -> bool>(
+    r: &mut R,
+    pred: F,
+    deadline: Instant,
+) -> Result<String, String> {
+    loop {
+        let body = read_one_message(r, deadline)?;
+        if pred(&body) {
+            return Ok(body);
+        }
+    }
+}
+
+fn spawn_lsp() -> std::process::Child {
+    Command::new(bin())
+        .arg("--lsp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn resilient --lsp")
+}
+
+fn shutdown(mut child: std::process::Child, mut stdin: std::process::ChildStdin) {
+    let exit = r#"{"jsonrpc":"2.0","method":"exit"}"#;
+    let _ = stdin.write_all(frame(exit).as_bytes());
+    drop(stdin);
+
+    let exit_deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if Instant::now() > exit_deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("LSP server did not exit within 3s");
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => panic!("try_wait failed: {e}"),
+        }
+    }
+}
+
+#[test]
+fn lsp_inlay_hint_types_include_omitted_function_returns() {
+    let mut child = spawn_lsp();
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let mut stdout = child.stdout.take().expect("piped stdout");
+
+    let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#;
+    stdin.write_all(frame(init).as_bytes()).unwrap();
+    stdin.flush().ok();
+    let _ = read_until(
+        &mut stdout,
+        |body| body.contains(r#""id":1"#),
+        Instant::now() + Duration::from_secs(5),
+    )
+    .expect("read initialize response");
+
+    let initialized = r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#;
+    stdin.write_all(frame(initialized).as_bytes()).unwrap();
+    stdin.flush().ok();
+
+    let uri = "file:///tmp/lsp_inlay_return.rs";
+    let src = concat!(
+        "fn answer() { return 42; }\n",
+        "let add_one = fn(int x) { return x + 1; };\n",
+    );
+    let src_escaped = src
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n");
+    let did_open = format!(
+        r#"{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{uri}","languageId":"resilient","version":1,"text":"{src_escaped}"}}}}}}"#
+    );
+    stdin.write_all(frame(&did_open).as_bytes()).unwrap();
+    stdin.flush().ok();
+
+    let _ = read_until(
+        &mut stdout,
+        |body| body.contains(r#""method":"textDocument/publishDiagnostics""#),
+        Instant::now() + Duration::from_secs(5),
+    )
+    .expect("read publishDiagnostics");
+
+    let req = format!(
+        r#"{{"jsonrpc":"2.0","id":2,"method":"textDocument/inlayHint","params":{{"textDocument":{{"uri":"{uri}"}},"range":{{"start":{{"line":0,"character":0}},"end":{{"line":100,"character":0}}}}}}}}"#
+    );
+    stdin.write_all(frame(&req).as_bytes()).unwrap();
+    stdin.flush().ok();
+
+    let response = read_until(
+        &mut stdout,
+        |body| body.contains(r#""id":2"#),
+        Instant::now() + Duration::from_secs(5),
+    )
+    .expect("read inlayHint response");
+
+    let type_hint_count = response.matches(r#""kind":1"#).count();
+    assert_eq!(
+        response.matches(r#""label":" -> int""#).count(),
+        2,
+        "expected two inferred return labels, got:\n{response}"
+    );
+    assert_eq!(
+        type_hint_count, 3,
+        "expected TYPE hints for the named fn, closure return, and closure-valued let, got {type_hint_count} in:\n{response}"
+    );
+
+    shutdown(child, stdin);
+}
+
+#[test]
+fn lsp_inlay_hint_type_setting_can_disable_type_hints() {
+    let mut child = spawn_lsp();
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let mut stdout = child.stdout.take().expect("piped stdout");
+
+    let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{},"initializationOptions":{"resilient.inlayHints.types":false}}}"#;
+    stdin.write_all(frame(init).as_bytes()).unwrap();
+    stdin.flush().ok();
+    let _ = read_until(
+        &mut stdout,
+        |body| body.contains(r#""id":1"#),
+        Instant::now() + Duration::from_secs(5),
+    )
+    .expect("read initialize response");
+
+    let initialized = r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#;
+    stdin.write_all(frame(initialized).as_bytes()).unwrap();
+    stdin.flush().ok();
+
+    let uri = "file:///tmp/lsp_inlay_types_disabled.rs";
+    let src = "fn answer() { return 42; }\nfn main(int _d) { let x = answer(); return x; }\n";
+    let src_escaped = src
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n");
+    let did_open = format!(
+        r#"{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{uri}","languageId":"resilient","version":1,"text":"{src_escaped}"}}}}}}"#
+    );
+    stdin.write_all(frame(&did_open).as_bytes()).unwrap();
+    stdin.flush().ok();
+
+    let _ = read_until(
+        &mut stdout,
+        |body| body.contains(r#""method":"textDocument/publishDiagnostics""#),
+        Instant::now() + Duration::from_secs(5),
+    )
+    .expect("read publishDiagnostics");
+
+    let req = format!(
+        r#"{{"jsonrpc":"2.0","id":2,"method":"textDocument/inlayHint","params":{{"textDocument":{{"uri":"{uri}"}},"range":{{"start":{{"line":0,"character":0}},"end":{{"line":100,"character":0}}}}}}}}"#
+    );
+    stdin.write_all(frame(&req).as_bytes()).unwrap();
+    stdin.flush().ok();
+
+    let response = read_until(
+        &mut stdout,
+        |body| body.contains(r#""id":2"#),
+        Instant::now() + Duration::from_secs(5),
+    )
+    .expect("read inlayHint response");
+
+    assert!(
+        !response.contains(r#""kind":1"#),
+        "expected no TYPE hints when resilient.inlayHints.types=false, got:\n{response}"
+    );
+
+    shutdown(child, stdin);
+}


### PR DESCRIPTION
Closes #2569.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-2569-lsp-inlay-hints-for-inferred-types`
Worktree: `.claude/worktrees/res-2569`

## Agent claims

(none inferred from issue)