### PR TITLE
RES-2923: Add an explicit `rz repl` alias instead of relying on the no-arg special case alone

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -190,13 +190,15 @@ rz verify-all ./certs --z3
 
 ## REPL
 
-Launched by running `rz` with no file argument.
+Launched by running `rz` with no file argument, or explicitly via
+`rz repl`.
 
 There is no dedicated `repl` subcommand; `rz repl` now prints a helpful
 `repl is not a subcommand` error and points users to the REPL launch path.
 
 ```bash
 rz                           # start REPL
+rz repl                      # explicit alias for REPL
 rz --examples-dir ./ex       # override the `examples` command's search path
 ```
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -193,8 +193,8 @@ rz verify-all ./certs --z3
 Launched by running `rz` with no file argument, or explicitly via
 `rz repl`.
 
-There is no dedicated `repl` subcommand; `rz repl` now prints a helpful
-`repl is not a subcommand` error and points users to the REPL launch path.
+`rz repl` is an explicit alias for the same interactive REPL that
+starts when `rz` is invoked with no file argument.
 
 ```bash
 rz                           # start REPL

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32044,6 +32044,7 @@ COMMON FLAGS:\n\
                                  debounce); press Ctrl-C to stop (RES-228)\n\
 \n\
 SUBCOMMANDS:\n\
+    repl                 Start interactive REPL (alias for bare `rz`)\n\
     check <file>        Type-check without running (RES-225)\n\
     bench <file>        Run `bench \"name\" {{ ... }}` benchmarks\n\
     self-host-parity-report [DIR]\n\
@@ -32062,6 +32063,26 @@ SUBCOMMANDS:\n\
 Tip: run `rz` with no file argument to start REPL.\n\
 `repl` is not a subcommand.\n\
 See SYNTAX.md for the language reference."
+    );
+}
+
+fn print_repl_help() {
+    println!(
+        "rz repl — start the interactive REPL\n\
+\n\
+USAGE:\n\
+    rz repl [--examples-dir DIR]\n\
+    rz repl --help\n\
+\n\
+FLAGS:\n\
+    --help, -h            Show this help and exit\n\
+    --examples-dir DIR     REPL examples directory\n\
+\n\
+EXAMPLES:\n\
+    rz repl                   # start REPL\n\
+    rz repl --examples-dir .   # use the current directory for `examples`\n\
+\n\
+For bare REPL startup, run plain `rz`."
     );
 }
 
@@ -32308,6 +32329,8 @@ pub fn run_cli() {
         std::process::exit(code);
     }
 
+    let explicit_repl = args.get(1).map(String::as_str) == Some("repl");
+
     // RES-205: intercept `pkg` subcommands before the normal flow.
     // Must run before the global --help check so that
     // `resilient pkg --help` reaches print_pkg_help() instead of
@@ -32337,7 +32360,7 @@ pub fn run_cli() {
     // RES-211: `--help` / `-h` prints a short usage summary listing
     // the most-used flags. Kept hand-rolled (no clap dep) to match
     // the rest of the driver's arg-parsing style.
-    if args.iter().any(|a| a == "--help" || a == "-h") {
+    if args.iter().any(|a| a == "--help" || a == "-h") && !explicit_repl {
         print_help();
         std::process::exit(0);
     }
@@ -32491,12 +32514,45 @@ pub fn run_cli() {
     // RES-228: `--watch` re-runs the program on every file save.
     let mut watch_mode = false;
     let mut filename = "";
+    let mut repl_help = false;
 
     // Simple argument parsing
     if args.len() > 1 {
         let mut i = 1;
         while i < args.len() {
             let arg = &args[i];
+            if explicit_repl {
+                if i == 1 {
+                    i += 1;
+                    continue;
+                }
+                if arg == "help" || arg == "--help" || arg == "-h" {
+                    repl_help = true;
+                    i += 1;
+                    continue;
+                }
+                if arg == "--examples-dir" {
+                    i += 1;
+                    if i >= args.len() {
+                        eprintln!("Error: --examples-dir requires a directory argument");
+                        std::process::exit(2);
+                    }
+                    examples_dir = Some(PathBuf::from(&args[i]));
+                    i += 1;
+                    continue;
+                }
+                if let Some(dir) = arg.strip_prefix("--examples-dir=") {
+                    examples_dir = Some(PathBuf::from(dir));
+                    i += 1;
+                    continue;
+                }
+                if arg.starts_with('-') {
+                    eprintln!("Error: unknown flag `{}` to `rz repl`", arg);
+                    std::process::exit(2);
+                }
+                eprintln!("Error: `rz repl` does not take file arguments");
+                std::process::exit(2);
+            }
             if arg == "--typecheck" || arg == "-t" {
                 type_check = true;
             } else if arg == "--typecheck-strict" {
@@ -33133,6 +33189,19 @@ pub fn run_cli() {
                     }
                 }
             });
+            return;
+        }
+
+        if explicit_repl {
+            if repl_help {
+                print_repl_help();
+                return;
+            }
+            let mut enhanced_repl = repl::EnhancedREPL::with_examples_dir(examples_dir);
+            if let Err(e) = enhanced_repl.run() {
+                eprintln!("REPL error: {}", e);
+                std::process::exit(1);
+            }
             return;
         }
 

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32061,7 +32061,7 @@ SUBCOMMANDS:\n\
 \n\
 \n\
 Tip: run `rz` with no file argument to start REPL.\n\
-`repl` is not a subcommand.\n\
+`rz repl` is an explicit alias for the REPL.\n\
 See SYNTAX.md for the language reference."
     );
 }

--- a/resilient/tests/repl_smoke.rs
+++ b/resilient/tests/repl_smoke.rs
@@ -1,0 +1,42 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+#[test]
+fn repl_alias_shows_help() {
+    // `rz repl --help` should route to the dedicated REPL help
+    // path and exit success.
+    let output = Command::new(bin())
+        .args(["repl", "--help"])
+        .output()
+        .expect("spawn resilient repl --help");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("rz repl"),
+        "repl help output missing heading: {stdout}"
+    );
+    assert!(
+        stdout.contains("--examples-dir"),
+        "repl help output missing examples dir flag: {stdout}"
+    );
+}
+
+#[test]
+fn help_includes_repl_subcommand() {
+    // Discoverability check for the explicit alias.
+    let output = Command::new(bin())
+        .arg("--help")
+        .output()
+        .expect("spawn resilient --help");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("repl"),
+        "global help output missing repl subcommand: {stdout}"
+    );
+}

--- a/resilient/tests/repl_smoke.rs
+++ b/resilient/tests/repl_smoke.rs
@@ -36,7 +36,7 @@ fn help_includes_repl_subcommand() {
     assert_eq!(output.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("repl"),
-        "global help output missing repl subcommand: {stdout}"
+        stdout.contains("repl                 Start interactive REPL (alias for bare `rz`)"),
+        "global help output missing repl alias entry: {stdout}"
     );
 }

--- a/resilient/tests/safety_critical_smoke.rs
+++ b/resilient/tests/safety_critical_smoke.rs
@@ -142,8 +142,8 @@ fn help_mentions_repl_launch_path() {
     assert_eq!(out.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.contains("start REPL") && stdout.contains("`repl` is not a subcommand"),
-        "--help should document REPL launch and state that `repl` is not a subcommand; got:\n{stdout}"
+        stdout.contains("start REPL") && stdout.contains("explicit alias"),
+        "--help should document the explicit REPL alias; got:\n{stdout}"
     );
 }
 
@@ -155,15 +155,16 @@ fn repl_token_points_to_direct_launch() {
         .expect("spawn rz repl");
     assert_eq!(
         out.status.code(),
-        Some(2),
-        "`rz repl` should be rejected as non-command; stdout={} stderr={}",
+        Some(0),
+        "`rz repl` should launch the REPL directly; stdout={} stderr={}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
-    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stderr.contains("`repl` is not a subcommand")
-            && stderr.contains("Run `rz` with no arguments to start the REPL"),
-        "`rz repl` error should guide users to REPL launch path; got: {stderr}"
+        stdout.contains("Resilient Programming Language REPL") && stdout.contains("CTRL-D"),
+        "`rz repl` should print the REPL banner and exit cleanly on EOF; got: {stdout}"
     );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("seed="), "`rz repl` should still seed the REPL; got: {stderr}");
 }

--- a/resilient/tests/safety_critical_smoke.rs
+++ b/resilient/tests/safety_critical_smoke.rs
@@ -166,5 +166,8 @@ fn repl_token_points_to_direct_launch() {
         "`rz repl` should print the REPL banner and exit cleanly on EOF; got: {stdout}"
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("seed="), "`rz repl` should still seed the REPL; got: {stderr}");
+    assert!(
+        stderr.contains("seed="),
+        "`rz repl` should still seed the REPL; got: {stderr}"
+    );
 }


### PR DESCRIPTION
Closes #2923.

## Summary
RES-2923: Add an explicit `rz repl` alias instead of relying on the no-arg special case alone
