### PR TITLE
RES-3369: clarify JIT limitation docs

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -106,10 +106,10 @@ As of Phase H (RES-105), the JIT lowers:
 - `fn name(int p1, int p2, ...)` declarations
 - Direct `name(args)` calls including recursion + mutual recursion
 
-What it doesn't yet do (use the VM instead):
+What it doesn't yet do (use the VM or tree walker for these today):
 
-- Reassignment (`x = x + 1`) — RES-107 (planned)
-- `while` loops — RES-107 (planned)
+- Reassignment (`x = x + 1`) — tracked by RES-107
+- `while` loops — tracked by RES-107
 - Closures / nested fns
 - Structs, arrays, strings
 - `live { }` blocks

--- a/resilient/tests/docs_performance_jit_copy_smoke.rs
+++ b/resilient/tests/docs_performance_jit_copy_smoke.rs
@@ -1,0 +1,27 @@
+//! RES-3369: performance docs state current JIT limitations as support boundaries.
+
+#[test]
+fn performance_docs_describe_jit_limitations_without_planned_labels() {
+    let docs = include_str!("../../docs/performance.md");
+
+    for expected in [
+        "What it doesn't yet do (use the VM or tree walker for these today):",
+        "Reassignment (`x = x + 1`) — tracked by RES-107",
+        "`while` loops — tracked by RES-107",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "performance docs should state current JIT support boundaries: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "What it doesn't yet do (use the VM instead):",
+        "RES-107 (planned)",
+    ] {
+        assert!(
+            !docs.contains(stale),
+            "performance docs should not use stale planned-limit wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3369

## Summary
- clarify the JIT limitation list so users know to use the VM or tree walker for unsupported constructs today
- replace terse `RES-107 (planned)` labels with `tracked by RES-107`
- add a docs smoke test that guards the support-boundary wording

## Test changes
- Added `resilient/tests/docs_performance_jit_copy_smoke.rs` to cover the performance docs copy.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_performance_jit_copy_smoke -- --nocapture`
