### PR TITLE
RES-3193: Route top-level help word to global usage

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32768,10 +32768,14 @@ pub fn run_cli() {
         std::process::exit(code);
     }
 
-    // RES-211: `--help` / `-h` prints a short usage summary listing
-    // the most-used flags. Kept hand-rolled (no clap dep) to match
-    // the rest of the driver's arg-parsing style.
-    if args.iter().any(|a| a == "--help" || a == "-h") && !explicit_repl {
+    let top_level_help_word = args.get(1).map(String::as_str) == Some("help")
+        && args.len() == 2
+        && !Path::new("help").is_file();
+
+    // RES-211: `--help` / `-h` / top-level `help` prints a short
+    // usage summary listing the most-used flags. Kept hand-rolled
+    // (no clap dep) to match the rest of the driver's arg-parsing style.
+    if (top_level_help_word || args.iter().any(|a| a == "--help" || a == "-h")) && !explicit_repl {
         print_help();
         std::process::exit(0);
     }

--- a/resilient/tests/help_word_smoke.rs
+++ b/resilient/tests/help_word_smoke.rs
@@ -1,0 +1,81 @@
+//! RES-3193: top-level `rz help` routes to global usage.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_parent(tag: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let p = std::env::temp_dir().join(format!(
+        "res_help_word_{}_{}_{}",
+        tag,
+        std::process::id(),
+        n
+    ));
+    std::fs::create_dir_all(&p).expect("mkdir help word tmp");
+    p
+}
+
+#[test]
+fn help_word_prints_global_usage() {
+    let output = Command::new(bin())
+        .arg("help")
+        .output()
+        .expect("spawn rz help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "rz help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "USAGE:\n    rz [FLAGS] [<file>]",
+        "COMMON FLAGS:",
+        "-h, --help",
+        "SUBCOMMANDS:",
+        "See SYNTAX.md for the language reference.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "global help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn file_named_help_still_runs_as_a_file() {
+    let parent = tmp_parent("file_named_help");
+    let help_path = parent.join("help");
+    std::fs::write(&help_path, "println(\"file-help\");\n").expect("write help source");
+
+    let output = Command::new(bin())
+        .arg("help")
+        .current_dir(&parent)
+        .output()
+        .expect("spawn rz help file");
+
+    assert!(
+        output.status.success(),
+        "expected file named help to run; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("file-help"),
+        "expected file output, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("COMMON FLAGS:"),
+        "file named help should not print global help; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&parent);
+}


### PR DESCRIPTION
Closes #3193.

## Summary

- Route the exact top-level `rz help` command to global usage.
- Preserve existing `rz --help` and `rz -h` behavior.
- Preserve execution for a real file named `help` in the current directory.
- Add new smoke coverage without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test help_word_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test help_layout_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- help`

## Test changes

- Added `resilient/tests/help_word_smoke.rs` to cover top-level help-word routing and the file-named-help preservation case.
