### PR TITLE
RES-3181: TLA check dispatch: route rz tla check before normal file execution

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32726,8 +32726,10 @@ pub fn run_cli() {
     // TLA+ bridge: `rz tla check <file.tla>` — shells out to TLC and
     // surfaces results in Resilient's diagnostic format.
     #[cfg(not(target_arch = "wasm32"))]
-    if let Some(code) = tla_bridge::dispatch_tla_subcommand(&args) {
-        std::process::exit(code);
+    if args.len() > 1 {
+        if let Some(code) = tla_bridge::dispatch_tla_subcommand(&args[1..]) {
+            std::process::exit(code);
+        }
     }
 
     let explicit_repl = args.get(1).map(String::as_str) == Some("repl");

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32726,10 +32726,10 @@ pub fn run_cli() {
     // TLA+ bridge: `rz tla check <file.tla>` — shells out to TLC and
     // surfaces results in Resilient's diagnostic format.
     #[cfg(not(target_arch = "wasm32"))]
-    if args.len() > 1 {
-        if let Some(code) = tla_bridge::dispatch_tla_subcommand(&args[1..]) {
-            std::process::exit(code);
-        }
+    if args.len() > 1
+        && let Some(code) = tla_bridge::dispatch_tla_subcommand(&args[1..])
+    {
+        std::process::exit(code);
     }
 
     let explicit_repl = args.get(1).map(String::as_str) == Some("repl");

--- a/resilient/tests/tla_dispatch_smoke.rs
+++ b/resilient/tests/tla_dispatch_smoke.rs
@@ -1,0 +1,65 @@
+//! RES-3181: real CLI dispatch for `rz tla ...`.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+#[test]
+fn tla_check_missing_file_reaches_tla_bridge() {
+    let output = Command::new(bin())
+        .args(["tla", "check", "/nonexistent/Spec.tla"])
+        .output()
+        .expect("spawn rz tla check missing file");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "missing TLA file should exit 1; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error: file not found: /nonexistent/Spec.tla"),
+        "missing-file diagnostic should come from TLA bridge; stderr={stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("seed="),
+        "TLA dispatch should not fall through to normal execution; stdout={stdout}"
+    );
+}
+
+#[test]
+fn tla_top_level_help_is_focused() {
+    let output = Command::new(bin())
+        .args(["tla", "--help"])
+        .output()
+        .expect("spawn rz tla --help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "tla help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "rz tla — TLA+ model checking integration",
+        "USAGE:\n    rz tla check [OPTIONS] <file.tla>",
+        "Path to tla2tools.jar",
+        "RESILIENT_TLC_JAR environment variable",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused TLA help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "tla help should not fall through to global help; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Closes #3181.

## Summary
- Routed real CLI `rz tla ...` invocations through the TLA bridge by passing the expected subcommand argv slice.
- Added smoke coverage proving `rz tla check /nonexistent/Spec.tla` reaches the TLA bridge and no longer falls through to normal file execution.
- Added smoke coverage for focused `rz tla --help` while preserving `rz tla check --help` from #3177.
- Fixed the follow-up clippy let-chain shape reported by `ready-or-bail`.

## Test changes
- Added `resilient/tests/tla_dispatch_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path resilient/Cargo.toml --test tla_dispatch_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml tla_bridge --lib -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- tla check /nonexistent/Spec.tla`
- `cargo run --manifest-path resilient/Cargo.toml -- tla --help`
- `cargo run --manifest-path resilient/Cargo.toml -- tla check --help`

## Safety
- No dependencies.
- No unsafe changes.
