### PR TITLE
RES-3172: Fmt subcommand help: show focused usage for rz fmt help

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32030,6 +32030,10 @@ fn dispatch_fmt_subcommand(args: &[String]) -> Option<i32> {
     if args.get(1).map(|s| s.as_str()) != Some("fmt") {
         return None;
     }
+    if is_fmt_help_request(args) {
+        print_fmt_help();
+        return Some(0);
+    }
 
     let mut file: Option<PathBuf> = None;
     let mut in_place = false;
@@ -32208,6 +32212,37 @@ fn print_help() {
 
 fn print_repl_help() {
     print!("{}", REPL_HELP_TEXT);
+}
+
+const FMT_HELP_TEXT: &str = r#"rz fmt — format a Resilient source file
+
+USAGE:
+    rz fmt <file> [--in-place]
+
+OUTPUT:
+    By default, prints the formatted source to stdout.
+    With --in-place, rewrites the file and prints nothing on success.
+
+FLAGS:
+    -i, --in-place    Rewrite the file instead of printing formatted source
+
+EXAMPLES:
+    rz fmt examples/hello.rz
+    rz fmt --in-place examples/hello.rz
+
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+fn is_fmt_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("fmt")
+        && matches!(
+            args.get(2).map(String::as_str),
+            Some("--help" | "-h" | "help")
+        )
+}
+
+fn print_fmt_help() {
+    print!("{}", FMT_HELP_TEXT);
 }
 
 const LINT_HELP_TEXT: &str = r#"rz lint — run Resilient lints without executing the file
@@ -32623,6 +32658,10 @@ pub fn run_cli() {
         std::process::exit(0);
     }
 
+    if is_fmt_help_request(&args) {
+        print_fmt_help();
+        std::process::exit(0);
+    }
     if is_check_help_request(&args) {
         print_check_help();
         std::process::exit(0);

--- a/resilient/tests/fmt_help_smoke.rs
+++ b/resilient/tests/fmt_help_smoke.rs
@@ -1,0 +1,56 @@
+//! RES-3172: focused help for the `rz fmt` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_fmt_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz fmt help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "fmt help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "rz fmt — format a Resilient source file",
+        "USAGE:\n    rz fmt <file> [--in-place]",
+        "By default, prints the formatted source to stdout.",
+        "With --in-place, rewrites the file and prints nothing on success.",
+        "-i, --in-place    Rewrite the file instead of printing formatted source",
+        "rz fmt examples/hello.rz",
+        "Run `rz --help` for global flags and other subcommands.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused fmt help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "fmt help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn fmt_long_help_is_focused() {
+    assert_focused_fmt_help(&["fmt", "--help"]);
+}
+
+#[test]
+fn fmt_short_help_is_focused() {
+    assert_focused_fmt_help(&["fmt", "-h"]);
+}
+
+#[test]
+fn fmt_help_word_is_focused() {
+    assert_focused_fmt_help(&["fmt", "help"]);
+}


### PR DESCRIPTION
Closes #3172.

## Summary
- Added focused `rz fmt` help for `rz fmt --help`, `rz fmt -h`, and `rz fmt help`.
- Routed fmt help before global help so it no longer falls through to `rz --help` or treats `help` as a file path.
- Added smoke coverage for stdout formatting language, `--in-place`, examples, and non-global output.

## Test changes
- Added `resilient/tests/fmt_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test fmt_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test stable_cli_surface_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- fmt --help`
- `cargo run --manifest-path resilient/Cargo.toml -- fmt -h`
- `cargo run --manifest-path resilient/Cargo.toml -- fmt help`

## Safety
- No dependencies.
- No unsafe changes.
