### PR TITLE
RES-2894: First-run docs: replace stale example paths with checkout-valid `resilient/examples/...` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ set to the signer's key.
 
 ```bash
 # Sign during emit:
-rz -t --emit-certificate ./certs --sign-cert ~/.resilient-priv.pem src/main.rz
+rz -t --emit-certificate ./certs --sign-cert ~/.resilient-priv.pem resilient/examples/sensor_monitor.rz
 
 # Verify against the binary's embedded public key:
 rz verify-cert ./certs
@@ -718,7 +718,7 @@ stdout; pass `--in-place` to overwrite the file.
 
 ```bash
 rz fmt resilient/examples/hello.rz    # print to stdout
-rz fmt --in-place src/main.rz         # overwrite
+rz fmt --in-place resilient/examples/hello.rz  # overwrite
 ```
 
 The formatter refuses to touch input with parse errors (exits 1).

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -216,8 +216,8 @@ and pretty-prints it in canonical style:
 - `live` blocks follow the same brace style
 
 ```bash
-rz fmt src/main.rs              # print to stdout
-rz fmt --in-place src/main.rs   # overwrite the file
+rz fmt resilient/examples/hello.rz         # print to stdout
+rz fmt --in-place resilient/examples/hello.rz # overwrite the file
 ```
 
 Exit codes: `0` = formatted, `1` = parse errors (formatter refuses
@@ -238,7 +238,7 @@ Creates a new Resilient project layout in the current directory:
 ```
 <name>/
   src/
-    main.rs
+    main.rz
   README.md
   .gitignore
 ```
@@ -246,7 +246,7 @@ Creates a new Resilient project layout in the current directory:
 ```bash
 rz pkg init my-proj
 cd my-proj
-rz src/main.rs
+rz src/main.rz
 ```
 
 `rz pkg` is the umbrella for future package operations
@@ -366,9 +366,9 @@ see `resilient/src/lint.rs` for the full list). Supports
 `// resilient: allow <code>` suppression comments.
 
 ```bash
-rz lint src/main.rs
-rz lint src/main.rs --deny L001
-rz lint src/main.rs --allow L003
+rz lint resilient/examples/hello.rz
+rz lint resilient/examples/hello.rz --deny L001
+rz lint resilient/examples/hello.rz --allow L003
 ```
 
 Exit codes: `0` = no diagnostics, `1` = warnings only, `2` = any


### PR DESCRIPTION
Closes #2894.

## Summary
RES-2894: First-run docs: replace stale example paths with checkout-valid `resilient/examples/...` commands
