### PR TITLE
RES-3161: Terminal-mode usage errors: suppress seed noise before missing path diagnostics

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -33109,6 +33109,26 @@ pub fn run_cli() {
             );
             std::process::exit(2);
         }
+        if dump_tokens && filename.is_empty() {
+            eprintln!("Error: --dump-tokens requires a path argument");
+            std::process::exit(2);
+        }
+        if ai_threats_mode && filename.is_empty() {
+            eprintln!("Error: --ai-threats requires a path argument");
+            std::process::exit(2);
+        }
+        if emit_lean_spec_fn.is_some() && filename.is_empty() {
+            eprintln!("Error: --emit-lean-spec requires a path argument");
+            std::process::exit(2);
+        }
+        if dump_ast_json && filename.is_empty() {
+            eprintln!("Error: --dump-ast-json requires a path argument");
+            std::process::exit(2);
+        }
+        if dump_chunks && filename.is_empty() {
+            eprintln!("Error: --dump-chunks requires a path argument");
+            std::process::exit(2);
+        }
 
         // RES-150: install the RNG seed before any user program
         // can pull from it. `--seed <N>` pins the sequence

--- a/resilient/tests/terminal_mode_usage_smoke.rs
+++ b/resilient/tests/terminal_mode_usage_smoke.rs
@@ -1,0 +1,113 @@
+//! RES-3161: terminal-mode usage errors should not print replay seeds.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_file(tag: &str, body: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "res_3161_terminal_mode_{}_{}_{}.rz",
+        tag,
+        std::process::id(),
+        n
+    ));
+    std::fs::write(&path, body).expect("write scratch source");
+    path
+}
+
+#[test]
+fn dump_ast_json_missing_path_does_not_print_seed() {
+    let output = Command::new(bin())
+        .arg("--dump-ast-json")
+        .output()
+        .expect("spawn rz --dump-ast-json");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "missing dump-ast-json path should be a usage error; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error: --dump-ast-json requires a path argument")
+            && !stderr.contains("seed="),
+        "usage error should not be preceded by a replay seed; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn dump_tokens_missing_path_does_not_print_seed() {
+    let output = Command::new(bin())
+        .arg("--dump-tokens")
+        .output()
+        .expect("spawn rz --dump-tokens");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "missing dump-tokens path should be a usage error; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error: --dump-tokens requires a path argument")
+            && !stderr.contains("seed="),
+        "usage error should not be preceded by a replay seed; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn normal_execution_still_prints_generated_seed() {
+    let path = tmp_file("generated_seed", "println(\"res3161 generated seed\");\n");
+    let output = Command::new(bin())
+        .arg(&path)
+        .output()
+        .expect("spawn rz program");
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "normal execution should still succeed; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("seed="),
+        "normal execution without --seed should still print replay seed; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn explicit_seed_still_suppresses_generated_seed() {
+    let path = tmp_file("explicit_seed", "println(\"res3161 explicit seed\");\n");
+    let output = Command::new(bin())
+        .args(["--seed", "0"])
+        .arg(&path)
+        .output()
+        .expect("spawn rz --seed program");
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "execution with explicit seed should still succeed; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("seed="),
+        "--seed should suppress generated seed output; got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Closes #3161.

## Summary
- Added pre-seed missing-path checks for terminal modes so usage errors such as `--dump-ast-json` and `--dump-tokens` do not print a generated replay seed first.
- Preserved normal execution seed behavior, including generated seed output without `--seed` and suppression with explicit `--seed N`.
- Added focused smoke coverage for missing terminal-mode paths and normal seed behavior.

## Test changes
- Added `resilient/tests/terminal_mode_usage_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test terminal_mode_usage_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test dump_tokens_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test stable_cli_surface_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- --dump-ast-json` (expected exit 2 with no `seed=` line)

## Safety
- No dependencies.
- No unsafe changes.
