### PR TITLE
RES-3271: document LSP code actions

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -114,6 +114,16 @@ top-level functions, structs, and type aliases in the current file.
 `workspace/symbol` indexes `.rz` files under the initialized workspace
 folder and returns matching top-level symbols across those files.
 
+### Code actions
+
+`textDocument/codeAction` offers quick fixes derived from diagnostics.
+Current actions include adding `requires true;` / `ensures true;`
+contract stubs for no-contract lint diagnostics, inserting a missing
+semicolon, suppressing lint diagnostics with `// resilient: allow`,
+prefixing unused variables or dead functions with `_`, adding numeric
+`as <type>` casts for type mismatches, and adding `use "..."` imports
+for undefined names found in the workspace index.
+
 ### Completion
 
 Triggering completion offers:

--- a/resilient/tests/docs_lsp_code_actions_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_code_actions_copy_smoke.rs
@@ -1,0 +1,26 @@
+//! RES-3271: LSP docs describe implemented code action quick fixes.
+
+#[test]
+fn lsp_docs_describe_code_action_support() {
+    let docs = include_str!("../../docs/lsp.md");
+
+    for expected in [
+        "### Code actions",
+        "`textDocument/codeAction` offers quick fixes derived from diagnostics.",
+        "adding `requires true;` / `ensures true;`",
+        "contract stubs for no-contract lint diagnostics",
+        "inserting a missing",
+        "semicolon",
+        "suppressing lint diagnostics with `// resilient: allow`",
+        "prefixing unused variables or dead functions with `_`",
+        "adding numeric",
+        "`as <type>` casts for type mismatches",
+        "adding `use \"...\"` imports",
+        "undefined names found in the workspace index",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "LSP docs should describe code action support; missing {expected:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `Code actions` section to `docs/lsp.md` for diagnostic-driven quick fixes.
- Document current quick-fix categories without promising speculative refactors.
- Add a docs smoke test to guard the new wording.

Closes #3271.

## Test changes

- Added `docs_lsp_code_actions_copy_smoke.rs` to pin current code-action docs copy.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_code_actions_copy_smoke -- --nocapture`
