### PR TITLE
RES-3253: drop retired self-host res extension copy

### DIFF
--- a/resilient/tests/self_host_extension_copy_smoke.rs
+++ b/resilient/tests/self_host_extension_copy_smoke.rs
@@ -1,0 +1,24 @@
+//! RES-3253: self-host docs and comments use the current `.rz` extension.
+
+#[test]
+fn self_host_copy_uses_rz_extension() {
+    let readme = include_str!("../../self-host/README.md");
+    let lexer = include_str!("../../self-host/lexer.rz");
+
+    assert!(
+        readme.contains("Walk `resilient/examples/*.rz`"),
+        "self-host README should point at current .rz examples"
+    );
+    assert!(
+        lexer.contains("running `lexer.rz` directly"),
+        "self-host lexer comment should mention lexer.rz"
+    );
+    assert!(
+        !readme.contains("*.{rz,res}"),
+        "self-host README should not mention the retired .res extension"
+    );
+    assert!(
+        !lexer.contains("lexer.res"),
+        "self-host lexer comment should not mention the retired .res extension"
+    );
+}

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -98,7 +98,7 @@ the harness pass).
 
 ## What's next
 
-1. **All-examples sweep.** Walk `resilient/examples/*.{rz,res}` and
+1. **All-examples sweep.** Walk `resilient/examples/*.rz` and
    add a snapshot per file. Some inputs use string interpolation
    (`{...}` segments inside string literals) which the current
    self-hosted lexer does not yet decompose into nested expressions

--- a/self-host/lexer.rz
+++ b/self-host/lexer.rz
@@ -365,7 +365,7 @@ fn resolve_input_path() {
         return unwrap(r);
     }
     // Fallback keeps the harness usable when the env var isn't set
-    // (e.g. running `lexer.res` directly during local development).
+    // (e.g. running `lexer.rz` directly during local development).
     return "resilient/examples/hello.rz";
 }
 


### PR DESCRIPTION
Closes #3253

Summary:
- Update self-host/README.md all-examples sweep to use resilient/examples/*.rz.
- Update self-host/lexer.rz local-development comment from lexer.res to lexer.rz.
- Add a smoke test covering self-host extension copy.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test self_host_extension_copy_smoke -- --nocapture