### PR TITLE
RES-3353: refresh JIT run-path comment

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -30408,11 +30408,10 @@ fn execute_file(
     }
 
     if use_jit {
-        // RES-072 Phase A: Cranelift JIT path. Stub today; RES-096+
-        // will add real AST lowering. Surfaces a clean error
+        // RES-072 / RES-096: Cranelift JIT path for the supported
+        // tree-walker subset. Unsupported AST shapes surface cleanly
         // through the same `<file>: ...` shape as the VM (RES-095)
-        // so the user knows the JIT isn't implemented yet without
-        // a panic or opaque message.
+        // so callers can fall back without a panic or opaque message.
         #[cfg(feature = "jit")]
         {
             // RES-405 PR 3: monomorphize before JIT compilation.

--- a/resilient/tests/jit_run_path_copy_smoke.rs
+++ b/resilient/tests/jit_run_path_copy_smoke.rs
@@ -1,0 +1,29 @@
+//! RES-3353: JIT run-path comments should describe current behavior.
+
+#[test]
+fn jit_run_path_comment_uses_current_backend_wording() {
+    let source = include_str!("../src/lib.rs");
+
+    for expected in [
+        "RES-072 / RES-096: Cranelift JIT path for the supported",
+        "tree-walker subset. Unsupported AST shapes surface cleanly",
+        "callers can fall back without a panic or opaque message",
+    ] {
+        assert!(
+            source.contains(expected),
+            "JIT run path comment should describe current behavior: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "RES-072 Phase A: Cranelift JIT path",
+        "Stub today; RES-096+",
+        "will add real AST lowering",
+        "the user knows the JIT isn't implemented yet",
+    ] {
+        assert!(
+            !source.contains(stale),
+            "JIT run path comment should not retain stale stub wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3353

## Summary

- Replaced stale `use_jit` execution-path comments that described the Cranelift path as Phase A/stub-only.
- Aligned the comment with the current supported tree-walker subset and clean unsupported-shape error behavior.
- Added a focused smoke test that guards this run-path wording.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test jit_run_path_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/jit_run_path_copy_smoke.rs` to lock the JIT run-path comment wording contract.
