### PR TITLE
RES-3375: clarify trait limitation docs

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -566,9 +566,9 @@ Associated types enable polymorphic interfaces where each implementation can spe
 The current trait system does not support:
 - Projection syntax (`T::AssocType`) in generic bounds (RES-779 follow-up)
 - `dyn Trait` / virtual tables (RES-293)
-- Generic associated types (future)
-- Default method bodies (future)
-- Blanket impls or specialization (future)
+- Generic associated types are not supported yet
+- Default method bodies are not supported yet
+- Blanket impls and specialization are not supported yet
 
 ## Data Types
 

--- a/resilient/tests/docs_syntax_trait_limits_copy_smoke.rs
+++ b/resilient/tests/docs_syntax_trait_limits_copy_smoke.rs
@@ -1,0 +1,30 @@
+//! RES-3375: root syntax docs describe trait limitations with support boundaries.
+
+#[test]
+fn root_syntax_docs_describe_trait_limitations_without_future_labels() {
+    let syntax = include_str!("../../SYNTAX.md");
+
+    for expected in [
+        "Projection syntax (`T::AssocType`) in generic bounds (RES-779 follow-up)",
+        "`dyn Trait` / virtual tables (RES-293)",
+        "Generic associated types are not supported yet",
+        "Default method bodies are not supported yet",
+        "Blanket impls and specialization are not supported yet",
+    ] {
+        assert!(
+            syntax.contains(expected),
+            "root syntax docs should describe trait limitation boundaries: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "Generic associated types (future)",
+        "Default method bodies (future)",
+        "Blanket impls or specialization (future)",
+    ] {
+        assert!(
+            !syntax.contains(stale),
+            "root syntax docs should not use bare future labels: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3375

## Summary
- replace bare `(future)` labels in the root trait limitation list with direct not-supported-yet wording
- preserve existing RES-linked limitations for projection syntax and virtual tables
- add a docs smoke test that guards the root SYNTAX.md trait limitation copy

## Test changes
- Added `resilient/tests/docs_syntax_trait_limits_copy_smoke.rs` to cover the root syntax docs copy.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_syntax_trait_limits_copy_smoke -- --nocapture`
