### PR TITLE
RES-3247: replace stale README goalpost ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,13 +869,10 @@ calls); for one-shot arithmetic the VM is the right backend.
 
 ### What's next
 
-- G4 (full source spans with snippets / carets)
-- G5 (replace hand-rolled lexer with `logos`)
-- G6 (one canonical AST, retire the unwired `parser.rs`)
-- G7 (real type checker: inference, unification, exhaustiveness)
-- G8–G10 (function contracts, symbolic assert, live-block invariants)
-- G11+ (stdlib, structs, pattern matching, cranelift backend, LSP,
-  `no_std`, self-hosting)
+Current priorities live in [ROADMAP.md](ROADMAP.md) and the
+[GitHub issue queue](https://github.com/EricSpencer00/Resilient/issues).
+Use the roadmap for the goalpost ladder and issues for active,
+ticket-sized work.
 
 ### Self-hosting progress (G20)
 

--- a/resilient/tests/readme_project_status_copy_smoke.rs
+++ b/resilient/tests/readme_project_status_copy_smoke.rs
@@ -1,0 +1,22 @@
+//! RES-3247: README project status points to live planning sources.
+
+#[test]
+fn readme_project_status_uses_live_planning_sources() {
+    let readme = include_str!("../../README.md");
+
+    assert!(
+        readme.contains("Current priorities live in [ROADMAP.md](ROADMAP.md)")
+            && readme.contains("GitHub issue queue"),
+        "README should point readers to live planning sources"
+    );
+    assert!(
+        readme.contains("Use the roadmap for the goalpost ladder"),
+        "README should explain how to use the roadmap"
+    );
+    for stale_goalpost in ["G4 (", "G5 (", "G6 (", "G7 (", "G8\u{2013}G10", "G11+"] {
+        assert!(
+            !readme.contains(stale_goalpost),
+            "README should not list stale static goalpost {stale_goalpost:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3247

Summary:
- Replace the stale static G4/G5/G6/G7/G8-G10/G11+ README ladder.
- Point current priorities to ROADMAP.md and the live GitHub issue queue.
- Add a smoke test covering the README project-status copy contract.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test readme_project_status_copy_smoke -- --nocapture