### PR TITLE
RES-3337: polish VS Code roadmap note

### DIFF
--- a/resilient/tests/vscode_readme_roadmap_copy_smoke.rs
+++ b/resilient/tests/vscode_readme_roadmap_copy_smoke.rs
@@ -1,0 +1,19 @@
+//! RES-3337: VS Code README avoids internal roadmap tracking wording.
+
+#[test]
+fn vscode_readme_roadmap_note_uses_public_wording() {
+    let readme = include_str!("../../vscode-extension/README.md");
+
+    assert!(
+        readme.contains("V2 design work is tracked separately and will be scoped independently"),
+        "VS Code README should describe V2 work with public roadmap wording"
+    );
+    assert!(
+        readme.contains("This release is purely additive on the V1 surface."),
+        "VS Code README should preserve the V1 additive-surface note"
+    );
+    assert!(
+        !readme.contains("tracked internally"),
+        "VS Code README should not expose internal tracking language"
+    );
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -87,7 +87,7 @@ This release tracks the major language milestone shipped in the Resilient 1.5 co
 
 **Self-hosting parser (RES-379)** — `self-host/parser.rz` PR 1: recursive-descent Pratt parser emitting JSON AST; covers expressions, statements, and fn declarations
 
-*Note: V2 design work is tracked internally and will be scoped separately. This release is purely additive on the V1 surface.*
+*Note: V2 design work is tracked separately and will be scoped independently. This release is purely additive on the V1 surface.*
 
 ---
 


### PR DESCRIPTION
## Summary

- replace “tracked internally” in the VS Code extension README roadmap note
- keep the V1 additive-surface statement intact
- add a narrow docs smoke test so internal roadmap wording does not return

Closes #3337

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test vscode_readme_roadmap_copy_smoke -- --nocapture`

## Test changes

- Added `vscode_readme_roadmap_copy_smoke.rs` to guard the VS Code README roadmap note.
