### PR TITLE
RES-3166: Stack-usage subcommand help: show focused usage for rz stack-usage help

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32266,6 +32266,38 @@ fn print_check_help() {
     print!("{}", CHECK_HELP_TEXT);
 }
 
+const STACK_USAGE_HELP_TEXT: &str = r#"rz stack-usage — estimate per-function worst-case stack use
+
+USAGE:
+    rz stack-usage <file>
+
+OUTPUT:
+    Prints one row per user function with estimated bytes and notes.
+    Recursive call chains are reported as unbounded.
+
+BUDGETS:
+    #[stack(bytes=N)] declarations are checked against estimates.
+    The command exits 1 when any declared budget is exceeded.
+
+EXAMPLES:
+    rz stack-usage examples/stack_budget.rz
+    rz stack-usage firmware/control.rz
+
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+fn is_stack_usage_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("stack-usage")
+        && matches!(
+            args.get(2).map(String::as_str),
+            Some("--help" | "-h" | "help")
+        )
+}
+
+fn print_stack_usage_help() {
+    print!("{}", STACK_USAGE_HELP_TEXT);
+}
+
 fn should_report_unknown_command_or_file(filename: &str) -> bool {
     !filename.is_empty()
         && !filename.contains('/')
@@ -32376,6 +32408,10 @@ pub fn run_program(src: &str) -> RunResult {
 fn dispatch_stack_usage_subcommand(args: &[String]) -> Option<i32> {
     if args.get(1).map(|s| s.as_str()) != Some("stack-usage") {
         return None;
+    }
+    if is_stack_usage_help_request(args) {
+        print_stack_usage_help();
+        return Some(0);
     }
 
     let mut file: Option<PathBuf> = None;
@@ -32516,6 +32552,10 @@ pub fn run_cli() {
     }
     if is_lint_help_request(&args) {
         print_lint_help();
+        std::process::exit(0);
+    }
+    if is_stack_usage_help_request(&args) {
+        print_stack_usage_help();
         std::process::exit(0);
     }
 

--- a/resilient/tests/stack_usage_help_smoke.rs
+++ b/resilient/tests/stack_usage_help_smoke.rs
@@ -1,0 +1,57 @@
+//! RES-3166: focused help for the `rz stack-usage` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_stack_usage_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz stack-usage help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stack-usage help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "rz stack-usage — estimate per-function worst-case stack use",
+        "USAGE:\n    rz stack-usage <file>",
+        "Prints one row per user function with estimated bytes and notes.",
+        "Recursive call chains are reported as unbounded.",
+        "#[stack(bytes=N)] declarations are checked against estimates.",
+        "The command exits 1 when any declared budget is exceeded.",
+        "rz stack-usage examples/stack_budget.rz",
+        "Run `rz --help` for global flags and other subcommands.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused stack-usage help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "stack-usage help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn stack_usage_long_help_is_focused() {
+    assert_focused_stack_usage_help(&["stack-usage", "--help"]);
+}
+
+#[test]
+fn stack_usage_short_help_is_focused() {
+    assert_focused_stack_usage_help(&["stack-usage", "-h"]);
+}
+
+#[test]
+fn stack_usage_help_word_is_focused() {
+    assert_focused_stack_usage_help(&["stack-usage", "help"]);
+}


### PR DESCRIPTION
Closes #3166.

## Summary
- Added focused `rz stack-usage` help for `rz stack-usage --help`, `rz stack-usage -h`, and `rz stack-usage help`.
- Routed stack-usage help before global help so it no longer falls through to the global `rz --help` page.
- Added smoke coverage for the focused stack-usage help heading, usage, output notes, budget behavior, examples, and non-global output.

## Test changes
- Added `resilient/tests/stack_usage_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test stack_usage_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test stable_cli_surface_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- stack-usage --help`
- `cargo run --manifest-path resilient/Cargo.toml -- stack-usage -h`

## Safety
- No dependencies.
- No unsafe changes.
