### PR TITLE
RES-3289: update semantic token source path

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -254,7 +254,7 @@ Speaks LSP over stdio. Shipped features:
 - Completion (builtins + top-level decls; RES-188)
 - Semantic tokens (keyword / function / variable / parameter / type /
   string / number / comment / operator; see `sem_tok` in
-  `resilient/src/main.rs`)
+  `resilient/src/lib.rs`)
 
 See [LSP / Editor Integration](lsp) for editor config examples.
 

--- a/resilient/src/lsp_server.rs
+++ b/resilient/src/lsp_server.rs
@@ -2195,7 +2195,7 @@ fn filter_workspace_symbols(
 }
 
 /// RES-187: the semantic-tokens legend. The order here MUST match
-/// the `sem_tok::*` token-type indices declared in `main.rs`
+/// the `sem_tok::*` token-type indices declared in `lib.rs`
 /// (KEYWORD=0 … OPERATOR=8) and the modifier bit positions
 /// (MOD_DECLARATION=bit0, MOD_READONLY=bit1). Any drift between
 /// these two tables yields mis-colored output in every client.

--- a/resilient/tests/docs_tooling_semantic_token_path_smoke.rs
+++ b/resilient/tests/docs_tooling_semantic_token_path_smoke.rs
@@ -1,0 +1,25 @@
+//! RES-3289: tooling docs point semantic-token readers at lib.rs.
+
+#[test]
+fn tooling_docs_use_current_semantic_token_source_path() {
+    let tooling = include_str!("../../docs/tooling.md");
+    let lsp_server = include_str!("../src/lsp_server.rs");
+
+    assert!(
+        tooling.contains("see `sem_tok` in\n  `resilient/src/lib.rs`"),
+        "tooling docs should point semantic-token readers at lib.rs"
+    );
+    assert!(
+        !tooling.contains("resilient/src/main.rs"),
+        "tooling docs should not point semantic-token readers at the CLI shim"
+    );
+
+    assert!(
+        lsp_server.contains("the `sem_tok::*` token-type indices declared in `lib.rs`"),
+        "LSP source comment should name the current sem_tok source file"
+    );
+    assert!(
+        !lsp_server.contains("indices declared in `main.rs`"),
+        "LSP source comment should not refer to the old monolithic file"
+    );
+}


### PR DESCRIPTION
## Summary
- Updated the LSP semantic-token note in `docs/tooling.md` from the old `resilient/src/main.rs` path to `resilient/src/lib.rs`.
- Updated the matching LSP source comment so it no longer refers to the old monolithic file.

Closes #3289.

## Test changes
- Added `docs_tooling_semantic_token_path_smoke.rs` to pin the current semantic-token source path and reject stale `main.rs` references.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_tooling_semantic_token_path_smoke -- --nocapture`
