### PR TITLE
RES-3379: update associated type docs

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -407,8 +407,8 @@ trait Iterator {
 ```
 
 Method signatures must include `self` (method receiver) as the first parameter.
-Method names must be unique within a trait. RES-779 (future) will add associated
-types.
+Method names must be unique within a trait. Associated type members are
+documented later in this trait section.
 
 ### Trait Implementation
 

--- a/resilient/tests/docs_syntax_associated_types_copy_smoke.rs
+++ b/resilient/tests/docs_syntax_associated_types_copy_smoke.rs
@@ -1,0 +1,22 @@
+//! RES-3379: root syntax docs do not describe associated types as future work.
+
+#[test]
+fn root_syntax_docs_point_to_current_associated_type_section() {
+    let syntax = include_str!("../../SYNTAX.md");
+
+    for expected in [
+        "Method names must be unique within a trait. Associated type members are\ndocumented later in this trait section.",
+        "### Associated Types (RES-783)",
+        "Traits can declare associated types",
+    ] {
+        assert!(
+            syntax.contains(expected),
+            "root syntax docs should point to current associated-type docs: {expected:?}"
+        );
+    }
+
+    assert!(
+        !syntax.contains("RES-779 (future) will add associated\ntypes."),
+        "root syntax docs should not describe associated types as future work"
+    );
+}


### PR DESCRIPTION
Closes #3379

## Summary
- replace a stale trait-overview note that described associated types as future work
- point readers to the current associated-type section already present in root SYNTAX.md
- add a docs smoke test that guards against restoring the stale future note

## Test changes
- Added `resilient/tests/docs_syntax_associated_types_copy_smoke.rs` to cover the root syntax docs copy.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test --manifest-path resilient/Cargo.toml --test docs_syntax_associated_types_copy_smoke -- --nocapture`
