### PR TITLE
RES-3128: Backfill regression coverage for current stable language and CLI features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,20 @@ cargo test --manifest-path resilient-runtime/Cargo.toml
 cargo test --manifest-path resilient/Cargo.toml <test_name>
 ```
 
+### Direct regression coverage
+
+Shipped language features and shipped CLI workflows should keep at least
+one direct regression or smoke test instead of relying on incidental
+coverage.
+
+- Update or extend the tracked inventory in
+  [`docs/stable-regression-inventory.md`](docs/stable-regression-inventory.md)
+  when you add a stable surface or intentionally defer one.
+- Prefer focused integration tests under `resilient/tests/` for CLI
+  wiring and end-to-end feature behavior.
+- If a behavior is not stable yet, document that explicitly rather than
+  treating it as uncovered stable functionality.
+
 ### With Z3 (contract verification)
 
 ```bash

--- a/docs/stable-regression-inventory.md
+++ b/docs/stable-regression-inventory.md
@@ -1,0 +1,67 @@
+# Stable Regression Inventory
+
+This file tracks the current stable Resilient language and CLI surface
+and the direct regression or smoke coverage that pins each area.
+
+Scope rules:
+
+- Track shipped surfaces users are expected to rely on today.
+- Prefer direct integration or smoke coverage over incidental unit-test
+  coverage.
+- When a surface is not yet stable, call it out explicitly instead of
+  treating it as uncovered stable behavior.
+
+## Stable Language Surface
+
+| Surface | Direct coverage | Status | Notes |
+|---|---|---|---|
+| Default interpreter execution path | `resilient/tests/examples_smoke.rs` | Covered | End-to-end run path over shipped example programs. |
+| Older stable core constructs from the roadmap reset backlog: assignment, forward references, modulo, prefix `!`/`-`, logical ops, bitwise ops, `while`, block comments, hex/binary literals with `_` separators | `resilient/tests/stable_language_surface_backfill.rs` | Covered | Added for RES-3128 to backfill older stable syntax/runtime surfaces that previously relied on incidental coverage. |
+| Older stable core constructs: `static let`, bare `return;`, string comparisons, `len()` | `resilient/tests/stable_language_surface_backfill.rs` | Covered | Added for RES-3128. |
+| Live blocks and retry semantics | `resilient/tests/live_block_spec.rs`, `resilient/tests/live_retry_log_cli.rs`, `resilient/tests/panic_on_fault_smoke.rs` | Covered | Runtime healing path plus emitted retry log / panic-on-fault modes. |
+| Contracts, bounds proof audit, and safety-critical checking | `resilient/tests/bounds_elision_smoke.rs`, `resilient/tests/safety_critical_smoke.rs` | Covered | Pins strict verification/audit behavior. |
+| Effects and effect explanation | `resilient/tests/effect_system_smoke.rs`, `resilient/tests/explain_effects_cli.rs` | Covered | Direct effect-system and CLI explanation coverage. |
+| `#[cfg(...)]` conditional compilation | `resilient/tests/cfg_smoke.rs` | Covered | Direct stable cfg path coverage. |
+| Linear types | `resilient/tests/linear_types.rs` | Covered | Direct end-to-end typechecker coverage. |
+| `try` / `catch` runtime semantics | `resilient/tests/try_catch_runtime.rs` | Covered | Direct runtime coverage. |
+| Recovery contracts / `recovers_to` | `resilient/tests/recovers_to_smoke.rs`, `resilient/tests/recovers_to_z3_obligation.rs` | Covered | Runtime and verifier paths. |
+| Information flow / noninterference | `resilient/tests/info_flow_smoke.rs`, `resilient/tests/noninterference_smoke.rs` | Covered | Direct end-to-end policy checks. |
+
+## Stable CLI Surface
+
+| Surface | Direct coverage | Status | Notes |
+|---|---|---|---|
+| Global help and REPL discoverability | `resilient/tests/repl_smoke.rs`, `resilient/tests/safety_critical_smoke.rs` | Covered | Pins `rz --help`, `rz repl --help`, and explicit REPL alias text. |
+| REPL startup path | `resilient/tests/safety_critical_smoke.rs` | Covered | Direct `rz repl` launch smoke. |
+| `rz check <file>` | `resilient/tests/check_smoke.rs` | Covered | Success, type-error, quiet, and usage paths. |
+| `rz fmt <file>` stdout path | `resilient/tests/roundtrip.rs` | Covered | Canonical round-trip formatting. |
+| `rz fmt <file> --in-place` | `resilient/tests/stable_cli_surface_smoke.rs` | Covered | Added for RES-3128. |
+| `rz lint <file>` | `resilient/tests/lint_smoke.rs` | Covered | Dedicated CLI wiring coverage. |
+| `--dump-tokens` | `resilient/tests/dump_tokens_smoke.rs` | Covered | Direct lexer-stream smoke. |
+| `--dump-ast-json` | `resilient/tests/stable_cli_surface_smoke.rs`, `resilient/tests/self_host_parity.rs` | Covered | Added dedicated CLI smoke in RES-3128; parity suite already consumes the JSON shape. |
+| `--dump-chunks` | `resilient/tests/dump_chunks_smoke.rs` | Covered | Direct VM disassembly smoke. |
+| `--audit` | `resilient/tests/bounds_elision_smoke.rs` | Covered | Direct verification audit coverage. |
+| `--explain-effects` | `resilient/tests/explain_effects_cli.rs` | Covered | Dedicated CLI coverage. |
+| `--version` / `--version --verbose` | `resilient/tests/stable_cli_surface_smoke.rs` | Covered | Added for RES-3128. |
+| `stack-usage <file>` | `resilient/tests/stable_cli_surface_smoke.rs` | Covered | Added for RES-3128. |
+| `pkg init` workflow | `resilient/tests/pkg_init_smoke.rs` | Covered | Dedicated project-scaffolding smoke. |
+| `bench <file>` | `resilient/tests/bench_cli.rs`, `resilient/tests/bench_cli_summary_json.rs` | Covered | Human and machine-readable outputs. |
+| Example corpus smoke | `resilient/tests/examples_smoke.rs`, `resilient/tests/examples_golden.rs` | Covered | Direct shipped-example coverage. |
+| Self-host parity report | `resilient/tests/self_host_parity_report_cli.rs` | Covered | Dedicated report artifact smoke. |
+| Certificate verification (`verify-cert`, `verify-all`) | `resilient/tests/verify_cert_smoke.rs`, `resilient/tests/verify_all_smoke.rs` | Covered | Stable when built with `--features z3`. |
+| Backend-limited execution (`--vm`, `--jit`) | `resilient/tests/examples_smoke.rs` | Covered | Stable subset / feature-gated, but still pinned by direct smoke. |
+| LSP server | `resilient/tests/lsp_smoke.rs` and focused LSP smoke files | Covered | Feature-gated shipped surface. |
+
+## Intentionally Deferred / Not Yet Stable
+
+| Surface | Reason | Follow-up shape |
+|---|---|---|
+| `rz test` | `docs/tooling.md` still classifies the first-class test runner as future work, so it is not counted as part of the stable surface in this inventory. | Reclassify in docs and add dedicated CLI smoke when the runner is promoted to stable. |
+| `rz tool ...` external tool bridge | Present in code but not documented as stable in the public tooling reference or top-level help. | Promote/document the subcommand first, then add direct smoke coverage as part of that stabilization slice. |
+| Debugger / profiler paths | Public docs classify them as future work. | Stabilize the user-facing workflows before adding them to this inventory. |
+
+## Maintenance Rule
+
+When a change ships new stable language behavior or a new stable CLI
+workflow, add or update a direct regression/smoke test in the same PR
+and update this inventory so the coverage source of truth stays current.

--- a/resilient/tests/stable_cli_surface_smoke.rs
+++ b/resilient/tests/stable_cli_surface_smoke.rs
@@ -1,0 +1,135 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_file(tag: &str, body: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("res_3128_{}_{}_{}.rz", tag, std::process::id(), n));
+    std::fs::write(&path, body).expect("write scratch file");
+    path
+}
+
+#[test]
+fn fmt_in_place_rewrites_file_to_canonical_form() {
+    let path = tmp_file("fmt_in_place", "fn main(){return 1;}\n");
+    let output = Command::new(bin())
+        .args(["fmt", "--in-place"])
+        .arg(&path)
+        .output()
+        .expect("spawn rz fmt --in-place");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "fmt --in-place should succeed; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "in-place formatter should not print rewritten source; stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let rewritten = std::fs::read_to_string(&path).expect("read formatted file");
+    assert_eq!(rewritten, "fn main() {\n    return 1;\n}\n");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn dump_ast_json_emits_parseable_ast() {
+    let path = tmp_file("dump_ast_json", "fn main() { return 1; }\nmain();\n");
+    let output = Command::new(bin())
+        .arg("--dump-ast-json")
+        .arg(&path)
+        .output()
+        .expect("spawn rz --dump-ast-json");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "--dump-ast-json should succeed; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse AST JSON");
+    assert_eq!(json["type"], "Program", "expected Program root: {json}");
+    let program = json["body"].as_array().expect("program body array");
+    assert!(
+        program.iter().any(|node| node["type"] == "Function"),
+        "expected function node in AST JSON: {json}"
+    );
+    assert!(
+        program
+            .iter()
+            .any(|node| node["type"] == "ExprStmt" && node["expr"]["type"] == "Call"),
+        "expected top-level call expression in AST JSON: {json}"
+    );
+}
+
+#[test]
+fn stack_usage_reports_budget_failure() {
+    let path = tmp_file(
+        "stack_usage",
+        "#[stack(bytes=1)]\nfn tiny() {\n    return;\n}\n\ntiny();\n",
+    );
+    let output = Command::new(bin())
+        .args(["stack-usage"])
+        .arg(&path)
+        .output()
+        .expect("spawn rz stack-usage");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stack-usage should fail when a declared budget is exceeded; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Function") && stdout.contains("Est. Bytes"));
+    assert!(stdout.contains("tiny"));
+    assert!(stdout.contains("OVER BUDGET"));
+}
+
+#[test]
+fn version_verbose_extends_short_banner() {
+    let short = Command::new(bin())
+        .arg("--version")
+        .output()
+        .expect("spawn rz --version");
+    assert_eq!(short.status.code(), Some(0));
+    let short_stdout = String::from_utf8_lossy(&short.stdout);
+    assert!(
+        short_stdout.starts_with("rz ") && short_stdout.contains("pre-1.0"),
+        "unexpected short version output: {short_stdout}"
+    );
+
+    let verbose = Command::new(bin())
+        .args(["--version", "--verbose"])
+        .output()
+        .expect("spawn rz --version --verbose");
+    assert_eq!(verbose.status.code(), Some(0));
+    let verbose_stdout = String::from_utf8_lossy(&verbose.stdout);
+    assert!(
+        verbose_stdout.starts_with(short_stdout.as_ref()),
+        "verbose version output should extend the short banner; short={short_stdout} verbose={verbose_stdout}"
+    );
+    assert!(
+        verbose_stdout.contains("target:") && verbose_stdout.contains("profile:"),
+        "verbose version output missing build metadata: {verbose_stdout}"
+    );
+}

--- a/resilient/tests/stable_language_surface_backfill.rs
+++ b/resilient/tests/stable_language_surface_backfill.rs
@@ -1,0 +1,114 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_file(tag: &str, body: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("res_3128_{}_{}_{}.rz", tag, std::process::id(), n));
+    std::fs::write(&path, body).expect("write scratch file");
+    path
+}
+
+fn run_source(tag: &str, body: &str) -> (String, String, Option<i32>) {
+    let path = tmp_file(tag, body);
+    let output = Command::new(bin()).arg(&path).output().expect("spawn rz");
+    let _ = std::fs::remove_file(&path);
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn meaningful_stdout_lines(stdout: &str) -> Vec<&str> {
+    stdout
+        .lines()
+        .filter(|line| !line.is_empty() && *line != "Program executed successfully")
+        .collect()
+}
+
+#[test]
+fn older_control_flow_and_operator_surface_executes_end_to_end() {
+    let src = r#"
+/* RES-3128: direct smoke for older stable parser/runtime constructs. */
+fn call_before_decl(int n) {
+    return helper(n);
+}
+
+fn helper(int n) {
+    return -n + 12;
+}
+
+fn main() {
+    let i = 0;
+    let total = 0;
+    while i < 4 {
+        total = total + i;
+        i = i + 1;
+    }
+
+    println(total);
+    println(call_before_decl(5));
+    println(0x1f + 0b10_10);
+    println(5 % 3);
+    println(!false && true);
+    println(((0b1010 & 0b1100) | 0b0011) ^ 0b0101);
+}
+
+main();
+"#;
+
+    let (stdout, stderr, code) = run_source("legacy_control_flow", src);
+    assert_eq!(
+        code,
+        Some(0),
+        "legacy stable surface should run cleanly; stdout={stdout} stderr={stderr}"
+    );
+
+    let lines = meaningful_stdout_lines(&stdout);
+    assert_eq!(lines, vec!["6", "7", "41", "2", "true", "14"]);
+}
+
+#[test]
+fn static_let_string_ops_and_bare_return_have_direct_smoke_coverage() {
+    let src = r#"
+static let hits = 0;
+
+fn bump() {
+    hits = hits + 1;
+    return;
+}
+
+fn main() {
+    bump();
+    bump();
+
+    println(hits);
+    println(len("gear"));
+
+    if "alpha" < "beta" && "gamma" >= "gamma" {
+        println("cmp-ok");
+    } else {
+        println("cmp-bad");
+    }
+}
+
+main();
+"#;
+
+    let (stdout, stderr, code) = run_source("legacy_static_and_strings", src);
+    assert_eq!(
+        code,
+        Some(0),
+        "static/string stable surface should run cleanly; stdout={stdout} stderr={stderr}"
+    );
+
+    let lines = meaningful_stdout_lines(&stdout);
+    assert_eq!(lines, vec!["2", "4", "cmp-ok"]);
+}


### PR DESCRIPTION
Closes #3128.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3128-backfill-regression-coverage-for-current`
Worktree: `.claude/worktrees/res-3128`

## Agent claims

(none inferred from issue)