### PR TITLE
RES-3283: update stdlib builtin paths

### DIFF
--- a/STDLIB.md
+++ b/STDLIB.md
@@ -1,7 +1,7 @@
 # Resilient Standard Library
 
 Reference for built-in functions visible in every Resilient program.
-Implementations live in `resilient/src/main.rs` (table: `BUILTINS`); type
+Implementations live in `resilient/src/lib.rs` (table: `BUILTINS`); type
 signatures live in `resilient/src/typechecker.rs` (`prelude` setup).
 
 The canonical, machine-checkable list of names is the `BUILTINS` table.
@@ -318,8 +318,8 @@ dispatched via the special StringBuilder method handler in
 
 When adding a new builtin, the canonical list to update is:
 
-1. The `BUILTINS` table in `resilient/src/main.rs`.
+1. The `BUILTINS` table in `resilient/src/lib.rs`.
 2. The type signature in the prelude block of `resilient/src/typechecker.rs`.
 3. The `PURE_BUILTINS` list in `resilient/src/typechecker.rs` (unless impure).
 4. A row in this file and in `SYNTAX.md`.
-5. A unit test in `resilient/src/main.rs`'s `mod tests`.
+5. A focused Rust test in `resilient/src/lib.rs` or `resilient/tests/`.

--- a/resilient/tests/stdlib_builtin_location_copy_smoke.rs
+++ b/resilient/tests/stdlib_builtin_location_copy_smoke.rs
@@ -1,0 +1,23 @@
+//! RES-3283: STDLIB contributor guidance follows the library split.
+
+#[test]
+fn stdlib_docs_point_builtin_contributors_at_library_sources() {
+    let docs = include_str!("../../STDLIB.md");
+
+    for expected in [
+        "Implementations live in `resilient/src/lib.rs` (table: `BUILTINS`);",
+        "signatures live in `resilient/src/typechecker.rs`",
+        "1. The `BUILTINS` table in `resilient/src/lib.rs`.",
+        "5. A focused Rust test in `resilient/src/lib.rs` or `resilient/tests/`.",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "STDLIB.md should use current builtin contributor locations; missing {expected:?}"
+        );
+    }
+
+    assert!(
+        !docs.contains("resilient/src/main.rs"),
+        "STDLIB.md should not send builtin contributors to the CLI shim"
+    );
+}


### PR DESCRIPTION
## Summary
- Updated `STDLIB.md` to point builtin implementations and the `BUILTINS` table at `resilient/src/lib.rs` after the library split.
- Kept typechecker guidance on `resilient/src/typechecker.rs`.
- Replaced old `src/main.rs` unit-test guidance with current `src/lib.rs` or integration-test placement.

Closes #3283.

## Test changes
- Added `stdlib_builtin_location_copy_smoke.rs` to pin current STDLIB contributor paths and reject stale `src/main.rs` guidance.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test stdlib_builtin_location_copy_smoke -- --nocapture`
