### PR TITLE
RES-3309: clarify ffi string docs

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -1123,10 +1123,14 @@ extern "LIBRARY_PATH" {
 | `Int`     | `int64_t` |
 | `Float`   | `double` |
 | `Bool`    | `bool` (i8) |
-| `String`  | not yet supported |
+| `String`  | variadic `printf`-style format strings; fixed-arity string ABI arms remain limited to implemented trampoline shapes |
 | `Void`    | `void` / no return |
 
 At most 8 parameters per extern function (v1 limit).
+String FFI is narrower than ordinary language string support: use it
+for documented trampoline shapes such as `fn c_printf(fmt: String, ...) -> Int`;
+do not assume arbitrary C string ownership or fixed-arity `char*`
+signatures are available without a matching trampoline arm.
 
 ### Contracts on extern fns
 

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -57,12 +57,18 @@ Only primitive types are supported in FFI Phase 1:
 | `Int`       | `int64_t`                                      |
 | `Float`     | `double`                                       |
 | `Bool`      | `bool`                                         |
-| `String`    | not yet supported                              |
+| `String`    | variadic `printf`-style format strings; fixed-arity string ABI arms remain limited to implemented trampoline shapes |
 | `Void`      | `void`                                         |
 | `OpaquePtr` | `void*` (opaque)                               |
 | `Callback`  | C function pointer (Phase 1 stub — see below)  |
 
 At most 8 parameters per extern function.
+
+String FFI is intentionally narrower than ordinary language string
+support. The shipped trampoline table covers the documented
+`fn c_printf(fmt: String, ...) -> Int` shape for `printf`-style
+variadic calls; arbitrary C string ownership and fixed-arity `char*`
+signatures need an explicitly documented trampoline arm before use.
 
 ### `OpaquePtr` — opaque C handles
 

--- a/resilient/tests/ffi_docs_string_support_smoke.rs
+++ b/resilient/tests/ffi_docs_string_support_smoke.rs
@@ -1,0 +1,36 @@
+//! RES-3309: FFI docs describe current String support precisely.
+
+#[test]
+fn ffi_docs_describe_current_string_trampoline_scope() {
+    let syntax = include_str!("../../SYNTAX.md");
+    let ffi_doc = include_str!("../../docs/ffi.md");
+    let ffi_source = include_str!("../src/ffi.rs");
+    let variadic_smoke = include_str!("ffi_variadic_integration.rs");
+
+    for doc in [syntax, ffi_doc] {
+        for expected in [
+            "variadic `printf`-style format strings",
+            "fixed-arity string ABI arms remain limited to implemented trampoline shapes",
+            "fn c_printf(fmt: String, ...) -> Int",
+        ] {
+            assert!(
+                doc.contains(expected),
+                "FFI docs should describe current String trampoline scope; missing {expected:?}"
+            );
+        }
+        assert!(
+            !doc.contains("| `String`  | not yet supported |")
+                && !doc.contains("| `String`    | not yet supported"),
+            "FFI docs should not claim String is wholly unsupported"
+        );
+    }
+
+    assert!(
+        ffi_source.contains("\"String\" => Some(FfiType::Str)"),
+        "FFI signature resolver should still recognize String as FfiType::Str"
+    );
+    assert!(
+        variadic_smoke.contains("fn c_printf(fmt: String, ...) -> Int"),
+        "variadic FFI smoke should still cover the documented String format-parameter shape"
+    );
+}


### PR DESCRIPTION
## Summary

- Clarify `String` in the FFI type maps instead of saying it is wholly unsupported.
- Document the current variadic `printf`-style format-parameter path and the limited fixed-arity string trampoline scope.
- Add a smoke test tying the docs to `FfiType::Str` recognition and the existing variadic FFI smoke shape.

Closes #3309

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test ffi_docs_string_support_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/ffi_docs_string_support_smoke.rs` to guard FFI docs against stale `String` unsupported wording.
