### PR TITLE
RES-3361: refresh landing supervisor copy

### DIFF
--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -396,7 +396,7 @@
       <div class="rl-target__body">
         <p class="rl-target__triplet">CORTEX-M0+</p>
         <h3>thumbv6m-none-eabi</h3>
-        <p>The smallest supervised target — soft&#8209;float, sub&#8209;100&nbsp;MHz cores. Live blocks compile away to ~80 bytes of supervisor stub per site.</p>
+        <p>The smallest supervised target — soft&#8209;float, sub&#8209;100&nbsp;MHz cores. Live blocks compile away to ~80 bytes of supervisor code per site.</p>
       </div>
     </article>
 

--- a/resilient/tests/docs_landing_copy_smoke.rs
+++ b/resilient/tests/docs_landing_copy_smoke.rs
@@ -1,0 +1,16 @@
+//! RES-3361: landing page copy should not imply placeholder runtime code.
+
+#[test]
+fn landing_copy_describes_supervisor_code_not_stub() {
+    let landing = include_str!("../../docs/_layouts/landing.html");
+
+    assert!(
+        landing.contains("Live blocks compile away to ~80 bytes of supervisor code per site."),
+        "landing page should describe live-block overhead with shipped-code wording"
+    );
+
+    assert!(
+        !landing.contains("supervisor stub"),
+        "landing page should not use placeholder-sounding supervisor stub wording"
+    );
+}


### PR DESCRIPTION
Closes #3361

## Summary

- Replaced customer-facing landing-page "supervisor stub" wording with "supervisor code".
- Added a focused smoke test that guards the landing copy contract.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_landing_copy_smoke -- --nocapture`
- Browser verification via local HTTP at `http://127.0.0.1:8766/docs/_layouts/landing.html`: rendered copy contains `Live blocks compile away to ~80 bytes of supervisor code per site.` and does not contain `supervisor stub`.

## Test changes

- Added `resilient/tests/docs_landing_copy_smoke.rs` to lock the landing page copy contract.
