### PR TITLE
RES-3297: update issue template test guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -26,7 +26,7 @@ _What should the state of the codebase be when this ticket is closed?_
 
 ## Acceptance criteria
 
-- [ ] _Criterion 1 — something observable, e.g. "`foo.rs` example runs and
+- [ ] _Criterion 1 — something observable, e.g. "`foo.rz` example runs and
       matches its `.expected.txt`"_
 - [ ] _Criterion 2_
 - [ ] _Criterion 3_
@@ -35,9 +35,9 @@ _What should the state of the codebase be when this ticket is closed?_
 
 - **Where to start**: _file / module / function the contributor should open
   first._
-- **Where to add tests**: _e.g. `resilient/src/main.rs` under `#[cfg(test)]
-  mod tests`, or a new `resilient/examples/foo.rs` with a
-  `foo.expected.txt` sidecar._
+- **Where to add tests**: _e.g. a unit test in `resilient/src/lib.rs`, a
+  focused integration test under `resilient/tests/`, or a new
+  `resilient/examples/foo.rz` with a `foo.expected.txt` sidecar._
 - **Relevant docs**: _links to SYNTAX.md / STABILITY.md / ROADMAP.md
   sections that explain surrounding context._
 

--- a/resilient/tests/issue_template_test_location_smoke.rs
+++ b/resilient/tests/issue_template_test_location_smoke.rs
@@ -1,0 +1,29 @@
+//! RES-3297: good-first-issue template uses current test locations.
+
+#[test]
+fn good_first_issue_template_uses_current_test_guidance() {
+    let template = include_str!("../../.github/ISSUE_TEMPLATE/good_first_issue.md");
+
+    for expected in [
+        "`foo.rz` example runs",
+        "a unit test in `resilient/src/lib.rs`",
+        "focused integration test under `resilient/tests/`",
+        "`resilient/examples/foo.rz` with a `foo.expected.txt` sidecar",
+    ] {
+        assert!(
+            template.contains(expected),
+            "good-first-issue template should use current contributor guidance; missing {expected:?}"
+        );
+    }
+
+    for stale in [
+        "`foo.rs` example runs",
+        "resilient/src/main.rs",
+        "mod tests`, or a new `resilient/examples/foo.rs`",
+    ] {
+        assert!(
+            !template.contains(stale),
+            "good-first-issue template should not retain stale guidance: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Updated the good-first-issue template to point contributors at current test locations after the library split.
- Corrected the example extension from `foo.rs` to `foo.rz` for Resilient examples.

Closes #3297.

## Test changes
- Added `issue_template_test_location_smoke.rs` to pin current issue-template guidance and reject stale `src/main.rs` / `.rs` example copy.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test issue_template_test_location_smoke -- --nocapture`
