### PR TITLE
RES-3261: document workspace goto support

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -76,8 +76,10 @@ of a guessed type.
 ### Go-to-definition
 
 Clicking "go to definition" on any **top-level function or struct
-name** jumps to its declaration site. Works across a single file;
-multi-file workspace lookup is a follow-up.
+name** jumps to its declaration site in the current file or an imported
+workspace file. Workspace lookup follows `use "..."` imports for
+top-level functions and structs, including unopened files under the
+initialized workspace folder.
 
 ### Completion
 
@@ -145,4 +147,3 @@ highlighting alone provides.
 - Scope-aware local-variable completion.
 - Post-dot field completion for structs.
 - Finer-grained parser error positions.
-- Multi-file workspace go-to-definition.

--- a/resilient/tests/docs_lsp_workspace_goto_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_workspace_goto_copy_smoke.rs
@@ -1,0 +1,27 @@
+//! RES-3261: LSP docs describe workspace go-to-definition support.
+
+#[test]
+fn lsp_docs_describe_workspace_go_to_definition_support() {
+    let docs = include_str!("../../docs/lsp.md");
+
+    for expected in [
+        "jumps to its declaration site in the current file or an imported",
+        "Workspace lookup follows `use \"...\"` imports",
+        "including unopened files under the",
+        "initialized workspace folder",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "LSP docs should describe workspace go-to-definition support; missing {expected:?}"
+        );
+    }
+
+    assert!(
+        !docs.contains("multi-file workspace lookup is a follow-up"),
+        "LSP docs should not describe workspace go-to-definition as future-only"
+    );
+    assert!(
+        !docs.contains("- Multi-file workspace go-to-definition."),
+        "LSP docs should not list implemented workspace go-to-definition as next work"
+    );
+}


### PR DESCRIPTION
## Summary

- Update `docs/lsp.md` so go-to-definition docs describe current workspace-import support.
- Remove implemented multi-file workspace go-to-definition from the "What's next" list.
- Add a docs smoke test to guard against the stale future-only wording.

Closes #3261.

## Test changes

- Added `docs_lsp_workspace_goto_copy_smoke.rs` to pin current go-to-definition docs copy.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_workspace_goto_copy_smoke -- --nocapture`
