### PR TITLE
RES-3287: update memory model source paths

### DIFF
--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -40,7 +40,7 @@ memory strategy.
 
 | Tier                     | Implementation                               | Allocation strategy                    |
 |--------------------------|----------------------------------------------|----------------------------------------|
-| Host interpreter         | `resilient/src/main.rs` — tree walker        | `Rc<RefCell<EnvFrame>>` (refcount + interior mutability) |
+| Host interpreter         | `resilient/src/lib.rs` — tree walker         | `Rc<RefCell<EnvFrame>>` (refcount + interior mutability) |
 | Bytecode VM              | `resilient/src/vm.rs` — stack machine        | Owned `Vec<Value>` operand stack + locals slab |
 | Cranelift JIT            | `resilient/src/jit_backend.rs`               | Cranelift-managed native stack frames + closure upvalues |
 | Embedded runtime         | `resilient-runtime/` (`#![no_std]`)          | Stack-only by default; optional `alloc` feature |
@@ -54,7 +54,7 @@ the configuration shipped onto hardware.
 
 ### Host `Value` enum
 
-Defined at `resilient/src/main.rs:4000`. The variants are:
+Defined by the `Value` enum in `resilient/src/lib.rs`. The variants are:
 
 | Variant      | Payload                                          | Backing storage                     |
 |--------------|--------------------------------------------------|-------------------------------------|
@@ -148,8 +148,8 @@ a language-level reference type, which Resilient does not expose.
 ## The live-block memory contract
 
 A `live { }` block is the language's recoverable-failure primitive.
-The host implementation is at `resilient/src/main.rs:6679`
-(`eval_live_block`).
+The host implementation is `eval_live_block` in
+`resilient/src/lib.rs`.
 
 ### What is snapshotted
 

--- a/resilient/tests/docs_memory_model_source_paths_smoke.rs
+++ b/resilient/tests/docs_memory_model_source_paths_smoke.rs
@@ -1,0 +1,22 @@
+//! RES-3287: memory-model docs follow the compiler library split.
+
+#[test]
+fn memory_model_docs_use_current_host_interpreter_source_paths() {
+    let docs = include_str!("../../docs/memory-model.md");
+
+    for expected in [
+        "| Host interpreter         | `resilient/src/lib.rs`",
+        "Defined by the `Value` enum in `resilient/src/lib.rs`.",
+        "The host implementation is `eval_live_block` in\n`resilient/src/lib.rs`.",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "memory model docs should point host implementation notes at lib.rs; missing {expected:?}"
+        );
+    }
+
+    assert!(
+        !docs.contains("resilient/src/main.rs"),
+        "memory model docs should not point implementation notes at the CLI shim"
+    );
+}


### PR DESCRIPTION
## Summary
- Updated memory-model host interpreter references from the old `resilient/src/main.rs` path to `resilient/src/lib.rs`.
- Replaced stale line-numbered `Value` and `eval_live_block` pointers with symbol-based source notes.

Closes #3287.

## Test changes
- Added `docs_memory_model_source_paths_smoke.rs` to pin current memory-model source paths and reject stale `src/main.rs` implementation notes.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_memory_model_source_paths_smoke -- --nocapture`
