### PR TITLE
RES-3303: refresh playground acceptance docs

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -69,9 +69,9 @@ command on every PR that touches `playground/`.
 | Criterion | State |
 |---|---|
 | `wasm32-unknown-unknown` target added to CI | ✅ — `.github/workflows/playground.yml` |
-| `resilient` binary compiles to WASM via `wasm-bindgen` | 🟡 — scaffold uses a stand-alone `resilient-playground` crate with a stub interpreter; full integration pending the lib refactor described above |
+| `resilient` binary compiles to WASM via `wasm-bindgen` | ✅ — `resilient-playground` builds against the compiler library target and calls the real `resilient::run_program` tree-walker; native CLI-only pieces stay cfg-gated |
 | HTML+JS page at `playground/index.html` with CodeMirror + run button | ✅ — `playground/web/index.html` |
-| Run → WASM → stdout in result pane | ✅ — round-trip works; output is a stub message until full integration |
+| Run → WASM → stdout in result pane | ✅ — round-trip returns stdout, diagnostics, exit code, duration, and `flavor: "tree-walker"`; no stub output remains |
 | Examples dropdown pre-loads `resilient/examples/` | ✅ — baked into `dist/examples.json` at build time |
 | GitHub Pages deploy on push to main | ✅ — `.github/workflows/playground.yml` deploy job |
 | Size gate ≤ 2 MiB gzip | ✅ — `playground/build.sh --check-size` |

--- a/resilient/tests/playground_acceptance_rows_smoke.rs
+++ b/resilient/tests/playground_acceptance_rows_smoke.rs
@@ -1,0 +1,39 @@
+//! RES-3303: playground acceptance rows match the tree-walker integration.
+
+#[test]
+fn playground_acceptance_table_no_longer_describes_stub_output() {
+    let readme = include_str!("../../playground/README.md");
+    let wasm_entry = include_str!("../../playground/src/lib.rs");
+
+    for expected in [
+        "`resilient-playground` builds against the compiler library target",
+        "calls the real `resilient::run_program` tree-walker",
+        "native CLI-only pieces stay cfg-gated",
+        "round-trip returns stdout, diagnostics, exit code, duration",
+        "`flavor: \"tree-walker\"`",
+        "no stub output remains",
+    ] {
+        assert!(
+            readme.contains(expected),
+            "playground acceptance table should reflect tree-walker wiring; missing {expected:?}"
+        );
+    }
+
+    assert!(
+        wasm_entry.contains("resilient::run_program(source)")
+            && wasm_entry.contains("flavor: \"tree-walker\""),
+        "playground entrypoint should still call the real tree-walker"
+    );
+
+    for stale in [
+        "stub interpreter",
+        "full integration pending the lib refactor",
+        "output is a stub message",
+        "until full integration",
+    ] {
+        assert!(
+            !readme.contains(stale),
+            "playground acceptance table should not retain stub-era wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Refresh the playground README acceptance-criteria rows that still described stub-era behavior.
- Align those rows with the current `resilient::run_program` tree-walker WASM integration.
- Add a new smoke test guarding the acceptance table and entrypoint against stale stub wording returning.

Closes #3303

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test playground_acceptance_rows_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/playground_acceptance_rows_smoke.rs` to guard new acceptance-table wording without modifying existing tests.
