### PR TITLE
RES-3217: use rz verify-all in Z3 tutorial

### DIFF
--- a/docs/tutorial/05-verifying-with-z3.md
+++ b/docs/tutorial/05-verifying-with-z3.md
@@ -134,7 +134,7 @@ cert + SHA-256 + (optionally) Ed25519 signature. The
 `verify-all` subcommand walks it:
 
 ```bash
-resilient verify-all certs
+rz verify-all certs
 ```
 
 ```
@@ -149,7 +149,7 @@ The `z3` column is skipped by default — add `--z3` to have
 require `unsat`:
 
 ```bash
-resilient verify-all --z3 certs
+rz verify-all --z3 certs
 ```
 
 ## What you learned

--- a/resilient/tests/docs_tutorial_verify_all_command_smoke.rs
+++ b/resilient/tests/docs_tutorial_verify_all_command_smoke.rs
@@ -1,0 +1,17 @@
+//! RES-3217: Z3 tutorial uses the current `rz verify-all` command.
+
+#[test]
+fn z3_tutorial_uses_rz_verify_all_examples() {
+    let doc = include_str!("../../docs/tutorial/05-verifying-with-z3.md");
+
+    for expected in ["rz verify-all certs", "rz verify-all --z3 certs"] {
+        assert!(
+            doc.contains(expected),
+            "Z3 tutorial missing current verify-all command {expected:?}"
+        );
+    }
+    assert!(
+        !doc.contains("resilient verify-all"),
+        "Z3 tutorial should not use the retired `resilient` command"
+    );
+}


### PR DESCRIPTION
Closes #3217.

## Summary

- Update the Z3 tutorial verify-all examples to use the current `rz` command.
- Preserve the surrounding explanation and sample output.
- Add focused docs smoke coverage for both plain and `--z3` verify-all examples.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_tutorial_verify_all_command_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/docs_tutorial_verify_all_command_smoke.rs` to pin the tutorial verify-all command examples.
