### PR TITLE
RES-3319: update lexer keyword comments

### DIFF
--- a/resilient/src/lexer_logos.rs
+++ b/resilient/src/lexer_logos.rs
@@ -2,7 +2,7 @@
 //! `logos-lexer` feature flag).
 //!
 //! This module defines a `#[derive(Logos)]` token enum that mirrors
-//! every variant the hand-rolled scanner in `main.rs` produces, and
+//! every variant the hand-rolled scanner in `lib.rs` produces, and
 //! exposes `tokenize` — the entry point `Lexer::new` reaches for when
 //! the `logos-lexer` feature is enabled.
 //!

--- a/resilient/src/repl.rs
+++ b/resilient/src/repl.rs
@@ -24,7 +24,7 @@ const BLUE: &str = "\x1B[34m";
 const CYAN: &str = "\x1B[36m";
 
 /// RES-311: language keywords surfaced as tab-completion candidates.
-/// Mirrors the keyword table in `main.rs::Lexer::next_token`. Hand-curated
+/// Mirrors the keyword table in `lib.rs::Lexer::next_token`. Hand-curated
 /// (the lexer hard-codes its keyword arms in a non-iterable `match`); when
 /// new keywords arrive there, append them here.
 const REPL_KEYWORDS: &[&str] = &[

--- a/resilient/tests/lexer_keyword_source_lib_split_smoke.rs
+++ b/resilient/tests/lexer_keyword_source_lib_split_smoke.rs
@@ -1,0 +1,25 @@
+//! RES-3319: lexer and REPL keyword comments point at lib.rs.
+
+#[test]
+fn lexer_keyword_comments_use_lib_rs_sources() {
+    let lexer_logos = include_str!("../src/lexer_logos.rs");
+    let repl = include_str!("../src/repl.rs");
+
+    assert!(
+        lexer_logos.contains("hand-rolled scanner in `lib.rs` produces"),
+        "lexer_logos should point scanner parity comments at lib.rs"
+    );
+    assert!(
+        !lexer_logos.contains("hand-rolled scanner in `main.rs` produces"),
+        "lexer_logos should not retain stale main.rs scanner wording"
+    );
+
+    assert!(
+        repl.contains("keyword table in `lib.rs::Lexer::next_token`"),
+        "REPL keyword comments should point at lib.rs::Lexer::next_token"
+    );
+    assert!(
+        !repl.contains("keyword table in `main.rs::Lexer::next_token`"),
+        "REPL keyword comments should not retain stale main.rs keyword wording"
+    );
+}


### PR DESCRIPTION
## Summary

- update `lexer_logos.rs` scanner parity comments to point at `lib.rs`
- update REPL keyword-completion comments to point at `lib.rs::Lexer::next_token`
- add a narrow source-text smoke test so stale `main.rs` wording does not return

Closes #3319

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test lexer_keyword_source_lib_split_smoke -- --nocapture`

## Test changes

- Added `lexer_keyword_source_lib_split_smoke.rs` to guard lexer / REPL keyword comment wording after the lib split.
