### PR TITLE
RES-3245: update README workspace copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,10 +495,11 @@ fn main() -> ! {
 }
 ```
 
-The `resilient/` crate is unaffected — it stays a single-crate
-project; `resilient-runtime/` is a separate Cargo project alongside
-it. A future ticket can promote both to a workspace if there's a
-real reason (shared profile config, cross-crate testing).
+The root Cargo workspace keeps `resilient/`, `resilient-runtime/`,
+and `resilient-span/` as separate packages while sharing profile
+settings and a single target directory. `resilient-runtime/` remains
+the no-std runtime package that embedded applications can depend on
+directly.
 
 See [`resilient-runtime-cortex-m-demo/`](resilient-runtime-cortex-m-demo/)
 for a buildable example that links the runtime with an

--- a/resilient/tests/readme_workspace_copy_smoke.rs
+++ b/resilient/tests/readme_workspace_copy_smoke.rs
@@ -1,0 +1,23 @@
+//! RES-3245: README runtime docs describe the current Cargo workspace.
+
+#[test]
+fn readme_runtime_section_mentions_current_workspace() {
+    let readme = include_str!("../../README.md");
+
+    assert!(
+        readme.contains("The root Cargo workspace keeps `resilient/`, `resilient-runtime/`,"),
+        "README should describe the existing workspace root"
+    );
+    assert!(
+        readme.contains("and `resilient-span/` as separate packages"),
+        "README should name the current workspace member crates"
+    );
+    assert!(
+        readme.contains("`resilient-runtime/` remains"),
+        "README should still identify resilient-runtime as the no-std runtime package"
+    );
+    assert!(
+        !readme.contains("A future ticket can promote both to a workspace"),
+        "README should not describe the existing workspace as future work"
+    );
+}


### PR DESCRIPTION
Closes #3245

Summary:
- Replace stale future-work workspace wording in README.md.
- Describe the current root Cargo workspace and member crates.
- Add a smoke test covering the README workspace copy contract.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test readme_workspace_copy_smoke -- --nocapture