### PR TITLE
RES-3173: Self-host parity report help: show focused usage for report generation

### DIFF
--- a/resilient/src/self_host_parity_report.rs
+++ b/resilient/src/self_host_parity_report.rs
@@ -261,6 +261,10 @@ pub(crate) fn dispatch_self_host_parity_report_subcommand(args: &[String]) -> Op
     if args.get(1).map(|arg| arg.as_str()) != Some("self-host-parity-report") {
         return None;
     }
+    if is_self_host_parity_report_help_request(args) {
+        print_self_host_parity_report_help();
+        return Some(0);
+    }
 
     let mut corpus_root: Option<PathBuf> = None;
     let mut json_out: Option<PathBuf> = None;
@@ -305,6 +309,40 @@ pub(crate) fn dispatch_self_host_parity_report_subcommand(args: &[String]) -> Op
             Some(1)
         }
     }
+}
+
+const SELF_HOST_PARITY_REPORT_HELP_TEXT: &str = r#"rz self-host-parity-report — publish self-hosting parity coverage
+
+USAGE:
+    rz self-host-parity-report [DIR] [--json-out PATH]
+
+INPUT:
+    DIR defaults to self-host/parity_corpus.
+    The report compares Rust and self-host lexer/parser output for that corpus.
+
+OUTPUT:
+    Prints a coverage and divergence summary to stdout.
+    With --json-out, also writes a stable JSON report artifact.
+
+FLAGS:
+        --json-out PATH    Write the machine-readable report to PATH
+
+EXAMPLES:
+    rz self-host-parity-report
+    rz self-host-parity-report self-host/parity_corpus --json-out parity.json
+
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+fn is_self_host_parity_report_help_request(args: &[String]) -> bool {
+    matches!(
+        args.get(2).map(String::as_str),
+        Some("--help" | "-h" | "help")
+    )
+}
+
+fn print_self_host_parity_report_help() {
+    print!("{}", SELF_HOST_PARITY_REPORT_HELP_TEXT);
 }
 
 fn build_report(corpus_root: &Path) -> Result<Report, String> {

--- a/resilient/tests/self_host_parity_help_smoke.rs
+++ b/resilient/tests/self_host_parity_help_smoke.rs
@@ -1,0 +1,58 @@
+//! RES-3173: focused help for the `rz self-host-parity-report` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_self_host_parity_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz self-host-parity-report help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "self-host parity help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "rz self-host-parity-report — publish self-hosting parity coverage",
+        "USAGE:\n    rz self-host-parity-report [DIR] [--json-out PATH]",
+        "DIR defaults to self-host/parity_corpus.",
+        "The report compares Rust and self-host lexer/parser output for that corpus.",
+        "Prints a coverage and divergence summary to stdout.",
+        "With --json-out, also writes a stable JSON report artifact.",
+        "--json-out PATH    Write the machine-readable report to PATH",
+        "rz self-host-parity-report self-host/parity_corpus --json-out parity.json",
+        "Run `rz --help` for global flags and other subcommands.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused self-host parity help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "self-host parity help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn self_host_parity_long_help_is_focused() {
+    assert_focused_self_host_parity_help(&["self-host-parity-report", "--help"]);
+}
+
+#[test]
+fn self_host_parity_short_help_is_focused() {
+    assert_focused_self_host_parity_help(&["self-host-parity-report", "-h"]);
+}
+
+#[test]
+fn self_host_parity_help_word_is_focused() {
+    assert_focused_self_host_parity_help(&["self-host-parity-report", "help"]);
+}


### PR DESCRIPTION
Closes #3173.

## Summary
- Added focused `rz self-host-parity-report` help for `--help`, `-h`, and `help`.
- Documented the default `self-host/parity_corpus` input, stdout summary, and `--json-out` report artifact.
- Added smoke coverage for all focused help paths and non-global output.

## Test changes
- Added `resilient/tests/self_host_parity_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test self_host_parity_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test self_host_parity_report_cli -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- self-host-parity-report --help`
- `cargo run --manifest-path resilient/Cargo.toml -- self-host-parity-report -h`
- `cargo run --manifest-path resilient/Cargo.toml -- self-host-parity-report help`

## Safety
- No dependencies.
- No unsafe changes.
