### PR TITLE
RES-3224: use existing example path on landing page

### DIFF
--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -512,7 +512,7 @@
       <span class="rl-cta__prompt">$</span>
 <pre class="rl-cta__cmd">git clone https://github.com/EricSpencer00/Resilient.git
 cd Resilient &amp;&amp; cargo install --path resilient
-rz examples/altitude_controller.rz</pre>
+rz resilient/examples/sensor_monitor.rz</pre>
       <button class="rl-cta__copy" aria-label="Copy install command">copy</button>
     </div>
 

--- a/resilient/tests/docs_landing_example_path_smoke.rs
+++ b/resilient/tests/docs_landing_example_path_smoke.rs
@@ -1,0 +1,27 @@
+//! RES-3224: landing page copy uses a checkout-valid run command.
+
+use std::path::Path;
+
+#[test]
+fn landing_page_run_command_points_at_existing_example() {
+    let html = include_str!("../../docs/_layouts/landing.html");
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("resilient crate has repo parent");
+
+    let command = "rz resilient/examples/sensor_monitor.rz";
+    assert!(
+        html.contains(command),
+        "landing page should show checkout-valid run command {command:?}"
+    );
+    assert!(
+        repo_root
+            .join("resilient/examples/sensor_monitor.rz")
+            .is_file(),
+        "landing page run command should reference an existing example"
+    );
+    assert!(
+        !html.contains("rz examples/altitude_controller.rz"),
+        "landing page should not show a missing example path"
+    );
+}


### PR DESCRIPTION
Closes #3224.

## Summary

- Update the landing-page install/run command to use the existing `resilient/examples/sensor_monitor.rz` path.
- Keep the surrounding layout and visual copy unchanged.
- Add focused docs smoke coverage that checks the command text and verifies the referenced example exists.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_landing_example_path_smoke -- --nocapture`

## Render note

- Attempted `bundle exec jekyll build --source docs --destination /tmp/resilient-site-3224`, but this environment does not have the Jekyll executable installed in the bundle (`bundler: command not found: jekyll`).
- Attempted a Playwright browser path through the available Node runtime, but `playwright` is not installed.
- The new smoke test pins the rendered HTML source text and validates the referenced checkout path exists.

## Test changes

- Added `resilient/tests/docs_landing_example_path_smoke.rs` to pin the landing-page run command.
