### PR TITLE
RES-3171: Debug subcommand help: show focused usage for DAP startup

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32245,6 +32245,34 @@ fn print_fmt_help() {
     print!("{}", FMT_HELP_TEXT);
 }
 
+const DEBUG_HELP_TEXT: &str = r#"rz debug — start the Debug Adapter Protocol server
+
+USAGE:
+    rz debug <file>
+
+BEHAVIOR:
+    Starts a DAP server on stdin/stdout for an editor or debugger client.
+    The file argument labels the session; the DAP launch request supplies the program path.
+
+EXAMPLES:
+    rz debug examples/hello.rz
+
+For direct adapter launches, clients may use `rz --dap`.
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+fn is_debug_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("debug")
+        && matches!(
+            args.get(2).map(String::as_str),
+            Some("--help" | "-h" | "help")
+        )
+}
+
+fn print_debug_help() {
+    print!("{}", DEBUG_HELP_TEXT);
+}
+
 const LINT_HELP_TEXT: &str = r#"rz lint — run Resilient lints without executing the file
 
 USAGE:
@@ -32660,6 +32688,10 @@ pub fn run_cli() {
 
     if is_fmt_help_request(&args) {
         print_fmt_help();
+        std::process::exit(0);
+    }
+    if is_debug_help_request(&args) {
+        print_debug_help();
         std::process::exit(0);
     }
     if is_check_help_request(&args) {

--- a/resilient/tests/debug_help_smoke.rs
+++ b/resilient/tests/debug_help_smoke.rs
@@ -1,0 +1,61 @@
+//! RES-3171: focused help for the `rz debug` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_debug_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz debug help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "debug help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for expected in [
+        "rz debug — start the Debug Adapter Protocol server",
+        "USAGE:\n    rz debug <file>",
+        "Starts a DAP server on stdin/stdout for an editor or debugger client.",
+        "The file argument labels the session; the DAP launch request supplies the program path.",
+        "rz debug examples/hello.rz",
+        "For direct adapter launches, clients may use `rz --dap`.",
+        "Run `rz --help` for global flags and other subcommands.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused debug help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "debug help should not fall through to global help; got:\n{stdout}"
+    );
+    assert!(
+        !stderr.contains("Starting DAP server"),
+        "debug help should not start the DAP server; stderr={stderr}"
+    );
+}
+
+#[test]
+fn debug_long_help_is_focused() {
+    assert_focused_debug_help(&["debug", "--help"]);
+}
+
+#[test]
+fn debug_short_help_is_focused() {
+    assert_focused_debug_help(&["debug", "-h"]);
+}
+
+#[test]
+fn debug_help_word_is_focused() {
+    assert_focused_debug_help(&["debug", "help"]);
+}


### PR DESCRIPTION
Closes #3171.

## Summary
- Added focused `rz debug` help for `rz debug --help`, `rz debug -h`, and `rz debug help`.
- Routed debug help before global help and before DAP startup, so help exits without starting the DAP server.
- Added smoke coverage for focused DAP wording, examples, non-global output, and no server-start stderr.

## Test changes
- Added `resilient/tests/debug_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test debug_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml dap_server --lib -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- debug --help`
- `cargo run --manifest-path resilient/Cargo.toml -- debug -h`
- `cargo run --manifest-path resilient/Cargo.toml -- debug help`

## Safety
- No dependencies.
- No unsafe changes.
