### PR TITLE
RES-3185: Route pkg publish help word to focused usage

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -30840,7 +30840,7 @@ fn dispatch_pkg_subcommand(args: &[String]) -> Option<i32> {
             let mut i = 3;
             while i < args.len() {
                 let a = &args[i];
-                if a == "--help" || a == "-h" {
+                if a == "--help" || a == "-h" || a == "help" {
                     print_pkg_publish_help();
                     return Some(0);
                 } else if a == "--dry-run" {

--- a/resilient/tests/pkg_publish_help_smoke.rs
+++ b/resilient/tests/pkg_publish_help_smoke.rs
@@ -1,0 +1,54 @@
+//! RES-3185: focused help for the `rz pkg publish` subcommand.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_focused_pkg_publish_help(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz pkg publish help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "pkg publish help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "package the current project for upload to a registry",
+        "USAGE:\n    rz pkg publish --dry-run",
+        "--dry-run   Required today",
+        "AUTH:",
+        "WHAT IT DOES:",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused pkg publish help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "pkg publish help should not fall through to global help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn pkg_publish_long_help_is_focused() {
+    assert_focused_pkg_publish_help(&["pkg", "publish", "--help"]);
+}
+
+#[test]
+fn pkg_publish_short_help_is_focused() {
+    assert_focused_pkg_publish_help(&["pkg", "publish", "-h"]);
+}
+
+#[test]
+fn pkg_publish_help_word_is_focused() {
+    assert_focused_pkg_publish_help(&["pkg", "publish", "help"]);
+}


### PR DESCRIPTION
Closes #3185.

## Summary

- Route `rz pkg publish help` to the focused publish help output.
- Preserve existing `rz pkg publish --help` and `rz pkg publish -h` behavior.
- Add new smoke coverage for all three focused help spellings without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test pkg_publish_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test pkg_init_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- pkg publish help`

## Test changes

- Added `resilient/tests/pkg_publish_help_smoke.rs` to cover focused package publish help spellings.
