### PR TITLE
RES-3229: update manifest example extension comment

### DIFF
--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.2.0"
 edition = "2024"
 description = "A programming language designed for extreme reliability in embedded and safety-critical systems"
 authors = ["Eric Spencer"]
-# `examples/*.rs` holds Resilient-language source files (they use the `.rs`
-# extension for editor support), not Rust. Disable Cargo's auto-discovery so
-# it doesn't try to build them as Rust examples.
+# `examples/*.rz` holds Resilient-language source files, not Rust examples.
+# Disable Cargo's auto-discovery so it doesn't try to build example sidecars
+# or future helper files as Rust examples.
 autoexamples = false
 
 # RES-510: the compiler is exposed as both a library and a binary.

--- a/resilient/tests/manifest_example_extension_comment_smoke.rs
+++ b/resilient/tests/manifest_example_extension_comment_smoke.rs
@@ -1,0 +1,19 @@
+//! RES-3229: manifest comments describe the current `.rz` example corpus.
+
+#[test]
+fn manifest_example_comment_uses_current_extension() {
+    let manifest = include_str!("../Cargo.toml");
+
+    assert!(
+        manifest.contains("`examples/*.rz` holds Resilient-language source files"),
+        "manifest should describe the current .rz example corpus"
+    );
+    assert!(
+        manifest.contains("autoexamples = false"),
+        "manifest should still disable Cargo example auto-discovery"
+    );
+    assert!(
+        !manifest.contains("`examples/*.rs` holds Resilient-language source files"),
+        "manifest should not mention the retired .rs example corpus"
+    );
+}


### PR DESCRIPTION
Closes #3229.

## Summary

- Update the resilient crate manifest comment to describe the current `.rz` example corpus.
- Preserve `autoexamples = false` and package metadata unchanged.
- Add focused smoke coverage for the contributor-facing manifest copy.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test manifest_example_extension_comment_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/manifest_example_extension_comment_smoke.rs` to pin the manifest example-extension comment.
