### PR TITLE
RES-2988: Cfg/feature integration: add end-to-end package-level tests for `--feature`, `--target`, and `--cfg` flows

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -197,6 +197,20 @@ Built-in commands:
 
 History is persisted via `rustyline`. Multi-line input is supported.
 
+## Conditional Compilation
+
+Use the CLI flags below to select `#[cfg(...)]` branches in examples and
+real projects:
+
+```bash
+rz --feature verbose examples/cfg_feature.rz
+rz --target thumbv7em examples/cfg_target.rz
+rz --cfg mode=demo examples/cfg_kv_demo.rz
+```
+
+The examples in `resilient/examples/` show the expected stdout for each
+path and are covered by smoke tests.
+
 ## Language Server (LSP)
 
 Opt-in; requires building with `--features lsp`.

--- a/resilient/examples/cfg_kv_demo.rz
+++ b/resilient/examples/cfg_kv_demo.rz
@@ -1,0 +1,21 @@
+// RES-2988: #[cfg(key = "value")] conditional compilation.
+//
+// Two versions of `banner` show how `--cfg mode=demo` selects a branch.
+// Default invocation (`rz examples/cfg_kv_demo.rz`) outputs "default mode".
+// `rz --cfg mode=demo examples/cfg_kv_demo.rz` outputs "demo mode".
+
+#[cfg(mode = "demo")]
+fn banner() {
+    println("demo mode");
+}
+
+#[cfg(not(mode = "demo"))]
+fn banner() {
+    println("default mode");
+}
+
+fn main() {
+    banner();
+}
+
+main();

--- a/resilient/tests/cfg_smoke.rs
+++ b/resilient/tests/cfg_smoke.rs
@@ -1,0 +1,70 @@
+//! RES-2988: end-to-end smoke coverage for cfg/feature/target flows.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn run_rz(args: &[&str]) -> (String, String, Option<i32>) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn resilient binary");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+#[test]
+fn feature_flag_selects_verbose_branch() {
+    let (stdout, _stderr, code) = run_rz(&["examples/cfg_feature.rz"]);
+    assert_eq!(code, Some(0), "default cfg_feature run should succeed");
+    assert!(
+        stdout.contains("quiet mode"),
+        "default cfg_feature output should be quiet mode; got:\n{stdout}"
+    );
+
+    let (stdout, _stderr, code) = run_rz(&["--feature", "verbose", "examples/cfg_feature.rz"]);
+    assert_eq!(code, Some(0), "--feature verbose run should succeed");
+    assert!(
+        stdout.contains("verbose mode"),
+        "verbose feature should activate verbose branch; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn target_flag_selects_thumb_branch() {
+    let (stdout, _stderr, code) = run_rz(&["examples/cfg_target.rz"]);
+    assert_eq!(code, Some(0), "default cfg_target run should succeed");
+    assert!(
+        stdout.contains("42"),
+        "default target should keep host branch; got:\n{stdout}"
+    );
+
+    let (stdout, _stderr, code) = run_rz(&["--target", "thumbv7em", "examples/cfg_target.rz"]);
+    assert_eq!(code, Some(0), "--target thumbv7em run should succeed");
+    assert!(
+        stdout.contains("0"),
+        "thumbv7em target should activate the thumb branch; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn cfg_key_value_selects_custom_branch() {
+    let (stdout, _stderr, code) = run_rz(&["examples/cfg_kv_demo.rz"]);
+    assert_eq!(code, Some(0), "default cfg_kv_demo run should succeed");
+    assert!(
+        stdout.contains("default mode"),
+        "default key/value cfg branch should be selected; got:\n{stdout}"
+    );
+
+    let (stdout, _stderr, code) = run_rz(&["--cfg", "mode=demo", "examples/cfg_kv_demo.rz"]);
+    assert_eq!(code, Some(0), "--cfg mode=demo run should succeed");
+    assert!(
+        stdout.contains("demo mode"),
+        "mode=demo should activate the custom cfg branch; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Closes #2988.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-2988-cfg-feature-integration-add-end-to-end-p`
Worktree: `.claude/worktrees/res-2988`

## Agent claims

(none inferred from issue)