### PR TITLE
RES-3343: clarify MCP server copy

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -139,7 +139,7 @@ mod dap_server;
 #[cfg(not(target_arch = "wasm32"))]
 mod debugger;
 
-/// RES-2645: MCP external-tool bridge registry — generic scaffolding for
+/// RES-2645: MCP external-tool bridge registry — integration support for
 /// connecting external verification/analysis tools as MCP tool providers.
 pub mod mcp_tool_registry;
 

--- a/resilient/src/mcp_server.rs
+++ b/resilient/src/mcp_server.rs
@@ -30,7 +30,7 @@
 //! | `resilient_verify` | Z3 contract verification (requires `--features z3`) |
 //!
 
-//! ## Prompts exposed (RES-2645 MCP Scaffolding)
+//! ## Prompts exposed (RES-2645 MCP Integration)
 //!
 //! | Prompt | Description |
 //! |---|---|
@@ -40,7 +40,7 @@
 //! | `explain_lint` | Guided workflow: understand and fix a lint warning |
 //! | `safety_review` | Guided workflow: full safety-critical review |
 //!
-//! ## Resources exposed (RES-2645 MCP Scaffolding)
+//! ## Resources exposed (RES-2645 MCP Integration)
 //!
 //! | Resource | Description |
 //! |---|---|
@@ -135,7 +135,7 @@ fn dispatch(
         "tools/list" => Some(handle_tools_list(id)),
         "tools/call" => Some(handle_tools_call(id, params)),
 
-        // RES-2645: MCP Scaffolding — prompts and resources support.
+        // RES-2645: MCP integration — prompts and resources support.
         "prompts/list" => Some(handle_prompts_list(id)),
         "prompts/get" => Some(handle_prompts_get(id, params)),
         "resources/list" => Some(handle_resources_list(id)),
@@ -256,7 +256,7 @@ fn handle_tools_call(id: &Value, params: Option<&Value>) -> Value {
     }
 }
 
-// ── Prompts (RES-2645: MCP Scaffolding) ──────────────────────────────────────
+// ── Prompts (RES-2645: MCP integration) ──────────────────────────────────────
 
 /// Guided workflow prompt descriptors surfaced via `prompts/list`.
 fn prompt_descriptors() -> Vec<Value> {
@@ -535,7 +535,7 @@ fn handle_prompts_get(id: &Value, params: Option<&Value>) -> Value {
     ok(id, json!({ "messages": messages }))
 }
 
-// ── Resources (RES-2645: MCP Scaffolding) ────────────────────────────────────
+// ── Resources (RES-2645: MCP integration) ────────────────────────────────────
 
 /// Static documentation resource descriptors.
 fn resource_descriptors() -> Vec<Value> {

--- a/resilient/tests/mcp_server_copy_smoke.rs
+++ b/resilient/tests/mcp_server_copy_smoke.rs
@@ -1,0 +1,32 @@
+//! RES-3343: MCP server docs should describe integration, not scaffolding.
+
+#[test]
+fn mcp_server_docs_use_integration_wording() {
+    let server = include_str!("../src/mcp_server.rs");
+    let lib = include_str!("../src/lib.rs");
+
+    for expected in [
+        "## Prompts exposed (RES-2645 MCP Integration)",
+        "## Resources exposed (RES-2645 MCP Integration)",
+        "RES-2645: MCP integration — prompts and resources support.",
+        "Prompts (RES-2645: MCP integration)",
+        "Resources (RES-2645: MCP integration)",
+    ] {
+        assert!(
+            server.contains(expected),
+            "MCP server docs/comments should use integration wording: {expected:?}"
+        );
+    }
+
+    assert!(
+        lib.contains("MCP external-tool bridge registry — integration support"),
+        "mcp_tool_registry module header should describe integration support"
+    );
+
+    for stale in ["MCP Scaffolding", "generic scaffolding for"] {
+        assert!(
+            !server.contains(stale) && !lib.contains(stale),
+            "MCP docs/comments should not retain scaffolding wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3343

## Summary

- Reworded MCP server prompt/resource docs from "MCP Scaffolding" to "MCP Integration".
- Updated internal MCP server section labels to use integration wording.
- Refreshed the `mcp_tool_registry` module header in `lib.rs` to describe integration support instead of generic scaffolding.
- Added a focused smoke test that guards the wording contract.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test mcp_server_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/mcp_server_copy_smoke.rs` to lock MCP server documentation/comment wording and reject stale scaffolding labels.
