### PR TITLE
RES-3327: update core touchpoint comments

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -352,7 +352,7 @@ mod ranges;
 
 // RES-343: conditional compilation via `#[cfg(...)]` attributes. The body
 // of the parser hook (predicate parsing + active-feature evaluation) lives
-// in this module; the main module only adds:
+// in this module; the core library only adds:
 //   * one Token variant for `#[` (in <EXTENSION_TOKENS>)
 //   * one lexer arm to emit it
 //   * one match arm in `parse_statement` to dispatch
@@ -366,18 +366,18 @@ mod cfg_attr;
 // must follow positional, no duplicates) lives next to the parser.
 mod named_args;
 
-// RES-221: string interpolation — `"text {expr} more"`. All feature
-// logic lives here; main.rs only adds a Node variant and two small
-// dispatch calls.
+// RES-221: string interpolation — `"text {expr} more"`. Feature logic
+// lives in `string_interp.rs`; `lib.rs` carries the Node variant and
+// two small dispatch calls.
 mod string_interp;
 // RES-401: tuples — literals, element access, destructuring let. All
 // feature logic (parser dispatch, interpreter helpers) lives in
-// `tuples.rs`; main.rs only adds the Node / Value variants and routes
+// `tuples.rs`; `lib.rs` carries the Node / Value variants and routes
 // through to the helpers.
 mod tuples;
 // RES-409: streaming file I/O — `file_open`, `file_read_chunk`,
 // `file_seek`, `file_close`, `file_write_chunk`. All builtins and the
-// thread-local handle registry live here; main.rs just registers
+// thread-local handle registry live here; `lib.rs` just registers
 // them in the BUILTINS table.
 mod file_io;
 // RES-324: `mod name { ... }` inline namespace blocks. All namespace
@@ -390,7 +390,7 @@ mod modules;
 mod default_params;
 // RES-289 (RES-81): generic type parameters — `fn identity<T>(x: T) -> T`.
 // Parse-time support (Token::Less/Greater reuse, parse_optional_type_params,
-// Node::Function::type_params field) lives in main.rs; this module owns the
+// Node::Function::type_params field) lives in lib.rs; this module owns the
 // typechecker validation pass (duplicate type-param detection).
 mod generics;
 // RES-2576: call-site type inference for generic function calls.
@@ -410,7 +410,7 @@ pub(crate) mod variance;
 // logic lives here: post-parse lowering (rewrites CallExpression to
 // NewtypeConstruct) and the typechecker validation pass. The hot
 // eval path is not touched — only two thin eval arms are added in
-// main.rs for NewtypeDecl (register) and NewtypeConstruct (wrap).
+// lib.rs for NewtypeDecl (register) and NewtypeConstruct (wrap).
 mod newtypes;
 // RES-394: region inference — assigns region variables to unlabeled
 // reference parameters; PR D5 integrates results into
@@ -25539,7 +25539,7 @@ impl Interpreter {
                 Ok(Value::Array(out))
             }
             // RES-401: tuple literal / element access / let destructure.
-            // All three dispatch into helpers in `tuples.rs`; main.rs
+            // All three dispatch into helpers in `tuples.rs`; `lib.rs`
             // just routes here so the feature stays isolated.
             Node::TupleLiteral { items, .. } => crate::tuples::eval_tuple_literal(self, items),
             Node::TupleIndex { tuple, index, span } => {

--- a/resilient/src/vm.rs
+++ b/resilient/src/vm.rs
@@ -248,7 +248,7 @@ impl OverflowMode {
         Ok(a % b)
     }
 
-    /// RES-349: tree-walker variant. The interpreter in `main.rs`
+    /// RES-349: tree-walker variant. The tree-walker interpreter in `lib.rs`
     /// reports errors as `String`, not `VmError`, so the trap path
     /// formats a matching diagnostic.
     pub fn add_for_eval(self, a: i64, b: i64, op: &str) -> Result<i64, String> {

--- a/resilient/tests/core_touchpoint_source_lib_split_smoke.rs
+++ b/resilient/tests/core_touchpoint_source_lib_split_smoke.rs
@@ -1,0 +1,39 @@
+//! RES-3327: remaining core touchpoint comments point at lib.rs.
+
+#[test]
+fn core_touchpoint_comments_use_lib_rs_sources() {
+    let lib = include_str!("../src/lib.rs");
+    let vm = include_str!("../src/vm.rs");
+
+    for expected in [
+        "the core library only adds:",
+        "`lib.rs` carries the Node variant",
+        "`lib.rs` carries the Node / Value variants",
+        "`lib.rs` just registers",
+        "Node::Function::type_params field) lives in lib.rs",
+        "lib.rs for NewtypeDecl (register)",
+        "helpers in `tuples.rs`; `lib.rs`",
+        "tree-walker interpreter in `lib.rs`",
+    ] {
+        assert!(
+            lib.contains(expected) || vm.contains(expected),
+            "core touchpoint comments should include lib.rs wording: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "the main module only adds:",
+        "All feature logic lives here; main.rs only adds",
+        "`tuples.rs`; main.rs only adds",
+        "thread-local handle registry live here; main.rs just registers",
+        "Node::Function::type_params field) lives in main.rs",
+        "main.rs for NewtypeDecl (register)",
+        "helpers in `tuples.rs`; main.rs",
+        "The interpreter in `main.rs`",
+    ] {
+        assert!(
+            !lib.contains(stale) && !vm.contains(stale),
+            "core touchpoint comments should not retain stale wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- update remaining core-language touchpoint comments in `lib.rs` to describe `lib.rs` / the core library accurately
- update the VM overflow tree-walker comment to point at the `lib.rs` interpreter path
- add a narrow source-text smoke test so these stale `main.rs` touchpoint comments do not return

Closes #3327

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test core_touchpoint_source_lib_split_smoke -- --nocapture`

## Test changes

- Added `core_touchpoint_source_lib_split_smoke.rs` to guard remaining core touchpoint comments after the lib split.
