### PR TITLE
RES-3183: Route test help word to focused usage

### DIFF
--- a/resilient/src/test_runner.rs
+++ b/resilient/src/test_runner.rs
@@ -36,7 +36,7 @@ pub fn dispatch_test_subcommand(args: &[String]) -> Option<i32> {
             filter = Some(args[i].clone());
         } else if let Some(f) = a.strip_prefix("--filter=") {
             filter = Some(f.to_string());
-        } else if a == "--help" || a == "-h" {
+        } else if a == "--help" || a == "-h" || a == "help" {
             print_test_help();
             return Some(0);
         } else if target.is_none() {

--- a/resilient/tests/test_help_smoke.rs
+++ b/resilient/tests/test_help_smoke.rs
@@ -1,0 +1,53 @@
+//! RES-3183: focused help for the `rz test` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_test_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz test help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "test help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "Usage: rz test [<file|dir>] [--filter <substring>]",
+        "Discover and run fn test_*() functions in .rz files.",
+        "(no argument)       Discover from the current directory",
+        "--filter <substr>   Only run tests whose name contains <substr>",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused test help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "test help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_long_help_is_focused() {
+    assert_focused_test_help(&["test", "--help"]);
+}
+
+#[test]
+fn test_short_help_is_focused() {
+    assert_focused_test_help(&["test", "-h"]);
+}
+
+#[test]
+fn test_help_word_is_focused() {
+    assert_focused_test_help(&["test", "help"]);
+}


### PR DESCRIPTION
Closes #3183.

## Summary

- Route `rz test help` to the focused test-runner help output.
- Preserve existing `rz test --help` and `rz test -h` behavior.
- Add new smoke coverage for all three focused help spellings without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test test_help_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- test help`

## Test changes

- Added `resilient/tests/test_help_smoke.rs` to cover focused test-runner help spellings.
