### PR TITLE
RES-3159: CLI unknown command diagnostics: distinguish typos from missing files

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32194,6 +32194,14 @@ fn print_repl_help() {
     print!("{}", REPL_HELP_TEXT);
 }
 
+fn should_report_unknown_command_or_file(filename: &str) -> bool {
+    !filename.is_empty()
+        && !filename.contains('/')
+        && !filename.contains('\\')
+        && Path::new(filename).extension().is_none()
+        && !Path::new(filename).exists()
+}
+
 pub(crate) fn execute_benchmark_body(
     program: &Node,
     body: &Node,
@@ -33030,6 +33038,13 @@ pub fn run_cli() {
         if filename == "repl" && !std::path::Path::new(filename).exists() {
             eprintln!(
                 "Error: `repl` is not a subcommand. Run `rz` with no arguments to start the REPL."
+            );
+            std::process::exit(2);
+        }
+        if should_report_unknown_command_or_file(filename) {
+            eprintln!(
+                "Error: unknown command or file `{}`. Run `rz --help` to list subcommands, or pass an existing file path.",
+                filename
             );
             std::process::exit(2);
         }

--- a/resilient/tests/unknown_command_diagnostics_smoke.rs
+++ b/resilient/tests/unknown_command_diagnostics_smoke.rs
@@ -1,0 +1,73 @@
+//! RES-3159: distinguish command typos from missing source files.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_dir(tag: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "res_3159_unknown_command_{}_{}_{}",
+        tag,
+        std::process::id(),
+        n
+    ));
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+#[test]
+fn bare_unknown_token_reports_command_or_file_hint() {
+    let output = Command::new(bin())
+        .arg("frobnicate")
+        .output()
+        .expect("spawn rz frobnicate");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "unknown command-like token should be a usage error; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error: unknown command or file `frobnicate`")
+            && stderr.contains("rz --help")
+            && !stderr.contains("Error reading file")
+            && !stderr.contains("seed="),
+        "unknown command diagnostic should be focused; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn existing_extensionless_relative_file_still_executes() {
+    let dir = tmp_dir("relative_file");
+    let src = dir.join("program");
+    std::fs::write(&src, "println(\"res3159 relative file ok\");\n").expect("write program");
+
+    let output = Command::new(bin())
+        .current_dir(&dir)
+        .args(["--seed", "0", "program"])
+        .output()
+        .expect("spawn rz program");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "existing relative file should still execute; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("res3159 relative file ok"),
+        "expected program output from extensionless relative file; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Closes #3159.

## Summary
- Added a narrow CLI guard for missing, single-component, extensionless tokens so command typos report `unknown command or file` instead of `Error reading file`.
- Kept existing-file execution intact, including extensionless relative files.
- Added focused smoke coverage for both the typo diagnostic and real relative-file execution.

## Test changes
- Added `resilient/tests/unknown_command_diagnostics_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test unknown_command_diagnostics_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test repl_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test stable_cli_surface_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- frobnicate` (expected exit 2 with the new usage diagnostic)

## Safety
- No dependencies.
- No unsafe changes.
