### PR TITLE
RES-3317: update CLI toggle comments

### DIFF
--- a/resilient/src/bounds_check.rs
+++ b/resilient/src/bounds_check.rs
@@ -41,8 +41,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// pattern in CLAUDE.md.
 static DENY_UNPROVEN_BOUNDS: AtomicBool = AtomicBool::new(false);
 
-/// Enable `--deny-unproven-bounds` mode. Called from `main.rs` CLI
-/// parsing before `check_program_with_source` runs.
+/// Enable `--deny-unproven-bounds` mode. Called from the `lib.rs` CLI
+/// dispatcher before `check_program_with_source` runs.
 pub fn set_deny_unproven_bounds(on: bool) {
     DENY_UNPROVEN_BOUNDS.store(on, Ordering::Relaxed);
 }

--- a/resilient/src/termination.rs
+++ b/resilient/src/termination.rs
@@ -105,8 +105,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// change. Mirrors the `bounds_check::DENY_UNPROVEN_BOUNDS` pattern.
 static STRICT_TERMINATION: AtomicBool = AtomicBool::new(false);
 
-/// Enable `--strict-termination` mode. Called from `main.rs` CLI
-/// parsing before `check_program_with_source` runs.
+/// Enable `--strict-termination` mode. Called from the `lib.rs` CLI
+/// dispatcher before `check_program_with_source` runs.
 pub fn set_strict_termination(on: bool) {
     STRICT_TERMINATION.store(on, Ordering::Relaxed);
 }

--- a/resilient/tests/cli_toggle_source_lib_split_smoke.rs
+++ b/resilient/tests/cli_toggle_source_lib_split_smoke.rs
@@ -1,0 +1,20 @@
+//! RES-3317: strict CLI toggle comments point at the library dispatcher.
+
+#[test]
+fn strict_cli_toggle_comments_use_lib_rs_dispatcher() {
+    let bounds_check = include_str!("../src/bounds_check.rs");
+    let termination = include_str!("../src/termination.rs");
+
+    for (name, source) in [("bounds_check", bounds_check), ("termination", termination)] {
+        assert!(
+            source.contains("Called from the `lib.rs` CLI\n/// dispatcher before `check_program_with_source` runs."),
+            "{name} should point strict CLI toggle setup at the lib.rs dispatcher"
+        );
+        assert!(
+            !source.contains(
+                "Called from `main.rs` CLI\n/// parsing before `check_program_with_source` runs."
+            ),
+            "{name} should not retain stale main.rs CLI toggle wording"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- update strict CLI toggle comments in `bounds_check.rs` and `termination.rs` to point at the `lib.rs` dispatcher
- add a narrow source-text smoke test so the stale `main.rs` CLI wording does not return

Closes #3317

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test cli_toggle_source_lib_split_smoke -- --nocapture`

## Test changes

- Added `cli_toggle_source_lib_split_smoke.rs` to guard comment wording after the lib split.
