### PR TITLE
RES-3165: Lint subcommand help: show focused usage for rz lint help

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -31502,6 +31502,10 @@ fn dispatch_lint_subcommand(args: &[String]) -> Option<i32> {
     if args.get(1).map(|s| s.as_str()) != Some("lint") {
         return None;
     }
+    if is_lint_help_request(args) {
+        print_lint_help();
+        return Some(0);
+    }
 
     // Fast path: `rz lint --explain LXXXX` prints explanation and exits.
     if args.get(2).map(|s| s.as_str()) == Some("--explain") {
@@ -32198,6 +32202,39 @@ fn print_repl_help() {
     print!("{}", REPL_HELP_TEXT);
 }
 
+const LINT_HELP_TEXT: &str = r#"rz lint — run Resilient lints without executing the file
+
+USAGE:
+    rz lint <file> [FLAGS]
+    rz lint --explain LCODE
+
+FLAGS:
+        --deny LCODE            Promote the named lint to error severity
+        --allow LCODE           Suppress the named lint
+        --explain LCODE         Print the lint explanation and exit
+        --emit-diagnostics-json Emit lint diagnostics as JSON
+        --safety-critical       Promote safety-critical lint failures
+
+EXAMPLES:
+    rz lint examples/hello.rz
+    rz lint --deny L0010 examples/hello.rz
+    rz lint --explain L0006
+
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+fn is_lint_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("lint")
+        && matches!(
+            args.get(2).map(String::as_str),
+            Some("--help" | "-h" | "help")
+        )
+}
+
+fn print_lint_help() {
+    print!("{}", LINT_HELP_TEXT);
+}
+
 const CHECK_HELP_TEXT: &str = r#"rz check — type-check a file without running it
 
 USAGE:
@@ -32475,6 +32512,10 @@ pub fn run_cli() {
 
     if is_check_help_request(&args) {
         print_check_help();
+        std::process::exit(0);
+    }
+    if is_lint_help_request(&args) {
+        print_lint_help();
         std::process::exit(0);
     }
 

--- a/resilient/tests/lint_help_smoke.rs
+++ b/resilient/tests/lint_help_smoke.rs
@@ -1,0 +1,58 @@
+//! RES-3165: focused help for the `rz lint` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_lint_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz lint help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "lint help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "rz lint — run Resilient lints without executing the file",
+        "USAGE:\n    rz lint <file> [FLAGS]",
+        "rz lint --explain LCODE",
+        "--deny LCODE            Promote the named lint to error severity",
+        "--allow LCODE           Suppress the named lint",
+        "--explain LCODE         Print the lint explanation and exit",
+        "--emit-diagnostics-json Emit lint diagnostics as JSON",
+        "--safety-critical       Promote safety-critical lint failures",
+        "Run `rz --help` for global flags and other subcommands.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused lint help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "lint help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn lint_long_help_is_focused() {
+    assert_focused_lint_help(&["lint", "--help"]);
+}
+
+#[test]
+fn lint_short_help_is_focused() {
+    assert_focused_lint_help(&["lint", "-h"]);
+}
+
+#[test]
+fn lint_help_word_is_focused() {
+    assert_focused_lint_help(&["lint", "help"]);
+}


### PR DESCRIPTION
Closes #3165.

## Summary
- Added focused `rz lint` help for `rz lint --help`, `rz lint -h`, and `rz lint help`.
- Routed lint help before global help so it no longer falls through to the global `rz --help` page.
- Added smoke coverage for the focused lint help heading, usage, lint flags, examples, and non-global output.

## Test changes
- Added `resilient/tests/lint_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test lint_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test lint_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- lint --help`
- `cargo run --manifest-path resilient/Cargo.toml -- lint -h`

## Safety
- No dependencies.
- No unsafe changes.
