### PR TITLE
RES-3275: document rz pkg subcommands

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -288,7 +288,7 @@ Comments are not preserved today (the parser discards them). Run
 hand. Comment-aware formatting is the next planned formatter
 improvement.
 
-## Package scaffolding
+## Package tooling
 
 ### `rz pkg init <name>`
 
@@ -308,8 +308,26 @@ cd my-proj
 rz src/main.rz
 ```
 
-`rz pkg` is the umbrella for future package operations
-(`pkg add`, `pkg build`, etc.); only `init` exists today.
+### `rz pkg add <name> <spec>`
+
+Adds a dependency to `[dependencies]` in `resilient.toml` and records
+the resolved source in `resilient.lock`. The source specifier can point
+at a local package or a pinned Git source:
+
+```bash
+rz pkg add mylib path:../libs/mylib
+rz pkg add netutil git:https://github.com/user/netutil --rev abc123
+```
+
+### `rz pkg publish --dry-run`
+
+Packages the current project and prints the upload summary without
+contacting a registry. The real registry POST path is still future
+work, so `--dry-run` is required today:
+
+```bash
+rz pkg publish --dry-run
+```
 
 ## Fuzz testing
 

--- a/resilient/tests/docs_tooling_pkg_subcommands_smoke.rs
+++ b/resilient/tests/docs_tooling_pkg_subcommands_smoke.rs
@@ -1,0 +1,32 @@
+//! RES-3275: tooling docs describe current `rz pkg` subcommands.
+
+#[test]
+fn tooling_docs_describe_current_pkg_subcommands() {
+    let docs = include_str!("../../docs/tooling.md");
+
+    for expected in [
+        "## Package tooling",
+        "### `rz pkg init <name>`",
+        "### `rz pkg add <name> <spec>`",
+        "rz pkg add mylib path:../libs/mylib",
+        "rz pkg add netutil git:https://github.com/user/netutil --rev abc123",
+        "### `rz pkg publish --dry-run`",
+        "real registry POST path is still future",
+        "`--dry-run` is required today",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "tooling docs should describe current package tooling; missing {expected:?}"
+        );
+    }
+
+    for stale in [
+        "`rz pkg` is the umbrella for future package operations",
+        "only `init` exists today",
+    ] {
+        assert!(
+            !docs.contains(stale),
+            "tooling docs should not retain stale package-tooling copy: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Updated `docs/tooling.md` so package tooling language reflects the current `rz pkg init`, `rz pkg add`, and `rz pkg publish --dry-run` surface.
- Removed stale copy claiming only `pkg init` exists today.
- Clarified that registry POSTs remain future work while dry-run packaging is available now.

Closes #3275.

## Test changes
- Added `docs_tooling_pkg_subcommands_smoke.rs` to pin current package-tooling docs copy and reject the stale "only init exists today" wording.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_tooling_pkg_subcommands_smoke -- --nocapture`
