### PR TITLE
RES-3267: document LSP rename support

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -94,6 +94,18 @@ locations for:
 The client controls whether the declaration site is included through
 the standard `includeDeclaration` request flag.
 
+### Rename
+
+Rename requests use `textDocument/prepareRename` first, so editors can
+reject unsupported cursor positions before prompting for a new name.
+Supported targets are top-level functions, top-level structs, and
+top-level `let`, `const`, or `static let` bindings.
+
+`textDocument/rename` validates the new identifier, rejects names that
+would shadow an existing visible top-level binding, and returns a
+workspace edit for matching references in open documents and workspace
+`.rz` files.
+
 ### Completion
 
 Triggering completion offers:

--- a/resilient/tests/docs_lsp_rename_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_rename_copy_smoke.rs
@@ -1,0 +1,23 @@
+//! RES-3267: LSP docs describe implemented rename support.
+
+#[test]
+fn lsp_docs_describe_rename_support() {
+    let docs = include_str!("../../docs/lsp.md");
+
+    for expected in [
+        "### Rename",
+        "Rename requests use `textDocument/prepareRename` first",
+        "Supported targets are top-level functions, top-level structs",
+        "top-level `let`, `const`, or `static let` bindings",
+        "`textDocument/rename` validates the new identifier",
+        "rejects names that",
+        "would shadow an existing visible top-level binding",
+        "workspace edit for matching references in open documents and workspace",
+        "`.rz` files",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "LSP docs should describe rename support; missing {expected:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `Rename` section to `docs/lsp.md` for current `prepareRename` / `rename` support.
- Document supported targets, new-name validation, shadow rejection, and workspace edit scope.
- Add a docs smoke test to guard the new wording.

Closes #3267.

## Test changes

- Added `docs_lsp_rename_copy_smoke.rs` to pin current rename docs copy.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_rename_copy_smoke -- --nocapture`
