### PR TITLE
RES-3223: use checkout-valid cfg example paths

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -228,9 +228,9 @@ Use the CLI flags below to select `#[cfg(...)]` branches in examples and
 real projects:
 
 ```bash
-rz --feature verbose examples/cfg_feature.rz
-rz --target thumbv7em examples/cfg_target.rz
-rz --cfg mode=demo examples/cfg_kv_demo.rz
+rz --feature verbose resilient/examples/cfg_feature.rz
+rz --target thumbv7em resilient/examples/cfg_target.rz
+rz --cfg mode=demo resilient/examples/cfg_kv_demo.rz
 ```
 
 The examples in `resilient/examples/` show the expected stdout for each

--- a/resilient/tests/docs_tooling_cfg_paths_smoke.rs
+++ b/resilient/tests/docs_tooling_cfg_paths_smoke.rs
@@ -1,0 +1,42 @@
+//! RES-3223: tooling docs cfg examples point at checkout-valid files.
+
+use std::path::Path;
+
+#[test]
+fn tooling_docs_use_existing_cfg_example_paths() {
+    let doc = include_str!("../../docs/tooling.md");
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("resilient crate has repo parent");
+
+    for expected in [
+        "rz --feature verbose resilient/examples/cfg_feature.rz",
+        "rz --target thumbv7em resilient/examples/cfg_target.rz",
+        "rz --cfg mode=demo resilient/examples/cfg_kv_demo.rz",
+    ] {
+        assert!(
+            doc.contains(expected),
+            "tooling docs missing checkout-valid cfg command {expected:?}"
+        );
+    }
+    for path in [
+        "resilient/examples/cfg_feature.rz",
+        "resilient/examples/cfg_target.rz",
+        "resilient/examples/cfg_kv_demo.rz",
+    ] {
+        assert!(
+            repo_root.join(path).is_file(),
+            "documented cfg example should exist: {path}"
+        );
+    }
+    for retired in [
+        "rz --feature verbose examples/cfg_feature.rz",
+        "rz --target thumbv7em examples/cfg_target.rz",
+        "rz --cfg mode=demo examples/cfg_kv_demo.rz",
+    ] {
+        assert!(
+            !doc.contains(retired),
+            "tooling docs should not use non-checkout-root cfg path {retired:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3223.

## Summary

- Update cfg examples in docs/tooling.md to use checkout-valid `resilient/examples/...` paths.
- Preserve the existing cfg flag guidance.
- Add focused docs smoke coverage that also checks the referenced files exist.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_tooling_cfg_paths_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/docs_tooling_cfg_paths_smoke.rs` to pin checkout-valid cfg example commands.
