### PR TITLE
RES-3323: update parser extension comments

### DIFF
--- a/resilient/src/newtypes.rs
+++ b/resilient/src/newtypes.rs
@@ -52,7 +52,7 @@ fn collect_newtypes_from_program(program: &Node) -> HashMap<String, String> {
 ///
 /// Accepts the root `Node::Program` node. No-ops on anything else. The
 /// function signature mirrors the pattern used by `try_catch`, `type_aliases`,
-/// and other post-parse passes so the `<EXTENSION_PASSES>` block in `main.rs`
+/// and other post-parse passes so the `<EXTENSION_PASSES>` block in `lib.rs`
 /// can call it uniformly.
 pub fn lower_program(program: &mut Node) {
     // Collect before mutating to avoid borrow-checker conflict.

--- a/resilient/src/parser_recovery.rs
+++ b/resilient/src/parser_recovery.rs
@@ -10,7 +10,7 @@
 //!
 //! Two predicates classify tokens for the synchronization scanner
 //! used by `Parser::synchronize_top_level` and
-//! `Parser::synchronize_in_block` in `main.rs`:
+//! `Parser::synchronize_in_block` in `lib.rs`:
 //!
 //! * [`starts_top_level_item`] — tokens that unambiguously start a
 //!   fresh top-level construct (`fn`, `let`, `struct`, …). When the

--- a/resilient/src/tuples.rs
+++ b/resilient/src/tuples.rs
@@ -16,14 +16,14 @@
 //! dedicated tuple shape.
 //!
 //! The tuple AST is stored as three new `Node` variants and one new
-//! `Value` variant in `main.rs` (per the feature-isolation pattern,
-//! these are the only main.rs touch points).
+//! `Value` variant in `lib.rs` (per the feature-isolation pattern,
+//! these are the only lib.rs touch points).
 
 use crate::span::Span;
 use crate::{Interpreter, Node, Parser, RResult, Token, Value};
 
 /// Parser entry — called from the `Token::LeftParen` prefix arm in
-/// `main.rs`. On entry, `parser.current_token` is `(`. On exit,
+/// `lib.rs`. On entry, `parser.current_token` is `(`. On exit,
 /// `parser.current_token` sits on the closing `)`.
 ///
 /// Disambiguation:

--- a/resilient/src/type_aliases.rs
+++ b/resilient/src/type_aliases.rs
@@ -14,13 +14,13 @@
 //!
 //! ## What lives elsewhere (and why)
 //!
-//! - **Token + keyword + AST node**: `main.rs` (`Token::Type`,
+//! - **Token + keyword + AST node**: `lib.rs` (`Token::Type`,
 //!   `"type" => Token::Type`, `Node::TypeAlias { name, target, span }`).
 //!   Predates the feature-isolation refactor — kept in place to avoid
 //!   churning every consumer (`free_vars`, `compiler`, `formatter`,
 //!   `lsp_server`, `jit_backend`).
 //! - **Logos token**: `lexer_logos.rs` (`#[token("type")] Type`).
-//! - **Parser**: `Parser::parse_type_alias` in `main.rs`.
+//! - **Parser**: `Parser::parse_type_alias` in `lib.rs`.
 //! - **Lazy alias expansion**: `TypeChecker::parse_type_name` in
 //!   `typechecker.rs` — the actual structural-equivalence step that
 //!   makes `Meters` interchangeable with `float`.

--- a/resilient/src/watch_mode.rs
+++ b/resilient/src/watch_mode.rs
@@ -1,7 +1,7 @@
 // RES-228: `rz run --watch <file>` — re-run the program on every save.
 //
 // All watch-mode logic lives here per the feature-isolation pattern in
-// CLAUDE.md.  The only changes to main.rs are:
+// CLAUDE.md. The library dispatcher touchpoints in `lib.rs` are:
 //   1. `mod watch_mode;`
 //   2. a dispatch call just before the normal `execute_file` path.
 //
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use notify_debouncer_mini::{DebounceEventResult, new_debouncer, notify::RecursiveMode};
 
-/// Entry point called from `main()` when `--watch` is passed.
+/// Entry point called from the library CLI dispatcher when `--watch` is passed.
 ///
 /// Runs `file_path` immediately, then re-runs it on every save until
 /// the user presses Ctrl-C.  `execute_once` is a closure that

--- a/resilient/tests/parser_extension_source_lib_split_smoke.rs
+++ b/resilient/tests/parser_extension_source_lib_split_smoke.rs
@@ -1,0 +1,39 @@
+//! RES-3323: parser and extension comments point touchpoints at lib.rs.
+
+#[test]
+fn parser_extension_comments_use_lib_rs_touchpoints() {
+    let files = [
+        ("newtypes", include_str!("../src/newtypes.rs")),
+        ("parser_recovery", include_str!("../src/parser_recovery.rs")),
+        ("tuples", include_str!("../src/tuples.rs")),
+        ("type_aliases", include_str!("../src/type_aliases.rs")),
+        ("watch_mode", include_str!("../src/watch_mode.rs")),
+    ];
+
+    for (name, source) in files {
+        assert!(
+            !source.contains("main.rs"),
+            "{name} should not point parser or extension touchpoints at main.rs"
+        );
+        assert!(
+            !source.contains("main()"),
+            "{name} should not describe watch/CLI dispatch as a direct main() hook"
+        );
+    }
+
+    for expected in [
+        "`<EXTENSION_PASSES>` block in `lib.rs`",
+        "`Parser::synchronize_in_block` in `lib.rs`",
+        "new `Node` variants and one new\n//! `Value` variant in `lib.rs`",
+        "`Token::LeftParen` prefix arm in\n/// `lib.rs`",
+        "**Token + keyword + AST node**: `lib.rs`",
+        "**Parser**: `Parser::parse_type_alias` in `lib.rs`",
+        "library dispatcher touchpoints in `lib.rs` are",
+        "Entry point called from the library CLI dispatcher",
+    ] {
+        assert!(
+            files.iter().any(|(_, source)| source.contains(expected)),
+            "parser extension comments should include current lib.rs wording: {expected:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- update parser / extension module comments to point core touchpoints at `lib.rs`
- refresh watch-mode comments to describe the library CLI dispatcher instead of direct `main()` wiring
- add a narrow source-text smoke test so stale parser-extension `main.rs` wording does not return in the listed files

Closes #3323

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test parser_extension_source_lib_split_smoke -- --nocapture`

## Test changes

- Added `parser_extension_source_lib_split_smoke.rs` to guard parser / extension source comments after the lib split.
