### PR TITLE
RES-3273: update LSP diagnostic docs

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -53,8 +53,8 @@ JSON-RPC LSP framing. Your editor client manages the process.
 Every `did_open` or `did_change` event re-runs the full parse +
 typecheck pipeline and publishes structured diagnostics with
 `<uri>:<line>:<col>:` locations. Editor squiggles appear in the
-correct column for type errors. Parser errors currently appear at
-line 1, column 1 — finer-grained parser spans land in a follow-up.
+reported column for parser and typechecker errors; lint diagnostics use
+the source positions recorded by the lint pass.
 
 ### Hover
 

--- a/resilient/tests/docs_lsp_diagnostics_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_diagnostics_copy_smoke.rs
@@ -1,0 +1,27 @@
+//! RES-3273: LSP docs describe current diagnostic range behavior.
+
+#[test]
+fn lsp_docs_describe_current_diagnostic_ranges() {
+    let docs = include_str!("../../docs/lsp.md");
+
+    for expected in [
+        "Every `did_open` or `did_change` event re-runs the full parse +",
+        "reported column for parser and typechecker errors",
+        "lint diagnostics use",
+        "the source positions recorded by the lint pass",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "LSP docs should describe current diagnostic ranges; missing {expected:?}"
+        );
+    }
+
+    assert!(
+        !docs.contains("Parser errors currently appear at"),
+        "LSP docs should not say parser errors use the old fallback range"
+    );
+    assert!(
+        !docs.contains("line 1, column 1"),
+        "LSP docs should not describe parser diagnostics as fixed at 1:1"
+    );
+}


### PR DESCRIPTION
## Summary

- Update `docs/lsp.md` so parser diagnostics are no longer described as fixed at line 1, column 1.
- Document that parser/typechecker diagnostics use reported columns and lint diagnostics use lint-recorded positions.
- Add a docs smoke test to guard against the stale wording returning.

Closes #3273.

## Test changes

- Added `docs_lsp_diagnostics_copy_smoke.rs` to pin current diagnostic-range docs copy.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_diagnostics_copy_smoke -- --nocapture`
