### PR TITLE
RES-3137: Documentation/examples parity: keep public docs, examples, and generated help in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,10 +294,12 @@ and the limitations or follow-up tickets.
 
 ### Running the REPL
 
-There is no `repl` subcommand.
+Run `rz` with no file argument to start the REPL, or use `rz repl`
+as an explicit alias if you prefer to spell it out.
 
 ```bash
 rz
+rz repl
 ```
 
 ### Building from source without installing

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -199,7 +199,7 @@ starts when `rz` is invoked with no file argument.
 ```bash
 rz                           # start REPL
 rz repl                      # explicit alias for REPL
-rz --examples-dir ./ex       # override the `examples` command's search path
+rz repl --examples-dir ./ex  # override the REPL examples directory
 ```
 
 Built-in commands:


### PR DESCRIPTION
Closes #3137.

Draft PR for docs/examples parity work.

Branch: `res-3137-documentation-examples-parity-keep-publi`
Worktree: `.claude/worktrees/res-3137`
