### PR TITLE
RES-3329: clarify FFI callback docs

### DIFF
--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -60,7 +60,7 @@ Only primitive types are supported in FFI Phase 1:
 | `String`    | variadic `printf`-style format strings; fixed-arity string ABI arms remain limited to implemented trampoline shapes |
 | `Void`      | `void`                                         |
 | `OpaquePtr` | `void*` (opaque)                               |
-| `Callback`  | C function pointer (Phase 1 stub — see below)  |
+| `Callback`  | C function pointer (recognised in declarations; calls unsupported in Phase 1) |
 
 At most 8 parameters per extern function.
 
@@ -112,7 +112,7 @@ Trampoline coverage today:
 Higher arities extend mechanically by adding an arm to
 `dispatch_explicit` in `ffi_trampolines.rs`.
 
-### `Callback` — Phase 1 stub
+### `Callback` — declaration-only in Phase 1
 
 Callback types are recognised in FFI declarations:
 
@@ -122,8 +122,8 @@ extern "libfoo.so" {
 }
 ```
 
-Passing a Resilient function as `Callback` is stubbed in Phase 1 and returns
-a clean error:
+Passing a Resilient function as `Callback` is not supported in Phase 1 and
+returns a clean error:
 
 ```
 FFI: extern fn `register_handler` uses a Callback parameter; callbacks

--- a/resilient/tests/ffi_docs_callback_copy_smoke.rs
+++ b/resilient/tests/ffi_docs_callback_copy_smoke.rs
@@ -1,0 +1,30 @@
+//! RES-3329: FFI callback docs use user-facing unsupported wording.
+
+#[test]
+fn ffi_docs_describe_callback_as_unsupported_not_stubbed() {
+    let ffi_doc = include_str!("../../docs/ffi.md");
+
+    for expected in [
+        "C function pointer (recognised in declarations; calls unsupported in Phase 1)",
+        "### `Callback` — declaration-only in Phase 1",
+        "Passing a Resilient function as `Callback` is not supported in Phase 1",
+        "returns a clean error:",
+        "callbacks\nrequire the trampoline feature (planned for Phase 2)",
+    ] {
+        assert!(
+            ffi_doc.contains(expected),
+            "FFI callback docs should use current user-facing wording: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "Phase 1 stub",
+        "Callback` is stubbed in Phase 1",
+        "Callback)  | C function pointer (Phase 1 stub",
+    ] {
+        assert!(
+            !ffi_doc.contains(stale),
+            "FFI callback docs should not expose internal stub wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- replace user-facing FFI callback “stub” wording with declaration-only / unsupported-in-Phase-1 language
- keep the documented clean error behavior unchanged
- add a narrow docs smoke test so the internal stub wording does not return

Closes #3329

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test ffi_docs_callback_copy_smoke -- --nocapture`

## Test changes

- Added `ffi_docs_callback_copy_smoke.rs` to guard FFI callback docs copy.
