### PR TITLE
RES-3359: clarify MCP syntax resource copy

### DIFF
--- a/resilient/src/mcp_server.rs
+++ b/resilient/src/mcp_server.rs
@@ -641,7 +641,7 @@ fn resource_syntax_doc() -> String {
      ## Types\n\
      int    float    bool    string    array    void\n\
      fn(T, ...) -> R   // function type\n\
-     Array<T>          // typed array (planned)\n\n\
+     Array<T>          // typed array (not yet supported)\n\n\
      ## Control Flow\n\
      if COND { ... } else { ... }\n\
      while COND { ... }\n\
@@ -666,7 +666,7 @@ fn resource_syntax_doc() -> String {
      live { ... }             // retry block\n\n\
      ## Closures\n\
      fn(int x) -> int { x * 2 }     // anonymous function\n\
-     fn(x) { x + 1 }                // type-inferred params (planned)\n\n\
+     fn(x) { x + 1 }                // type-inferred params (not yet supported)\n\n\
      ## String Interpolation\n\
      let msg = \"value is {x}\";\n\n\
      ## Pattern Matching\n\

--- a/resilient/tests/mcp_syntax_resource_copy_smoke.rs
+++ b/resilient/tests/mcp_syntax_resource_copy_smoke.rs
@@ -1,0 +1,26 @@
+//! RES-3359: MCP syntax resource states current support boundaries.
+
+#[test]
+fn mcp_syntax_resource_uses_not_yet_supported_wording() {
+    let source = include_str!("../src/mcp_server.rs");
+
+    for expected in [
+        "Array<T>          // typed array (not yet supported)",
+        "fn(x) { x + 1 }                // type-inferred params (not yet supported)",
+    ] {
+        assert!(
+            source.contains(expected),
+            "MCP syntax resource should label unsupported examples clearly: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "Array<T>          // typed array (planned)",
+        "fn(x) { x + 1 }                // type-inferred params (planned)",
+    ] {
+        assert!(
+            !source.contains(stale),
+            "MCP syntax resource should not use vague planned wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3359

## Summary

- Reworded unsupported MCP syntax resource examples from vague "planned" labels to explicit "not yet supported" labels.
- Added a focused smoke test that guards the MCP syntax resource copy contract.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test mcp_syntax_resource_copy_smoke -- --nocapture`

## Test changes

- Added `resilient/tests/mcp_syntax_resource_copy_smoke.rs` to lock MCP syntax resource wording for unsupported examples.
