### PR TITLE
RES-3295: update lib split source comments

### DIFF
--- a/resilient/benches/interpreter.rs
+++ b/resilient/benches/interpreter.rs
@@ -1,19 +1,18 @@
 //! RES-218: Criterion benchmark harness for the tree-walker interpreter.
 //!
 //! Drives three representative Resilient workloads through the compiled
-//! `resilient` binary:
+//! `rz` binary:
 //!
 //!   1. `fib(25)` — exponential recursion; stresses dispatch + env cloning.
 //!   2. Bubble-sort on a 50-element descending array — O(n^2) array ops.
 //!   3. String-concatenation loop — exercises the string builtins path.
 //!
-//! Why shell out to the binary instead of calling an in-process entry
-//! point? `resilient/src/main.rs` is a 16k-line binary crate with no
-//! public `lib.rs`; carving out a library surface for benchmarks alone
-//! would be a bigger ticket than RES-218 is scoped for. The process
-//! startup overhead is visible in the numbers but is constant across
-//! runs, so deltas between commits still show the shape the harness is
-//! meant to surface.
+//! Why shell out to the binary instead of calling the library directly?
+//! This harness measures the CLI path users invoke, including argument
+//! parsing, diagnostics, process startup, and stdout capture around the
+//! tree-walker. The process startup overhead is visible in the numbers
+//! but is constant across runs, so deltas between commits still show the
+//! shape the harness is meant to surface.
 //!
 //! Sample sizes are deliberately small (10 samples per bench) because
 //! the tree-walker is slow enough that a default 100-sample run would

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -10726,7 +10726,7 @@ impl TypeChecker {
 /// observable side effects or nondeterminism. Any `@pure` fn
 /// that calls one of these is rejected at type-check time.
 ///
-/// Keep in sync with `resilient/src/main.rs::BUILTINS` — adding a
+/// Keep in sync with `resilient/src/lib.rs::BUILTINS` — adding a
 /// new I/O / clock / env builtin there means adding it here.
 const IMPURE_BUILTINS: &[&str] = &[
     // RES-004 / RES-144: stdio.
@@ -11133,7 +11133,7 @@ fn check_body_purity(
 /// Input is the callee name. Returns true iff the name is one of
 /// the pure-by-default builtins we ship.
 fn is_known_pure_builtin(name: &str) -> bool {
-    // Keep this list in sync with `resilient/src/main.rs::BUILTINS`
+    // Keep this list in sync with `resilient/src/lib.rs::BUILTINS`
     // minus the names in `IMPURE_BUILTINS`.
     const PURE_BUILTINS: &[&str] = &[
         // Math.

--- a/resilient/tests/source_comment_lib_split_smoke.rs
+++ b/resilient/tests/source_comment_lib_split_smoke.rs
@@ -1,0 +1,40 @@
+//! RES-3295: source comments reflect the compiler library split.
+
+#[test]
+fn source_comments_use_current_lib_split_language() {
+    let typechecker = include_str!("../src/typechecker.rs");
+    let interpreter_bench = include_str!("../benches/interpreter.rs");
+
+    for expected in [
+        "Keep in sync with `resilient/src/lib.rs::BUILTINS`",
+        "minus the names in `IMPURE_BUILTINS`",
+    ] {
+        assert!(
+            typechecker.contains(expected),
+            "typechecker comments should reference current builtin source; missing {expected:?}"
+        );
+    }
+
+    for expected in [
+        "through the compiled\n//! `rz` binary",
+        "measures the CLI path users invoke",
+        "including argument\n//! parsing, diagnostics, process startup, and stdout capture",
+    ] {
+        assert!(
+            interpreter_bench.contains(expected),
+            "interpreter bench comment should describe current benchmark rationale; missing {expected:?}"
+        );
+    }
+
+    for stale in [
+        "resilient/src/main.rs::BUILTINS",
+        "resilient/src/main.rs` is a 16k-line binary crate",
+        "no\n//! public `lib.rs`",
+        "compiled\n//! `resilient` binary",
+    ] {
+        assert!(
+            !typechecker.contains(stale) && !interpreter_bench.contains(stale),
+            "source comments should not retain stale lib-split wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Updated typechecker builtin-list comments to reference `resilient/src/lib.rs::BUILTINS` after the library split.
- Reworded the interpreter benchmark header around the compiled `rz` CLI path instead of stale binary-only/no-lib wording.

Closes #3295.

## Test changes
- Added `source_comment_lib_split_smoke.rs` to pin the current comment language and reject stale lib-split references.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test source_comment_lib_split_smoke -- --nocapture`
