### PR TITLE
RES-3377: clarify syntax boundary docs

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -766,8 +766,9 @@ loop {
 ```
 
 Equivalent to `while true { ... }` and shares the same 1M-iteration
-runaway guard. `loop` is a statement, not an expression — `let x =
-loop { break v; }` (loop-with-value) is a future enhancement.
+runaway guard. `loop` is a statement, not an expression;
+loop-with-value forms such as `let x = loop { break v; }` are not
+supported yet.
 
 ### `while let` (RES-914)
 
@@ -1007,8 +1008,8 @@ match n {
 Both endpoints must be integer literals (negative `hi` allowed:
 `1..=-3` is degenerate and matches nothing). Range patterns only
 fire on `Int` scrutinees; non-Int values fall through to the
-wildcard. Range patterns bind no names today (`1..=5 @ x` binding
-is a future enhancement).
+wildcard. Range patterns bind no names today; forms such as
+`1..=5 @ x` are not supported yet.
 
 ### `if let` (RES-908)
 

--- a/resilient/tests/docs_syntax_control_boundary_copy_smoke.rs
+++ b/resilient/tests/docs_syntax_control_boundary_copy_smoke.rs
@@ -1,0 +1,26 @@
+//! RES-3377: root syntax docs describe unsupported control/pattern forms plainly.
+
+#[test]
+fn root_syntax_docs_describe_loop_and_range_binding_boundaries() {
+    let syntax = include_str!("../../SYNTAX.md");
+
+    for expected in [
+        "loop-with-value forms such as `let x = loop { break v; }` are not\nsupported yet.",
+        "Range patterns bind no names today; forms such as\n`1..=5 @ x` are not supported yet.",
+    ] {
+        assert!(
+            syntax.contains(expected),
+            "root syntax docs should state unsupported syntax boundaries: {expected:?}"
+        );
+    }
+
+    for stale in [
+        "loop { break v; }` (loop-with-value) is a future enhancement.",
+        "`1..=5 @ x` binding\nis a future enhancement).",
+    ] {
+        assert!(
+            !syntax.contains(stale),
+            "root syntax docs should not use vague future-enhancement wording: {stale:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3377

## Summary
- clarify that loop-with-value forms are not supported yet
- clarify that range-pattern bindings such as `1..=5 @ x` are not supported yet
- add a docs smoke test that guards both root SYNTAX.md limitation notes

## Test changes
- Added `resilient/tests/docs_syntax_control_boundary_copy_smoke.rs` to cover the root syntax docs copy.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_syntax_control_boundary_copy_smoke -- --nocapture`
