### PR TITLE
RES-3339: refresh JIT backend header

### DIFF
--- a/resilient/src/jit_backend.rs
+++ b/resilient/src/jit_backend.rs
@@ -1,9 +1,7 @@
-//! RES-072 Phase A + RES-096 Phase B: Cranelift JIT backend.
+//! RES-072 / RES-096: Cranelift JIT backend.
 //!
-//! Phase A wired the dep tree, the `--jit` flag, and a stub
-//! `run` that returned `JitError::Unsupported`. Phase B (this
-//! revision) actually lowers a tiny subset of the AST to native
-//! code and executes it:
+//! The backend lowers the currently supported tree-walker subset to
+//! native code and executes it:
 //!
 //! - `Node::IntegerLiteral { value, .. }` → `iconst`
 //! - `Node::InfixExpression` with `+` → recursive lower + `iadd`
@@ -12,9 +10,8 @@
 //! - Top-level `Node::Program` containing a single
 //!   `ReturnStatement` is wrapped as the JIT's `main`
 //!
-//! Anything else returns `JitError::Unsupported(...)`. Future
-//! tickets layer on let bindings (RES-097-?), control flow,
-//! function calls, etc.
+//! Unsupported AST shapes return `JitError::Unsupported(...)` cleanly
+//! so callers can fall back to the interpreter instead of panicking.
 
 #![allow(dead_code)]
 

--- a/resilient/tests/jit_backend_header_copy_smoke.rs
+++ b/resilient/tests/jit_backend_header_copy_smoke.rs
@@ -1,0 +1,29 @@
+//! RES-3339: JIT backend header describes the current implementation.
+
+#[test]
+fn jit_backend_header_uses_current_backend_wording() {
+    let source = include_str!("../src/jit_backend.rs");
+
+    for expected in [
+        "RES-072 / RES-096: Cranelift JIT backend.",
+        "lowers the currently supported tree-walker subset to\n//! native code",
+        "Unsupported AST shapes return `JitError::Unsupported(...)` cleanly",
+        "fall back to the interpreter instead of panicking",
+    ] {
+        assert!(
+            source.contains(expected),
+            "JIT backend header should describe current behavior: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "stub\n//! `run`",
+        "Phase B (this\n//! revision)",
+        "Future\n//! tickets layer on",
+    ] {
+        assert!(
+            !source.contains(stale),
+            "JIT backend header should not retain stale revision wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- refresh the JIT backend module header to describe the current Cranelift lowering path directly
- remove stale “stub run / this revision” wording from the header
- add a narrow source-text smoke test to keep the header current

Closes #3339

## Tests

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test jit_backend_header_copy_smoke -- --nocapture`

## Test changes

- Added `jit_backend_header_copy_smoke.rs` to guard the JIT backend header wording.
