### PR TITLE
RES-3239: refresh README release tag examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ curl -fsSL https://raw.githubusercontent.com/EricSpencer00/Resilient/main/script
 
 Then add `~/.rz/bin` to `PATH` (the script prints the exact line for your
 shell). For a system-wide install: `RZ_PREFIX=/usr/local sudo bash`.
-Pin a version with `RZ_VERSION=v0.1.0 …`.
+Pin a version with `RZ_VERSION=v0.2.0 …`.
 
 #### Pre-built binaries
 
@@ -201,7 +201,7 @@ Grab the archive matching your platform from the
 extract `rz`, and put it on `PATH`:
 
 ```bash
-TAG=v0.1.0  # see the releases page for the latest
+TAG=v0.2.0  # see the releases page for the latest
 TARGET=aarch64-apple-darwin  # or x86_64-apple-darwin / *-unknown-linux-gnu
 curl -fSL "https://github.com/EricSpencer00/Resilient/releases/download/${TAG}/rz-${TAG}-${TARGET}.tar.gz" \
     | tar xz -C /usr/local/bin

--- a/resilient/tests/readme_install_release_tag_smoke.rs
+++ b/resilient/tests/readme_install_release_tag_smoke.rs
@@ -1,0 +1,23 @@
+//! RES-3239: README install examples point at the current release tag.
+
+#[test]
+fn readme_install_examples_use_current_release_tag() {
+    let readme = include_str!("../../README.md");
+
+    assert!(
+        readme.contains("Pin a version with `RZ_VERSION=v0.2.0"),
+        "README should show the current release in the one-liner pin example"
+    );
+    assert!(
+        readme.contains("TAG=v0.2.0  # see the releases page for the latest"),
+        "README should show the current release in the pre-built binary example"
+    );
+    assert!(
+        !readme.contains("RZ_VERSION=v0.1.0"),
+        "README should not suggest the stale v0.1.0 pin"
+    );
+    assert!(
+        !readme.contains("TAG=v0.1.0"),
+        "README should not suggest the stale v0.1.0 archive tag"
+    );
+}


### PR DESCRIPTION
Closes #3239

Summary:
- Update README install pin examples from v0.1.0 to v0.2.0.
- Add a smoke test covering the README release-tag copy.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test readme_install_release_tag_smoke -- --nocapture