### PR TITLE
RES-3259: document LSP identifier hover

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -58,17 +58,20 @@ line 1, column 1 — finer-grained parser spans land in a follow-up.
 
 ### Hover
 
-Hovering over any **literal token** shows its type:
+Hovering over any **literal token** shows its surface type:
 
 | Literal | Hover shows |
 |---------|-------------|
-| `42`    | `int`       |
-| `3.14`  | `float`     |
-| `"hi"`  | `string`    |
-| `true`  | `bool`      |
+| `42`    | `Int`       |
+| `3.14`  | `Float`     |
+| `"hi"`  | `String`    |
+| `true`  | `Bool`      |
 
-Hover over identifiers (variables, functions) is a planned
-follow-up that depends on the full type-inference pass.
+Hovering over identifiers also returns current best-effort type or
+signature information for top-level `let`, `const`, `static let`,
+top-level function names, function parameters, and local `let`
+bindings. Names outside those supported scopes return no hover instead
+of a guessed type.
 
 ### Go-to-definition
 
@@ -139,7 +142,6 @@ highlighting alone provides.
 
 ## What's next
 
-- Hover for identifiers (variables, parameters, function names).
 - Scope-aware local-variable completion.
 - Post-dot field completion for structs.
 - Finer-grained parser error positions.

--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -5,9 +5,10 @@
 //! and publish diagnostics with source ranges derived from
 //! RES-077's per-statement `Spanned<Node>` wrappers.
 //!
-//! Nothing else yet — no hover, no completion, no go-to-definition.
-//! Those are dedicated follow-up tickets. This ticket is the
-//! scaffolding that makes an editor light up with red squiggles.
+//! The same server also exposes best-effort hover, completion,
+//! go-to-definition, references, semantic tokens, inlay hints, rename,
+//! document symbols, and code actions. Unsupported cursor positions
+//! return the normal empty/null LSP result instead of a guessed answer.
 //!
 //! The `mod lsp_server;` declaration in `main.rs` is already
 //! gated on `cfg(feature = "lsp")`, so this file is only compiled

--- a/resilient/tests/docs_lsp_identifier_hover_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_identifier_hover_copy_smoke.rs
@@ -1,0 +1,39 @@
+//! RES-3259: LSP docs describe implemented identifier hover support.
+
+#[test]
+fn lsp_docs_describe_current_identifier_hover_support() {
+    let docs = include_str!("../../docs/lsp.md");
+    let server = include_str!("../src/lsp_server.rs");
+
+    for expected in [
+        "| `42`    | `Int`",
+        "| `3.14`  | `Float`",
+        "| `\"hi\"`  | `String`",
+        "| `true`  | `Bool`",
+        "Hovering over identifiers also returns current best-effort type or",
+        "top-level `let`, `const`, `static let`",
+        "top-level function names, function parameters, and local `let`",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "LSP docs should describe current hover support; missing {expected:?}"
+        );
+    }
+
+    assert!(
+        !docs.contains("Hover over identifiers (variables, functions) is a planned"),
+        "LSP docs should not describe identifier hover as future-only"
+    );
+    assert!(
+        !docs.contains("- Hover for identifiers (variables, parameters, function names)."),
+        "LSP docs should not list implemented identifier hover as next work"
+    );
+    assert!(
+        server.contains("The same server also exposes best-effort hover"),
+        "LSP module header should mention current hover support"
+    );
+    assert!(
+        !server.contains("Nothing else yet — no hover, no completion, no go-to-definition."),
+        "LSP module header should not advertise the original minimum-viable scope"
+    );
+}


### PR DESCRIPTION
## Summary

- Update `docs/lsp.md` so hover docs match current literal and identifier hover behavior.
- Remove implemented identifier hover from the "What's next" list.
- Refresh the stale LSP module header that still described the original diagnostics-only scope.
- Add a docs smoke test to guard against reintroducing stale identifier-hover wording.

Closes #3259.

## Test changes

- Added `docs_lsp_identifier_hover_copy_smoke.rs` to pin current LSP docs/header copy.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_identifier_hover_copy_smoke -- --nocapture`
