### PR TITLE
RES-3233: update E0010 verifier wording

### DIFF
--- a/docs/errors/E0010.md
+++ b/docs/errors/E0010.md
@@ -19,8 +19,8 @@ A `requires` or `ensures` clause evaluated to false at runtime.
 is checked after with `result` bound to the return value. When
 the clause evaluates to `false`, the runtime aborts with E0010
 and names the clause that failed. Programs run through
-`resilient verify` can lift these to compile-time Z3 checks
-instead.
+`rz --audit` on a binary built with `--features z3` can lift
+these to compile-time Z3 checks instead.
 
 ## Minimal example
 

--- a/resilient/tests/docs_error_e0010_verify_copy_smoke.rs
+++ b/resilient/tests/docs_error_e0010_verify_copy_smoke.rs
@@ -1,0 +1,15 @@
+//! RES-3233: E0010 docs use current verifier/audit wording.
+
+#[test]
+fn e0010_docs_use_rz_audit_for_z3_checking() {
+    let doc = include_str!("../../docs/errors/E0010.md");
+
+    assert!(
+        doc.contains("`rz --audit` on a binary built with `--features z3`"),
+        "E0010 docs should describe the current rz audit verifier path"
+    );
+    assert!(
+        !doc.contains("`resilient verify`"),
+        "E0010 docs should not mention the retired resilient verify command"
+    );
+}


### PR DESCRIPTION
Closes #3233.

## Summary

- Replace stale `resilient verify` wording in E0010 docs with current `rz --audit` verifier wording.
- Preserve the Z3 build prerequisite in the error explanation.
- Add focused docs smoke coverage to block the retired command phrase.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_error_e0010_verify_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/docs_error_e0010_verify_copy_smoke.rs` to pin the E0010 verifier wording.
