### PR TITLE
RES-3255: document self-host input path

### DIFF
--- a/resilient/tests/self_host_readme_input_copy_smoke.rs
+++ b/resilient/tests/self_host_readme_input_copy_smoke.rs
@@ -1,0 +1,19 @@
+//! RES-3255: self-host README documents the current lexer input path.
+
+#[test]
+fn self_host_readme_uses_self_host_input_in_acceptance_table() {
+    let doc = include_str!("../../self-host/README.md");
+
+    assert!(
+        doc.contains("`SELF_HOST_INPUT=<input_file> rz self-host/lexer.rz`"),
+        "self-host README should label the supported env-var input path"
+    );
+    assert!(
+        doc.contains("env-var input is the current language-level substitute"),
+        "self-host README should explain why SELF_HOST_INPUT is used"
+    );
+    assert!(
+        !doc.contains("resilient run self-host/lexer.rz -- <input_file>"),
+        "self-host README should not document the retired resilient run shape"
+    );
+}

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -93,7 +93,7 @@ the harness pass).
 |---|---|
 | `self-host/lexer.rz` implements the complete Resilient lexer | 🟡 — covers significantly more than the RES-196 prototype (verification keywords, escapes, hex/bin, block comments, 3-char ops); full coverage matching every example in `resilient/examples/` is a follow-up |
 | Test harness compares against the Rust frontend on a representative corpus | ✅ — `cargo test --manifest-path resilient/Cargo.toml --test self_host_parity` cross-checks lexer parity, parser AST parity, and one diagnostic-path case |
-| `resilient run self-host/lexer.rz -- <input_file>` | ✅ — `SELF_HOST_INPUT` env var; CLI arg passing isn't a current language surface, env var is the idiomatic substitute |
+| `SELF_HOST_INPUT=<input_file> rz self-host/lexer.rz` | ✅ — env-var input is the current language-level substitute for CLI arg passing |
 | No new language features added to support this | ✅ — uses existing `file_read`, `env`, `is_ok`, `unwrap`, `split`, `push`, `len`, struct field access |
 
 ## What's next


### PR DESCRIPTION
Closes #3255

Summary:
- Update self-host/README.md acceptance mapping to lead with SELF_HOST_INPUT.
- Remove the retired resilient run command shape from that contributor doc.
- Add a smoke test covering the self-host input copy contract.

Verification:
- git diff --check
- cargo fmt --all --check
- cargo test --manifest-path resilient/Cargo.toml --test self_host_readme_input_copy_smoke -- --nocapture