### PR TITLE
RES-3198: Mention package help word in catalog

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -31024,7 +31024,8 @@ fn print_pkg_help() {
              add      Add a dependency to resilient.toml\n    \
              help     Show this message\n\
          \n\
-         Run `rz pkg <subcommand> --help` for subcommand-specific options."
+         Run `rz pkg <subcommand> --help` or `rz pkg <subcommand> help`\n\
+         for subcommand-specific options."
     );
 }
 

--- a/resilient/tests/pkg_help_copy_smoke.rs
+++ b/resilient/tests/pkg_help_copy_smoke.rs
@@ -1,0 +1,37 @@
+//! RES-3198: package help documents help-word subcommand usage.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+#[test]
+fn pkg_help_documents_help_word_form() {
+    let output = Command::new(bin())
+        .args(["pkg", "--help"])
+        .output()
+        .expect("spawn rz pkg --help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "pkg help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "SUBCOMMANDS:",
+        "init     Scaffold a new project",
+        "publish",
+        "add      Add a dependency",
+        "rz pkg <subcommand> --help",
+        "rz pkg <subcommand> help",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "pkg help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3198.

## Summary

- Document `rz pkg <subcommand> help` alongside `--help` in the package catalog.
- Preserve existing package help behavior and subcommand listing.
- Add new smoke coverage without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test pkg_help_copy_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test pkg_init_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- pkg --help`

## Test changes

- Added `resilient/tests/pkg_help_copy_smoke.rs` to cover the documented package help-word form.
