### PR TITLE
RES-3305: split debugger profiler inventory

### DIFF
--- a/docs/stable-regression-inventory.md
+++ b/docs/stable-regression-inventory.md
@@ -50,6 +50,7 @@ Scope rules:
 | `--dump-chunks` | `resilient/tests/dump_chunks_smoke.rs` | Covered | Direct VM disassembly smoke. |
 | `--audit` | `resilient/tests/bounds_elision_smoke.rs` | Covered | Direct verification audit coverage. |
 | `--explain-effects` | `resilient/tests/explain_effects_cli.rs` | Covered | Dedicated CLI coverage. |
+| `rz debug <file>` / `--dap` | `resilient/tests/debug_help_smoke.rs`, `resilient/src/dap_server.rs` | Covered | DAP server CLI entrypoints are documented and help-covered; breakpoints, stepping, and watch expressions remain maturing. |
 | `--version` / `--version --verbose` | `resilient/tests/stable_cli_surface_smoke.rs` | Covered | Added for RES-3128. |
 | `stack-usage <file>` | `resilient/tests/stable_cli_surface_smoke.rs` | Covered | Added for RES-3128. |
 | `pkg init` workflow | `resilient/tests/pkg_init_smoke.rs` | Covered | Dedicated project-scaffolding smoke. |
@@ -66,7 +67,7 @@ Scope rules:
 | Surface | Reason | Follow-up shape |
 |---|---|---|
 | `rz tool ...` external tool bridge | Present in code but not documented as stable in the public tooling reference or top-level help. | Promote/document the subcommand first, then add direct smoke coverage as part of that stabilization slice. |
-| Debugger / profiler paths | Public docs classify them as future work. | Stabilize the user-facing workflows before adding them to this inventory. |
+| Profiler path | `docs/tooling.md` documents the profiler as future; current timing data comes from `rz bench` and `--jit-cache-stats`. | Stabilize a profiler CLI and add direct smoke coverage before promoting it. |
 
 ## Maintenance Rule
 

--- a/resilient/tests/stable_inventory_debugger_profiler_smoke.rs
+++ b/resilient/tests/stable_inventory_debugger_profiler_smoke.rs
@@ -1,0 +1,41 @@
+//! RES-3305: stable inventory splits documented debugger status from profiler future work.
+
+#[test]
+fn stable_inventory_splits_debugger_from_future_profiler() {
+    let inventory = include_str!("../../docs/stable-regression-inventory.md");
+    let tooling = include_str!("../../docs/tooling.md");
+
+    for expected in [
+        "## Debugger",
+        "### `rz debug <file>`",
+        "For direct adapter launches, clients may also use `rz --dap`.",
+        "## Profiler",
+        "There is no profiler today.",
+    ] {
+        assert!(
+            tooling.contains(expected),
+            "tooling docs should keep debugger documented and profiler future status explicit; missing {expected:?}"
+        );
+    }
+
+    for expected in [
+        "| `rz debug <file>` / `--dap` | `resilient/tests/debug_help_smoke.rs`, `resilient/src/dap_server.rs` | Covered | DAP server CLI entrypoints are documented and help-covered; breakpoints, stepping, and watch expressions remain maturing. |",
+        "| Profiler path | `docs/tooling.md` documents the profiler as future; current timing data comes from `rz bench` and `--jit-cache-stats`. | Stabilize a profiler CLI and add direct smoke coverage before promoting it. |",
+    ] {
+        assert!(
+            inventory.contains(expected),
+            "stable inventory should split debugger and profiler status; missing {expected:?}"
+        );
+    }
+
+    for stale in [
+        "| Debugger / profiler paths |",
+        "Public docs classify them as future work.",
+        "Stabilize the user-facing workflows before adding them to this inventory.",
+    ] {
+        assert!(
+            !inventory.contains(stale),
+            "stable inventory should not retain combined debugger/profiler future wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add documented `rz debug <file>` / `--dap` to the stable CLI inventory.
- Replace the combined debugger/profiler deferred row with a profiler-only future row.
- Add a smoke test that keeps `docs/tooling.md` and the stable inventory aligned on debugger versus profiler status.

Closes #3305

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test stable_inventory_debugger_profiler_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/stable_inventory_debugger_profiler_smoke.rs` to guard inventory/tooling wording alignment without modifying existing tests.
