### PR TITLE
RES-3331: polish LSP extension docs

### DIFF
--- a/LSP.md
+++ b/LSP.md
@@ -61,7 +61,7 @@ lspconfig.resilient.setup({})
 
 ### VS Code
 
-Use the bundled `vscode-extension/` scaffold or any generic LSP runner
+Use the bundled `vscode-extension/` workspace or any generic LSP runner
 extension. Point `command` at the Resilient binary and pass `--lsp` as
 the argument.
 

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -170,8 +170,8 @@ extension (e.g. *Generic LSP Client*). Point `command` at the
 `rz` binary with `--lsp` as the argument and set the language
 ID to `resilient` for `.rz` files.
 
-The `vscode-extension/` directory in the repo contains a minimal
-extension scaffold — `npm install && vsce package` inside it
+The `vscode-extension/` directory in the repo contains a minimal VS Code
+extension workspace; `npm install && vsce package` inside it
 produces an installable `.vsix`.
 
 ---

--- a/resilient/tests/docs_lsp_extension_workspace_copy_smoke.rs
+++ b/resilient/tests/docs_lsp_extension_workspace_copy_smoke.rs
@@ -1,0 +1,25 @@
+//! RES-3331: LSP docs describe the VS Code extension as a workspace.
+
+#[test]
+fn lsp_docs_use_workspace_language_for_vscode_extension() {
+    let lsp_root = include_str!("../../LSP.md");
+    let lsp_docs = include_str!("../../docs/lsp.md");
+
+    for expected in [
+        "bundled `vscode-extension/` workspace",
+        "contains a minimal VS Code\nextension workspace",
+        "`npm install && vsce package` inside it\nproduces an installable `.vsix`",
+    ] {
+        assert!(
+            lsp_root.contains(expected) || lsp_docs.contains(expected),
+            "LSP docs should use workspace/package wording: {expected:?}"
+        );
+    }
+
+    for stale in ["`vscode-extension/` scaffold", "extension scaffold"] {
+        assert!(
+            !lsp_root.contains(stale) && !lsp_docs.contains(stale),
+            "LSP docs should not describe the VS Code extension as a scaffold: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- describe the bundled `vscode-extension/` as a workspace instead of a scaffold
- polish the LSP docs packaging sentence for the VS Code extension
- add a narrow docs smoke test so scaffold wording does not return

Closes #3331

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_lsp_extension_workspace_copy_smoke -- --nocapture`

## Test changes

- Added `docs_lsp_extension_workspace_copy_smoke.rs` to guard LSP extension setup wording.
