### PR TITLE
RES-2991: Benchmark CLI UX: emit stable summaries and artifact locations suitable for CI tracking

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -319,6 +319,16 @@ implementations in `benchmarks/ref/`) and writes a Markdown table
 to `benchmarks/RESULTS.md`. See [Performance](performance) for the
 methodology and headline numbers.
 
+For file-local microbenchmarks, use `rz bench <file>`. Add
+`--summary-json <path>` when CI needs a stable artifact with the
+per-benchmark stats and baseline deltas, and the CLI will also echo
+`artifact.summary_json=<path>` on stdout for log scraping.
+
+```bash
+rz bench resilient/examples/bench_simple.rz \
+  --summary-json artifacts/bench-summary.json
+```
+
 ## Reproducibility
 
 ### `--seed <u64>`

--- a/resilient/src/bench.rs
+++ b/resilient/src/bench.rs
@@ -67,6 +67,7 @@ pub fn dispatch_bench_subcommand(args: &[String]) -> Option<i32> {
     let mut file: Option<PathBuf> = None;
     let mut baseline_ref: Option<String> = None;
     let mut filter: Option<String> = None;
+    let mut summary_json_path: Option<PathBuf> = None;
     let mut warmup_iters = DEFAULT_WARMUP_ITERS;
     let mut run_iters = DEFAULT_RUN_ITERS;
 
@@ -94,6 +95,15 @@ pub fn dispatch_bench_subcommand(args: &[String]) -> Option<i32> {
             filter = Some(args[i].clone());
         } else if let Some(value) = arg.strip_prefix("--filter=") {
             filter = Some(value.to_string());
+        } else if arg == "--summary-json" {
+            i += 1;
+            if i >= args.len() {
+                eprintln!("Error: --summary-json requires a file path");
+                return Some(2);
+            }
+            summary_json_path = Some(PathBuf::from(&args[i]));
+        } else if let Some(value) = arg.strip_prefix("--summary-json=") {
+            summary_json_path = Some(PathBuf::from(value));
         } else if arg == "--warmup" {
             i += 1;
             if i >= args.len() {
@@ -211,12 +221,29 @@ pub fn dispatch_bench_subcommand(args: &[String]) -> Option<i32> {
         None
     };
 
+    if let Some(output_path) = summary_json_path.as_deref()
+        && let Err(err) = write_summary_json(
+            output_path,
+            &path,
+            &current_results,
+            baseline_results.as_ref(),
+            warmup_iters,
+            run_iters,
+            baseline_ref.as_deref(),
+        )
+    {
+        eprintln!("Error: could not write summary JSON: {err}");
+        return Some(1);
+    }
+
     print_results(
+        &path,
         &current_results,
         baseline_results.as_ref(),
         warmup_iters,
         run_iters,
         baseline_ref.as_deref(),
+        summary_json_path.as_deref(),
     );
     Some(0)
 }
@@ -251,12 +278,15 @@ struct BenchmarkResult {
 }
 
 fn print_bench_help() {
-    println!("Usage: rz bench <file> [--baseline <git-ref>] [--warmup N] [--runs N]");
+    println!(
+        "Usage: rz bench <file> [--baseline <git-ref>] [--summary-json <path>] [--warmup N] [--runs N]"
+    );
     println!();
     println!("Discover and run `bench \"name\" {{ ... }}` blocks.");
     println!();
     println!("Options:");
     println!("  --baseline <ref>   Compare mean ns/op against a git ref");
+    println!("  --summary-json <path>  Write a stable JSON summary artifact");
     println!("  --warmup <N>       Warmup iterations before timing (default: 1)");
     println!("  --runs <N>         Timed iterations per benchmark (default: 3)");
     println!("  --filter <substr>  Only run benchmarks whose names contain <substr>");
@@ -446,11 +476,13 @@ fn compute_stats(samples_ns: &[f64]) -> BenchmarkStats {
 }
 
 fn print_results(
+    source_path: &Path,
     current: &[BenchmarkResult],
     baseline: Option<&Vec<BenchmarkResult>>,
     warmup_iters: usize,
     run_iters: usize,
     baseline_ref: Option<&str>,
+    summary_json_path: Option<&Path>,
 ) {
     println!("Benchmark results (warmup: {warmup_iters}, runs: {run_iters})");
 
@@ -497,6 +529,84 @@ fn print_results(
             delta_text,
         );
     }
+
+    println!();
+    println!("summary.source={}", source_path.display());
+    println!("summary.benchmarks={}", current.len());
+    println!("summary.warmup_iters={warmup_iters}");
+    println!("summary.run_iters={run_iters}");
+    if let Some(reference) = baseline_ref {
+        println!("summary.baseline_ref={reference}");
+    }
+    if let Some(path) = summary_json_path {
+        println!("artifact.summary_json={}", path.display());
+    }
+}
+
+fn write_summary_json(
+    output_path: &Path,
+    source_path: &Path,
+    current: &[BenchmarkResult],
+    baseline: Option<&Vec<BenchmarkResult>>,
+    warmup_iters: usize,
+    run_iters: usize,
+    baseline_ref: Option<&str>,
+) -> Result<(), String> {
+    let baseline_by_name: HashMap<&str, &BenchmarkResult> = baseline
+        .into_iter()
+        .flat_map(|results| results.iter())
+        .map(|result| (result.name.as_str(), result))
+        .collect();
+
+    let benches: Vec<_> = current
+        .iter()
+        .map(|result| {
+            let (baseline_mean_ns, delta_pct) = if let Some(base) =
+                baseline_by_name.get(result.name.as_str())
+            {
+                let delta_pct = if base.stats.mean_ns == 0.0 {
+                    None
+                } else {
+                    Some(((result.stats.mean_ns - base.stats.mean_ns) / base.stats.mean_ns) * 100.0)
+                };
+                (Some(base.stats.mean_ns), delta_pct)
+            } else {
+                (None, None)
+            };
+            serde_json::json!({
+                "name": result.name,
+                "mean_ns": result.stats.mean_ns,
+                "median_ns": result.stats.median_ns,
+                "stddev_ns": result.stats.stddev_ns,
+                "min_ns": result.stats.min_ns,
+                "max_ns": result.stats.max_ns,
+                "baseline_mean_ns": baseline_mean_ns,
+                "delta_pct": delta_pct,
+            })
+        })
+        .collect();
+
+    let summary = serde_json::json!({
+        "schema_version": 1,
+        "source": source_path.display().to_string(),
+        "warmup_iters": warmup_iters,
+        "run_iters": run_iters,
+        "benchmark_count": current.len(),
+        "baseline_ref": baseline_ref,
+        "benchmarks": benches,
+    });
+
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("could not create {}: {e}", parent.display()))?;
+    }
+    let text = serde_json::to_string_pretty(&summary)
+        .map_err(|e| format!("could not serialize summary JSON: {e}"))?;
+    fs::write(output_path, text)
+        .map_err(|e| format!("could not write {}: {e}", output_path.display()))?;
+    Ok(())
 }
 
 fn format_ns(value: f64) -> String {

--- a/resilient/tests/bench_cli_summary_json.rs
+++ b/resilient/tests/bench_cli_summary_json.rs
@@ -1,0 +1,82 @@
+//! RES-2991: smoke test for `rz bench --summary-json`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_dir(tag: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let p = std::env::temp_dir().join(format!(
+        "res_bench_cli_summary_{}_{}_{}",
+        tag,
+        std::process::id(),
+        n
+    ));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+#[test]
+fn bench_writes_machine_readable_summary_artifact() {
+    let dir = tmp_dir("summary_json");
+    let summary_path = dir.join("bench-summary.json");
+
+    let output = Command::new(bin())
+        .args([
+            "bench",
+            "examples/bench_simple.rz",
+            "--summary-json",
+            summary_path.to_str().expect("summary path utf8"),
+        ])
+        .output()
+        .expect("spawn resilient bench");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit 0; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("summary.benchmarks="),
+        "expected stable summary footer; stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("artifact.summary_json="),
+        "expected artifact location footer; stdout={stdout}"
+    );
+    assert!(
+        stdout.contains(summary_path.to_str().expect("summary path utf8")),
+        "expected emitted summary path; stdout={stdout}"
+    );
+
+    let text = fs::read_to_string(&summary_path).expect("read summary json");
+    let json: serde_json::Value = serde_json::from_str(&text).expect("parse summary json");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["source"], "examples/bench_simple.rz");
+    assert_eq!(json["warmup_iters"], 1);
+    assert_eq!(json["run_iters"], 3);
+    assert_eq!(json["benchmark_count"], 5);
+
+    let benches = json["benchmarks"].as_array().expect("benchmarks array");
+    assert_eq!(benches.len(), 5);
+    let first = &benches[0];
+    assert_eq!(first["name"], "empty block");
+    assert!(first.get("mean_ns").is_some(), "missing mean_ns: {first:?}");
+    assert!(
+        first.get("baseline_mean_ns").is_some(),
+        "missing baseline_mean_ns field: {first:?}"
+    );
+    assert!(
+        first.get("delta_pct").is_some(),
+        "missing delta_pct field: {first:?}"
+    );
+}


### PR DESCRIPTION
Closes #2991.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-2991-benchmark-cli-ux-emit-stable-summaries-a`
Worktree: `.claude/worktrees/res-2991`

## Agent claims

(none inferred from issue)