### PR TITLE
RES-3265: document LSP inlay hints

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -155,6 +155,19 @@ highlighting alone provides.
 
 ---
 
+## Inlay hints
+
+The server advertises `textDocument/inlayHint` support. Type hints are
+enabled by default for inferred `let` bindings and omitted function
+return types, including anonymous function literals. Disable those
+hints with the initialization option
+`resilient.inlayHints.types: false`.
+
+Parameter hints for user-function call sites are opt-in. Enable them
+with `resilient.inlayHints.parameters: true`.
+
+---
+
 ## What's next
 
 - Scope-aware local-variable completion.

--- a/resilient/tests/docs_lsp_inlay_hints_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_inlay_hints_copy_smoke.rs
@@ -1,0 +1,22 @@
+//! RES-3265: LSP docs describe implemented inlay hint support.
+
+#[test]
+fn lsp_docs_describe_inlay_hint_support() {
+    let docs = include_str!("../../docs/lsp.md");
+
+    for expected in [
+        "## Inlay hints",
+        "The server advertises `textDocument/inlayHint` support.",
+        "enabled by default for inferred `let` bindings",
+        "omitted function",
+        "return types",
+        "`resilient.inlayHints.types: false`",
+        "Parameter hints for user-function call sites are opt-in.",
+        "`resilient.inlayHints.parameters: true`",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "LSP docs should describe inlay hint support; missing {expected:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add an `Inlay hints` section to `docs/lsp.md` for implemented `textDocument/inlayHint` support.
- Document default type hints, the type-hint disable option, and opt-in parameter hints.
- Add a docs smoke test to guard the new wording.

Closes #3265.

## Test changes

- Added `docs_lsp_inlay_hints_copy_smoke.rs` to pin current inlay hint docs copy.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_inlay_hints_copy_smoke -- --nocapture`
