### PR TITLE
RES-3365: clarify citation validation docs

### DIFF
--- a/docs/STRUCTURAL_ENFORCEMENT.md
+++ b/docs/STRUCTURAL_ENFORCEMENT.md
@@ -110,9 +110,10 @@ useless. This is a real gap. Our answer:
    <api-contract>". The point is that the invariant has a paper trail
    independent of the LLM that wrote the surrounding code.
 
-3. **Future work**: validate that the cited source actually exists
-   (resolvable URL, ISBN, repo path), promote the lint to a hard gate
-   for safety-critical builds.
+3. **Citation validation boundary**: today L0012 requires the source
+   comment; a later hardening pass should also validate that the cited
+   source resolves (URL, ISBN, repo path) and promote unresolved
+   citations to a hard gate for safety-critical builds.
 
 ## What's still expressible-but-invalid
 

--- a/resilient/tests/docs_structural_enforcement_copy_smoke.rs
+++ b/resilient/tests/docs_structural_enforcement_copy_smoke.rs
@@ -1,0 +1,28 @@
+//! RES-3365: structural enforcement docs state citation validation boundaries.
+
+#[test]
+fn structural_enforcement_docs_describe_citation_validation_boundary() {
+    let docs = include_str!("../../docs/STRUCTURAL_ENFORCEMENT.md");
+
+    for expected in [
+        "**Citation validation boundary**: today L0012 requires the source",
+        "a later hardening pass should also validate that the cited",
+        "source resolves (URL, ISBN, repo path) and promote unresolved",
+        "citations to a hard gate for safety-critical builds.",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "structural enforcement docs should describe citation validation boundaries: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "**Future work**: validate that the cited source actually exists",
+        "promote the lint to a hard gate",
+    ] {
+        assert!(
+            !docs.contains(stale),
+            "structural enforcement docs should not use vague future-work wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3365

## Summary
- replace vague `Future work` language in the structural enforcement trust-model docs
- state the current L0012 provenance-comment boundary and the later citation-resolution hardening step
- add a docs smoke test that keeps the section from drifting back to vague roadmap wording

## Test changes
- Added `resilient/tests/docs_structural_enforcement_copy_smoke.rs` to cover the public doc wording.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_structural_enforcement_copy_smoke -- --nocapture`
