### PR TITLE
RES-3194: Suppress seed banner for repl help

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -33429,6 +33429,11 @@ pub fn run_cli() {
             std::process::exit(2);
         }
 
+        if explicit_repl && repl_help {
+            print_repl_help();
+            return;
+        }
+
         // RES-150: install the RNG seed before any user program
         // can pull from it. `--seed <N>` pins the sequence
         // (silently, since the user asked for reproducibility);
@@ -33662,10 +33667,6 @@ pub fn run_cli() {
         }
 
         if explicit_repl {
-            if repl_help {
-                print_repl_help();
-                return;
-            }
             let mut enhanced_repl = repl::EnhancedREPL::with_examples_dir(examples_dir);
             if let Err(e) = enhanced_repl.run() {
                 eprintln!("REPL error: {}", e);

--- a/resilient/tests/repl_help_smoke.rs
+++ b/resilient/tests/repl_help_smoke.rs
@@ -1,0 +1,54 @@
+//! RES-3194: focused REPL help should not print the runtime seed banner.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn assert_repl_help_without_seed(args: &[&str]) {
+    let output = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rz repl help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "repl help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "rz repl",
+        "USAGE:\n    rz repl [--examples-dir DIR]",
+        "FLAGS:\n    --help, -h",
+        "For bare REPL startup, run plain `rz`.",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "focused repl help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("seed="),
+        "repl help should not print seed banner; got stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn repl_help_word_has_no_seed_banner() {
+    assert_repl_help_without_seed(&["repl", "help"]);
+}
+
+#[test]
+fn repl_long_help_has_no_seed_banner() {
+    assert_repl_help_without_seed(&["repl", "--help"]);
+}
+
+#[test]
+fn repl_short_help_has_no_seed_banner() {
+    assert_repl_help_without_seed(&["repl", "-h"]);
+}


### PR DESCRIPTION
Closes #3194.

## Summary

- Keep `rz repl help`, `rz repl --help`, and `rz repl -h` routed to focused REPL help.
- Suppress the runtime `seed=...` banner for REPL help output by returning before seed installation.
- Preserve normal REPL startup seed behavior.
- Add new smoke coverage without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test repl_help_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test repl_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- repl help`

## Test changes

- Added `resilient/tests/repl_help_smoke.rs` to cover all focused REPL help spellings and assert stderr does not contain `seed=`.
