### PR TITLE
RES-3218: use rz verify-all in certification docs

### DIFF
--- a/docs/certification.md
+++ b/docs/certification.md
@@ -326,10 +326,10 @@ needed beyond the verifier subcommand):
 
 ```bash
 # Cryptographic regression check — fast.
-resilient verify-all ./artifacts/certs
+rz verify-all ./artifacts/certs
 
 # With re-run of Z3 on every certificate — slower but strongest.
-resilient verify-all ./artifacts/certs --z3
+rz verify-all ./artifacts/certs --z3
 ```
 
 ### Incorporating into a DO-178C Software Accomplishment Summary

--- a/resilient/tests/docs_certification_verify_all_command_smoke.rs
+++ b/resilient/tests/docs_certification_verify_all_command_smoke.rs
@@ -1,0 +1,20 @@
+//! RES-3218: certification docs use the current `rz verify-all` command.
+
+#[test]
+fn certification_docs_use_rz_verify_all_examples() {
+    let doc = include_str!("../../docs/certification.md");
+
+    for expected in [
+        "rz verify-all ./artifacts/certs",
+        "rz verify-all ./artifacts/certs --z3",
+    ] {
+        assert!(
+            doc.contains(expected),
+            "certification docs missing current verify-all command {expected:?}"
+        );
+    }
+    assert!(
+        !doc.contains("resilient verify-all"),
+        "certification docs should not use the retired `resilient` command"
+    );
+}


### PR DESCRIPTION
Closes #3218.

## Summary

- Update certification docs verification examples to use the current `rz verify-all` command.
- Preserve the existing output and Z3 guidance.
- Add focused docs smoke coverage for both plain and `--z3` verify-all examples.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_certification_verify_all_command_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/docs_certification_verify_all_command_smoke.rs` to pin the certification verify-all command examples.
