### PR TITLE
RES-2920: Stability surfacing: clearly separate stable, experimental, and backend-limited features across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ This puts `rz` in `~/.cargo/bin/rz` (already on `PATH` if cargo is configured
 normally). Add `--features z3` for SMT-backed verification (requires
 `brew install z3` or `apt-get install libz3-dev`).
 
+### Feature tiers
+
+The project intentionally separates feature surfaces:
+
+- **Stable:** baseline CLI behavior and standard diagnostics on the default
+  build.
+- **Backend-limited:** commands that need optional runtime features:
+  `--jit` (`--features jit`), `--lsp` (`--features lsp`), and SMT-backed
+  modes (`--features z3`, `--z3`).
+- **Experimental:** surfaces with evolving contracts and policy (`--ai-threats`).
+
 #### Docker (RES-203)
 
 A prebuilt image is published to GitHub Container Registry on every

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -45,6 +45,22 @@ documented in [Performance](performance). Features outside the
 subset fall through to the interpreter at runtime rather than
 erroring.
 
+### Stability surface
+
+Public behavior is grouped by stability class:
+
+- **Stable:** `--check`, `--typecheck`, `--fmt`, `--lint`,
+  `--examples`, `--audit` (without SMT features), `--run`, and
+  the default/interpreter execution path.
+- **Backend-limited:** options that depend on backend/feature flags
+  and are not available in every build, including:
+  `--vm`, `--jit` (requires `--features jit`),
+  `--lsp` (requires `--features lsp`), and SMT-enabled
+  verification (`--features z3` / `--z3`).
+- **Experimental:** surfaces that may change while policy and
+  diagnostics are still evolving: `--ai-threats` and
+  `--dump-ast-json`.
+
 ## Inspection
 
 ### `--dump-tokens <file>`


### PR DESCRIPTION
Closes #2920.

## Summary
RES-2920: Stability surfacing: clearly separate stable, experimental, and backend-limited features across docs
