### PR TITLE
RES-2893: CLI help: document REPL launch path and retire the phantom `repl` entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ and the limitations or follow-up tickets.
 
 ### Running the REPL
 
+There is no `repl` subcommand.
+
 ```bash
 rz
 ```

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -161,6 +161,9 @@ rz verify-all ./certs --z3
 
 Launched by running `rz` with no file argument.
 
+There is no dedicated `repl` subcommand; `rz repl` now prints a helpful
+`repl is not a subcommand` error and points users to the REPL launch path.
+
 ```bash
 rz                           # start REPL
 rz --examples-dir ./ex       # override the `examples` command's search path

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -31974,7 +31974,8 @@ fn print_help() {
         "rz — the Resilient language compiler & interpreter\n\
 \n\
 USAGE:\n\
-    rz [FLAGS] <file>\n\
+    rz [FLAGS] [<file>]\n\
+    rz                      # start REPL when no file is provided\n\
     rz <subcommand> [ARGS]\n\
 \n\
 COMMON FLAGS:\n\
@@ -32043,6 +32044,9 @@ SUBCOMMANDS:\n\
     verify-cert <dir>   Verify an RES-071 certificate directory\n\
     verify-all <dir>    Re-check every obligation in a manifest\n\
 \n\
+\n\
+Tip: run `rz` with no file argument to start REPL.\n\
+`repl` is not a subcommand.\n\
 See SYNTAX.md for the language reference."
     );
 }
@@ -32810,6 +32814,13 @@ pub fn run_cli() {
                 filename = arg;
             }
             i += 1;
+        }
+
+        if filename == "repl" && !std::path::Path::new(filename).exists() {
+            eprintln!(
+                "Error: `repl` is not a subcommand. Run `rz` with no arguments to start the REPL."
+            );
+            std::process::exit(2);
         }
 
         // RES-343: install the cfg state before any parser runs. Every

--- a/resilient/tests/safety_critical_smoke.rs
+++ b/resilient/tests/safety_critical_smoke.rs
@@ -162,8 +162,8 @@ fn repl_token_points_to_direct_launch() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("`repl` is not a subcommand") &&
-            stderr.contains("Run `rz` with no arguments to start the REPL"),
+        stderr.contains("`repl` is not a subcommand")
+            && stderr.contains("Run `rz` with no arguments to start the REPL"),
         "`rz repl` error should guide users to REPL launch path; got: {stderr}"
     );
 }

--- a/resilient/tests/safety_critical_smoke.rs
+++ b/resilient/tests/safety_critical_smoke.rs
@@ -132,3 +132,38 @@ fn help_lists_safety_critical_flag() {
         "--help should mention --safety-critical; got:\n{stdout}"
     );
 }
+
+#[test]
+fn help_mentions_repl_launch_path() {
+    let out = Command::new(bin())
+        .arg("--help")
+        .output()
+        .expect("spawn rz --help");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("start REPL") && stdout.contains("`repl` is not a subcommand"),
+        "--help should document REPL launch and state that `repl` is not a subcommand; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn repl_token_points_to_direct_launch() {
+    let out = Command::new(bin())
+        .arg("repl")
+        .output()
+        .expect("spawn rz repl");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "`rz repl` should be rejected as non-command; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("`repl` is not a subcommand") &&
+            stderr.contains("Run `rz` with no arguments to start the REPL"),
+        "`rz repl` error should guide users to REPL launch path; got: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #2893.

## Summary
RES-2893: CLI help: document REPL launch path and retire the phantom `repl` entrypoint
