### PR TITLE
RES-3285: update error doc source paths

### DIFF
--- a/docs/errors/E0001.md
+++ b/docs/errors/E0001.md
@@ -47,6 +47,6 @@ let x = 1 + 1;
 
 ## Source
 
-Emitted from the parser in `resilient/src/main.rs`. Search for
+Emitted from the parser in `resilient/src/lib.rs`. Search for
 `record_error` calls that don't yet attach a more specific
 code.

--- a/docs/errors/E0002.md
+++ b/docs/errors/E0002.md
@@ -52,4 +52,4 @@ fn main() {
 ## Source
 
 Emitted from `parse_let_statement` and the statement-list walker
-in `resilient/src/main.rs`.
+in `resilient/src/lib.rs`.

--- a/docs/errors/E0003.md
+++ b/docs/errors/E0003.md
@@ -50,4 +50,4 @@ fn main() {
 ## Source
 
 Emitted from the parser's delimiter-balance check in
-`resilient/src/main.rs`.
+`resilient/src/lib.rs`.

--- a/docs/errors/E0004.md
+++ b/docs/errors/E0004.md
@@ -53,5 +53,5 @@ fn main() {
 ## Source
 
 Emitted from the typechecker (`resilient/src/typechecker.rs`),
-the interpreter (`resilient/src/main.rs`), and the VM compiler
+the interpreter (`resilient/src/lib.rs`), and the VM compiler
 (`resilient/src/compiler.rs`).

--- a/docs/errors/E0006.md
+++ b/docs/errors/E0006.md
@@ -51,4 +51,4 @@ fn add_one(int a) -> int { return add(a, 1); }
 ## Source
 
 Emitted from the VM compiler in `resilient/src/compiler.rs`
-and the interpreter in `resilient/src/main.rs`.
+and the interpreter in `resilient/src/lib.rs`.

--- a/docs/errors/E0010.md
+++ b/docs/errors/E0010.md
@@ -66,4 +66,4 @@ fn main() {
 ## Source
 
 Emitted from `apply_function` in
-`resilient/src/main.rs` (both `requires` and `ensures` arms).
+`resilient/src/lib.rs` (both `requires` and `ensures` arms).

--- a/resilient/tests/docs_error_source_paths_smoke.rs
+++ b/resilient/tests/docs_error_source_paths_smoke.rs
@@ -1,0 +1,37 @@
+//! RES-3285: error docs point at library sources after the lib split.
+
+#[test]
+fn error_docs_use_current_parser_and_interpreter_source_paths() {
+    let docs = [
+        ("E0001", include_str!("../../docs/errors/E0001.md")),
+        ("E0002", include_str!("../../docs/errors/E0002.md")),
+        ("E0003", include_str!("../../docs/errors/E0003.md")),
+        ("E0004", include_str!("../../docs/errors/E0004.md")),
+        ("E0006", include_str!("../../docs/errors/E0006.md")),
+        ("E0010", include_str!("../../docs/errors/E0010.md")),
+    ];
+
+    for (code, doc) in docs {
+        assert!(
+            doc.contains("resilient/src/lib.rs"),
+            "{code} should point parser/interpreter source notes at resilient/src/lib.rs"
+        );
+        assert!(
+            !doc.contains("resilient/src/main.rs"),
+            "{code} should not point source notes at the CLI shim"
+        );
+    }
+
+    let e0004 = include_str!("../../docs/errors/E0004.md");
+    assert!(
+        e0004.contains("resilient/src/typechecker.rs")
+            && e0004.contains("resilient/src/compiler.rs"),
+        "E0004 should preserve typechecker and compiler source references"
+    );
+
+    let e0006 = include_str!("../../docs/errors/E0006.md");
+    assert!(
+        e0006.contains("resilient/src/compiler.rs"),
+        "E0006 should preserve the VM compiler source reference"
+    );
+}


### PR DESCRIPTION
## Summary
- Updated six error-doc source notes from the old monolithic `resilient/src/main.rs` path to `resilient/src/lib.rs` for parser/interpreter/apply-function code.
- Preserved existing typechecker and VM compiler references where those remain accurate.

Closes #3285.

## Test changes
- Added `docs_error_source_paths_smoke.rs` to pin current error-doc source paths and reject stale `src/main.rs` guidance.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_error_source_paths_smoke -- --nocapture`
