### PR TITLE
RES-2642: add variance subtype helpers

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -81,6 +81,7 @@ mod compiler;
 mod const_fold;
 mod disasm;
 mod hash_builtins;
+mod type_relations;
 // RES-2560 / RES-2561: SHA-256, SHA-512, CRC-32, CRC-16 builtins.
 mod crypto_hash;
 // RES-1172: small string + array gaps — split_once / rsplit_once /

--- a/resilient/src/type_relations.rs
+++ b/resilient/src/type_relations.rs
@@ -1,0 +1,341 @@
+//! Shared type-relation helpers used by the typechecker, variance
+//! analysis, and generic substitution code.
+//!
+//! The goal is to keep the semantic rules in one place so the compiler
+//! has a single source of truth for:
+//!
+//! - compatibility checks between two concrete types
+//! - conservative subtype checks for variance
+//! - recursive type-parameter substitution
+//! - inference-friendly return-type substitution at generic call sites
+
+#![allow(dead_code)]
+
+use crate::typechecker::Type;
+use std::collections::HashMap;
+
+pub(crate) fn is_pinned_int(t: &Type) -> bool {
+    matches!(
+        t,
+        Type::Int8
+            | Type::Int16
+            | Type::Int32
+            | Type::UInt8
+            | Type::UInt16
+            | Type::UInt32
+            | Type::UInt64
+    )
+}
+
+fn infer_common_type_inner(types: &[Type]) -> Type {
+    let mut result: Option<&Type> = None;
+    for t in types {
+        if matches!(t, Type::Any) {
+            continue;
+        }
+        match result {
+            None => result = Some(t),
+            Some(r) if r == t => {}
+            _ => return Type::Any,
+        }
+    }
+    result.cloned().unwrap_or(Type::Any)
+}
+
+pub(crate) fn infer_common_type(types: &[Type]) -> Type {
+    infer_common_type_inner(types)
+}
+
+pub(crate) fn substitute_type_params(ty: &Type, type_params: &[String]) -> Type {
+    match ty {
+        Type::Struct(name) if type_params.iter().any(|p| p == name) => Type::Any,
+        Type::Function {
+            params,
+            return_type,
+        } => Type::Function {
+            params: params
+                .iter()
+                .map(|p| substitute_type_params(p, type_params))
+                .collect(),
+            return_type: Box::new(substitute_type_params(return_type, type_params)),
+        },
+        Type::Tuple(elems) => Type::Tuple(
+            elems
+                .iter()
+                .map(|e| substitute_type_params(e, type_params))
+                .collect(),
+        ),
+        Type::AnonymousStruct(fields) => Type::AnonymousStruct(
+            fields
+                .iter()
+                .map(|(name, ty)| (name.clone(), substitute_type_params(ty, type_params)))
+                .collect(),
+        ),
+        Type::Option(inner) => Type::Option(Box::new(substitute_type_params(inner, type_params))),
+        other => other.clone(),
+    }
+}
+
+pub(crate) fn substitute_with_bindings(
+    ty: &Type,
+    type_params: &[String],
+    bindings: &HashMap<&str, Type>,
+) -> Type {
+    match ty {
+        Type::Struct(name) if type_params.iter().any(|p| p == name) => {
+            bindings.get(name.as_str()).cloned().unwrap_or(Type::Any)
+        }
+        Type::Function {
+            params,
+            return_type,
+        } => Type::Function {
+            params: params
+                .iter()
+                .map(|p| substitute_with_bindings(p, type_params, bindings))
+                .collect(),
+            return_type: Box::new(substitute_with_bindings(return_type, type_params, bindings)),
+        },
+        Type::Tuple(elems) => Type::Tuple(
+            elems
+                .iter()
+                .map(|e| substitute_with_bindings(e, type_params, bindings))
+                .collect(),
+        ),
+        Type::AnonymousStruct(fields) => Type::AnonymousStruct(
+            fields
+                .iter()
+                .map(|(name, ty)| {
+                    (
+                        name.clone(),
+                        substitute_with_bindings(ty, type_params, bindings),
+                    )
+                })
+                .collect(),
+        ),
+        Type::Option(inner) => Type::Option(Box::new(substitute_with_bindings(
+            inner,
+            type_params,
+            bindings,
+        ))),
+        other => other.clone(),
+    }
+}
+
+pub(crate) fn infer_generic_return_type(
+    return_type: &Type,
+    callee_type_params: &Option<Vec<String>>,
+    tp_bindings: &HashMap<&str, Type>,
+) -> Type {
+    let tp = match callee_type_params {
+        Some(tp) if !tp.is_empty() => tp,
+        _ => return return_type.clone(),
+    };
+    substitute_with_bindings(return_type, tp, tp_bindings)
+}
+
+/// Conservative subtype relation used by the variance checker and any
+/// future call-site relation logic.
+///
+/// The current lattice is intentionally small:
+/// - exact equality always holds
+/// - `Any` is the top type
+/// - tuples are covariant element-wise
+/// - `Option<T>` is covariant in `T`
+/// - function types are contravariant in parameters and covariant in
+///   their return type
+/// - pinned integer widths do not form a subtype chain; they remain
+///   equal-only until an explicit conversion or a declared widening
+///   relation exists
+pub(crate) fn is_subtype(sub: &Type, sup: &Type) -> bool {
+    if sub == sup {
+        return true;
+    }
+    if matches!(sup, Type::Any) {
+        return true;
+    }
+    if matches!(sub, Type::Any) {
+        return false;
+    }
+    match (sub, sup) {
+        (Type::Option(a), Type::Option(b)) => is_subtype(a, b),
+        (
+            Type::Function {
+                params: a_params,
+                return_type: a_ret,
+            },
+            Type::Function {
+                params: b_params,
+                return_type: b_ret,
+            },
+        ) => {
+            a_params.len() == b_params.len()
+                && a_params
+                    .iter()
+                    .zip(b_params.iter())
+                    .all(|(a, b)| is_subtype(b, a))
+                && is_subtype(a_ret, b_ret)
+        }
+        (Type::Tuple(a_elems), Type::Tuple(b_elems)) => {
+            a_elems.len() == b_elems.len()
+                && a_elems
+                    .iter()
+                    .zip(b_elems.iter())
+                    .all(|(a, b)| is_subtype(a, b))
+        }
+        _ => false,
+    }
+}
+
+/// Compatibility is a slightly looser relation than subtype: it keeps
+/// the existing numeric-literal and `Any` ergonomics used by the
+/// typechecker.
+pub(crate) fn compatible(a: &Type, b: &Type) -> bool {
+    if a == b {
+        return true;
+    }
+    if matches!(a, Type::Any) || matches!(b, Type::Any) {
+        return true;
+    }
+    if let (Type::Option(inner_a), Type::Option(inner_b)) = (a, b) {
+        return compatible(inner_a, inner_b);
+    }
+    if let (
+        Type::Function {
+            params: pa,
+            return_type: ra,
+        },
+        Type::Function {
+            params: pb,
+            return_type: rb,
+        },
+    ) = (a, b)
+    {
+        return pa.len() == pb.len()
+            && pa.iter().zip(pb.iter()).all(|(x, y)| compatible(x, y))
+            && compatible(ra, rb);
+    }
+    if let (Type::Tuple(a_elems), Type::Tuple(b_elems)) = (a, b) {
+        return a_elems.len() == b_elems.len()
+            && a_elems
+                .iter()
+                .zip(b_elems.iter())
+                .all(|(x, y)| compatible(x, y));
+    }
+    if *a == Type::Int && is_pinned_int(b) {
+        return true;
+    }
+    if is_pinned_int(a) && *b == Type::Int {
+        return true;
+    }
+    if (*a == Type::Float32 && *b == Type::Float) || (*a == Type::Float && *b == Type::Float32) {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subtype_is_covariant_for_option_and_tuple() {
+        let sup = Type::Option(Box::new(Type::Any));
+        let sub = Type::Option(Box::new(Type::Int));
+        assert!(is_subtype(&sub, &sup));
+
+        let sup = Type::Tuple(vec![Type::Any, Type::Bool]);
+        let sub = Type::Tuple(vec![Type::Int, Type::Bool]);
+        assert!(is_subtype(&sub, &sup));
+    }
+
+    #[test]
+    fn subtype_is_function_contravariant_in_params() {
+        let sup = Type::Function {
+            params: vec![Type::Int],
+            return_type: Box::new(Type::Int),
+        };
+        let sub = Type::Function {
+            params: vec![Type::Any],
+            return_type: Box::new(Type::Int),
+        };
+        assert!(is_subtype(&sub, &sup));
+    }
+
+    #[test]
+    fn compatibility_keeps_numeric_ergonomics() {
+        assert!(compatible(&Type::Int, &Type::UInt16));
+        assert!(compatible(&Type::Float, &Type::Float32));
+    }
+
+    #[test]
+    fn recursive_type_parameter_substitution_works() {
+        let ty = Type::Function {
+            params: vec![Type::Struct("T".to_string())],
+            return_type: Box::new(Type::Tuple(vec![
+                Type::Struct("U".to_string()),
+                Type::Option(Box::new(Type::Struct("T".to_string()))),
+            ])),
+        };
+        let out = substitute_type_params(&ty, &["T".into(), "U".into()]);
+        assert_eq!(
+            out,
+            Type::Function {
+                params: vec![Type::Any],
+                return_type: Box::new(Type::Tuple(vec![
+                    Type::Any,
+                    Type::Option(Box::new(Type::Any)),
+                ])),
+            }
+        );
+    }
+
+    #[test]
+    fn recursive_substitution_preserves_anonymous_struct_shape() {
+        let ty = Type::AnonymousStruct(vec![
+            ("left".to_string(), Type::Struct("T".to_string())),
+            (
+                "right".to_string(),
+                Type::Option(Box::new(Type::Struct("U".to_string()))),
+            ),
+        ]);
+        let out = substitute_type_params(&ty, &["T".into(), "U".into()]);
+        assert_eq!(
+            out,
+            Type::AnonymousStruct(vec![
+                ("left".to_string(), Type::Any),
+                ("right".to_string(), Type::Option(Box::new(Type::Any))),
+            ])
+        );
+    }
+
+    #[test]
+    fn bound_substitution_preserves_anonymous_struct_shape() {
+        let ty = Type::AnonymousStruct(vec![
+            ("value".to_string(), Type::Struct("T".to_string())),
+            (
+                "nested".to_string(),
+                Type::Tuple(vec![Type::Struct("U".to_string()), Type::Int]),
+            ),
+        ]);
+        let mut bindings = HashMap::new();
+        bindings.insert("T", Type::Bool);
+        bindings.insert("U", Type::String);
+        let out = substitute_with_bindings(&ty, &["T".into(), "U".into()], &bindings);
+        assert_eq!(
+            out,
+            Type::AnonymousStruct(vec![
+                ("value".to_string(), Type::Bool),
+                (
+                    "nested".to_string(),
+                    Type::Tuple(vec![Type::String, Type::Int]),
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn common_type_skips_any() {
+        let got = infer_common_type(&[Type::Any, Type::Int, Type::Int]);
+        assert_eq!(got, Type::Int);
+    }
+}

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -279,18 +279,7 @@ pub(crate) fn body_yields_value(body: &Node) -> bool {
 /// to `Type::Any` when types differ (or when the slice is empty /
 /// all-Any), keeping inference conservative.
 fn infer_common_arm_type(types: &[Type]) -> Type {
-    let mut result: Option<&Type> = None;
-    for t in types {
-        if matches!(t, Type::Any) {
-            continue;
-        }
-        match result {
-            None => result = Some(t),
-            Some(r) if r == t => {}
-            _ => return Type::Any,
-        }
-    }
-    result.cloned().unwrap_or(Type::Any)
+    crate::type_relations::infer_common_type(types)
 }
 
 /// with every pinned integer type — assigning a literal `42` to an
@@ -304,33 +293,7 @@ fn infer_common_arm_type(types: &[Type]) -> Type {
 /// `Struct("T") → Any` substitution in RES-425 did not recurse into
 /// composite types (Function, Tuple, Option).
 fn substitute_type_params(ty: &Type, type_params: &[String]) -> Type {
-    match ty {
-        Type::Struct(name) if type_params.iter().any(|p| p == name) => Type::Any,
-        Type::Function {
-            params,
-            return_type,
-        } => Type::Function {
-            params: params
-                .iter()
-                .map(|p| substitute_type_params(p, type_params))
-                .collect(),
-            return_type: Box::new(substitute_type_params(return_type, type_params)),
-        },
-        Type::Tuple(elems) => Type::Tuple(
-            elems
-                .iter()
-                .map(|e| substitute_type_params(e, type_params))
-                .collect(),
-        ),
-        Type::AnonymousStruct(fields) => Type::AnonymousStruct(
-            fields
-                .iter()
-                .map(|(name, ty)| (name.clone(), substitute_type_params(ty, type_params)))
-                .collect(),
-        ),
-        Type::Option(inner) => Type::Option(Box::new(substitute_type_params(inner, type_params))),
-        other => other.clone(),
-    }
+    crate::type_relations::substitute_type_params(ty, type_params)
 }
 
 /// RES-2805: produce a concrete return type for a generic function call
@@ -341,116 +304,11 @@ fn infer_generic_return_type(
     callee_type_params: &Option<Vec<String>>,
     tp_bindings: &std::collections::HashMap<&str, Type>,
 ) -> Type {
-    let tp = match callee_type_params {
-        Some(tp) if !tp.is_empty() => tp,
-        _ => return return_type.clone(),
-    };
-    substitute_with_bindings(return_type, tp, tp_bindings)
-}
-
-/// Recursively replace type-parameter references with their inferred
-/// concrete types. Unbound parameters fall back to `Type::Any`.
-fn substitute_with_bindings(
-    ty: &Type,
-    type_params: &[String],
-    bindings: &std::collections::HashMap<&str, Type>,
-) -> Type {
-    match ty {
-        Type::Struct(name) if type_params.iter().any(|p| p == name) => {
-            bindings.get(name.as_str()).cloned().unwrap_or(Type::Any)
-        }
-        Type::Function {
-            params,
-            return_type,
-        } => Type::Function {
-            params: params
-                .iter()
-                .map(|p| substitute_with_bindings(p, type_params, bindings))
-                .collect(),
-            return_type: Box::new(substitute_with_bindings(return_type, type_params, bindings)),
-        },
-        Type::Tuple(elems) => Type::Tuple(
-            elems
-                .iter()
-                .map(|e| substitute_with_bindings(e, type_params, bindings))
-                .collect(),
-        ),
-        Type::AnonymousStruct(fields) => Type::AnonymousStruct(
-            fields
-                .iter()
-                .map(|(name, ty)| {
-                    (
-                        name.clone(),
-                        substitute_with_bindings(ty, type_params, bindings),
-                    )
-                })
-                .collect(),
-        ),
-        Type::Option(inner) => Type::Option(Box::new(substitute_with_bindings(
-            inner,
-            type_params,
-            bindings,
-        ))),
-        other => other.clone(),
-    }
+    crate::type_relations::infer_generic_return_type(return_type, callee_type_params, tp_bindings)
 }
 
 fn compatible(a: &Type, b: &Type) -> bool {
-    if a == b {
-        return true;
-    }
-    if matches!(a, Type::Any) || matches!(b, Type::Any) {
-        return true;
-    }
-    // RES-2651: Option<T> is compatible with Option<U> when T and U
-    // are compatible, and also with the legacy unparameterised Result
-    // (which represented Option before this PR).
-    if let (Type::Option(inner_a), Type::Option(inner_b)) = (a, b) {
-        return compatible(inner_a, inner_b);
-    }
-    // RES-2701: Function types are compatible when all parameter types and
-    // the return type are pairwise compatible. This handles cases where
-    // substitute_type_params replaced type variables with Any — e.g.
-    // `fn(Any) -> Any` must accept a concrete `fn(int) -> int`.
-    if let (
-        Type::Function {
-            params: pa,
-            return_type: ra,
-        },
-        Type::Function {
-            params: pb,
-            return_type: rb,
-        },
-    ) = (a, b)
-    {
-        return pa.len() == pb.len()
-            && pa.iter().zip(pb.iter()).all(|(x, y)| compatible(x, y))
-            && compatible(ra, rb);
-    }
-    // RES-2801: Tuple types are compatible when element-wise compatible.
-    if let (Type::Tuple(a_elems), Type::Tuple(b_elems)) = (a, b) {
-        return a_elems.len() == b_elems.len()
-            && a_elems
-                .iter()
-                .zip(b_elems.iter())
-                .all(|(x, y)| compatible(x, y));
-    }
-    // Integer literals produce Type::Int; allow assigning them to any
-    // pinned integer type without an explicit cast.
-    if *a == Type::Int && is_pinned_int(b) {
-        return true;
-    }
-    if is_pinned_int(a) && *b == Type::Int {
-        return true;
-    }
-    // RES-2691: float literals produce Type::Float; allow assigning them to
-    // f32-annotated variables and vice-versa — mirrors the Int ↔ pinned-int rule.
-    // Note: unify() still errors on Float/Float32 in arithmetic to prevent
-    // implicit cross-width mixing.
-    if (*a == Type::Float32 && *b == Type::Float) || (*a == Type::Float && *b == Type::Float32) {
-        return true;
-    }
-    false
+    crate::type_relations::compatible(a, b)
 }
 
 /// RES-2713: map a literal-pattern node to its type so
@@ -668,16 +526,7 @@ fn pattern_is_exhaustive_wrt_scrutinee(
 /// `Type::Int` (= Int64) is the generic integer type and is NOT
 /// in this set; it's handled separately to allow literal assignment.
 fn is_pinned_int(t: &Type) -> bool {
-    matches!(
-        t,
-        Type::Int8
-            | Type::Int16
-            | Type::Int32
-            | Type::UInt8
-            | Type::UInt16
-            | Type::UInt32
-            | Type::UInt64
-    )
+    crate::type_relations::is_pinned_int(t)
 }
 
 /// RES-2831: is `t` a type that the `[]` index operator can never apply
@@ -16407,6 +16256,7 @@ mod res2701_generic_fn_type_params {
 #[cfg(test)]
 mod res2805_generic_return_type_inference {
     use super::*;
+    use crate::type_relations::substitute_with_bindings;
 
     fn check_ok(src: &str) {
         let (prog, errs) = crate::parse(src);

--- a/resilient/src/variance.rs
+++ b/resilient/src/variance.rs
@@ -134,27 +134,23 @@ impl VarianceMap {
     /// - Invariant: `actual` must equal `expected` exactly.
     /// - Phantom: always OK.
     ///
-    /// When a full subtype lattice is added, Covariant will allow
-    /// `actual :> expected` and Contravariant will allow
-    /// `actual <: expected`.  Today the check is just equality, which
-    /// is always sound — it may over-reject valid programs once the
-    /// lattice exists, but it never accepts unsound ones.
+    /// The shared relation layer keeps this conservative and future-proof:
+    /// covariant positions accept subtypes, contravariant positions accept
+    /// supertypes, and invariants stay exact.
     pub fn check_use(&self, tp_name: &str, expected: &Type, actual: &Type) -> Result<(), String> {
         let v = self.get(tp_name);
         match v {
             Variance::Phantom => Ok(()),
-            Variance::Covariant | Variance::Contravariant | Variance::Invariant => {
-                if expected == actual {
-                    Ok(())
-                } else {
-                    Err(format!(
-                        "type parameter `{}` is {} — expected `{}`, got `{}`. \
-                         Variance violation: the types must agree exactly until \
-                         a subtype lattice is defined.",
-                        tp_name, v, expected, actual
-                    ))
-                }
+            Variance::Covariant if crate::type_relations::is_subtype(actual, expected) => Ok(()),
+            Variance::Contravariant if crate::type_relations::is_subtype(expected, actual) => {
+                Ok(())
             }
+            Variance::Invariant if expected == actual => Ok(()),
+            _ => Err(format!(
+                "type parameter `{}` is {} — expected `{}`, got `{}`. \
+                 Variance violation: the relation does not hold.",
+                tp_name, v, expected, actual
+            )),
         }
     }
 }
@@ -518,6 +514,20 @@ mod tests {
         let vmap = infer_variance(&["T".to_string()], &[], &s("T")); // Covariant
         vmap.check_use("T", &Type::Int, &Type::Int)
             .expect("same type must be acceptable");
+    }
+
+    #[test]
+    fn check_use_accepts_covariant_subtype() {
+        let vmap = infer_variance(&["T".to_string()], &[], &s("T"));
+        vmap.check_use("T", &Type::Any, &Type::Int)
+            .expect("subtype should be acceptable in covariant position");
+    }
+
+    #[test]
+    fn check_use_accepts_contravariant_supertype() {
+        let vmap = infer_variance(&["T".to_string()], &[s("T")], &Type::Void);
+        vmap.check_use("T", &Type::Int, &Type::Any)
+            .expect("supertype should be acceptable in contravariant position");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extract shared generic-substitution and type-relation logic into `type_relations`
- use the shared relation helpers from the typechecker/variance path
- preserve anonymous-struct recursion during substitution so the extraction does not regress generic call-site checking

## Why
The in-flight RES-2642 subtype/variance work had been rebased onto newer typechecker cleanup, and the shared helper extraction dropped anonymous-struct recursion that previously lived inline in `typechecker.rs`. This PR keeps the extraction, restores the missing behavior, and leaves the variance-aware call-site path using one shared relation layer.

## Validation
- `cargo fmt --manifest-path resilient/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings`
- `bash agent-scripts/verify-scope.sh --base origin/main --head HEAD` is running locally against this slice; PR CI will also validate the full suite

Closes #2642
