### PR TITLE
RES-3341: clarify MCP tool bridge copy

### DIFF
--- a/resilient/src/mcp_tool_registry.rs
+++ b/resilient/src/mcp_tool_registry.rs
@@ -1,6 +1,6 @@
 //! MCP external-tool bridge registry.
 //!
-//! Provides a generic scaffolding framework for connecting external
+//! Provides a generic integration framework for connecting external
 //! verification and analysis tools to the Resilient MCP server.  Each
 //! external tool — TLA+ TLC, Z3, Lean 4, CBMC, or a user-supplied binary
 //! — is registered as a `BridgedTool` and exposed automatically via the
@@ -875,7 +875,7 @@ fn cmd_check(args: &[String]) -> i32 {
 
 fn print_tool_help() {
     println!(
-        "rz tool — external tool bridge (MCP scaffolding)
+        "rz tool — external tool bridge (MCP integration)
 
 USAGE:
     rz tool list                     List all registered external tools

--- a/resilient/tests/mcp_tool_help_copy_smoke.rs
+++ b/resilient/tests/mcp_tool_help_copy_smoke.rs
@@ -1,0 +1,23 @@
+//! RES-3341: MCP tool help should describe integration, not scaffolding.
+
+#[test]
+fn mcp_tool_registry_uses_integration_wording() {
+    let source = include_str!("../src/mcp_tool_registry.rs");
+
+    for expected in [
+        "generic integration framework",
+        "rz tool — external tool bridge (MCP integration)",
+    ] {
+        assert!(
+            source.contains(expected),
+            "MCP tool registry copy should use integration wording: {expected:?}"
+        );
+    }
+
+    for stale in ["generic scaffolding framework", "MCP scaffolding"] {
+        assert!(
+            !source.contains(stale),
+            "MCP tool registry copy should not retain scaffolding wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3341

## Summary

- Reworded the MCP external-tool bridge module docs from scaffolding to integration language.
- Updated `rz tool` help to describe MCP integration instead of MCP scaffolding.
- Added a focused smoke test that guards the integration wording and rejects the stale scaffolding phrasing.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test mcp_tool_help_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/mcp_tool_help_copy_smoke.rs` to lock the user-facing/source copy contract for MCP tool bridge wording.
