### PR TITLE
RES-3313: update agent playbook allowlist docs

### DIFF
--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -67,8 +67,10 @@ opportunistically when a new claim is recorded.
 
 ### 2b. Append-only extension points
 
-`resilient/src/{main.rs,typechecker.rs,lexer_logos.rs}` are shared by
-every feature. They contain explicit comment markers:
+`resilient/src/{lib.rs,typechecker.rs,lexer_logos.rs}` are shared by
+every feature. `lib.rs` is the large core file; `main.rs` remains in
+the resolver allowlist only for legacy compatibility. The shared files
+contain explicit comment markers:
 
 ```rust
 // <EXTENSION_TOKENS>
@@ -112,8 +114,9 @@ ready. If either pass fails, the PR stays draft.
 1. `git fetch origin` and rebase the current branch onto
    `origin/main`.
 2. If the rebase hits conflicts, check each file against the
-   append-only allowlist (main.rs, typechecker.rs, lexer_logos.rs,
-   file-claims.json). If all conflict files are in the allowlist, run
+   append-only allowlist (lib.rs, typechecker.rs, lexer_logos.rs,
+   file-claims.json; main.rs is legacy-compatible). If all conflict
+   files are in the allowlist, run
    `auto-resolve-extensions.sh` and continue. Otherwise abort — a
    human or a sonnet-tier agent must resolve.
 3. `git push --force-with-lease` the rebased feature branch.

--- a/resilient/tests/agent_playbook_lib_allowlist_smoke.rs
+++ b/resilient/tests/agent_playbook_lib_allowlist_smoke.rs
@@ -1,0 +1,39 @@
+//! RES-3313: agent playbook treats lib.rs as the primary extension-block file.
+
+#[test]
+fn agent_playbook_uses_lib_rs_for_primary_append_only_guidance() {
+    let playbook = include_str!("../../docs/AGENT_PLAYBOOK.md");
+    let auto_resolve = include_str!("../../agent-scripts/auto-resolve-extensions.sh");
+    let sync_integration = include_str!("../../agent-scripts/sync-integration.sh");
+
+    for expected in [
+        "`resilient/src/{lib.rs,typechecker.rs,lexer_logos.rs}` are shared by",
+        "`lib.rs` is the large core file; `main.rs` remains in",
+        "the resolver allowlist only for legacy compatibility",
+        "append-only allowlist (lib.rs, typechecker.rs, lexer_logos.rs,\n   file-claims.json; main.rs is legacy-compatible)",
+    ] {
+        assert!(
+            playbook.contains(expected),
+            "agent playbook should make lib.rs primary in append-only guidance; missing {expected:?}"
+        );
+    }
+
+    for script in [auto_resolve, sync_integration] {
+        assert!(
+            script.contains("resilient/src/lib.rs")
+                && script.contains("resilient/src/main.rs")
+                && script.contains("legacy"),
+            "agent scripts should keep lib.rs primary while retaining legacy main.rs compatibility"
+        );
+    }
+
+    for stale in [
+        "`resilient/src/{main.rs,typechecker.rs,lexer_logos.rs}` are shared by",
+        "append-only allowlist (main.rs, typechecker.rs, lexer_logos.rs,\n   file-claims.json)",
+    ] {
+        assert!(
+            !playbook.contains(stale),
+            "agent playbook should not retain stale main.rs-primary guidance: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Update `docs/AGENT_PLAYBOOK.md` so `lib.rs` is the primary append-only extension-block file.
- Keep `main.rs` described only as a legacy-compatible allowlist entry.
- Add a smoke test that guards the playbook against stale `main.rs`-primary guidance.

Closes #3313

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test agent_playbook_lib_allowlist_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/agent_playbook_lib_allowlist_smoke.rs` to guard agent playbook wording without modifying existing tests.
