### PR TITLE
RES-3269: document LSP symbol support

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -106,6 +106,14 @@ would shadow an existing visible top-level binding, and returns a
 workspace edit for matching references in open documents and workspace
 `.rz` files.
 
+### Symbols
+
+`textDocument/documentSymbol` returns a source-ordered outline for
+top-level functions, structs, and type aliases in the current file.
+
+`workspace/symbol` indexes `.rz` files under the initialized workspace
+folder and returns matching top-level symbols across those files.
+
 ### Completion
 
 Triggering completion offers:

--- a/resilient/tests/docs_lsp_symbols_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_symbols_copy_smoke.rs
@@ -1,0 +1,20 @@
+//! RES-3269: LSP docs describe implemented symbol support.
+
+#[test]
+fn lsp_docs_describe_symbol_support() {
+    let docs = include_str!("../../docs/lsp.md");
+
+    for expected in [
+        "### Symbols",
+        "`textDocument/documentSymbol` returns a source-ordered outline",
+        "top-level functions, structs, and type aliases",
+        "`workspace/symbol` indexes `.rz` files",
+        "under the initialized workspace",
+        "matching top-level symbols across those files",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "LSP docs should describe symbol support; missing {expected:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `Symbols` section to `docs/lsp.md` for document and workspace symbol support.
- Document file outlines for top-level functions, structs, and type aliases plus workspace `.rz` indexing.
- Add a docs smoke test to guard the new wording.

Closes #3269.

## Test changes

- Added `docs_lsp_symbols_copy_smoke.rs` to pin current symbol docs copy.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_symbols_copy_smoke -- --nocapture`
