### PR TITLE
RES-3363: clarify live-block clock docs

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -256,10 +256,9 @@ Runtime error: Live block timed out after 1 attempt(s) (retry depth: 1):
     ASSERTION ERROR: forced
 ```
 
-Note: the `no_std` embedded runtime shares RES-139's clock
-placeholder — the wall-clock check is currently std-only;
-embedded targets ignore the clause until a real monotonic
-clock is wired in.
+Note: the `no_std` embedded runtime does not enforce `within`
+wall-clock budgets yet; the check is currently std-only until a
+monotonic clock hook is wired in.
 
 ## Assertions
 

--- a/docs/live-block-semantics.md
+++ b/docs/live-block-semantics.md
@@ -199,9 +199,9 @@ Backoff sleeps count against the budget. A `live backoff(...) within
 the deadline check on its next retry attempt even if the body's
 execution time is trivial.
 
-The `no_std` runtime's clock is a placeholder and does NOT enforce
-`within` today — embedded targets ignore the clause until a real
-monotonic clock lands. This is a known divergence noted in
+The `no_std` runtime does not provide `within` wall-clock enforcement
+yet: embedded targets ignore the clause until a monotonic clock hook is
+wired in. This is a known divergence noted in
 [`SYNTAX.md`](../SYNTAX.md).
 
 ## 7. State roll-back contract

--- a/resilient/tests/docs_live_clock_copy_smoke.rs
+++ b/resilient/tests/docs_live_clock_copy_smoke.rs
@@ -1,0 +1,31 @@
+//! RES-3363: live-block docs describe no_std clock support boundaries plainly.
+
+#[test]
+fn live_block_docs_describe_no_std_clock_boundary_without_placeholder_wording() {
+    let live_docs = include_str!("../../docs/live-block-semantics.md");
+    let syntax = include_str!("../../SYNTAX.md");
+
+    for expected in [
+        "`no_std` runtime does not provide `within` wall-clock enforcement",
+        "embedded targets ignore the clause until a monotonic clock hook is",
+        "`no_std` embedded runtime does not enforce `within`",
+        "wall-clock budgets yet; the check is currently std-only",
+    ] {
+        assert!(
+            live_docs.contains(expected) || syntax.contains(expected),
+            "live-block docs should plainly describe no_std clock support: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "clock is a placeholder",
+        "clock\nplaceholder",
+        "real monotonic clock lands",
+        "real monotonic\nclock is wired in",
+    ] {
+        assert!(
+            !live_docs.contains(stale) && !syntax.contains(stale),
+            "live-block docs should not retain placeholder clock wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3363

## Summary
- replace placeholder-style no_std live-block clock wording with support-boundary language
- keep SYNTAX.md and live-block semantics docs aligned on std-only `within` enforcement
- add a smoke test that guards the current copy and rejects the stale placeholder phrasing

## Test changes
- Added `resilient/tests/docs_live_clock_copy_smoke.rs` to cover the new doc wording.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_live_clock_copy_smoke -- --nocapture`
