### PR TITLE
RES-3355: clarify FFI backend comments

### DIFF
--- a/resilient/src/ffi.rs
+++ b/resilient/src/ffi.rs
@@ -7,9 +7,10 @@
 //!   registry populated by the embedder. Lives in `resilient-runtime`
 //!   and is not referenced here — this module is host-only.
 
-// Phase 1 skeleton: public types/functions here are wired up in later
-// tasks (tree-walker dispatch, trampoline layer). Suppress dead-code and
-// unused-import lints so the build stays warning-clean as a stub.
+// FFI v1 ships as a shared API plus backend boundary: `ffi` enables
+// dynamic loading, while the default backend returns `FfiDisabled`.
+// Keep dead-code allowances because cfg-specific backend paths do not
+// all compile into every build.
 #![allow(dead_code)]
 
 use crate::ExternDecl;

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -260,7 +260,7 @@ mod cache;
 // FFI Phase 1: loader module that resolves extern-block symbols.
 // Two backends share one public API: the `ffi` feature routes through
 // `libloading` (dynamic linking); the default build compiles the
-// `disabled` stub that returns `FfiError::FfiDisabled` on every call.
+// disabled backend that returns `FfiError::FfiDisabled` on every call.
 mod ffi;
 #[cfg(feature = "ffi")]
 mod ffi_trampolines;

--- a/resilient/tests/ffi_comment_copy_smoke.rs
+++ b/resilient/tests/ffi_comment_copy_smoke.rs
@@ -1,0 +1,30 @@
+//! RES-3355: FFI comments should describe backend boundaries, not stubs.
+
+#[test]
+fn ffi_comments_describe_backend_boundary() {
+    let ffi_source = include_str!("../src/ffi.rs");
+    let lib_source = include_str!("../src/lib.rs");
+
+    for expected in [
+        "FFI v1 ships as a shared API plus backend boundary",
+        "`ffi` enables\n// dynamic loading",
+        "default backend returns `FfiDisabled`",
+        "disabled backend that returns `FfiError::FfiDisabled`",
+    ] {
+        assert!(
+            ffi_source.contains(expected) || lib_source.contains(expected),
+            "FFI comments should describe the enabled/disabled backend boundary: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "Phase 1 skeleton",
+        "build stays warning-clean as a stub",
+        "`disabled` stub that returns `FfiError::FfiDisabled`",
+    ] {
+        assert!(
+            !ffi_source.contains(stale) && !lib_source.contains(stale),
+            "FFI comments should not retain skeleton/stub wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3355

## Summary

- Reworded FFI module comments from skeleton/stub language to shared API plus backend-boundary language.
- Updated the `lib.rs` module comment to call the default path a disabled backend returning `FfiError::FfiDisabled`.
- Added a focused smoke test that guards the FFI comment wording contract.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test ffi_comment_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/ffi_comment_copy_smoke.rs` to lock the FFI backend comment wording contract.
