### PR TITLE
RES-3213: update community crash-report command

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -84,7 +84,7 @@ Found a bug? Have a feature idea? Open an issue on GitHub:
 
 For compiler crashes, please include:
 - The Resilient source that triggered the crash
-- The full error output (`RUST_BACKTRACE=1 resilient your_file.rs`)
+- The full error output (`RUST_BACKTRACE=1 rz your_file.rz`)
 - Your OS and `cargo --version`
 
 ---

--- a/resilient/tests/docs_community_crash_command_smoke.rs
+++ b/resilient/tests/docs_community_crash_command_smoke.rs
@@ -1,0 +1,15 @@
+//! RES-3213: community docs use the current crash-report command.
+
+#[test]
+fn community_docs_use_current_crash_report_command() {
+    let doc = include_str!("../../docs/community.md");
+
+    assert!(
+        doc.contains("RUST_BACKTRACE=1 rz your_file.rz"),
+        "community docs should show the current `rz` crash-report command"
+    );
+    assert!(
+        !doc.contains("RUST_BACKTRACE=1 resilient your_file.rs"),
+        "community docs should not show the retired binary name or .rs placeholder"
+    );
+}


### PR DESCRIPTION
Closes #3213.

## Summary

- Update the community crash-report command to use the current `rz` binary.
- Replace the stale `.rs` placeholder with a `.rz` source placeholder.
- Add focused docs smoke coverage for the current command and retired form.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_community_crash_command_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/docs_community_crash_command_smoke.rs` to pin the customer-facing crash-report command.
