### PR TITLE
RES-3243: polish philosophy code examples

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -51,7 +51,7 @@ caller's perspective, the live block either eventually
 succeeds or escalates after exhausting its retry budget. The
 unhappy path is the runtime's problem, not the programmer's.
 
-```rust
+```resilient
 live {
     let frame = read_sensor();        // may transient-fail
     assert(is_valid(frame), "bad frame");
@@ -79,7 +79,7 @@ clause at compile time. With `--features z3`, hard clauses
 get dispatched to Z3. What can't be proven becomes a runtime
 check — same semantics, different cost.
 
-```rust
+```resilient
 fn safe_div(int a, int b)
     requires b != 0
     ensures  result * b == a
@@ -95,7 +95,7 @@ to trust the Resilient binary — they re-run the proof under
 any compatible solver and confirm the answer themselves.
 
 ```bash
-cargo run --features z3 -- --emit-certificate ./certs prog.rz
+cargo run --manifest-path resilient/Cargo.toml --features z3 -- --emit-certificate ./certs prog.rz
 z3 -smt2 ./certs/safe_div__post__0.smt2
 # unsat
 ```

--- a/resilient/tests/docs_philosophy_copy_smoke.rs
+++ b/resilient/tests/docs_philosophy_copy_smoke.rs
@@ -1,0 +1,23 @@
+//! RES-3243: philosophy docs use Resilient fences and root-safe commands.
+
+#[test]
+fn philosophy_docs_use_resilient_fences_and_root_safe_cargo() {
+    let doc = include_str!("../../docs/philosophy.md");
+
+    assert!(
+        doc.contains("```resilient\nlive {"),
+        "live-block example should be fenced as Resilient"
+    );
+    assert!(
+        doc.contains("```resilient\nfn safe_div"),
+        "contract example should be fenced as Resilient"
+    );
+    assert!(
+        doc.contains("cargo run --manifest-path resilient/Cargo.toml --features z3 -- --emit-certificate ./certs prog.rz"),
+        "certificate command should be runnable from the repository root"
+    );
+    assert!(
+        !doc.contains("cargo run --features z3 -- --emit-certificate"),
+        "docs should not assume the reader is already inside resilient/"
+    );
+}


### PR DESCRIPTION
Closes #3243

Summary:
- Fence philosophy-page Resilient snippets as resilient instead of rust.
- Make the Z3 certificate cargo command root-safe with --manifest-path resilient/Cargo.toml.
- Add a smoke test covering the philosophy-page copy contract.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test docs_philosophy_copy_smoke -- --nocapture