### PR TITLE
RES-3227: use checkout-valid hello path in syntax docs

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -1201,7 +1201,7 @@ unaffected by this flag.
 After installing `rz` (see [README's Getting Started](README.md#getting-started)):
 
 ```bash
-rz examples/hello.rz                   # run a program
+rz resilient/examples/hello.rz         # run a program
 rz --typecheck foo.rz                  # with type checking
 rz                                     # interactive REPL
 ```

--- a/resilient/tests/docs_syntax_hello_path_smoke.rs
+++ b/resilient/tests/docs_syntax_hello_path_smoke.rs
@@ -1,0 +1,25 @@
+//! RES-3227: SYNTAX.md uses a checkout-valid hello example path.
+
+use std::path::Path;
+
+#[test]
+fn syntax_docs_use_checkout_valid_hello_path() {
+    let doc = include_str!("../../SYNTAX.md");
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("resilient crate has repo parent");
+
+    let command = "rz resilient/examples/hello.rz";
+    assert!(
+        doc.contains(command),
+        "SYNTAX.md should show checkout-valid hello command {command:?}"
+    );
+    assert!(
+        repo_root.join("resilient/examples/hello.rz").is_file(),
+        "documented hello example should exist"
+    );
+    assert!(
+        !doc.contains("rz examples/hello.rz"),
+        "SYNTAX.md should not show a non-checkout-root hello path"
+    );
+}


### PR DESCRIPTION
Closes #3227.

## Summary

- Update SYNTAX.md to use the checkout-valid `resilient/examples/hello.rz` path.
- Preserve the surrounding compiling/running guidance.
- Add focused docs smoke coverage that checks the referenced example exists.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_syntax_hello_path_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/docs_syntax_hello_path_smoke.rs` to pin the SYNTAX.md hello run command.
