### PR TITLE
RES-3299: update agent core file examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,14 +95,14 @@ the merge.** Your job is to make CI green.
      pick a different ticket.
 2. **Pre-dispatch overlap check.** Before creating your branch:
    ```bash
-   agent-scripts/check-overlaps.sh resilient/src/main.rs resilient/src/typechecker.rs resilient/src/lexer_logos.rs
+   agent-scripts/check-overlaps.sh resilient/src/lib.rs resilient/src/typechecker.rs resilient/src/lexer_logos.rs
    ```
    If conflicts are reported, wait for those PRs to merge before starting.
 3. **Claim the ticket.** Comment on the issue, then create a branch named
    `res-NNN-short-title`.
 4. **Claim core files** immediately (before any edits):
    ```bash
-   agent-scripts/claim-files.sh res-NNN-short-title resilient/src/main.rs resilient/src/typechecker.rs resilient/src/lexer_logos.rs
+   agent-scripts/claim-files.sh res-NNN-short-title resilient/src/lib.rs resilient/src/typechecker.rs resilient/src/lexer_logos.rs
    ```
 5. **Open a draft PR early** with `Closes #N` in the body — this signals
    the ticket is taken.

--- a/resilient/tests/agent_docs_core_file_paths_smoke.rs
+++ b/resilient/tests/agent_docs_core_file_paths_smoke.rs
@@ -1,0 +1,26 @@
+//! RES-3299: agent docs use current core compiler file paths.
+
+#[test]
+fn claude_doc_core_file_examples_use_lib_rs() {
+    let docs = include_str!("../../CLAUDE.md");
+
+    for expected in [
+        "agent-scripts/check-overlaps.sh resilient/src/lib.rs resilient/src/typechecker.rs resilient/src/lexer_logos.rs",
+        "agent-scripts/claim-files.sh res-NNN-short-title resilient/src/lib.rs resilient/src/typechecker.rs resilient/src/lexer_logos.rs",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "CLAUDE.md should use current core-file examples; missing {expected:?}"
+        );
+    }
+
+    for stale in [
+        "check-overlaps.sh resilient/src/main.rs",
+        "claim-files.sh res-NNN-short-title resilient/src/main.rs",
+    ] {
+        assert!(
+            !docs.contains(stale),
+            "CLAUDE.md should not send agents to the CLI shim in core-file examples"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Updated `CLAUDE.md` overlap-check and claim-files examples to use `resilient/src/lib.rs` after the library split.

Closes #3299.

## Test changes
- Added `agent_docs_core_file_paths_smoke.rs` to pin current agent-doc core-file examples and reject stale `src/main.rs` usage.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test agent_docs_core_file_paths_smoke -- --nocapture`
