### PR TITLE
RES-2997: Backfill regression coverage for current stable language and CLI features

### DIFF
--- a/docs/stable-regression-inventory.md
+++ b/docs/stable-regression-inventory.md
@@ -34,6 +34,7 @@ Scope rules:
 | Global help and REPL discoverability | `resilient/tests/repl_smoke.rs`, `resilient/tests/safety_critical_smoke.rs` | Covered | Pins `rz --help`, `rz repl --help`, and explicit REPL alias text. |
 | REPL startup path | `resilient/tests/safety_critical_smoke.rs` | Covered | Direct `rz repl` launch smoke. |
 | `rz check <file>` | `resilient/tests/check_smoke.rs` | Covered | Success, type-error, quiet, and usage paths. |
+| `--typecheck-strict` | `resilient/tests/typecheck_strict_smoke.rs` | Covered | Pins the fatal typecheck path that turns soft diagnostics into a hard error. |
 | `rz fmt <file>` stdout path | `resilient/tests/roundtrip.rs` | Covered | Canonical round-trip formatting. |
 | `rz fmt <file> --in-place` | `resilient/tests/stable_cli_surface_smoke.rs` | Covered | Added for RES-3128. |
 | `rz lint <file>` | `resilient/tests/lint_smoke.rs` | Covered | Dedicated CLI wiring coverage. |

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -49,7 +49,7 @@ erroring.
 
 Public behavior is grouped by stability class:
 
-- **Stable:** `--check`, `--typecheck`, `--fmt`, `--lint`,
+- **Stable:** `--check`, `--typecheck`, `--typecheck-strict`, `--fmt`, `--lint`,
   `--examples`, `--audit` (without SMT features), `--run`, and
   the default/interpreter execution path.
 - **Backend-limited:** options that depend on backend/feature flags
@@ -129,6 +129,8 @@ rz -t prog.rz
 ```
 
 `--typecheck` is implied by `--emit-certificate`.
+`--typecheck-strict` keeps the same checker but turns any type error
+into a fatal exit instead of a soft diagnostic.
 
 ## Verification
 

--- a/resilient/tests/typecheck_strict_smoke.rs
+++ b/resilient/tests/typecheck_strict_smoke.rs
@@ -1,0 +1,85 @@
+//! RES-3128: integration tests for `--typecheck-strict`.
+//!
+//! The default driver keeps type errors soft so it can still execute
+//! the program, but `--typecheck-strict` must flip that behavior into
+//! a fatal compile-time failure.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_file(tag: &str, body: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "res_typecheck_strict_{}_{}_{}.rz",
+        tag,
+        std::process::id(),
+        n
+    ));
+    std::fs::write(&path, body).expect("write scratch file");
+    path
+}
+
+#[test]
+fn default_driver_keeps_type_errors_soft() {
+    let path = tmp_file(
+        "soft",
+        "fn main() {\n    let x: Int = \"not an int\";\n    return 0;\n}\nmain();\n",
+    );
+    let output = Command::new(bin()).arg(&path).output().expect("spawn rz");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "default driver should stay soft on type errors; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("Program executed successfully"),
+        "default driver should still reach program completion; stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("Type error:"),
+        "default driver should surface the type error as a diagnostic; stderr={stderr}"
+    );
+}
+
+#[test]
+fn typecheck_strict_turns_type_errors_fatal() {
+    let path = tmp_file(
+        "strict",
+        "fn main() {\n    let x: Int = \"not an int\";\n    return 0;\n}\nmain();\n",
+    );
+    let output = Command::new(bin())
+        .args(["--typecheck-strict"])
+        .arg(&path)
+        .output()
+        .expect("spawn rz --typecheck-strict");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "strict typecheck should fail fast on type errors; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error: Type check failed"),
+        "strict mode should report a fatal typecheck failure; stderr={stderr}"
+    );
+}


### PR DESCRIPTION
Closes #3128.

Draft PR for stable-surface regression coverage backfill.

Branch: `res-3128-backfill-regression-coverage-for-current`
Worktree: `.claude/worktrees/res-3128`
