### PR TITLE
RES-3373: clarify formatter comment docs

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -282,11 +282,10 @@ rz fmt --in-place resilient/examples/hello.rz # overwrite the file
 Exit codes: `0` = formatted, `1` = parse errors (formatter refuses
 to touch broken input), `2` = usage error.
 
-**Known limitation.** The formatter is a structural round-trip.
-Comments are not preserved today (the parser discards them). Run
-`fmt` only on code you're willing to re-attach comments to by
-hand. Comment-aware formatting is the next planned formatter
-improvement.
+**Known limitation.** The formatter is a structural round-trip,
+and the parser discards comments. Comments are not preserved today.
+Run `fmt` only on code you're willing to re-attach comments to by
+hand; comment-preserving formatting is not available yet.
 
 ## Package tooling
 

--- a/resilient/tests/docs_tooling_fmt_copy_smoke.rs
+++ b/resilient/tests/docs_tooling_fmt_copy_smoke.rs
@@ -1,0 +1,23 @@
+//! RES-3373: tooling docs describe formatter comment preservation plainly.
+
+#[test]
+fn tooling_docs_describe_formatter_comment_preservation_boundary() {
+    let docs = include_str!("../../docs/tooling.md");
+
+    for expected in [
+        "The formatter is a structural round-trip,\nand the parser discards comments.",
+        "Comments are not preserved today.",
+        "Run `fmt` only on code you're willing to re-attach comments to by",
+        "hand; comment-preserving formatting is not available yet.",
+    ] {
+        assert!(
+            docs.contains(expected),
+            "tooling docs should describe formatter comment preservation boundaries: {expected:?}"
+        );
+    }
+
+    assert!(
+        !docs.contains("Comment-aware formatting is the next planned formatter\nimprovement."),
+        "tooling docs should not use roadmap-ish comment-aware formatter wording"
+    );
+}


### PR DESCRIPTION
Closes #3373

## Summary
- clarify that `rz fmt` does not preserve comments today because comments are discarded by the parser
- replace roadmap-ish comment-aware formatter phrasing with a direct availability boundary
- add a docs smoke test that guards the formatter comment-preservation wording

## Test changes
- Added `resilient/tests/docs_tooling_fmt_copy_smoke.rs` to cover the tooling docs copy.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_tooling_fmt_copy_smoke -- --nocapture`
