### PR TITLE
RES-3167: Verification subcommand help: show focused usage for certificate checks

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -31135,6 +31135,10 @@ fn dispatch_verify_cert_subcommand(args: &[String]) -> Option<i32> {
     if args.get(1).map(|s| s.as_str()) != Some("verify-cert") {
         return None;
     }
+    if is_verify_cert_help_request(args) {
+        print_verify_cert_help();
+        return Some(0);
+    }
 
     let mut dir_path: Option<PathBuf> = None;
     let mut pubkey_path: Option<PathBuf> = None;
@@ -31261,6 +31265,10 @@ fn dispatch_verify_cert_subcommand(args: &[String]) -> Option<i32> {
 fn dispatch_verify_all_subcommand(args: &[String]) -> Option<i32> {
     if args.get(1).map(|s| s.as_str()) != Some("verify-all") {
         return None;
+    }
+    if is_verify_all_help_request(args) {
+        print_verify_all_help();
+        return Some(0);
     }
 
     let mut dir_path: Option<PathBuf> = None;
@@ -32298,6 +32306,75 @@ fn print_stack_usage_help() {
     print!("{}", STACK_USAGE_HELP_TEXT);
 }
 
+const VERIFY_CERT_HELP_TEXT: &str = r#"rz verify-cert — verify a signed certificate directory
+
+USAGE:
+    rz verify-cert <dir> [--pubkey <path>]
+
+STATUS:
+    backend-limited; requires --features z3
+
+CHECKS:
+    Reads cert.sig and every .smt2 file in the directory.
+    Verifies the directory signature with the embedded key or --pubkey.
+
+FLAGS:
+        --pubkey PATH    Verify with a PEM public key instead of the embedded key
+
+EXAMPLES:
+    rz verify-cert certs/
+    rz verify-cert certs/ --pubkey keys/pub.pem
+
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+const VERIFY_ALL_HELP_TEXT: &str = r#"rz verify-all — re-check every obligation in a manifest
+
+USAGE:
+    rz verify-all <dir> [--pubkey <path>] [--z3]
+
+STATUS:
+    backend-limited; requires --features z3
+
+CHECKS:
+    Reads manifest.json, checks certificate hashes, and verifies signatures.
+    With --z3, also runs `z3 -smt2` for solver re-verification when z3 is on PATH.
+
+FLAGS:
+        --pubkey PATH    Verify signatures with a PEM public key override
+        --z3             Re-run Z3 on each certificate when the z3 binary is available
+
+EXAMPLES:
+    rz verify-all certs/
+    rz verify-all certs/ --z3
+
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+fn is_verify_cert_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("verify-cert")
+        && matches!(
+            args.get(2).map(String::as_str),
+            Some("--help" | "-h" | "help")
+        )
+}
+
+fn is_verify_all_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("verify-all")
+        && matches!(
+            args.get(2).map(String::as_str),
+            Some("--help" | "-h" | "help")
+        )
+}
+
+fn print_verify_cert_help() {
+    print!("{}", VERIFY_CERT_HELP_TEXT);
+}
+
+fn print_verify_all_help() {
+    print!("{}", VERIFY_ALL_HELP_TEXT);
+}
+
 fn should_report_unknown_command_or_file(filename: &str) -> bool {
     !filename.is_empty()
         && !filename.contains('/')
@@ -32556,6 +32633,14 @@ pub fn run_cli() {
     }
     if is_stack_usage_help_request(&args) {
         print_stack_usage_help();
+        std::process::exit(0);
+    }
+    if is_verify_cert_help_request(&args) {
+        print_verify_cert_help();
+        std::process::exit(0);
+    }
+    if is_verify_all_help_request(&args) {
+        print_verify_all_help();
         std::process::exit(0);
     }
 

--- a/resilient/tests/verification_help_smoke.rs
+++ b/resilient/tests/verification_help_smoke.rs
@@ -1,0 +1,96 @@
+//! RES-3167: focused help for certificate verification subcommands.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_help(args: &[&str], expected: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz verification help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "verification help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for text in expected {
+        assert!(
+            stdout.contains(text),
+            "focused verification help missing {text:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "verification help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+fn assert_verify_cert_help(args: &[&str]) {
+    assert_focused_help(
+        args,
+        &[
+            "rz verify-cert — verify a signed certificate directory",
+            "USAGE:\n    rz verify-cert <dir> [--pubkey <path>]",
+            "backend-limited; requires --features z3",
+            "Reads cert.sig and every .smt2 file in the directory.",
+            "Verifies the directory signature with the embedded key or --pubkey.",
+            "--pubkey PATH    Verify with a PEM public key instead of the embedded key",
+            "rz verify-cert certs/",
+            "Run `rz --help` for global flags and other subcommands.",
+        ],
+    );
+}
+
+fn assert_verify_all_help(args: &[&str]) {
+    assert_focused_help(
+        args,
+        &[
+            "rz verify-all — re-check every obligation in a manifest",
+            "USAGE:\n    rz verify-all <dir> [--pubkey <path>] [--z3]",
+            "backend-limited; requires --features z3",
+            "Reads manifest.json, checks certificate hashes, and verifies signatures.",
+            "With --z3, also runs `z3 -smt2` for solver re-verification when z3 is on PATH.",
+            "--pubkey PATH    Verify signatures with a PEM public key override",
+            "--z3             Re-run Z3 on each certificate when the z3 binary is available",
+            "rz verify-all certs/ --z3",
+            "Run `rz --help` for global flags and other subcommands.",
+        ],
+    );
+}
+
+#[test]
+fn verify_cert_long_help_is_focused() {
+    assert_verify_cert_help(&["verify-cert", "--help"]);
+}
+
+#[test]
+fn verify_cert_short_help_is_focused() {
+    assert_verify_cert_help(&["verify-cert", "-h"]);
+}
+
+#[test]
+fn verify_cert_help_word_is_focused() {
+    assert_verify_cert_help(&["verify-cert", "help"]);
+}
+
+#[test]
+fn verify_all_long_help_is_focused() {
+    assert_verify_all_help(&["verify-all", "--help"]);
+}
+
+#[test]
+fn verify_all_short_help_is_focused() {
+    assert_verify_all_help(&["verify-all", "-h"]);
+}
+
+#[test]
+fn verify_all_help_word_is_focused() {
+    assert_verify_all_help(&["verify-all", "help"]);
+}


### PR DESCRIPTION
Closes #3167.

## Summary
- Added focused `rz verify-cert` help for `--help`, `-h`, and `help`.
- Added focused `rz verify-all` help for `--help`, `-h`, and `help`.
- Routed verification help before backend-limited/default global fallthrough so default builds show focused help while still identifying the `--features z3` requirement.
- Added smoke coverage for both verification help pages and non-global output.

## Test changes
- Added `resilient/tests/verification_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test verification_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test verify_cert_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --features z3 --test verification_help_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- verify-cert --help`
- `cargo run --manifest-path resilient/Cargo.toml -- verify-all --help`
- `cargo run --manifest-path resilient/Cargo.toml -- verify-cert -h`
- `cargo run --manifest-path resilient/Cargo.toml -- verify-all -h`

## Safety
- No dependencies.
- No unsafe changes.
