### PR TITLE
RES-2993: Library decomposition follow-through: continue splitting `lib.rs` and restore doctests for stable public APIs

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -409,6 +409,7 @@ For CI, the model is the compiler's own test suite:
 ```bash
 cd resilient
 cargo test              # unit + integration tests
+cargo test --doc        # public API doctests
 cargo test --features z3  # also exercises the SMT layer
 ```
 

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -17,17 +17,13 @@ autoexamples = false
 #                 matches the `.rz` source extension; from RES-219).
 # The bin's `main.rs` is a thin shim that calls `resilient::run_cli()`.
 #
-# `doctest = false` because the codebase pre-dates the lib split:
-# `///` doc comments throughout the moved code were authored as
-# bin-only documentation (no `use` statements, freely referencing
-# private items). Running them as doctests against the lib API
-# fails — fixing them is out of scope for the lib-split PR; a
-# follow-up can re-enable doctests once the visibility surface is
-# audited.
+# RES-2993: doctests are back on for the stable public API surface.
+# Legacy non-runnable snippets are marked as `text` / `ignore`
+# explicitly so they no longer force doctests off for the whole crate.
 [lib]
 name = "resilient"
 path = "src/lib.rs"
-doctest = false
+doctest = true
 
 [[bin]]
 name = "rz"

--- a/resilient/src/mcp_tool_registry.rs
+++ b/resilient/src/mcp_tool_registry.rs
@@ -8,7 +8,7 @@
 //!
 //! # Pattern
 //!
-//! ```
+//! ```text
 //! // register at startup:
 //! McpBridgeRegistry::global().register(tlc_adapter());
 //!

--- a/resilient/src/output_sink.rs
+++ b/resilient/src/output_sink.rs
@@ -20,10 +20,12 @@
 //! outer buffer (with the inner's contents merged in) on exit. That
 //! matches what a caller writing
 //!
-//!     with_captured_output(|| {
-//!         with_captured_output(|| inner());
-//!         outer();
-//!     })
+//! ```text
+//! with_captured_output(|| {
+//!     with_captured_output(|| inner());
+//!     outer();
+//! })
+//! ```
 //!
 //! intuitively expects.
 

--- a/resilient/src/package_manager.rs
+++ b/resilient/src/package_manager.rs
@@ -196,7 +196,7 @@ fn is_valid_semver(s: &str) -> bool {
 }
 
 /// Parse a simple `resilient.lock` format:
-/// ```
+/// ```text
 /// dep_name = "resolved_version"
 /// ```
 fn parse_lock_file(s: &str) -> std::collections::HashMap<String, String> {

--- a/resilient/src/string_interning.rs
+++ b/resilient/src/string_interning.rs
@@ -2,6 +2,22 @@
 //!
 //! String interning deduplicates identical string literals into a single memory location.
 //! This reduces binary bloat and enables pointer-based equality checks.
+//!
+//! ```rust
+//! use resilient::string_interning::{
+//!     get_interned_string, intern_string, reset_interning_pool, strings_equal,
+//! };
+//!
+//! reset_interning_pool();
+//! let hello = intern_string("hello".to_string());
+//! let same = intern_string("hello".to_string());
+//! let world = intern_string("world".to_string());
+//!
+//! assert_eq!(hello, same);
+//! assert_ne!(hello, world);
+//! assert_eq!(get_interned_string(hello).as_deref(), Some("hello"));
+//! assert!(strings_equal(hello, same));
+//! ```
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};

--- a/resilient/src/supervisor.rs
+++ b/resilient/src/supervisor.rs
@@ -3,7 +3,7 @@ use crate::typechecker::TypeEnvironment;
 ///
 /// Supervisor declarations provide restart policies for actor failures.
 /// Syntax:
-/// ```
+/// ```text
 /// supervisor {
 ///     strategy: one_for_one,
 ///     children: [

--- a/resilient/src/tla_bridge.rs
+++ b/resilient/src/tla_bridge.rs
@@ -16,7 +16,7 @@
 //!
 //! TLC output is parsed into Resilient diagnostics:
 //!
-//! ```
+//! ```text
 //! tla:1:0: error: Invariant Inv violated.
 //! tla:0:0: info: Model checking completed — no errors found.
 //! ```
@@ -99,7 +99,7 @@ pub fn java_available() -> bool {
 /// Parse TLC's stdout/stderr into Resilient-format diagnostics.
 ///
 /// TLC emits lines like:
-/// ```
+/// ```text
 /// TLC2 Version 2.16 of 31 December 2021 (rev: ...)
 /// @!@!@STARTMSG 2189:0 @!@!@
 /// Model checking completed. No error has been found.


### PR DESCRIPTION
Closes #2993.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-2993-library-decomposition-follow-through-con`
Worktree: `.claude/worktrees/res-2993`

## Agent claims

(none inferred from issue)