### PR TITLE
RES-3133: Stability matrix: classify stable, experimental, and backend-limited features across docs and help

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -32,7 +32,7 @@ three different backends.
 |------|------|--------|-------|
 | Tree-walking interpreter | *(default)* | stable | Fastest to iterate on. Accepts every language feature. |
 | Bytecode VM | `--vm` | stable | ~12x faster than the interpreter on `fib(25)`. Stack-based. |
-| Cranelift JIT | `--jit` | stable subset | Requires `--features jit`. ~12x faster than the VM. |
+| Cranelift JIT | `--jit` | backend-limited stable subset | Requires `--features jit`. ~12x faster than the VM. |
 
 ```bash
 rz prog.rz              # interpreter
@@ -47,19 +47,20 @@ erroring.
 
 ### Stability surface
 
-Public behavior is grouped by stability class:
+Public behavior is grouped by the same stability classes printed by
+`rz --help`:
 
-- **Stable:** `--check`, `--typecheck`, `--typecheck-strict`, `--fmt`, `--lint`,
-  `--examples`, `--audit` (without SMT features), `--run`, and
-  the default/interpreter execution path.
-- **Backend-limited:** options that depend on backend/feature flags
-  and are not available in every build, including:
-  `--vm`, `--jit` (requires `--features jit`),
-  `--lsp` (requires `--features lsp`), and SMT-enabled
-  verification (`--features z3` / `--z3`).
-- **Experimental:** surfaces that may change while policy and
-  diagnostics are still evolving: `--ai-threats` and
-  `--dump-ast-json`.
+- **Stable:** supported for scripts and CI on the default build:
+  `--check`, `--typecheck`, `--typecheck-strict`, `--fmt`, `--lint`,
+  `--examples`, `--audit` (without SMT features), `--run`, and the
+  default/interpreter execution path.
+- **Backend-limited:** stable when the named backend/build feature is
+  present; unavailable builds print a rebuild hint. This includes
+  `--vm`, `--jit` (requires `--features jit`), `--lsp` (requires
+  `--features lsp`), and SMT-enabled verification (`--features z3` /
+  `--z3`).
+- **Experimental:** user-facing, but policy/output may still evolve:
+  `--ai-threats` and `--dump-ast-json`.
 
 ## Inspection
 

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -30390,9 +30390,11 @@ fn execute_file(
         }
         #[cfg(not(feature = "jit"))]
         {
-            return Err("--jit requires the `jit` feature. Rebuild with:\n  \
+            return Err(
+                "Backend-limited: --jit requires the `jit` feature. Rebuild with:\n  \
                  cargo build --features jit"
-                .to_string());
+                    .to_string(),
+            );
         }
     }
 
@@ -32031,8 +32033,10 @@ COMMON FLAGS:\n\
         --sign-cert PATH         Ed25519-sign the emitted certificate\n\
         --vm                     Route through the bytecode VM\n\
         --jit                    Route through the Cranelift JIT\n\
+                                 (backend-limited; requires --features jit)\n\
         --dump-tokens            Print the lexer stream and exit\n\
         --dump-ast-json          Print the parsed AST as JSON and exit\n\
+                                 (experimental tooling surface)\n\
         --dump-chunks            Print the VM disassembly and exit\n\
         --verifier-timeout-ms N  Per-Z3-query timeout (ms, 0 = off)\n\
         --seed N                 Pin the RNG seed for determinism\n\
@@ -32042,6 +32046,7 @@ COMMON FLAGS:\n\
         --emit-live-log PATH     NDJSON log of live-block retries (RES-371)\n\
         --examples-dir DIR       REPL examples directory\n\
         --lsp                    Run the LSP server on stdio\n\
+                                 (backend-limited; requires --features lsp)\n\
         --mcp                    Run the MCP server on stdio\n\
                                  Exposes compiler tools (parse/typecheck/run/\n\
                                  lint/format/verify) to AI assistants via the\n\
@@ -32060,6 +32065,12 @@ COMMON FLAGS:\n\
                                  (RES-2581)\n\
         --watch                  Re-run the file on every save (200 ms\n\
                                  debounce); press Ctrl-C to stop (RES-228)\n\
+\n\
+STATUS:\n\
+    stable             Supported for scripts and CI on the default build\n\
+    backend-limited    Stable when the named backend/build feature is present;\n\
+                       unavailable builds print a rebuild hint\n\
+    experimental       User-facing, but policy/output may still evolve\n\
 \n\
 SUBCOMMANDS:\n\
     repl                 Start interactive REPL (alias for bare `rz`)\n\
@@ -33320,7 +33331,7 @@ pub fn run_cli() {
         #[cfg(not(feature = "lsp"))]
         {
             eprintln!(
-                "--lsp requires the `lsp` feature. Rebuild with:\n  cargo build --features lsp"
+                "Backend-limited: --lsp requires the `lsp` feature. Rebuild with:\n  cargo build --features lsp"
             );
             std::process::exit(1);
         }

--- a/resilient/tests/stability_help_smoke.rs
+++ b/resilient/tests/stability_help_smoke.rs
@@ -1,0 +1,100 @@
+//! RES-3133: pin user-facing stability vocabulary in CLI help.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_file(tag: &str, body: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "res_3133_stability_{}_{}_{}.rz",
+        tag,
+        std::process::id(),
+        n
+    ));
+    std::fs::write(&path, body).expect("write scratch file");
+    path
+}
+
+#[test]
+fn help_prints_canonical_stability_vocabulary() {
+    let output = Command::new(bin())
+        .arg("--help")
+        .output()
+        .expect("spawn rz --help");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "STATUS:",
+        "stable             Supported for scripts and CI on the default build",
+        "backend-limited    Stable when the named backend/build feature is present;",
+        "experimental       User-facing, but policy/output may still evolve",
+        "--jit                    Route through the Cranelift JIT",
+        "(backend-limited; requires --features jit)",
+        "--lsp                    Run the LSP server on stdio",
+        "(backend-limited; requires --features lsp)",
+        "--dump-ast-json          Print the parsed AST as JSON and exit",
+        "(experimental tooling surface)",
+        "repl                 Start interactive REPL (alias for bare `rz`)",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "help output missing {expected:?}; got:\n{stdout}"
+        );
+    }
+}
+
+#[cfg(not(feature = "jit"))]
+#[test]
+fn jit_feature_gate_uses_backend_limited_language() {
+    let path = tmp_file("jit_gate", "fn main() { return 1; }\nmain();\n");
+    let output = Command::new(bin())
+        .arg("--jit")
+        .arg(&path)
+        .output()
+        .expect("spawn rz --jit");
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--jit without the jit feature should fail; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Backend-limited: --jit requires the `jit` feature")
+            && stderr.contains("cargo build --features jit"),
+        "--jit feature gate should use backend-limited wording; got:\n{stderr}"
+    );
+}
+
+#[cfg(not(feature = "lsp"))]
+#[test]
+fn lsp_feature_gate_uses_backend_limited_language() {
+    let output = Command::new(bin())
+        .arg("--lsp")
+        .output()
+        .expect("spawn rz --lsp");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--lsp without the lsp feature should fail; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Backend-limited: --lsp requires the `lsp` feature")
+            && stderr.contains("cargo build --features lsp"),
+        "--lsp feature gate should use backend-limited wording; got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Closes #3133.

Aligns the public stability vocabulary across CLI help and tooling docs:
- adds the `stable` / `backend-limited` / `experimental` legend to `rz --help`;
- labels `--jit`, `--lsp`, and `--dump-ast-json` consistently in help;
- makes missing `jit` / `lsp` feature errors use backend-limited language with rebuild hints;
- pins the wording with a new smoke test.

Verification:
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test stability_help_smoke -- --nocapture
- cargo test --manifest-path resilient/Cargo.toml --test repl_smoke --test safety_critical_smoke --test lsp_smoke -- --nocapture
- cargo test --manifest-path resilient/Cargo.toml --features lsp --test lsp_smoke -- --nocapture
- cargo run --manifest-path resilient/Cargo.toml -- --help
- cargo run --manifest-path resilient/Cargo.toml -- repl --help