### PR TITLE
RES-3219: use rz and resilient filetype in LSP docs

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -100,8 +100,8 @@ local configs   = require("lspconfig.configs")
 if not configs.resilient then
   configs.resilient = {
     default_config = {
-      cmd      = { "/absolute/path/to/resilient", "--lsp" },
-      filetypes = { "rust" },   -- .rs files; change to "resilient" if you register a custom filetype
+      cmd      = { "/absolute/path/to/rz", "--lsp" },
+      filetypes = { "resilient" }, -- .rz files
       root_dir  = lspconfig.util.root_pattern("Cargo.toml", ".git"),
       settings  = {},
     },
@@ -110,15 +110,17 @@ end
 lspconfig.resilient.setup({})
 ```
 
-Replace `/absolute/path/to/resilient` with the path to your built
+Replace `/absolute/path/to/rz` with the path to your built
 binary (e.g. `~/GitHub/Resilient/resilient/target/release/rz`).
+If your editor does not already know the `resilient` filetype, map
+`.rz` files to it before starting the client.
 
 ### VS Code
 
 Use the bundled `vscode-extension/` or any generic LSP runner
 extension (e.g. *Generic LSP Client*). Point `command` at the
-Resilient binary with `--lsp` as the argument and set the language
-ID to `rust` (or register a custom `resilient` language ID).
+`rz` binary with `--lsp` as the argument and set the language
+ID to `resilient` for `.rz` files.
 
 The `vscode-extension/` directory in the repo contains a minimal
 extension scaffold — `npm install && vsce package` inside it

--- a/resilient/tests/docs_lsp_setup_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_setup_copy_smoke.rs
@@ -1,0 +1,28 @@
+//! RES-3219: LSP docs use the current `rz` binary and resilient filetype.
+
+#[test]
+fn lsp_docs_use_rz_and_resilient_filetype() {
+    let doc = include_str!("../../docs/lsp.md");
+
+    for expected in [
+        r#"cmd      = { "/absolute/path/to/rz", "--lsp" }"#,
+        r#"filetypes = { "resilient" }"#,
+        "map\n`.rz` files to it",
+        "set the language\nID to `resilient` for `.rz` files",
+    ] {
+        assert!(
+            doc.contains(expected),
+            "LSP docs missing current setup copy {expected:?}"
+        );
+    }
+    for retired in [
+        "/absolute/path/to/resilient",
+        r#"filetypes = { "rust" }"#,
+        "ID to `rust`",
+    ] {
+        assert!(
+            !doc.contains(retired),
+            "LSP docs should not use retired setup copy {retired:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3219.

## Summary

- Update the Neovim LSP example to point at an `rz` binary path.
- Prefer the `resilient` filetype and language ID for `.rz` files.
- Add focused docs smoke coverage to keep the old resilient/rust setup copy from returning.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_setup_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/docs_lsp_setup_copy_smoke.rs` to pin the LSP setup copy.
