### PR TITLE
RES-3333: clarify generic syntax docs

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -68,9 +68,9 @@ fn identity<T>(T x) -> T { return x; }
 fn swap<A, B>(A a, B b) { return [b, a]; }
 ```
 
-Type parameters are currently parse-and-AST only; the
-typechecker uses the HM scaffolding from RES-122 and
-monomorphizes at the call site. Constraints (`fn<T: Trait>`)
+Type parameters currently have parser/AST support plus call-site
+monomorphization. The typechecker builds on the Hindley-Milner
+inference machinery from RES-122. Constraints (`fn<T: Trait>`)
 are a future extension.
 
 ### Contracts

--- a/resilient/tests/docs_syntax_generics_copy_smoke.rs
+++ b/resilient/tests/docs_syntax_generics_copy_smoke.rs
@@ -1,0 +1,24 @@
+//! RES-3333: generic syntax docs use public inference terminology.
+
+#[test]
+fn syntax_docs_describe_generics_without_scaffolding_jargon() {
+    let syntax = include_str!("../../docs/syntax.md");
+
+    for expected in [
+        "Type parameters currently have parser/AST support plus call-site\nmonomorphization.",
+        "The typechecker builds on the Hindley-Milner\ninference machinery from RES-122.",
+        "Constraints (`fn<T: Trait>`)\nare a future extension.",
+    ] {
+        assert!(
+            syntax.contains(expected),
+            "generic syntax docs should use clear public wording: {expected:?}"
+        );
+    }
+
+    for stale in ["HM scaffolding", "parse-and-AST only"] {
+        assert!(
+            !syntax.contains(stale),
+            "generic syntax docs should not retain stale/internal wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- replace internal “HM scaffolding” wording in `docs/syntax.md`
- describe current generic type-parameter support as parser/AST support plus call-site monomorphization
- add a narrow docs smoke test to keep the public wording clear

Closes #3333

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_syntax_generics_copy_smoke -- --nocapture`

## Test changes

- Added `docs_syntax_generics_copy_smoke.rs` to guard generic syntax docs wording.
