### PR TITLE
RES-3345: refresh JIT comment wording

### DIFF
--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -62,7 +62,8 @@ lsp = ["dep:tower-lsp", "dep:tokio"]
 #
 # and run `rz --jit prog.rz` to lower the program to native
 # code instead of going through the tree walker / bytecode VM.
-# Phase A only ships the scaffolding; RES-096+ adds AST lowering.
+# The JIT lowers the supported tree-walker subset to native code and
+# reports unsupported AST shapes cleanly so callers can fall back.
 jit = ["dep:cranelift", "dep:cranelift-jit", "dep:cranelift-native", "dep:cranelift-module"]
 # RES-108: opt-in logos-based lexer (G5 foundation). Default off so the
 # hand-rolled scanner stays authoritative until RES-109 benchmarks land.

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -33069,8 +33069,8 @@ pub fn run_cli() {
                 // the tree-walking interpreter.
                 use_vm = true;
             } else if arg == "--jit" {
-                // RES-072: route through the Cranelift JIT backend.
-                // Phase A is a stub — RES-096+ adds real lowering.
+                // RES-072 / RES-096: route through the Cranelift JIT
+                // backend for the supported tree-walker subset.
                 use_jit = true;
             } else if arg == "--lsp" {
                 // RES-074: start the Language Server on stdio. Only

--- a/resilient/tests/jit_comment_copy_smoke.rs
+++ b/resilient/tests/jit_comment_copy_smoke.rs
@@ -1,0 +1,31 @@
+//! RES-3345: JIT comments should describe the current backend path.
+
+#[test]
+fn jit_comments_use_current_backend_wording() {
+    let cargo_toml = include_str!("../Cargo.toml");
+    let lib = include_str!("../src/lib.rs");
+
+    for expected in [
+        "The JIT lowers the supported tree-walker subset to native code",
+        "reports unsupported AST shapes cleanly so callers can fall back",
+        "RES-072 / RES-096: route through the Cranelift JIT",
+        "backend for the supported tree-walker subset",
+    ] {
+        assert!(
+            cargo_toml.contains(expected) || lib.contains(expected),
+            "JIT comments should describe current backend behavior: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "Phase A only ships the scaffolding",
+        "Phase A is a stub",
+        "RES-096+ adds AST lowering",
+        "RES-096+ adds real lowering",
+    ] {
+        assert!(
+            !cargo_toml.contains(stale) && !lib.contains(stale),
+            "JIT comments should not retain stale Phase A wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3345

## Summary

- Replaced stale JIT Phase A scaffolding/stub wording in `resilient/Cargo.toml`.
- Refreshed the `--jit` CLI path comment to describe the current Cranelift backend routing for the supported tree-walker subset.
- Added a focused smoke test that guards the current wording and rejects stale Phase A phrasing.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test jit_comment_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/jit_comment_copy_smoke.rs` to lock the JIT comment wording contract.
