### PR TITLE
RES-3281: use rz names in fuzz docs

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -8,8 +8,8 @@ libFuzzer.
 
 | Target  | Ticket   | What it fuzzes                                                                              |
 | ------- | -------- | ------------------------------------------------------------------------------------------- |
-| `parse` | RES-201  | The parser: random bytes → UTF-8 filter → `resilient -t`. Fails on panic.                   |
-| `lex`   | RES-111  | The lexer: random bytes → UTF-8 filter → `resilient --dump-tokens`. Fails on panic.         |
+| `parse` | RES-201  | The parser: random bytes → UTF-8 filter → `rz -t`. Fails on panic.                          |
+| `lex`   | RES-111  | The lexer: random bytes → UTF-8 filter → `rz --dump-tokens`. Fails on panic.                |
 | `jit`   | RES-310  | The Cranelift JIT lowering path: random bytes → UTF-8 filter → `rz --jit`. Fails on panic.  |
 
 Additional targets slot in by adding a file under

--- a/fuzz/fuzz_targets/jit.rs
+++ b/fuzz/fuzz_targets/jit.rs
@@ -8,11 +8,11 @@
 // SIGABRT on Linux, similar on macOS) is re-raised as a local
 // panic so libFuzzer records the offending input.
 //
-// Same subprocess pattern as RES-201's `parse` target and
+// Same CLI-boundary pattern as RES-201's `parse` target and
 // RES-111's `lex` target — see `fuzz/README.md` for the design
-// rationale (TL;DR: `resilient` is binary-only, no library
-// surface to link against). We shell out to `rz --jit <file>`
-// which routes through:
+// rationale. We shell out to `rz --jit <file>`, keeping coverage
+// aligned with the shipped binary while avoiding private
+// in-process parser/lexer/JIT APIs. The command routes through:
 //
 //     lex (lexer)
 //   -> parse (parser)

--- a/fuzz/fuzz_targets/lex.rs
+++ b/fuzz/fuzz_targets/lex.rs
@@ -61,7 +61,7 @@ fuzz_target!(|data: &[u8]| {
     if output.status.code().is_none() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         panic!(
-            "resilient --dump-tokens process crashed (signal) on fuzz input:\n\
+            "rz --dump-tokens process crashed (signal) on fuzz input:\n\
              stderr tail: {}",
             stderr.lines().rev().take(5).collect::<Vec<_>>().join(" | ")
         );

--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -76,7 +76,7 @@ fuzz_target!(|data: &[u8]| {
     if output.status.code().is_none() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         panic!(
-            "resilient process crashed (signal) on fuzz input:\n\
+            "rz -t process crashed (signal) on fuzz input:\n\
              stderr tail: {}",
             stderr.lines().rev().take(5).collect::<Vec<_>>().join(" | ")
         );

--- a/resilient/tests/fuzz_docs_cli_names_smoke.rs
+++ b/resilient/tests/fuzz_docs_cli_names_smoke.rs
@@ -1,0 +1,58 @@
+//! RES-3281: fuzz docs and crash text use the shipped `rz` CLI name.
+
+#[test]
+fn fuzz_docs_and_targets_use_current_rz_cli_names() {
+    let fuzz_readme = include_str!("../../fuzz/README.md");
+    let parse_target = include_str!("../../fuzz/fuzz_targets/parse.rs");
+    let lex_target = include_str!("../../fuzz/fuzz_targets/lex.rs");
+    let jit_target = include_str!("../../fuzz/fuzz_targets/jit.rs");
+
+    for expected in ["`rz -t`", "`rz --dump-tokens`", "`rz --jit`"] {
+        assert!(
+            fuzz_readme.contains(expected),
+            "fuzz README target table should use current rz command {expected:?}"
+        );
+    }
+
+    for expected in [
+        "Same CLI-boundary pattern",
+        "We shell out to `rz --jit <file>`",
+        "avoiding private\n// in-process parser/lexer/JIT APIs",
+    ] {
+        assert!(
+            jit_target.contains(expected),
+            "JIT fuzz target should use current CLI-boundary rationale; missing {expected:?}"
+        );
+    }
+
+    assert!(
+        parse_target.contains("rz -t process crashed (signal) on fuzz input"),
+        "parse fuzz crash message should name the rz command"
+    );
+    assert!(
+        lex_target.contains("rz --dump-tokens process crashed (signal) on fuzz input"),
+        "lex fuzz crash message should name the rz command"
+    );
+
+    for stale in [
+        "`resilient -t`",
+        "`resilient --dump-tokens`",
+        "resilient process crashed",
+        "resilient --dump-tokens process crashed",
+        "binary-only",
+        "no library\n// surface",
+        "no library surface",
+    ] {
+        for (name, text) in [
+            ("fuzz README", fuzz_readme),
+            ("parse target", parse_target),
+            ("lex target", lex_target),
+            ("jit target", jit_target),
+        ] {
+            assert!(
+                !text.contains(stale),
+                "{name} should not retain stale fuzz CLI language: {stale:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Updated the fuzz README target table to use the shipped `rz` CLI names for parse and lex targets.
- Reworded the JIT fuzz target's subprocess rationale to use the current CLI-boundary language instead of the stale binary-only note.
- Updated parse/lex fuzz crash messages so libFuzzer artifacts name the actual `rz` commands.

Closes #3281.

## Test changes
- Added `fuzz_docs_cli_names_smoke.rs` to pin current fuzz CLI naming and reject the remaining stale `resilient`/binary-only wording.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test fuzz_docs_cli_names_smoke -- --nocapture`
