### PR TITLE
RES-3321: update builtin JIT comments

### DIFF
--- a/resilient/src/bytecode.rs
+++ b/resilient/src/bytecode.rs
@@ -184,7 +184,7 @@ pub enum Op {
     ///
     /// Storing the name (rather than a function pointer index) keeps the
     /// `Op` enum `Copy` and avoids embedding a separate per-program
-    /// builtin table — the canonical `BUILTINS` slice in `main.rs` is
+    /// builtin table — the canonical `BUILTINS` slice in `lib.rs` is
     /// the single source of truth and is consulted at dispatch time.
     CallBuiltin { name_const: u16, arity: u8 },
     /// RES-335: build a `Value::Struct` from `field_count` `(name, value)`

--- a/resilient/src/jit_backend.rs
+++ b/resilient/src/jit_backend.rs
@@ -483,7 +483,7 @@ static GLOBAL_JIT_COMPILES: std::sync::atomic::AtomicU64 = std::sync::atomic::At
 
 /// Read the process-wide JIT cache counters. Returns `(hits,
 /// misses, compiles)`. Called by the CLI's `--jit-cache-stats`
-/// handler from `main.rs` at program exit.
+/// handler from `lib.rs` at program exit.
 pub fn cache_stats() -> (u64, u64, u64) {
     use std::sync::atomic::Ordering;
     (
@@ -1214,7 +1214,7 @@ fn register_runtime_symbols(builder: &mut JITBuilder) {
 // ============================================================
 //
 // The interpreter's builtin functions (`abs`, `min`, `max`, etc.
-// — see `BUILTINS` in main.rs) take `&[Value]` and return
+// — see `BUILTINS` in lib.rs) take `&[Value]` and return
 // `RResult<Value>`. That signature isn't callable from
 // Cranelift-compiled code, which only speaks i64 (and soon f64
 // via RES-098). This module provides thin `extern "C-unwind"`
@@ -1240,7 +1240,7 @@ fn register_runtime_symbols(builder: &mut JITBuilder) {
 
 pub(crate) mod jit_builtins {
     //! RES-167a: extern-"C-unwind" shim wrappers over the arity-
-    //! stable Int builtins in main.rs's BUILTINS table. These
+    //! stable Int builtins in lib.rs's BUILTINS table. These
     //! match the interpreter's semantics for the integer-only
     //! case so tree-walker and JIT output agree.
     //!
@@ -1248,7 +1248,7 @@ pub(crate) mod jit_builtins {
     //! the shims directly without going through Cranelift.
 
     /// Integer absolute value. Matches `builtin_abs` for the
-    /// `Value::Int` case in main.rs. `i64::MIN` wraps (same as
+    /// `Value::Int` case in lib.rs. `i64::MIN` wraps (same as
     /// `wrapping_abs`) to avoid a panic on the minimum value —
     /// the interpreter does the same via `.abs()` on two's-
     /// complement, which panics in debug but wraps in release.
@@ -1258,13 +1258,13 @@ pub(crate) mod jit_builtins {
     }
 
     /// Two-argument integer min. Matches `builtin_min` for the
-    /// two-Int case in main.rs.
+    /// two-Int case in lib.rs.
     pub extern "C-unwind" fn res_jit_min(a: i64, b: i64) -> i64 {
         a.min(b)
     }
 
     /// Two-argument integer max. Matches `builtin_max` for the
-    /// two-Int case in main.rs.
+    /// two-Int case in lib.rs.
     pub extern "C-unwind" fn res_jit_max(a: i64, b: i64) -> i64 {
         a.max(b)
     }
@@ -1606,7 +1606,7 @@ fn run_internal(program: &Node) -> Result<(i64, JitCache), JitError> {
     };
     // RES-174: fold this run's cache stats into the process-wide
     // counters so `--jit-cache-stats` can print lifetime totals
-    // from `main.rs` at exit. Counters are relaxed-atomic — no
+    // from `lib.rs` at exit. Counters are relaxed-atomic — no
     // synchronization semantics, just diagnostic accumulation.
     flush_cache_stats_to_globals(&cache);
     Ok((result, cache))

--- a/resilient/tests/builtin_jit_source_lib_split_smoke.rs
+++ b/resilient/tests/builtin_jit_source_lib_split_smoke.rs
@@ -1,0 +1,37 @@
+//! RES-3321: VM/JIT comments point builtin and exit hooks at lib.rs.
+
+#[test]
+fn builtin_and_jit_comments_use_lib_rs_sources() {
+    let bytecode = include_str!("../src/bytecode.rs");
+    let jit_backend = include_str!("../src/jit_backend.rs");
+
+    for expected in [
+        "canonical `BUILTINS` slice in `lib.rs`",
+        "handler from `lib.rs` at program exit",
+        "see `BUILTINS` in lib.rs",
+        "Int builtins in lib.rs's BUILTINS table",
+        "`Value::Int` case in lib.rs",
+        "two-Int case in lib.rs",
+        "from `lib.rs` at exit",
+    ] {
+        assert!(
+            bytecode.contains(expected) || jit_backend.contains(expected),
+            "VM/JIT comments should include current lib.rs wording: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "canonical `BUILTINS` slice in `main.rs`",
+        "handler from `main.rs` at program exit",
+        "see `BUILTINS` in main.rs",
+        "Int builtins in main.rs's BUILTINS table",
+        "`Value::Int` case in main.rs",
+        "two-Int case in main.rs",
+        "from `main.rs` at exit",
+    ] {
+        assert!(
+            !bytecode.contains(stale) && !jit_backend.contains(stale),
+            "VM/JIT comments should not retain stale main.rs wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- update VM bytecode builtin comments to point the canonical `BUILTINS` table at `lib.rs`
- update JIT cache stats and builtin shim comments to point at `lib.rs`
- add a narrow source-text smoke test so stale VM/JIT `main.rs` wording does not return

Closes #3321

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test builtin_jit_source_lib_split_smoke -- --nocapture`

## Test changes

- Added `builtin_jit_source_lib_split_smoke.rs` to guard VM/JIT source comments after the lib split.
