### PR TITLE
RES-3249: update README self-hosting status

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,23 +876,22 @@ ticket-sized work.
 
 ### Self-hosting progress (G20)
 
-G20 is a long arc. The first milestone is a Resilient program
-that can lex Resilient source.
+G20 is a long arc. The tree keeps the original RES-196 lexer
+prototype for history, and the current parity harness now
+cross-checks self-hosted front-end pieces against the Rust front end.
 
-- **RES-196** — [`self-host/lex.rs`](./self-host/lex.rs): a byte-
-  level lexer for a restricted subset of the language, written
-  in Resilient itself. Recognizes identifiers, integer + string
-  literals, the `fn` / `let` / `return` / `if` / `else` / `while` /
-  `true` / `false` keywords, single-char punctuation,
-  single-char operators, the two-char comparison / logical
-  operators, and `//` line comments. Whitespace-skipping with
-  line / column tracking.
+- **RES-196 prototype** — [`self-host/lex.rs`](./self-host/lex.rs)
+  plus [`self-host/run.sh`](./self-host/run.sh) remains the first
+  proof that Resilient could express a lexer at all.
+- **Current parity path** — [`self-host/lexer.rz`](./self-host/lexer.rz)
+  and [`self-host/parser.rz`](./self-host/parser.rz) run against
+  `self-host/parity_corpus/` through:
 
-  Run it: `./self-host/run.sh` (diffs output against
-  [`self-host/hello.tokens.txt`](./self-host/hello.tokens.txt)).
+  ```bash
+  cargo test --manifest-path resilient/Cargo.toml --test self_host_parity
+  ```
 
-  Not in CI — informative only until the self-hosted toolchain
-  becomes load-bearing. See the source file's top-comment for
-  the feature gaps (multiline strings, block comments, `live`
-  contracts, float / bytes literals) and the parser workarounds
-  the prototype needed to land today.
+  For a contributor-facing coverage artifact, run
+  `rz self-host-parity-report --json-out artifacts/self-host-parity.json`.
+  See [`self-host/README.md`](./self-host/README.md) for the harness
+  details and current coverage limits.

--- a/resilient/tests/readme_self_hosting_status_smoke.rs
+++ b/resilient/tests/readme_self_hosting_status_smoke.rs
@@ -1,0 +1,24 @@
+//! RES-3249: README self-hosting status reflects the current parity harness.
+
+#[test]
+fn readme_self_hosting_section_mentions_current_parity_harness() {
+    let readme = include_str!("../../README.md");
+
+    for expected in [
+        "`self-host/lexer.rz`",
+        "`self-host/parser.rz`",
+        "cargo test --manifest-path resilient/Cargo.toml --test self_host_parity",
+        "rz self-host-parity-report --json-out artifacts/self-host-parity.json",
+        "`self-host/lex.rs`",
+        "`self-host/README.md`",
+    ] {
+        assert!(
+            readme.contains(expected),
+            "README self-hosting section missing {expected:?}"
+        );
+    }
+    assert!(
+        !readme.contains("Not in CI"),
+        "README should not describe the self-hosting harness as outside CI"
+    );
+}


### PR DESCRIPTION
Closes #3249

Summary:
- Update README self-hosting progress to describe the current lexer/parser parity harness.
- Preserve RES-196 lex.rs as historical context.
- Add a smoke test covering the README self-hosting status copy.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test readme_self_hosting_status_smoke -- --nocapture