### PR TITLE
RES-3184: Bench help word: route rz bench help to focused benchmark usage

### DIFF
--- a/resilient/src/bench.rs
+++ b/resilient/src/bench.rs
@@ -74,7 +74,7 @@ pub fn dispatch_bench_subcommand(args: &[String]) -> Option<i32> {
     let mut i = 2;
     while i < args.len() {
         let arg = &args[i];
-        if arg == "--help" || arg == "-h" {
+        if arg == "--help" || arg == "-h" || arg == "help" {
             print_bench_help();
             return Some(0);
         } else if arg == "--baseline" {

--- a/resilient/tests/bench_help_smoke.rs
+++ b/resilient/tests/bench_help_smoke.rs
@@ -1,0 +1,53 @@
+//! RES-3184: focused help for the `rz bench` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_bench_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz bench help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "bench help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "Usage: rz bench <file> [--baseline <git-ref>] [--summary-json <path>] [--warmup N] [--runs N]",
+        "Discover and run `bench \"name\" { ... }` blocks.",
+        "--summary-json <path>  Write a stable JSON summary artifact",
+        "--filter <substr>  Only run benchmarks whose names contain <substr>",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused bench help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "bench help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn bench_long_help_is_focused() {
+    assert_focused_bench_help(&["bench", "--help"]);
+}
+
+#[test]
+fn bench_short_help_is_focused() {
+    assert_focused_bench_help(&["bench", "-h"]);
+}
+
+#[test]
+fn bench_help_word_is_focused() {
+    assert_focused_bench_help(&["bench", "help"]);
+}


### PR DESCRIPTION
Closes #3184.

## Summary
- Routed `rz bench help` to the existing focused benchmark help page.
- Preserved `rz bench --help` and `rz bench -h` behavior.
- Added smoke coverage for all three focused bench help paths.

## Test changes
- Added `resilient/tests/bench_help_smoke.rs`.
- No existing tests or golden files were modified.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test bench_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test bench_cli -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test bench_cli_summary_json -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- bench help`

## Safety
- No dependencies.
- No unsafe changes.
