### PR TITLE
RES-3205: Document repl help word in usage

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32204,6 +32204,7 @@ const REPL_HELP_TEXT: &str = r#"rz repl — start the interactive REPL
 USAGE:
     rz repl [--examples-dir DIR]
     rz repl --help
+    rz repl help
 
 FLAGS:
     --help, -h            Show this help and exit

--- a/resilient/tests/repl_help_copy_smoke.rs
+++ b/resilient/tests/repl_help_copy_smoke.rs
@@ -1,0 +1,41 @@
+//! RES-3205: REPL help documents the help-word usage form.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+#[test]
+fn repl_help_documents_help_word_usage() {
+    let output = Command::new(bin())
+        .args(["repl", "help"])
+        .output()
+        .expect("spawn rz repl help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "repl help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "USAGE:\n    rz repl [--examples-dir DIR]",
+        "rz repl --help",
+        "rz repl help",
+        "FLAGS:",
+        "--examples-dir DIR",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "repl help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("seed="),
+        "repl help copy path should not print seed banner; got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Closes #3205.

## Summary

- Add `rz repl help` to the focused REPL help usage block.
- Preserve existing REPL help behavior and no-seed output.
- Add new smoke coverage without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --manifest-path resilient/Cargo.toml --test repl_help_copy_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test repl_help_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- repl help`

## Test changes

- Added `resilient/tests/repl_help_copy_smoke.rs` to cover the documented `rz repl help` usage line.
