### PR TITLE
RES-3235: align error docs with rz copy

### DIFF
--- a/docs/errors/E0001.md
+++ b/docs/errors/E0001.md
@@ -23,14 +23,14 @@ followed by another literal with no operator between them.
 
 ## Minimal example
 
-```rs
+```resilient
 let x = 1 1;
 ```
 
 Output:
 
 ```text
-scratch.rs:1:11: error[E0001]: unexpected token
+scratch.rz:1:11: error[E0001]: unexpected token
    let x = 1 1;
              ^
 ```
@@ -41,7 +41,7 @@ Introduce the missing operator, separator, or keyword. The
 parser points at the token that didn't fit — walk backwards
 from there to find what's missing.
 
-```rs
+```resilient
 let x = 1 + 1;
 ```
 

--- a/docs/errors/E0002.md
+++ b/docs/errors/E0002.md
@@ -23,7 +23,7 @@ surfaces E0002.
 
 ## Minimal example
 
-```rs
+```resilient
 fn main() {
     let x = 1
     let y = 2;
@@ -33,7 +33,7 @@ fn main() {
 Output:
 
 ```text
-scratch.rs:3:5: error[E0002]: expected `;` after let binding
+scratch.rz:3:5: error[E0002]: expected `;` after let binding
    let y = 2;
    ^
 ```
@@ -42,7 +42,7 @@ scratch.rs:3:5: error[E0002]: expected `;` after let binding
 
 Add the missing `;` at the end of the statement that wanted one:
 
-```rs
+```resilient
 fn main() {
     let x = 1;
     let y = 2;

--- a/docs/errors/E0003.md
+++ b/docs/errors/E0003.md
@@ -22,7 +22,7 @@ pointing at the unclosed opener.
 
 ## Minimal example
 
-```rs
+```resilient
 fn main() {
     let xs = [1, 2, 3;
 }
@@ -31,7 +31,7 @@ fn main() {
 Output:
 
 ```text
-scratch.rs:2:14: error[E0003]: unclosed `[`
+scratch.rz:2:14: error[E0003]: unclosed `[`
    let xs = [1, 2, 3;
             ^
 ```
@@ -41,7 +41,7 @@ scratch.rs:2:14: error[E0003]: unclosed `[`
 Close every delimiter you open. Editors with bracket-pair
 highlighting make this easy to spot.
 
-```rs
+```resilient
 fn main() {
     let xs = [1, 2, 3];
 }

--- a/docs/errors/E0004.md
+++ b/docs/errors/E0004.md
@@ -22,7 +22,7 @@ scope references land here.
 
 ## Minimal example
 
-```rs
+```resilient
 fn main() {
     let x = 1;
     return y;
@@ -32,7 +32,7 @@ fn main() {
 Output:
 
 ```text
-scratch.rs:3:12: error[E0004]: unknown identifier `y`
+scratch.rz:3:12: error[E0004]: unknown identifier `y`
    return y;
           ^
 ```
@@ -43,7 +43,7 @@ Declare the name or fix the typo. If you meant a builtin, check
 the spelling — builtin names are case-sensitive (`println`, not
 `Println`).
 
-```rs
+```resilient
 fn main() {
     let y = 1;
     return y;

--- a/docs/errors/E0005.md
+++ b/docs/errors/E0005.md
@@ -23,7 +23,7 @@ generic unknown-identifier error wouldn't.
 
 ## Minimal example
 
-```rs
+```resilient
 fn main() {
     return helper(1);
 }
@@ -32,7 +32,7 @@ fn main() {
 Output:
 
 ```text
-scratch.rs:2:12: error[E0005]: unknown function `helper`
+scratch.rz:2:12: error[E0005]: unknown function `helper`
    return helper(1);
           ^
 ```
@@ -41,7 +41,7 @@ scratch.rs:2:12: error[E0005]: unknown function `helper`
 
 Declare the function, import it, or correct the spelling.
 
-```rs
+```resilient
 fn helper(int n) -> int { return n + 1; }
 fn main() {
     return helper(1);

--- a/docs/errors/E0006.md
+++ b/docs/errors/E0006.md
@@ -22,7 +22,7 @@ many arguments is rejected at compile time.
 
 ## Minimal example
 
-```rs
+```resilient
 fn add(int a, int b) -> int {
     return a + b;
 }
@@ -34,7 +34,7 @@ fn main() {
 Output:
 
 ```text
-scratch.rs:5:12: error[E0006]: call to `add` has 1 args, expected 2
+scratch.rz:5:12: error[E0006]: call to `add` has 1 args, expected 2
    return add(1);
           ^
 ```
@@ -44,7 +44,7 @@ scratch.rs:5:12: error[E0006]: call to `add` has 1 args, expected 2
 Pass the right number of arguments. If you genuinely want
 defaults, declare a second function that fills them in:
 
-```rs
+```resilient
 fn add_one(int a) -> int { return add(a, 1); }
 ```
 

--- a/docs/errors/E0007.md
+++ b/docs/errors/E0007.md
@@ -23,7 +23,7 @@ all surface here.
 
 ## Minimal example
 
-```rs
+```resilient
 fn main() {
     let x: int = "hi";
     return 0;
@@ -33,7 +33,7 @@ fn main() {
 Output:
 
 ```text
-scratch.rs:2:18: error[E0007]: type mismatch: expected `int`, got `String`
+scratch.rz:2:18: error[E0007]: type mismatch: expected `int`, got `String`
    let x: int = "hi";
                 ^^^^
 ```
@@ -44,7 +44,7 @@ Change one side to match the other. If you meant to parse /
 convert, call the matching builtin (`to_int`, `to_float`,
 etc.).
 
-```rs
+```resilient
 fn main() {
     let x: int = 42;
     return 0;

--- a/docs/errors/E0008.md
+++ b/docs/errors/E0008.md
@@ -23,7 +23,7 @@ check happens in all three backends (interpreter, VM, JIT).
 
 ## Minimal example
 
-```rs
+```resilient
 fn main() {
     let n = 0;
     return 100 / n;
@@ -33,7 +33,7 @@ fn main() {
 Output:
 
 ```text
-scratch.rs:3:12: error[E0008]: division by zero
+scratch.rz:3:12: error[E0008]: division by zero
    return 100 / n;
           ^^^^^^^
 ```
@@ -45,7 +45,7 @@ Guard the divisor before the operation, or add a `requires n !=
 out. For programs you want Z3-verified ahead of time, see
 [Verifying with Z3](../tutorial/05-verifying-with-z3).
 
-```rs
+```resilient
 fn main() {
     let n = 0;
     if n == 0 {

--- a/docs/errors/E0009.md
+++ b/docs/errors/E0009.md
@@ -22,7 +22,7 @@ runtime; no silent out-of-bounds reads, no undefined behaviour.
 
 ## Minimal example
 
-```rs
+```resilient
 fn main() {
     let xs = [1, 2, 3];
     return xs[5];
@@ -32,7 +32,7 @@ fn main() {
 Output:
 
 ```text
-scratch.rs:3:12: error[E0009]: array index 5 out of bounds for length 3
+scratch.rz:3:12: error[E0009]: array index 5 out of bounds for length 3
    return xs[5];
           ^^^^^
 ```
@@ -43,7 +43,7 @@ Guard the index. `len(xs)` returns the current length; pair it
 with a runtime check or, better, a `requires i < len(xs)`
 contract so the bound is lifted to compile time.
 
-```rs
+```resilient
 fn main() {
     let xs = [1, 2, 3];
     let i = 1;

--- a/docs/errors/E0010.md
+++ b/docs/errors/E0010.md
@@ -24,7 +24,7 @@ these to compile-time Z3 checks instead.
 
 ## Minimal example
 
-```rs
+```resilient
 fn halve(int n) -> int
     requires n >= 0
 {
@@ -38,7 +38,7 @@ fn main() {
 Output:
 
 ```text
-scratch.rs:2:18: error[E0010]: contract violation in fn halve: requires n >= 0 failed
+scratch.rz:2:18: error[E0010]: contract violation in fn halve: requires n >= 0 failed
     requires n >= 0
              ^^^^^^
 ```
@@ -52,7 +52,7 @@ how the clause is written, the
 through how to prove clauses ahead of time so violations
 become impossible, not just reported.
 
-```rs
+```resilient
 fn halve(int n) -> int
     requires n >= 0
 {

--- a/resilient/tests/docs_error_example_copy_smoke.rs
+++ b/resilient/tests/docs_error_example_copy_smoke.rs
@@ -1,0 +1,36 @@
+//! RES-3235: error docs use Resilient snippets and `.rz` diagnostics.
+
+const ERROR_DOCS: [(&str, &str); 10] = [
+    ("E0001", include_str!("../../docs/errors/E0001.md")),
+    ("E0002", include_str!("../../docs/errors/E0002.md")),
+    ("E0003", include_str!("../../docs/errors/E0003.md")),
+    ("E0004", include_str!("../../docs/errors/E0004.md")),
+    ("E0005", include_str!("../../docs/errors/E0005.md")),
+    ("E0006", include_str!("../../docs/errors/E0006.md")),
+    ("E0007", include_str!("../../docs/errors/E0007.md")),
+    ("E0008", include_str!("../../docs/errors/E0008.md")),
+    ("E0009", include_str!("../../docs/errors/E0009.md")),
+    ("E0010", include_str!("../../docs/errors/E0010.md")),
+];
+
+#[test]
+fn error_docs_use_resilient_fences_and_rz_filenames() {
+    for (code, doc) in ERROR_DOCS {
+        assert!(
+            doc.contains("```resilient"),
+            "{code} should mark language snippets as resilient"
+        );
+        assert!(
+            !doc.contains("```rs"),
+            "{code} should not use Rust-flavored fences for Resilient snippets"
+        );
+        assert!(
+            doc.contains("scratch.rz:"),
+            "{code} should report diagnostics against a .rz file"
+        );
+        assert!(
+            !doc.contains("scratch.rs"),
+            "{code} should not report diagnostics against a .rs file"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3235

Summary:
- Mark error-reference snippets as resilient instead of rs.
- Update diagnostic examples from scratch.rs to scratch.rz.
- Add a smoke test covering the error-doc copy contract.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test docs_error_example_copy_smoke -- --nocapture