### PR TITLE
RES-3335: polish safety docs copy

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -583,8 +583,8 @@ Resilient today is qualification-ready.
   actor-safety argument; V1 actors are for interpreter use only.
 - The roadmap points to Erlang-style actors + supervisor trees,
   built on top of effect tracking and an AOT path.
-- Real-time scheduling guarantees are a future work item gated
-  on AOT; today, hard-RT code stays in C.
+- Real-time scheduling guarantees depend on the planned AOT path;
+  today's runtime does not provide them, so hard-RT code stays in C.
 
 If you are evaluating Resilient for a safety-critical project:
 the honest pitch is "a single-threaded, verifiable,

--- a/docs/standards/do-178c.md
+++ b/docs/standards/do-178c.md
@@ -69,7 +69,7 @@ where the mapping is direct.
   discharge is direct evidence of requirements satisfaction
   for the discharged subset.
 
-- **Robustness testing scaffolding.** Contracts that *cannot*
+- **Robustness testing support.** Contracts that *cannot*
   be discharged at compile time become typed runtime asserts
   that act as instrumented oracles for robustness testing.
 

--- a/resilient/tests/docs_safety_roadmap_copy_smoke.rs
+++ b/resilient/tests/docs_safety_roadmap_copy_smoke.rs
@@ -1,0 +1,29 @@
+//! RES-3335: safety docs use direct support-boundary wording.
+
+#[test]
+fn safety_docs_avoid_internal_future_scaffold_wording() {
+    let concurrency = include_str!("../../docs/concurrency.md");
+    let do178c = include_str!("../../docs/standards/do-178c.md");
+
+    for expected in [
+        "Real-time scheduling guarantees depend on the planned AOT path;",
+        "today's runtime does not provide them, so hard-RT code stays in C.",
+        "**Robustness testing support.** Contracts that *cannot*",
+        "instrumented oracles for robustness testing",
+    ] {
+        assert!(
+            concurrency.contains(expected) || do178c.contains(expected),
+            "safety docs should use direct support-boundary wording: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "future work item gated\n  on AOT",
+        "**Robustness testing scaffolding.**",
+    ] {
+        assert!(
+            !concurrency.contains(stale) && !do178c.contains(stale),
+            "safety docs should not retain internal roadmap/scaffold wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- clarify concurrency docs by stating that real-time scheduling guarantees depend on planned AOT work and are not in today’s runtime
- rename DO-178C “robustness testing scaffolding” to “robustness testing support”
- add a narrow docs smoke test so the old internal wording does not return

Closes #3335

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_safety_roadmap_copy_smoke -- --nocapture`

## Test changes

- Added `docs_safety_roadmap_copy_smoke.rs` to guard safety docs wording.
