### PR TITLE
RES-3178: Dump-source-map help: show focused usage for bytecode source maps

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32714,6 +32714,10 @@ pub fn run_cli() {
         print_verify_all_help();
         std::process::exit(0);
     }
+    if source_map::is_dump_source_map_help_request(&args) {
+        source_map::print_dump_source_map_help();
+        std::process::exit(0);
+    }
 
     // TLA+ bridge: `rz tla check <file.tla>` — shells out to TLC and
     // surfaces results in Resilient's diagnostic format.

--- a/resilient/src/source_map.rs
+++ b/resilient/src/source_map.rs
@@ -97,6 +97,10 @@ pub(crate) fn dispatch_dump_source_map(args: &[String]) -> Option<i32> {
     if args.get(1).map(|s| s.as_str()) != Some("dump-source-map") {
         return None;
     }
+    if is_dump_source_map_help_request(args) {
+        print_dump_source_map_help();
+        return Some(0);
+    }
 
     let file = match args.get(2) {
         Some(f) => f.clone(),
@@ -158,6 +162,34 @@ pub(crate) fn dispatch_dump_source_map(args: &[String]) -> Option<i32> {
     }
 
     Some(0)
+}
+
+const DUMP_SOURCE_MAP_HELP_TEXT: &str = r#"rz dump-source-map — print bytecode-to-source-line mappings
+
+USAGE:
+    rz dump-source-map <file>
+
+OUTPUT:
+    Compiles the file, then prints bytecode program counters with source lines.
+    The report includes the main chunk and one section per compiled function.
+
+EXAMPLES:
+    rz dump-source-map examples/hello.rz
+    rz dump-source-map firmware/control.rz
+
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+pub(crate) fn is_dump_source_map_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("dump-source-map")
+        && matches!(
+            args.get(2).map(String::as_str),
+            Some("--help" | "-h" | "help")
+        )
+}
+
+pub(crate) fn print_dump_source_map_help() {
+    print!("{}", DUMP_SOURCE_MAP_HELP_TEXT);
 }
 
 // ---------------------------------------------------------------------------

--- a/resilient/tests/dump_source_map_help_smoke.rs
+++ b/resilient/tests/dump_source_map_help_smoke.rs
@@ -1,0 +1,55 @@
+//! RES-3178: focused help for the `rz dump-source-map` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_dump_source_map_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz dump-source-map help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "dump-source-map help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "rz dump-source-map — print bytecode-to-source-line mappings",
+        "USAGE:\n    rz dump-source-map <file>",
+        "Compiles the file, then prints bytecode program counters with source lines.",
+        "The report includes the main chunk and one section per compiled function.",
+        "rz dump-source-map examples/hello.rz",
+        "Run `rz --help` for global flags and other subcommands.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused dump-source-map help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "dump-source-map help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn dump_source_map_long_help_is_focused() {
+    assert_focused_dump_source_map_help(&["dump-source-map", "--help"]);
+}
+
+#[test]
+fn dump_source_map_short_help_is_focused() {
+    assert_focused_dump_source_map_help(&["dump-source-map", "-h"]);
+}
+
+#[test]
+fn dump_source_map_help_word_is_focused() {
+    assert_focused_dump_source_map_help(&["dump-source-map", "help"]);
+}


### PR DESCRIPTION
Closes #3178.

## Summary
- Added focused `rz dump-source-map` help for `--help`, `-h`, and `help`.
- Routed source-map help before global help while keeping the module-owned dispatcher handling `help` directly.
- Added smoke coverage for bytecode/source-line wording, examples, and non-global output.

## Test changes
- Added `resilient/tests/dump_source_map_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test dump_source_map_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml source_map --lib -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- dump-source-map --help`
- `cargo run --manifest-path resilient/Cargo.toml -- dump-source-map -h`
- `cargo run --manifest-path resilient/Cargo.toml -- dump-source-map help`

## Safety
- No dependencies.
- No unsafe changes.
