### PR TITLE
RES-3201: Mention rz help in unknown command hint

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -33344,7 +33344,7 @@ pub fn run_cli() {
         }
         if should_report_unknown_command_or_file(filename) {
             eprintln!(
-                "Error: unknown command or file `{}`. Run `rz --help` to list subcommands, or pass an existing file path.",
+                "Error: unknown command or file `{}`. Run `rz help` or `rz --help` to list subcommands, or pass an existing file path.",
                 filename
             );
             std::process::exit(2);

--- a/resilient/tests/unknown_command_help_hint_smoke.rs
+++ b/resilient/tests/unknown_command_help_hint_smoke.rs
@@ -1,0 +1,34 @@
+//! RES-3201: unknown command diagnostics mention the help-word route.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+#[test]
+fn unknown_command_hint_mentions_help_word() {
+    let output = Command::new(bin())
+        .arg("frobnicate")
+        .output()
+        .expect("spawn rz frobnicate");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "unknown command should remain a usage error; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for expected in [
+        "Error: unknown command or file `frobnicate`.",
+        "Run `rz help` or `rz --help` to list subcommands",
+        "pass an existing file path",
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "unknown command hint missing {expected:?}; got:\n{stderr}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3201.

## Summary

- Mention `rz help` alongside `rz --help` in the unknown top-level command recovery hint.
- Preserve the existing usage-error exit code and behavior.
- Add new smoke coverage without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test unknown_command_help_hint_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test unknown_command_diagnostics_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- frobnicate`

## Test changes

- Added `resilient/tests/unknown_command_help_hint_smoke.rs` to cover the updated recovery hint.
