### PR TITLE
RES-3206: document focused subcommand help

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -32196,6 +32196,8 @@ SUBCOMMANDS:
 
 Tip: run `rz` with no file argument to start REPL.
 `rz repl` is an explicit alias for the REPL.
+Run `rz <subcommand> --help` (or `rz <subcommand> help` where supported)
+for focused usage.
 See SYNTAX.md for the language reference.
 "#;
 

--- a/resilient/tests/global_subcommand_help_copy_smoke.rs
+++ b/resilient/tests/global_subcommand_help_copy_smoke.rs
@@ -1,0 +1,36 @@
+//! RES-3206: global help documents focused subcommand help forms.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+#[test]
+fn global_help_mentions_focused_subcommand_help_forms() {
+    let output = Command::new(bin())
+        .arg("help")
+        .output()
+        .expect("spawn rz help");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "rz help should exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "SUBCOMMANDS:",
+        "pkg <verb>",
+        "rz <subcommand> --help",
+        "rz <subcommand> help",
+        "focused usage",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "global help missing {expected:?}; got:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3206.

## Summary

- Add global help footer copy pointing users to `rz <subcommand> --help`.
- Mention `rz <subcommand> help` as the supported help-word form where available.
- Add focused smoke coverage without modifying existing tests or golden files.

## Verification

- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test global_subcommand_help_copy_smoke -- --nocapture`
- `cargo test --manifest-path resilient/Cargo.toml --test help_layout_smoke -- --nocapture`
- `cargo run --manifest-path resilient/Cargo.toml -- help`

## Test changes

- Added `resilient/tests/global_subcommand_help_copy_smoke.rs` to cover the new customer-facing global help copy.
