### PR TITLE
RES-3197: Document top-level help word in global usage

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32107,6 +32107,7 @@ const GLOBAL_HELP_TEXT: &str = r#"rz — the Resilient language compiler & inter
 USAGE:
     rz [FLAGS] [<file>]
     rz                      # start REPL when no file is provided
+    rz help                 # show this help
     rz <subcommand> [ARGS]
 
 COMMON FLAGS:

--- a/resilient/tests/global_help_word_copy_smoke.rs
+++ b/resilient/tests/global_help_word_copy_smoke.rs
@@ -1,0 +1,35 @@
+//! RES-3197: global help documents the top-level `rz help` word.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+#[test]
+fn global_help_documents_help_word_usage() {
+    let output = Command::new(bin())
+        .arg("help")
+        .output()
+        .expect("spawn rz help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "rz help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "USAGE:\n    rz [FLAGS] [<file>]",
+        "rz help                 # show this help",
+        "COMMON FLAGS:",
+        "SUBCOMMANDS:",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "global help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3197.

## Summary

- Add `rz help` to the global usage block now that the top-level help word is supported.
- Preserve existing global help layout and behavior.
- Add new smoke coverage without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test global_help_word_copy_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test help_layout_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- help`

## Test changes

- Added `resilient/tests/global_help_word_copy_smoke.rs` to cover the documented `rz help` usage line.
