### PR TITLE
RES-3371: clarify JIT diagnostic docs

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -199,10 +199,12 @@ Honest self-criticism (more useful than marketing):
   immutable `let`. Reassignment + `while` loops are the next
   small JIT phase (RES-107). Until then, the JIT can't take
   loop-heavy workloads — use the VM.
-- **The error type carries `&'static str`.** Diagnostics for
-  things like "call to unknown function: NAME" can't include
-  the actual name. A future ticket will widen `JitError` to
-  carry owned strings.
+- **Unsupported JIT diagnostics still use static labels.**
+  `JitError::Unsupported(&'static str)` covers shapes the JIT
+  cannot lower, so messages like "call to unknown function" can't
+  include the actual name yet. A follow-up should let that variant
+  carry owned context without changing the already string-backed
+  JIT errors.
 - **No struct system yet.** `Node::StructDecl` exists in the
   AST and the interpreter handles it; the bytecode VM and JIT
   don't. Plays in goalpost G11+.

--- a/resilient/tests/docs_philosophy_jit_copy_smoke.rs
+++ b/resilient/tests/docs_philosophy_jit_copy_smoke.rs
@@ -1,0 +1,30 @@
+//! RES-3371: philosophy docs describe the JIT diagnostic boundary accurately.
+
+#[test]
+fn philosophy_docs_describe_static_jit_unsupported_diagnostics() {
+    let doc = include_str!("../../docs/philosophy.md");
+
+    for expected in [
+        "**Unsupported JIT diagnostics still use static labels.**",
+        "`JitError::Unsupported(&'static str)` covers shapes the JIT",
+        "include the actual name yet. A follow-up should let that variant",
+        "carry owned context without changing the already string-backed",
+        "JIT errors.",
+    ] {
+        assert!(
+            doc.contains(expected),
+            "philosophy docs should describe the JIT diagnostic boundary: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "**The error type carries `&'static str`.**",
+        "A future ticket will widen `JitError` to",
+        "carry owned strings.",
+    ] {
+        assert!(
+            !doc.contains(stale),
+            "philosophy docs should not imply every JitError is static-only: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3371

## Summary
- clarify that the philosophy-page JIT diagnostic limitation applies to `JitError::Unsupported`, not every JIT error variant
- note that other JIT errors already carry owned string context
- add a docs smoke test to guard the updated wording

## Test changes
- Added `resilient/tests/docs_philosophy_jit_copy_smoke.rs` to cover the philosophy docs copy.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_philosophy_jit_copy_smoke -- --nocapture`
