### PR TITLE
RES-3349: refresh free-vars docs

### DIFF
--- a/resilient/src/free_vars.rs
+++ b/resilient/src/free_vars.rs
@@ -48,10 +48,10 @@
 //! - It doesn't follow `use` imports (those are resolved before
 //!   this pass runs — RES-073).
 //!
-//! The public entry point `free_vars` is only consumed from the
-//! tests in this module today; RES-164c/d will wire it into the
-//! JIT lowering. We `allow(dead_code)` at the module level so the
-//! regular build stays warning-clean until then.
+//! The public entry point `free_vars` is consumed by recovery
+//! checking and by this module's regression tests today. It stays
+//! pure so RES-164c/d can reuse it for JIT closure capture without
+//! threading runtime `Environment` state through the analysis.
 
 #![allow(dead_code)]
 

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -247,11 +247,11 @@ mod formatter;
 // RES-test: `rz test` subcommand — discover and run `fn test_*()`
 // functions. Standalone from the compiler pipeline.
 mod test_runner;
-// RES-164a: pure free-variable analysis on the AST. Phase-K
-// scaffolding for JIT closure capture (RES-164c/d) — returns the
-// set of names referenced inside a subtree that aren't bound
-// by a parameter / let / for-in / match pattern within it.
-// No runtime deps; no Environment touched.
+// RES-164a: reusable pure free-variable analysis on the AST.
+// Returns the set of names referenced inside a subtree that aren't
+// bound by a parameter / let / for-in / match pattern within it.
+// Used by recovery checking today and kept runtime-free so JIT
+// closure capture can reuse it without Environment state.
 mod free_vars;
 // RES-355: function-level bytecode cache. Stores a small JSON header per
 // source-file SHA-256 so re-runs of unchanged programs skip re-parsing.

--- a/resilient/tests/free_vars_docs_copy_smoke.rs
+++ b/resilient/tests/free_vars_docs_copy_smoke.rs
@@ -1,0 +1,31 @@
+//! RES-3349: free-variable docs should describe current consumers.
+
+#[test]
+fn free_vars_docs_describe_current_consumers() {
+    let lib = include_str!("../src/lib.rs");
+    let free_vars = include_str!("../src/free_vars.rs");
+
+    for expected in [
+        "RES-164a: reusable pure free-variable analysis on the AST.",
+        "Used by recovery checking today and kept runtime-free",
+        "free_vars` is consumed by recovery\n//! checking",
+        "this module's regression tests today",
+        "reuse it for JIT closure capture without\n//! threading runtime `Environment` state",
+    ] {
+        assert!(
+            lib.contains(expected) || free_vars.contains(expected),
+            "free-variable docs should describe current consumers: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "Phase-K\n// scaffolding for JIT closure capture",
+        "only consumed from the\n//! tests in this module today",
+        "RES-164c/d will wire it into the\n//! JIT lowering",
+    ] {
+        assert!(
+            !lib.contains(stale) && !free_vars.contains(stale),
+            "free-variable docs should not retain stale scaffolding wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3349

## Summary

- Reworded the free-variable analysis module registration comment from scaffolding language to reusable pure-analysis language.
- Updated `free_vars.rs` rustdocs to acknowledge recovery-checking usage and module regression tests today.
- Added a focused smoke test that guards the updated wording and rejects stale scaffolding/test-only phrasing.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test free_vars_docs_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/free_vars_docs_copy_smoke.rs` to lock the free-variable docs wording contract.
