### PR TITLE
RES-3160: Check subcommand help: show focused usage for rz check help

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -31706,6 +31706,10 @@ fn dispatch_check_subcommand(args: &[String]) -> Option<i32> {
     if args.get(1).map(|s| s.as_str()) != Some("check") {
         return None;
     }
+    if is_check_help_request(args) {
+        print_check_help();
+        return Some(0);
+    }
 
     let mut file: Option<PathBuf> = None;
     let mut quiet = false;
@@ -32194,6 +32198,37 @@ fn print_repl_help() {
     print!("{}", REPL_HELP_TEXT);
 }
 
+const CHECK_HELP_TEXT: &str = r#"rz check — type-check a file without running it
+
+USAGE:
+    rz check <file> [FLAGS]
+
+FLAGS:
+    -q, --quiet                 Suppress success output
+        --emit-diagnostics-json Emit parse/type diagnostics as JSON
+        --safety-critical       Promote safety-critical lint failures
+        --verifier-timeout-ms N Per-Z3-query timeout in milliseconds
+        --z3-theory MODE        Backend-limited; requires --features z3
+
+EXAMPLES:
+    rz check examples/hello.rz
+    rz check --quiet examples/hello.rz
+
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+fn is_check_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("check")
+        && matches!(
+            args.get(2).map(String::as_str),
+            Some("--help" | "-h" | "help")
+        )
+}
+
+fn print_check_help() {
+    print!("{}", CHECK_HELP_TEXT);
+}
+
 fn should_report_unknown_command_or_file(filename: &str) -> bool {
     !filename.is_empty()
         && !filename.contains('/')
@@ -32435,6 +32470,11 @@ pub fn run_cli() {
             version_info::short()
         };
         print!("{}", banner);
+        std::process::exit(0);
+    }
+
+    if is_check_help_request(&args) {
+        print_check_help();
         std::process::exit(0);
     }
 

--- a/resilient/tests/check_help_smoke.rs
+++ b/resilient/tests/check_help_smoke.rs
@@ -1,0 +1,55 @@
+//! RES-3160: focused help for the `rz check` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_check_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz check help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "check help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "rz check — type-check a file without running it",
+        "USAGE:\n    rz check <file> [FLAGS]",
+        "FLAGS:\n    -q, --quiet",
+        "--emit-diagnostics-json",
+        "--z3-theory MODE        Backend-limited; requires --features z3",
+        "Run `rz --help` for global flags and other subcommands.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused check help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "check help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn check_long_help_is_focused() {
+    assert_focused_check_help(&["check", "--help"]);
+}
+
+#[test]
+fn check_short_help_is_focused() {
+    assert_focused_check_help(&["check", "-h"]);
+}
+
+#[test]
+fn check_help_word_is_focused() {
+    assert_focused_check_help(&["check", "help"]);
+}


### PR DESCRIPTION
Closes #3160.

## Summary
- Added focused `rz check` help text for `rz check --help`, `rz check -h`, and `rz check help`.
- Routed check help before global help so it no longer falls through to the global `rz --help` page.
- Added smoke coverage that pins the focused check help heading, usage, flags, and non-global output.

## Test changes
- Added `resilient/tests/check_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test check_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test check_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test help_layout_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- check --help`

## Safety
- No dependencies.
- No unsafe changes.
