### PR TITLE
RES-3251: update self-host parser docs

### DIFF
--- a/resilient/tests/self_host_readme_parser_status_smoke.rs
+++ b/resilient/tests/self_host_readme_parser_status_smoke.rs
@@ -1,0 +1,27 @@
+//! RES-3251: self-host README treats parser.rz as a current artifact.
+
+#[test]
+fn self_host_readme_lists_parser_as_current_artifact() {
+    let doc = include_str!("../../self-host/README.md");
+
+    assert!(
+        doc.contains("Three artifact generations live here"),
+        "self-host README should describe the current artifact count"
+    );
+    assert!(
+        doc.contains("`parser.rz` + `parser_tests/` + `parity_corpus/`"),
+        "self-host README should list parser.rz in the artifact table"
+    );
+    assert!(
+        doc.contains("`parser.rz` exists and is covered by"),
+        "self-host README should frame parser work as present but expanding"
+    );
+    assert!(
+        !doc.contains("Two artifacts live here"),
+        "self-host README should not say only two artifacts exist"
+    );
+    assert!(
+        !doc.contains("Self-hosting parser** is tracked as the follow-up"),
+        "self-host README should not describe parser.rz as future-only"
+    );
+}

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -1,11 +1,12 @@
 # self-host/ — Resilient compiler in Resilient
 
-Two artifacts live here, in increasing scope:
+Three artifact generations live here, in increasing scope:
 
 | Path | Ticket | Scope |
 |---|---|---|
 | `lex.rs` + `hello.tokens.txt` + `run.sh` | RES-196 | Prototype lexer covering a restricted Resilient subset; one snapshot input (`hello.rz`). Goal was "prove the language can express scanning at all." |
 | `lexer.rz` + `lexer_tests/` + `lexer_check.sh` | RES-323 | Production-step-up lexer covering the verification surface (requires/ensures/invariant/assume/assert/...), block comments, escapes, hex/bin literals, and 2/3-char operators. |
+| `parser.rz` + `parser_tests/` + `parity_corpus/` | RES-379 | Self-hosted parser step that consumes lexer tokens and emits JSON for the curated success/error corpus checked by `self_host_parity`. |
 
 ## Running the RES-323 harness
 
@@ -104,5 +105,7 @@ the harness pass).
    — that would be a bigger lexer extension.
 2. **Multi-line strings.** If/when Resilient grows raw string
    literals, the `scan_string` function will need a separate path.
-3. **Self-hosting parser** is tracked as the follow-up [#171](https://github.com/EricSpencer00/Resilient/issues/171)
-   (RES-379). Sequenced after this lexer ships.
+3. **Parser coverage expansion.** `parser.rz` exists and is covered by
+   `self_host_parity` on the curated corpus. The next step is widening
+   grammar coverage and corpus breadth toward the stable language
+   surface.


### PR DESCRIPTION
Closes #3251

Summary:
- List parser.rz as a current self-host artifact in self-host/README.md.
- Reframe future parser work as coverage expansion instead of initial landing.
- Add a smoke test covering the self-host README parser status copy.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test self_host_readme_parser_status_smoke -- --nocapture