### PR TITLE
RES-3351: refresh playground banner copy

### DIFF
--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -40,8 +40,8 @@ struct RunResult {
     /// "ran in N ms" footer.
     duration_ms: f64,
     /// Build flavor — `"tree-walker"` once the real interpreter is
-    /// wired (RES-510 PR 3). The page's "scaffold" banner hides
-    /// itself on any non-`"stub"` flavor.
+    /// wired (RES-510 PR 3). The page's fallback banner remains
+    /// hidden for any non-`"stub"` flavor.
     flavor: &'static str,
 }
 

--- a/playground/web/index.html
+++ b/playground/web/index.html
@@ -17,8 +17,8 @@
   <body>
     <header>
       <h1>Resilient Playground</h1>
-      <span class="banner" id="scaffold-banner" hidden>
-        scaffold build &mdash; interpreter integration pending
+      <span class="banner" id="fallback-banner" hidden>
+        Limited playground build &mdash; execution is unavailable
       </span>
       <nav>
         <label for="example-select">Examples:</label>

--- a/playground/web/main.js
+++ b/playground/web/main.js
@@ -506,7 +506,7 @@ const runBtn = document.getElementById("run-btn");
 const shareBtn = document.getElementById("share-btn");
 const clearBtn = document.getElementById("clear-btn");
 const select = document.getElementById("example-select");
-const banner = document.getElementById("scaffold-banner");
+const banner = document.getElementById("fallback-banner");
 
 // RES-2624: restore code from URL hash before initialising the editor
 function getHashCode() {

--- a/resilient/tests/playground_banner_copy_smoke.rs
+++ b/resilient/tests/playground_banner_copy_smoke.rs
@@ -1,0 +1,32 @@
+//! RES-3351: playground fallback banner uses user-facing copy.
+
+#[test]
+fn playground_banner_uses_neutral_fallback_copy() {
+    let html = include_str!("../../playground/web/index.html");
+    let js = include_str!("../../playground/web/main.js");
+    let wasm_entry = include_str!("../../playground/src/lib.rs");
+
+    for expected in [
+        r#"id="fallback-banner""#,
+        "Limited playground build &mdash; execution is unavailable",
+        r#"getElementById("fallback-banner")"#,
+        "fallback banner remains\n    /// hidden for any non-`\"stub\"` flavor",
+    ] {
+        assert!(
+            html.contains(expected) || js.contains(expected) || wasm_entry.contains(expected),
+            "playground banner copy should use neutral fallback wording: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "scaffold-banner",
+        "scaffold build",
+        "interpreter integration pending",
+        "page's \"scaffold\" banner",
+    ] {
+        assert!(
+            !html.contains(stale) && !js.contains(stale) && !wasm_entry.contains(stale),
+            "playground banner should not expose internal scaffold wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3351

## Summary

- Replaced the playground hidden banner's internal scaffold-era copy with neutral user-facing fallback copy.
- Renamed the banner DOM id from `scaffold-banner` to `fallback-banner` and updated the JS selector.
- Refreshed the WASM entry comment to describe the fallback banner without scaffold wording.
- Added a smoke test covering the shipped HTML/JS/comment copy contract.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test playground_banner_copy_smoke -- --nocapture`
- Browser verification at `http://127.0.0.1:8765/`: rendered `fallback-banner` text is `Limited playground build — execution is unavailable`, hidden in the current tree-walker build, and old scaffold copy/id are absent.

## Test changes

- Added `resilient/tests/playground_banner_copy_smoke.rs` to lock the playground banner copy contract.
