### PR TITLE
RES-3257: clarify self-host lexer criterion

### DIFF
--- a/resilient/tests/self_host_readme_lexer_criterion_smoke.rs
+++ b/resilient/tests/self_host_readme_lexer_criterion_smoke.rs
@@ -1,0 +1,21 @@
+//! RES-3257: self-host README labels lexer coverage without overstating it.
+
+#[test]
+fn self_host_readme_lexer_criterion_matches_partial_coverage() {
+    let doc = include_str!("../../self-host/README.md");
+
+    assert!(
+        doc.contains("`self-host/lexer.rz` covers the curated lexer parity corpus"),
+        "self-host README should label the current lexer coverage goal"
+    );
+    assert!(
+        doc.contains(
+            "full coverage matching every example in `resilient/examples/` is a follow-up"
+        ),
+        "self-host README should keep the remaining lexer coverage explicit"
+    );
+    assert!(
+        !doc.contains("`self-host/lexer.rz` implements the complete Resilient lexer"),
+        "self-host README should not claim complete lexer coverage"
+    );
+}

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -91,7 +91,7 @@ the harness pass).
 
 | Criterion | State |
 |---|---|
-| `self-host/lexer.rz` implements the complete Resilient lexer | 🟡 — covers significantly more than the RES-196 prototype (verification keywords, escapes, hex/bin, block comments, 3-char ops); full coverage matching every example in `resilient/examples/` is a follow-up |
+| `self-host/lexer.rz` covers the curated lexer parity corpus | 🟡 — covers significantly more than the RES-196 prototype (verification keywords, escapes, hex/bin, block comments, 3-char ops); full coverage matching every example in `resilient/examples/` is a follow-up |
 | Test harness compares against the Rust frontend on a representative corpus | ✅ — `cargo test --manifest-path resilient/Cargo.toml --test self_host_parity` cross-checks lexer parity, parser AST parity, and one diagnostic-path case |
 | `SELF_HOST_INPUT=<input_file> rz self-host/lexer.rz` | ✅ — env-var input is the current language-level substitute for CLI arg passing |
 | No new language features added to support this | ✅ — uses existing `file_read`, `env`, `is_ok`, `unwrap`, `split`, `push`, `len`, struct field access |


### PR DESCRIPTION
## Summary

- Reword the self-host README acceptance criterion so it describes curated lexer parity coverage instead of claiming a complete lexer.
- Add a README smoke test that locks the corrected wording and rejects the stale complete-lexer claim.

Closes #3257.

## Test changes

- Added `self_host_readme_lexer_criterion_smoke.rs` to guard public docs wording for this current-status table.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test self_host_readme_lexer_criterion_smoke -- --nocapture`
