### PR TITLE
RES-3357: refresh playground runtime comments

### DIFF
--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -8,12 +8,11 @@
 // and the playground value is the language semantics, not the
 // supporting tooling).
 //
-// RES-510 PR 3: previously a stub that echoed the source text. Now
-// calls into the real `resilient::run_program` interpreter — the lib
-// refactor (PR 1) and injectable stdout sink (PR 2) made that
-// possible. The CLI-only deps in `resilient` are cfg-gated on
-// `not(target_arch = "wasm32")`, so this crate compiles to
-// `wasm32-unknown-unknown` without dragging termios or fs-watcher
+// RES-510 PR 3 calls into the real `resilient::run_program`
+// tree-walker. The lib refactor (PR 1) and injectable stdout sink
+// (PR 2) made that possible. The CLI-only deps in `resilient` are
+// cfg-gated on `not(target_arch = "wasm32")`, so this crate compiles
+// to `wasm32-unknown-unknown` without dragging termios or fs-watcher
 // platform APIs in.
 
 #![allow(clippy::needless_pass_by_value)]

--- a/playground/web/main.js
+++ b/playground/web/main.js
@@ -682,8 +682,8 @@ async function runCode(isAuto = false) {
   if (!isAuto) footerEl.textContent = "";
 
   // Yield to the event loop so the "Running…" placeholder paints
-  // before the (potentially blocking) WASM call. Stubs are fast,
-  // but the full interpreter will benefit from this once integrated.
+  // before the WASM tree-walker call. Fast snippets should still show
+  // the pending state consistently.
   await new Promise((r) => setTimeout(r, 0));
 
   let result;

--- a/resilient/tests/playground_runtime_comment_copy_smoke.rs
+++ b/resilient/tests/playground_runtime_comment_copy_smoke.rs
@@ -1,0 +1,30 @@
+//! RES-3357: playground runtime comments should describe current behavior.
+
+#[test]
+fn playground_runtime_comments_use_tree_walker_wording() {
+    let wasm_entry = include_str!("../../playground/src/lib.rs");
+    let browser_js = include_str!("../../playground/web/main.js");
+
+    for expected in [
+        "RES-510 PR 3 calls into the real `resilient::run_program`",
+        "tree-walker. The lib refactor",
+        "before the WASM tree-walker call",
+        "Fast snippets should still show\n  // the pending state consistently",
+    ] {
+        assert!(
+            wasm_entry.contains(expected) || browser_js.contains(expected),
+            "playground runtime comments should describe current tree-walker behavior: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "previously a stub",
+        "Stubs are fast",
+        "full interpreter will benefit from this once integrated",
+    ] {
+        assert!(
+            !wasm_entry.contains(stale) && !browser_js.contains(stale),
+            "playground runtime comments should not retain stub-era wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3357

## Summary

- Reworded playground WASM entrypoint comments to describe the current `resilient::run_program` tree-walker integration.
- Refreshed the browser-side run-loop comment to describe yielding before the WASM tree-walker call without stub-era wording.
- Added a focused smoke test guarding the updated comment wording.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test playground_runtime_comment_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/playground_runtime_comment_copy_smoke.rs` to lock the playground runtime comment wording contract.
