### PR TITLE
RES-3202: Mention pkg help in unknown subcommand hint

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -30993,7 +30993,7 @@ fn dispatch_pkg_subcommand(args: &[String]) -> Option<i32> {
         Some(other) => {
             eprintln!(
                 "Error: unknown pkg subcommand `{}`. Known: init, publish, add. \
-                 Run `rz pkg --help` for usage.",
+                 Run `rz pkg help` or `rz pkg --help` for usage.",
                 other
             );
             Some(2)

--- a/resilient/tests/pkg_unknown_help_hint_smoke.rs
+++ b/resilient/tests/pkg_unknown_help_hint_smoke.rs
@@ -1,0 +1,34 @@
+//! RES-3202: unknown package subcommands mention the help-word route.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+#[test]
+fn unknown_pkg_subcommand_hint_mentions_pkg_help_word() {
+    let output = Command::new(bin())
+        .args(["pkg", "floofnicate"])
+        .output()
+        .expect("spawn rz pkg floofnicate");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "unknown pkg subcommand should remain a usage error; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for expected in [
+        "Error: unknown pkg subcommand `floofnicate`.",
+        "Known: init, publish, add.",
+        "Run `rz pkg help` or `rz pkg --help` for usage.",
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "unknown pkg hint missing {expected:?}; got:\n{stderr}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3202.

## Summary

- Mention `rz pkg help` alongside `rz pkg --help` in the unknown package subcommand recovery hint.
- Preserve the existing usage-error exit code and behavior.
- Add new smoke coverage without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test pkg_unknown_help_hint_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test pkg_init_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- pkg floofnicate`

## Test changes

- Added `resilient/tests/pkg_unknown_help_hint_smoke.rs` to cover the updated recovery hint.
