### PR TITLE
RES-3263: document LSP references support

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -81,6 +81,19 @@ workspace file. Workspace lookup follows `use "..."` imports for
 top-level functions and structs, including unopened files under the
 initialized workspace folder.
 
+### Find references
+
+Running "find references" on a supported identifier returns LSP
+locations for:
+
+1. Top-level functions across the current file and imported workspace
+   files.
+2. Struct types across the current file and imported workspace files.
+3. Same-file variable declarations, reads, and writes.
+
+The client controls whether the declaration site is included through
+the standard `includeDeclaration` request flag.
+
 ### Completion
 
 Triggering completion offers:

--- a/resilient/tests/docs_lsp_references_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_references_copy_smoke.rs
@@ -1,0 +1,20 @@
+//! RES-3263: LSP docs describe implemented find-references support.
+
+#[test]
+fn lsp_docs_describe_find_references_support() {
+    let docs = include_str!("../../docs/lsp.md");
+
+    for expected in [
+        "### Find references",
+        "Running \"find references\" on a supported identifier returns LSP",
+        "Top-level functions across the current file and imported workspace",
+        "Struct types across the current file and imported workspace files.",
+        "Same-file variable declarations, reads, and writes.",
+        "standard `includeDeclaration` request flag",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "LSP docs should describe find-references support; missing {expected:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `Find references` section to `docs/lsp.md` for implemented `textDocument/references` support.
- Scope the docs to supported behavior: top-level functions/structs across workspace imports and same-file variable references.
- Add a docs smoke test to guard the new wording.

Closes #3263.

## Test changes

- Added `docs_lsp_references_copy_smoke.rs` to pin current find-references docs copy.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_references_copy_smoke -- --nocapture`
