### PR TITLE
RES-3307: align vscode readme rz defaults

### DIFF
--- a/resilient/tests/vscode_readme_rz_defaults_smoke.rs
+++ b/resilient/tests/vscode_readme_rz_defaults_smoke.rs
@@ -1,0 +1,41 @@
+//! RES-3307: VS Code README command examples match the `rz` extension defaults.
+
+#[test]
+fn vscode_readme_uses_rz_binary_names_consistently() {
+    let readme = include_str!("../../vscode-extension/README.md");
+    let package_json = include_str!("../../vscode-extension/package.json");
+    let extension = include_str!("../../vscode-extension/src/extension.ts");
+
+    for expected in [
+        "it contains the rz binary",
+        "rz --typecheck --audit divide.rz",
+        "| `resilient.serverPath` | `rz` | Path to the `rz` binary.",
+        "resilient/target/debug/rz",
+    ] {
+        assert!(
+            readme.contains(expected),
+            "VS Code README should use current rz binary wording; missing {expected:?}"
+        );
+    }
+
+    assert!(
+        package_json.contains("\"resilient.serverPath\"")
+            && package_json.contains("\"default\": \"rz\""),
+        "VS Code package configuration should default resilient.serverPath to rz"
+    );
+    assert!(
+        extension.contains("serverPath\", \"rz\""),
+        "VS Code extension runtime fallback should default serverPath to rz"
+    );
+
+    for stale in [
+        "resilient --typecheck --audit divide.rz",
+        "| `resilient.serverPath` | `resilient` |",
+        "Path to the `resilient` binary.",
+    ] {
+        assert!(
+            !readme.contains(stale),
+            "VS Code README should not retain stale resilient-binary wording: {stale:?}"
+        );
+    }
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -20,7 +20,7 @@ Full tutorial: [ericspencer.us/Resilient/tutorial](https://ericspencer.us/Resili
    git clone https://github.com/EricSpencer00/Resilient.git
    cd Resilient/resilient
    cargo build --release
-   # Add resilient/target/release/ to your PATH
+   # Add resilient/target/release/ to your PATH; it contains the rz binary
    ```
 
 2. Create `hello.rz`:
@@ -52,7 +52,7 @@ println(divide(10, 2));   // prints: 5
 
 Run with:
 ```bash
-resilient --typecheck --audit divide.rz
+rz --typecheck --audit divide.rz
 ```
 
 `requires` / `ensures` are checked statically; the compiler rejects a call like `divide(10, 0)` at compile time.
@@ -95,7 +95,7 @@ This release tracks the major language milestone shipped in the Resilient 1.5 co
 
 | Setting | Default | Purpose |
 |---|---|---|
-| `resilient.serverPath` | `resilient` | Path to the `resilient` binary. Point at a dev build when hacking. |
+| `resilient.serverPath` | `rz` | Path to the `rz` binary. Defaults to the one on PATH; point at a dev build such as `resilient/target/debug/rz` when hacking. |
 | `resilient.serverArgs` | `["--lsp"]` | Arguments passed to the binary when starting the LSP. |
 | `resilient.trace.server` | `off` | `off` / `messages` / `verbose` — traces LSP traffic to the output channel. |
 


### PR DESCRIPTION
## Summary

- Update the VS Code README safe-divide command to use `rz --typecheck --audit`.
- Align the README `resilient.serverPath` default and description with `package.json` / extension runtime defaults.
- Add a smoke test that keeps the README, package config, and extension fallback aligned on the `rz` binary name.

Closes #3307

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test vscode_readme_rz_defaults_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/vscode_readme_rz_defaults_smoke.rs` to guard VS Code README/package/default binary-name alignment.
