### PR TITLE
RES-3279: update fuzz library-surface docs

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,9 +25,11 @@ jit = []
 # fuzz recommended pin.
 libfuzzer-sys = "0.4"
 
-# All targets shell out to the built `resilient` binary (since
-# `resilient` is binary-only; there's no lib surface to link
-# against). `tempfile` gives us the scratch .rs files.
+# All targets shell out to the built `rz` binary. The compiler has
+# a library target, but these harnesses intentionally exercise the
+# shipped CLI boundary instead of depending on private parser/lexer
+# internals as an in-process fuzzing API. `tempfile` gives us the
+# scratch .rs files.
 tempfile = "3"
 
 [[bin]]

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -19,17 +19,21 @@ them up via the `target:` key.
 
 ## Design note: subprocess, not in-process
 
-The `resilient` crate is binary-only (no `src/lib.rs`) today, so
-the fuzz target can't call `parse()` directly. It shells out to
-the built binary via `RESILIENT_FUZZ_BIN` and re-raises
-subprocess crashes as local panics so libFuzzer records the
+The compiler crate now exposes a library target, but these fuzz
+targets still exercise the shipped CLI boundary. That keeps fuzz
+coverage aligned with the parser, lexer, feature flags, diagnostics,
+and panic hooks users reach through `rz` instead of depending on
+private parser/lexer internals as an in-process fuzzing API. The
+harness shells out to the built binary via `RESILIENT_FUZZ_BIN` and
+re-raises subprocess crashes as local panics so libFuzzer records the
 input.
 
 This is slower than an in-process fuzzer would be — expect
 hundreds to a few thousand iterations per second instead of
 millions. Still fast enough to find parser panics in a CI
-budget; moving to in-process would require a library refactor
-(`src/lib.rs` exposing `pub fn parse`) and is a follow-up.
+budget. Moving selected targets in-process would require committing a
+small public fuzzing API, such as stable parse/lex entry points with
+diagnostic guarantees.
 
 ## Running locally
 
@@ -80,12 +84,12 @@ a parser fix is expected to land in the same PR that reports it:
 
 ```bash
 # Reproduce locally:
-resilient -t fuzz/artifacts/parse/crash-<hash>
+rz -t fuzz/artifacts/parse/crash-<hash>
 
 # Add the input to a Rust unit test under
-# `resilient/src/main.rs` `mod tests`, asserting that parsing
-# the bytes returns an error vec instead of panicking. Then fix
-# the parser site.
+# `resilient/src/lib.rs` or an integration test, asserting that
+# parsing the bytes returns an error vec instead of panicking.
+# Then fix the parser site.
 ```
 
 ## CI

--- a/fuzz/fuzz_targets/lex.rs
+++ b/fuzz/fuzz_targets/lex.rs
@@ -4,16 +4,17 @@
 // emit a token stream ending in EOF or record a diagnostic and
 // stop cleanly. Never panic, never loop.
 //
-// Same subprocess pattern as RES-201's `parse` target: we shell
-// out to the built `resilient` binary with `--dump-tokens`,
+// Same CLI-boundary pattern as RES-201's `parse` target: we shell
+// out to the built `rz` binary with `--dump-tokens`,
 // which calls `Lexer::new(input).next_token_with_span()` to EOF
 // and prints one token per line. A child exit via signal (Rust
 // panic → SIGABRT) is re-raised as a local panic so libFuzzer
 // records the offending input.
 //
-// Why subprocess, not in-process? The `resilient` crate is
-// binary-only today (no `src/lib.rs`). Same trade-off as the
-// parse target — see `fuzz/README.md`.
+// Why subprocess, not in-process? These fuzzers exercise the
+// shipped CLI boundary because lexer internals are not a committed
+// public fuzzing API. Same trade-off as the parse target — see
+// `fuzz/README.md`.
 //
 // Runner expectations:
 // - `RESILIENT_FUZZ_BIN` points at the release binary (set by

--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -10,22 +10,22 @@
 //    random byte sequence is usually not valid UTF-8; reject
 //    early so libFuzzer doesn't waste budget on the str ctor.
 // 2. Write the input to a temp file.
-// 3. Spawn `resilient --typecheck --seed 0 <tempfile>` and
+// 3. Spawn `rz -t --seed 0 <tempfile>` and
 //    wait for it to exit. A clean exit (any status) is a pass;
 //    a signal (SIGABRT from a Rust panic) is a fail we re-raise
 //    as a panic so libFuzzer records the input.
 //
-// Why subprocess, not in-process? The `resilient` crate is
-// binary-only (no `src/lib.rs`), so there's no library we can
-// link against and call `parse(&str)` directly. Subprocess is
-// ~1ms per iteration — slower than in-process would be, but
-// still millions of iters/hour, which is enough to surface
-// parser panics in a CI budget.
+// Why subprocess, not in-process? These fuzzers exercise the
+// shipped CLI boundary because the parser internals are not a
+// committed public fuzzing API. Subprocess is ~1ms per iteration
+// — slower than in-process would be, but still millions of
+// iters/hour, which is enough to surface parser panics in a CI
+// budget.
 //
 // Runner expectations:
-// - The `resilient` binary must be built (debug or release).
+// - The `rz` binary must be built (debug or release).
 // - Its path is read from `RESILIENT_FUZZ_BIN` (preferred) or
-//   assumed to be `resilient` on `PATH`. The workflow in
+//   assumed to be `rz` on `PATH`. The workflow in
 //   `.github/workflows/fuzz.yml` sets `RESILIENT_FUZZ_BIN` to
 //   the release build.
 

--- a/resilient/tests/fuzz_docs_library_surface_smoke.rs
+++ b/resilient/tests/fuzz_docs_library_surface_smoke.rs
@@ -1,0 +1,82 @@
+//! RES-3279: fuzz docs know the compiler crate has a library target.
+
+#[test]
+fn fuzz_docs_use_current_library_and_cli_language() {
+    let fuzz_readme = include_str!("../../fuzz/README.md");
+    let fuzz_manifest = include_str!("../../fuzz/Cargo.toml");
+    let parse_target = include_str!("../../fuzz/fuzz_targets/parse.rs");
+    let lex_target = include_str!("../../fuzz/fuzz_targets/lex.rs");
+    let compiler_manifest = include_str!("../Cargo.toml");
+
+    assert!(
+        compiler_manifest.contains("[lib]\nname = \"resilient\"\npath = \"src/lib.rs\""),
+        "compiler manifest should expose the library target this docs smoke test relies on"
+    );
+
+    for expected in [
+        "The compiler crate now exposes a library target",
+        "targets still exercise the shipped CLI boundary",
+        "committing a\nsmall public fuzzing API",
+        "rz -t fuzz/artifacts/parse/crash-<hash>",
+        "`resilient/src/lib.rs` or an integration test",
+    ] {
+        assert!(
+            fuzz_readme.contains(expected),
+            "fuzz README should use current library/CLI language; missing {expected:?}"
+        );
+    }
+
+    for expected in [
+        "All targets shell out to the built `rz` binary.",
+        "The compiler has\n# a library target",
+        "shipped CLI boundary",
+    ] {
+        assert!(
+            fuzz_manifest.contains(expected),
+            "fuzz manifest comments should use current subprocess rationale; missing {expected:?}"
+        );
+    }
+
+    for expected in [
+        "Spawn `rz -t --seed 0 <tempfile>`",
+        "These fuzzers exercise the\n// shipped CLI boundary",
+        "parser internals are not a\n// committed public fuzzing API",
+        "The `rz` binary must be built",
+    ] {
+        assert!(
+            parse_target.contains(expected),
+            "parse fuzz target comments should use current subprocess rationale; missing {expected:?}"
+        );
+    }
+
+    for expected in [
+        "Same CLI-boundary pattern",
+        "built `rz` binary with `--dump-tokens`",
+        "lexer internals are not a committed\n// public fuzzing API",
+    ] {
+        assert!(
+            lex_target.contains(expected),
+            "lex fuzz target comments should use current subprocess rationale; missing {expected:?}"
+        );
+    }
+
+    for stale in [
+        "binary-only",
+        "no `src/lib.rs`",
+        "no lib surface to link",
+        "resilient -t fuzz/artifacts/parse/crash-<hash>",
+        "`resilient/src/main.rs` `mod tests`",
+    ] {
+        for (name, text) in [
+            ("fuzz README", fuzz_readme),
+            ("fuzz manifest", fuzz_manifest),
+            ("parse target", parse_target),
+            ("lex target", lex_target),
+        ] {
+            assert!(
+                !text.contains(stale),
+                "{name} should not retain stale fuzz language: {stale:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Removed stale fuzz docs/comments that described the compiler crate as binary-only with no `src/lib.rs`.
- Reworded the subprocess-fuzzer rationale around the current shipped `rz` CLI boundary and uncommitted in-process fuzzing API.
- Updated stale fuzz crash-reproduction guidance from `resilient -t` / `src/main.rs` tests to `rz -t` / `src/lib.rs` or integration tests.

Closes #3279.

## Test changes
- Added `fuzz_docs_library_surface_smoke.rs` to pin the current library-aware fuzz docs/comments and reject the old binary-only wording.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test fuzz_docs_library_surface_smoke -- --nocapture`
