### PR TITLE
RES-3241: use rz import path in language reference

### DIFF
--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -613,7 +613,7 @@ calls observe the value left by the previous call.
 
 ### `use` semantics
 
-`use "path/to/file.rs";` is a textual splice performed by the
+`use "path/to/file.rz";` is a textual splice performed by the
 importer *before* parsing of the importing file completes — the
 imported file's top-level declarations become part of the importing
 file. Imports are resolved relative to the importing file's

--- a/resilient/tests/docs_language_reference_use_path_smoke.rs
+++ b/resilient/tests/docs_language_reference_use_path_smoke.rs
@@ -1,0 +1,15 @@
+//! RES-3241: language reference import examples use `.rz` paths.
+
+#[test]
+fn language_reference_use_semantics_use_rz_paths() {
+    let doc = include_str!("../../docs/language-reference.md");
+
+    assert!(
+        doc.contains("`use \"path/to/file.rz\";` is a textual splice"),
+        "language reference should show a .rz import path"
+    );
+    assert!(
+        !doc.contains("path/to/file.rs"),
+        "language reference should not show a Rust file extension for imports"
+    );
+}


### PR DESCRIPTION
Closes #3241

Summary:
- Update the language-reference `use` example from path/to/file.rs to path/to/file.rz.
- Add a smoke test covering the import-path copy.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test docs_language_reference_use_path_smoke -- --nocapture