### PR TITLE
RES-3177: TLA check help: show focused usage for TLC model checking

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32718,6 +32718,10 @@ pub fn run_cli() {
         source_map::print_dump_source_map_help();
         std::process::exit(0);
     }
+    if tla_bridge::is_tla_check_help_request(&args) {
+        tla_bridge::print_tla_check_help();
+        std::process::exit(0);
+    }
 
     // TLA+ bridge: `rz tla check <file.tla>` — shells out to TLC and
     // surfaces results in Resilient's diagnostic format.

--- a/resilient/src/tla_bridge.rs
+++ b/resilient/src/tla_bridge.rs
@@ -287,6 +287,11 @@ pub fn dispatch_tla_subcommand(args: &[String]) -> Option<i32> {
 }
 
 fn run_tla_check(args: &[String]) -> i32 {
+    if is_tla_check_help_args(args) {
+        print_tla_check_help();
+        return 0;
+    }
+
     // Trivial flag parser: --tlc-jar PATH, --verbose, positional = file.
     let mut tla_file: Option<&str> = None;
     let mut tlc_jar: Option<&str> = None;
@@ -371,6 +376,48 @@ EXIT CODES:
     0 — no violations found
     1 — violation found, parse error, or TLC unavailable"
     );
+}
+
+const TLA_CHECK_HELP_TEXT: &str = r#"rz tla check — run TLC model checking for a TLA+ spec
+
+USAGE:
+    rz tla check [OPTIONS] <file.tla>
+
+BEHAVIOR:
+    Shells out to TLC via `java -jar tla2tools.jar`.
+    TLC output is surfaced as Resilient-style diagnostics.
+
+OPTIONS:
+    --tlc-jar PATH   Path to tla2tools.jar; overrides RESILIENT_TLC_JAR
+    --verbose        Print raw TLC output before diagnostics
+
+DISCOVERY:
+    1. --tlc-jar PATH
+    2. RESILIENT_TLC_JAR environment variable
+    3. tlc.jar or tla2tools.jar anywhere on PATH
+
+EXAMPLES:
+    rz tla check MySpec.tla
+    rz tla check --tlc-jar /opt/tla2tools.jar --verbose MySpec.tla
+
+Run `rz --help` for global flags and other subcommands.
+"#;
+
+pub(crate) fn is_tla_check_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("tla")
+        && args.get(2).map(String::as_str) == Some("check")
+        && is_tla_check_help_args(&args[3..])
+}
+
+fn is_tla_check_help_args(args: &[String]) -> bool {
+    matches!(
+        args.first().map(String::as_str),
+        Some("--help" | "-h" | "help")
+    )
+}
+
+pub(crate) fn print_tla_check_help() {
+    print!("{}", TLA_CHECK_HELP_TEXT);
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/resilient/tests/tla_help_smoke.rs
+++ b/resilient/tests/tla_help_smoke.rs
@@ -1,0 +1,58 @@
+//! RES-3177: focused help for the `rz tla check` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_tla_check_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz tla check help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "tla check help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "rz tla check — run TLC model checking for a TLA+ spec",
+        "USAGE:\n    rz tla check [OPTIONS] <file.tla>",
+        "Shells out to TLC via `java -jar tla2tools.jar`.",
+        "TLC output is surfaced as Resilient-style diagnostics.",
+        "--tlc-jar PATH   Path to tla2tools.jar; overrides RESILIENT_TLC_JAR",
+        "--verbose        Print raw TLC output before diagnostics",
+        "RESILIENT_TLC_JAR environment variable",
+        "rz tla check --tlc-jar /opt/tla2tools.jar --verbose MySpec.tla",
+        "Run `rz --help` for global flags and other subcommands.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused tla check help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "tla check help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn tla_check_long_help_is_focused() {
+    assert_focused_tla_check_help(&["tla", "check", "--help"]);
+}
+
+#[test]
+fn tla_check_short_help_is_focused() {
+    assert_focused_tla_check_help(&["tla", "check", "-h"]);
+}
+
+#[test]
+fn tla_check_help_word_is_focused() {
+    assert_focused_tla_check_help(&["tla", "check", "help"]);
+}


### PR DESCRIPTION
Closes #3177.

## Summary
- Added focused `rz tla check` help for `--help`, `-h`, and `help`.
- Routed `rz tla check --help` before global help so it explains TLC/TLA behavior directly and does not require Java or TLC.
- Added a bridge-owned help path for sliced dispatcher args plus smoke coverage for all CLI help forms.

## Test changes
- Added `resilient/tests/tla_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test tla_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml tla_bridge --lib -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- tla check --help`
- `cargo run --manifest-path resilient/Cargo.toml -- tla check -h`
- `cargo run --manifest-path resilient/Cargo.toml -- tla check help`

## Safety
- No dependencies.
- No unsafe changes.
