### PR TITLE
RES-3154: Docs stability vocabulary: keep README, tooling, and getting-started aligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,13 @@ normally). Add `--features z3` for SMT-backed verification (requires
 
 The project intentionally separates feature surfaces:
 
-- **Stable:** baseline CLI behavior and standard diagnostics on the default
-  build.
-- **Backend-limited:** commands that need optional runtime features:
-  `--jit` (`--features jit`), `--lsp` (`--features lsp`), and SMT-backed
-  modes (`--features z3`, `--z3`).
-- **Experimental:** surfaces with evolving contracts and policy (`--ai-threats`).
+- **Stable:** Supported for scripts and CI on the default build.
+- **Backend-limited:** Stable when the named backend/build feature is present;
+  unavailable builds print a rebuild hint. Examples include `--jit`
+  (`--features jit`), `--lsp` (`--features lsp`), and SMT-backed modes
+  (`--features z3`, `--z3`).
+- **Experimental:** User-facing, but policy/output may still evolve. Examples
+  include `--ai-threats` and `--dump-ast-json`.
 
 #### Docker (RES-203)
 
@@ -322,7 +323,7 @@ optional `z3` feature to get full SMT-backed proofs:
 ```bash
 # macOS:  brew install z3
 # Linux:  sudo apt-get install libz3-dev z3
-rz --audit prog.rz   # requires the binary built with --features z3
+rz --audit prog.rz   # SMT proofs require a binary built with --features z3
 ```
 
 The audit report tags clauses proven by Z3 separately so users can
@@ -336,7 +337,7 @@ re-verify it under their own solver — without trusting the Resilient
 binary:
 
 ```bash
-rz --emit-certificate ./certs resilient/examples/cert_demo.rz   # requires --features z3 build
+rz --emit-certificate ./certs resilient/examples/cert_demo.rz   # requires a --features z3 build
 ```
 
 One file is written per discharged obligation:
@@ -349,8 +350,8 @@ z3 -smt2 ./certs/ident_round__decl__0.smt2
 # unsat        ← the proof: negation is unsatisfiable, so the original holds
 ```
 
-Implies `--typecheck`. Without `--features z3`, no certificates are
-emitted (the cheap folder isn't asked to produce them).
+Implies `--typecheck`. Default builds report a `Backend-limited:`
+rebuild hint instead of emitting certificates.
 
 #### Signed certificates (RES-194)
 
@@ -359,13 +360,13 @@ Pass `--sign-cert <path-to-ed25519-private-key.pem>` alongside
 `<dir>/cert.sig`. The signed payload is the byte-for-byte
 concatenation of the `.smt2` files in the directory (sorted by
 filename, joined with `\n`); the signature binds the certificate
-set to the signer's key.
+set to the signer's key. Requires a `--features z3` build.
 
 ```bash
 # Sign during emit:
 rz -t --emit-certificate ./certs --sign-cert ~/.resilient-priv.pem resilient/examples/sensor_monitor.rz
 
-# Verify against the binary's embedded public key:
+# Verify against the binary's embedded public key (requires --features z3):
 rz verify-cert ./certs
 
 # Or against a custom public key (e.g. a rotated / test key):
@@ -417,7 +418,9 @@ Every `--emit-certificate <dir>` run also writes a
   payload — both are written on signed runs so either can be
   used for verification.
 
-The `verify-all` subcommand re-checks every obligation:
+The `verify-all` subcommand re-checks every obligation. It requires
+a `--features z3` build; default builds report a `Backend-limited:`
+rebuild hint.
 
 ```bash
 # Fast cryptographic-only pass:
@@ -794,7 +797,7 @@ Resilient supports LSP, so any editor with LSP client support (Vim, Neovim, Emac
 
 \`\`\`bash
 # Start the LSP server:
-rz --lsp
+rz --lsp   # requires a binary built with --features lsp
 
 # Then point your editor's LSP client to this process.
 \`\`\`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,6 +71,16 @@ There are four feature configs depending on what you need:
 You can stack them with `cargo install`:
 `cargo install --path resilient --features "z3 lsp jit"`.
 
+## Status vocabulary
+
+`rz --help` and the public docs use the same status classes:
+
+- **Stable:** Supported for scripts and CI on the default build.
+- **Backend-limited:** Stable when the named backend/build feature is present;
+  unavailable builds print a rebuild hint. Examples in this guide name the
+  required `--features ...` build at the point of use.
+- **Experimental:** User-facing, but policy/output may still evolve.
+
 ## Hello, world
 
 ```rust
@@ -177,7 +187,7 @@ rz --vm prog.rz
 # real, so use this for hot loops and long-running programs
 # where compile cost amortizes.
 cargo install --path resilient --features jit  # one-time
-rz --jit prog.rz
+rz --jit prog.rz                                # requires --features jit
 ```
 
 See the [performance page](performance) for the actual numbers
@@ -210,10 +220,11 @@ the verifier (`--features z3`); proofs that succeed don't emit
 runtime checks. For compliance / certification:
 `--emit-certificate ./certs prog.rz` writes one SMT-LIB2 file
 per discharged obligation, each independently re-verifiable
-under any compatible solver.
+under any compatible solver. Default builds report a `Backend-limited:`
+rebuild hint for certificate flags.
 
 ```bash
-rz --emit-certificate ./certs resilient/examples/cert_demo.rz   # binary built with --features z3
+rz --emit-certificate ./certs resilient/examples/cert_demo.rz   # requires a --features z3 build
 z3 -smt2 ./certs/ident_round__decl__0.smt2
 # unsat   ← the proof: negation is unsatisfiable, so the original holds
 ```
@@ -241,8 +252,17 @@ relevant JIT phase ships.
 
 ## REPL
 
+Run bare `rz` with no file argument, or use the explicit `rz repl`
+alias when you want the launch path spelled out.
+
 ```bash
-rz
+rz       # bare launch path
+rz repl  # explicit alias
+```
+
+Inside either launch path:
+
+```text
 > let x = 5;
 > x + 10
 15
@@ -255,7 +275,8 @@ checking.
 
 ## Editor integration
 
-Run the LSP server (built with `--features lsp`):
+Run the LSP server. This is backend-limited and requires a binary
+built with `--features lsp`:
 
 ```bash
 rz --lsp

--- a/docs/stable-regression-inventory.md
+++ b/docs/stable-regression-inventory.md
@@ -11,6 +11,13 @@ Scope rules:
 - When a surface is not yet stable, call it out explicitly instead of
   treating it as uncovered stable behavior.
 
+## Status Vocabulary
+
+- **Stable:** Supported for scripts and CI on the default build.
+- **Backend-limited:** Stable when the named backend/build feature is present;
+  unavailable builds print a rebuild hint.
+- **Experimental:** User-facing, but policy/output may still evolve.
+
 ## Stable Language Surface
 
 | Surface | Direct coverage | Status | Notes |
@@ -49,9 +56,9 @@ Scope rules:
 | `bench <file>` | `resilient/tests/bench_cli.rs`, `resilient/tests/bench_cli_summary_json.rs` | Covered | Human and machine-readable outputs. |
 | Example corpus smoke | `resilient/tests/examples_smoke.rs`, `resilient/tests/examples_golden.rs` | Covered | Direct shipped-example coverage. |
 | Self-host parity report | `resilient/tests/self_host_parity_report_cli.rs` | Covered | Dedicated report artifact smoke. |
-| Certificate verification (`verify-cert`, `verify-all`) | `resilient/tests/verify_cert_smoke.rs`, `resilient/tests/verify_all_smoke.rs` | Covered | Stable when built with `--features z3`. |
-| Backend-limited execution (`--vm`, `--jit`) | `resilient/tests/examples_smoke.rs` | Covered | Stable subset / feature-gated, but still pinned by direct smoke. |
-| LSP server | `resilient/tests/lsp_smoke.rs` and focused LSP smoke files | Covered | Feature-gated shipped surface. |
+| Certificate verification (`verify-cert`, `verify-all`) | `resilient/tests/verify_cert_smoke.rs`, `resilient/tests/verify_all_smoke.rs` | Covered | Backend-limited; stable when built with `--features z3`, and default builds print a rebuild hint. |
+| Backend execution (`--vm`, `--jit`) | `resilient/tests/examples_smoke.rs` | Covered | `--vm` is stable on the default build; `--jit` is backend-limited and requires `--features jit`. |
+| LSP server | `resilient/tests/lsp_smoke.rs` and focused LSP smoke files | Covered | Backend-limited; stable when built with `--features lsp`, and default builds print a rebuild hint. |
 
 ## Intentionally Deferred / Not Yet Stable
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -50,17 +50,16 @@ erroring.
 Public behavior is grouped by the same stability classes printed by
 `rz --help`:
 
-- **Stable:** supported for scripts and CI on the default build:
-  `--check`, `--typecheck`, `--typecheck-strict`, `--fmt`, `--lint`,
+- **Stable:** Supported for scripts and CI on the default build. Examples
+  include `--check`, `--typecheck`, `--typecheck-strict`, `--fmt`, `--lint`,
   `--examples`, `--audit` (without SMT features), `--run`, and the
   default/interpreter execution path.
-- **Backend-limited:** stable when the named backend/build feature is
-  present; unavailable builds print a rebuild hint. This includes
-  `--vm`, `--jit` (requires `--features jit`), `--lsp` (requires
-  `--features lsp`), and SMT-enabled verification (`--features z3` /
-  `--z3`).
-- **Experimental:** user-facing, but policy/output may still evolve:
-  `--ai-threats` and `--dump-ast-json`.
+- **Backend-limited:** Stable when the named backend/build feature is present;
+  unavailable builds print a rebuild hint. This includes `--jit` (requires
+  `--features jit`), `--lsp` (requires `--features lsp`), and SMT-enabled
+  verification (`--features z3` / `--z3`).
+- **Experimental:** User-facing, but policy/output may still evolve. Examples
+  include `--ai-threats` and `--dump-ast-json`.
 
 ## Inspection
 
@@ -398,7 +397,7 @@ a future deliverable.
 
 ```bash
 # What exists today:
-rz --jit --jit-cache-stats prog.rz
+rz --jit --jit-cache-stats prog.rz   # requires a --features jit build
 ```
 
 ## Test framework — *future*

--- a/resilient/tests/docs_stability_vocabulary_smoke.rs
+++ b/resilient/tests/docs_stability_vocabulary_smoke.rs
@@ -1,0 +1,77 @@
+//! RES-3154: keep public docs aligned with the CLI stability vocabulary.
+
+fn public_docs() -> [(&'static str, &'static str); 4] {
+    [
+        ("README.md", include_str!("../../README.md")),
+        ("docs/tooling.md", include_str!("../../docs/tooling.md")),
+        (
+            "docs/getting-started.md",
+            include_str!("../../docs/getting-started.md"),
+        ),
+        (
+            "docs/stable-regression-inventory.md",
+            include_str!("../../docs/stable-regression-inventory.md"),
+        ),
+    ]
+}
+
+#[test]
+fn docs_share_cli_status_vocabulary() {
+    for (name, doc) in public_docs() {
+        for expected in [
+            "**Stable:** Supported for scripts and CI on the default build.",
+            "**Backend-limited:** Stable when the named backend/build feature is present;",
+            "unavailable builds print a rebuild hint.",
+            "**Experimental:** User-facing, but policy/output may still evolve.",
+        ] {
+            assert!(
+                doc.contains(expected),
+                "{name} missing shared stability vocabulary {expected:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn backend_examples_name_required_features() {
+    for (name, doc) in [
+        ("README.md", include_str!("../../README.md")),
+        ("docs/tooling.md", include_str!("../../docs/tooling.md")),
+        (
+            "docs/getting-started.md",
+            include_str!("../../docs/getting-started.md"),
+        ),
+    ] {
+        for (surface, feature) in [
+            ("--jit", "--features jit"),
+            ("--lsp", "--features lsp"),
+            ("--emit-certificate", "--features z3"),
+        ] {
+            assert!(
+                doc.contains(surface) && doc.contains(feature),
+                "{name} should mention {feature} near backend-limited {surface} examples"
+            );
+        }
+    }
+}
+
+#[test]
+fn repl_launch_paths_are_consistent() {
+    for (name, doc) in [
+        ("README.md", include_str!("../../README.md")),
+        ("docs/tooling.md", include_str!("../../docs/tooling.md")),
+        (
+            "docs/getting-started.md",
+            include_str!("../../docs/getting-started.md"),
+        ),
+    ] {
+        assert!(
+            doc.contains("rz repl"),
+            "{name} should mention the explicit `rz repl` alias"
+        );
+        assert!(
+            doc.contains("bare `rz`") || doc.contains("no file argument"),
+            "{name} should mention the bare `rz` REPL launch path"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3154.

## Summary
- Aligned README, tooling, getting-started, and stable-regression inventory around the same `Stable` / `Backend-limited` / `Experimental` meanings used by `rz --help`.
- Added feature callouts at backend-limited command examples for `--jit`, `--lsp`, certificate emission, and verifier subcommands.
- Made REPL launch wording consistent across docs: bare `rz` and explicit `rz repl`.
- Added an additive docs smoke test to catch future vocabulary drift.

## Test changes
- Added `resilient/tests/docs_stability_vocabulary_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_stability_vocabulary_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- --help`
- `cargo run --manifest-path resilient/Cargo.toml -- repl --help`
- `cargo test --manifest-path resilient/Cargo.toml --test repl_smoke --test stability_help_smoke -- --nocapture`

## Safety
- Docs-focused wording change plus additive smoke coverage.
- No dependencies.
- No unsafe changes.
