### PR TITLE
RES-3214: remove Cargo feature flag from rz docs command

### DIFF
--- a/docs/certification.md
+++ b/docs/certification.md
@@ -296,12 +296,12 @@ naming conventions, file organization).
 ## Generating audit artifacts
 
 The three commands that produce certifiable evidence are
-`--audit`, `--emit-certificate`, and `--sign-cert`. They compose:
+`--audit`, `--emit-certificate`, and `--sign-cert`. They compose when
+the `rz` binary was built with `--features z3`:
 
 ```bash
 # One shot: typecheck + verify + audit + emit signed certificates.
 rz \
-    --features z3 \
     --audit \
     --emit-certificate ./artifacts/certs \
     --sign-cert ~/.resilient-priv.pem \

--- a/resilient/tests/docs_certification_z3_command_smoke.rs
+++ b/resilient/tests/docs_certification_z3_command_smoke.rs
@@ -1,0 +1,21 @@
+//! RES-3214: certification docs keep Cargo feature flags out of `rz` commands.
+
+#[test]
+fn certification_docs_describe_z3_as_build_prerequisite() {
+    let doc = include_str!("../../docs/certification.md");
+
+    assert!(
+        doc.contains("the `rz` binary was built with `--features z3`"),
+        "certification docs should preserve the z3 build prerequisite"
+    );
+    assert!(
+        doc.contains(
+            "# One shot: typecheck + verify + audit + emit signed certificates.\nrz \\\n    --audit"
+        ),
+        "certification docs should show `rz --audit` without Cargo feature flags"
+    );
+    assert!(
+        !doc.contains("rz \\\n    --features z3"),
+        "certification docs should not pass Cargo feature flags to `rz`"
+    );
+}


### PR DESCRIPTION
Closes #3214.

## Summary

- Clarify that the certification artifact command assumes an `rz` binary built with `--features z3`.
- Remove the Cargo-only `--features z3` flag from the runtime `rz` command snippet.
- Add focused docs smoke coverage to keep Cargo feature flags out of that `rz` command.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_certification_z3_command_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/docs_certification_z3_command_smoke.rs` to pin the certification docs command shape.
