### PR TITLE
RES-3347: refresh diagnostic model comments

### DIFF
--- a/resilient/src/diag.rs
+++ b/resilient/src/diag.rs
@@ -177,14 +177,12 @@ fn expand_tabs(line: &str) -> String {
 }
 
 // ============================================================
-// RES-119 (scaffolding-only): unified Diagnostic data model.
+// RES-119: shared Diagnostic data model.
 // ============================================================
 //
-// This section lands the data types + terminal renderer. Call-
-// site migration (parser / typechecker / VM / verifier / LSP)
-// is deliberately NOT in scope here per the bail's Option 2 —
-// the existing pipelines keep emitting `String` errors unchanged
-// until follow-up tickets migrate each phase individually.
+// This section owns the typed diagnostic data structures and
+// terminal renderer. Some call sites still emit `String` errors;
+// follow-up migrations can adopt these types phase by phase.
 //
 // The types are `pub` so RES-206 (error-code registry) and
 // later phase-migration tickets can consume them directly.
@@ -492,7 +490,7 @@ mod tests {
         assert!(d.contains("^"), "missing caret even on empty line: {}", d);
     }
 
-    // ---------- RES-119: Diagnostic scaffolding ----------
+    // ---------- RES-119: Diagnostic model ----------
 
     #[test]
     fn severity_renders_lowercase_rustc_style() {

--- a/resilient/tests/diagnostic_model_copy_smoke.rs
+++ b/resilient/tests/diagnostic_model_copy_smoke.rs
@@ -1,0 +1,29 @@
+//! RES-3347: diagnostic comments should describe a shared model.
+
+#[test]
+fn diagnostic_comments_use_shared_model_wording() {
+    let source = include_str!("../src/diag.rs");
+
+    for expected in [
+        "RES-119: shared Diagnostic data model.",
+        "typed diagnostic data structures and\n// terminal renderer",
+        "follow-up migrations can adopt these types phase by phase",
+        "RES-119: Diagnostic model",
+    ] {
+        assert!(
+            source.contains(expected),
+            "diagnostic comments should describe the shared model: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "RES-119 (scaffolding-only)",
+        "Diagnostic scaffolding",
+        "This section lands the data types",
+    ] {
+        assert!(
+            !source.contains(stale),
+            "diagnostic comments should not retain scaffolding wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3347

## Summary

- Reworded RES-119 diagnostics comments from scaffolding-only language to shared diagnostic model language.
- Updated the diagnostic test section header to avoid stale scaffolding wording.
- Added a focused smoke test guarding the new wording contract.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test diagnostic_model_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/diagnostic_model_copy_smoke.rs` to lock the diagnostics comment wording contract.
