### PR TITLE
RES-3367: clarify certification roadmap docs

### DIFF
--- a/docs/certification.md
+++ b/docs/certification.md
@@ -365,7 +365,9 @@ of the verification artifact.
 
 The gap between "features that contribute to a safety argument"
 and "a qualified toolchain" is the honest subject of this
-section. Items below are planned, not delivered.
+section. The items below are roadmap work only: they are not
+current toolchain capability, certification evidence, or a claim of
+conformance.
 
 - **Tool qualification dossier (G19+).** A DO-330 TQL-5 (or
   ISO 26262 TCL3) evaluation of the verifier subset used for

--- a/resilient/tests/docs_certification_roadmap_copy_smoke.rs
+++ b/resilient/tests/docs_certification_roadmap_copy_smoke.rs
@@ -1,0 +1,22 @@
+//! RES-3367: certification roadmap docs state capability boundaries plainly.
+
+#[test]
+fn certification_docs_roadmap_avoids_current_capability_claims() {
+    let doc = include_str!("../../docs/certification.md");
+
+    for expected in [
+        "The items below are roadmap work only: they are not",
+        "current toolchain capability, certification evidence, or a claim of",
+        "conformance.",
+    ] {
+        assert!(
+            doc.contains(expected),
+            "certification roadmap should state capability boundaries: {expected:?}"
+        );
+    }
+
+    assert!(
+        !doc.contains("Items below are planned, not delivered."),
+        "certification roadmap should not use vague planned/not-delivered wording"
+    );
+}


### PR DESCRIPTION
Closes #3367

## Summary
- clarify that certification roadmap items are not current toolchain capability, certification evidence, or conformance claims
- keep the page's safety posture conservative and explicit
- add a docs smoke test that guards the capability-boundary wording

## Test changes
- Added `resilient/tests/docs_certification_roadmap_copy_smoke.rs` to cover the certification roadmap copy.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_certification_roadmap_copy_smoke -- --nocapture`
