### PR TITLE
RES-3392: atomic_types check should validate atomic_types declarations and reject malformed forms

### DIFF
--- a/resilient/src/atomic_types.rs
+++ b/resilient/src/atomic_types.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::collapsible_if, clippy::doc_lazy_continuation, dead_code)]
 
 use crate::Node;
+use crate::span::Span;
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -30,6 +31,10 @@ pub fn collect_names() -> Vec<String> {
         .into_iter()
         .map(|(item, _)| item)
         .collect()
+}
+
+fn collect_attrs() -> Vec<(String, crate::feature_attrs::AttrRecord)> {
+    crate::feature_attrs::find_kind("atomic")
 }
 
 // RES-1406: removed `fn ensure()` — its sole caller was `declare`,
@@ -86,14 +91,196 @@ pub fn fetch_add(name: &str, delta: i64) -> Option<i64> {
     })
 }
 
-pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
+#[derive(Clone, Copy)]
+enum AtomicTarget<'a> {
+    StaticLet { value: &'a Node, span: Span },
+    Other { kind: &'static str, span: Span },
+}
+
+fn find_atomic_target<'a>(node: &'a Node, name: &str) -> Option<AtomicTarget<'a>> {
+    match node {
+        Node::Program(stmts) => {
+            for stmt in stmts {
+                if let Some(found) = find_atomic_target(&stmt.node, name) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Node::Block { stmts, .. } => {
+            for stmt in stmts {
+                if let Some(found) = find_atomic_target(stmt, name) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Node::StaticLet {
+            name: decl_name,
+            value,
+            span,
+        } if decl_name == name => Some(AtomicTarget::StaticLet {
+            value: value.as_ref(),
+            span: *span,
+        }),
+        Node::LetStatement {
+            name: decl_name,
+            span,
+            ..
+        } if decl_name == name => Some(AtomicTarget::Other {
+            kind: "`let` binding",
+            span: *span,
+        }),
+        Node::Function {
+            name: decl_name,
+            span,
+            ..
+        } if decl_name == name => Some(AtomicTarget::Other {
+            kind: "function",
+            span: *span,
+        }),
+        Node::StructDecl {
+            name: decl_name,
+            span,
+            ..
+        } if decl_name == name => Some(AtomicTarget::Other {
+            kind: "struct",
+            span: *span,
+        }),
+        Node::TypeAlias {
+            name: decl_name,
+            span,
+            ..
+        } if decl_name == name => Some(AtomicTarget::Other {
+            kind: "type alias",
+            span: *span,
+        }),
+        Node::NewtypeDecl {
+            name: decl_name,
+            span,
+            ..
+        } if decl_name == name => Some(AtomicTarget::Other {
+            kind: "newtype",
+            span: *span,
+        }),
+        Node::EnumDecl {
+            name: decl_name,
+            span,
+            ..
+        } if decl_name == name => Some(AtomicTarget::Other {
+            kind: "enum",
+            span: *span,
+        }),
+        Node::TraitDecl {
+            name: decl_name,
+            span,
+            ..
+        } if decl_name == name => Some(AtomicTarget::Other {
+            kind: "trait",
+            span: *span,
+        }),
+        Node::ActorDecl {
+            name: decl_name,
+            span,
+            ..
+        } if decl_name == name => Some(AtomicTarget::Other {
+            kind: "actor",
+            span: *span,
+        }),
+        Node::Function { body, .. } => find_atomic_target(body, name),
+        _ => None,
+    }
+}
+
+fn static_integer_value(node: &Node) -> Option<i64> {
+    match node {
+        Node::IntegerLiteral { value, .. } => Some(*value),
+        Node::PrefixExpression {
+            operator: "-",
+            right,
+            ..
+        } => match right.as_ref() {
+            Node::IntegerLiteral { value, .. } => value.checked_neg(),
+            _ => None,
+        },
+        Node::PrefixExpression {
+            operator: "+",
+            right,
+            ..
+        } => match right.as_ref() {
+            Node::IntegerLiteral { value, .. } => Some(*value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn diagnostic(source_path: &str, span: Span, message: &str) -> String {
+    format!(
+        "{}:{}:{}: error: {}",
+        source_path, span.start.line, span.start.column, message
+    )
+}
+
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    let attrs = collect_attrs();
+    if attrs.is_empty() {
+        return Ok(());
+    }
+
     // RES-2206: move each owned `String` straight into the registry
     // via `declare_owned`. The previous `declare(&n, 0)` form borrowed
     // `n` into `declare`, which then called `name.to_string()` —
     // paying a fresh allocation per `#[atomic]` name on top of the
     // one `collect_names` already produced.
-    for n in collect_names() {
-        declare_owned(n, 0);
+    for (name, rec) in attrs {
+        let target = find_atomic_target(program, name.as_str());
+        let span = match target {
+            Some(AtomicTarget::StaticLet { span, .. } | AtomicTarget::Other { span, .. }) => span,
+            None => Span::default(),
+        };
+        if !rec.args.trim().is_empty() {
+            return Err(diagnostic(
+                source_path,
+                span,
+                &format!(
+                    "#[atomic] on `{}` does not accept arguments; use bare #[atomic]",
+                    name
+                ),
+            ));
+        }
+        match target {
+            Some(AtomicTarget::StaticLet { value, span }) => {
+                let Some(initial) = static_integer_value(value) else {
+                    return Err(diagnostic(
+                        source_path,
+                        span,
+                        &format!(
+                            "atomic type `{}` must be initialized with an integer literal",
+                            name
+                        ),
+                    ));
+                };
+                declare_owned(name, initial);
+            }
+            Some(AtomicTarget::Other { kind, span }) => {
+                return Err(diagnostic(
+                    source_path,
+                    span,
+                    &format!(
+                        "atomic type `{}` must be declared as `static let`, found {}",
+                        name, kind
+                    ),
+                ));
+            }
+            None => {
+                return Err(diagnostic(
+                    source_path,
+                    span,
+                    &format!("atomic type `{}` is missing a matching declaration", name),
+                ));
+            }
+        }
     }
     Ok(())
 }

--- a/resilient/src/cfg_attr.rs
+++ b/resilient/src/cfg_attr.rs
@@ -482,7 +482,11 @@ fn parse_feature_attribute(parser: &mut Parser, name: String) -> Option<crate::N
     // best-effort lookup — anonymous statements don't get a key.
     let item = parser.parse_statement();
     if let Some(node) = &item
-        && let Some(item_name) = node_item_name(node)
+        && let Some(item_name) = if name == "atomic" {
+            atomic_node_item_name(node)
+        } else {
+            node_item_name(node)
+        }
     {
         crate::feature_attrs::record(
             item_name,
@@ -515,6 +519,21 @@ fn node_item_name(node: &crate::Node) -> Option<&str> {
         crate::Node::EnumDecl { name, .. } => Some(name.as_str()),
         crate::Node::TraitDecl { name, .. } => Some(name.as_str()),
         crate::Node::ActorDecl { name, .. } => Some(name.as_str()),
+        _ => None,
+    }
+}
+
+fn atomic_node_item_name(node: &crate::Node) -> Option<&str> {
+    match node {
+        crate::Node::LetStatement { name, .. }
+        | crate::Node::StaticLet { name, .. }
+        | crate::Node::Function { name, .. }
+        | crate::Node::StructDecl { name, .. }
+        | crate::Node::TypeAlias { name, .. }
+        | crate::Node::NewtypeDecl { name, .. }
+        | crate::Node::EnumDecl { name, .. }
+        | crate::Node::TraitDecl { name, .. }
+        | crate::Node::ActorDecl { name, .. } => Some(name.as_str()),
         _ => None,
     }
 }

--- a/resilient/tests/atomic_types_smoke.rs
+++ b/resilient/tests/atomic_types_smoke.rs
@@ -1,0 +1,122 @@
+//! RES-3392: end-to-end checks for `#[atomic]` declaration validation.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_dir(tag: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let p = std::env::temp_dir().join(format!(
+        "res_atomic_types_{}_{}_{}",
+        tag,
+        std::process::id(),
+        n
+    ));
+    std::fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn check_source(tag: &str, source: &str) -> (PathBuf, String, String, Option<i32>) {
+    let dir = tmp_dir(tag);
+    let path = dir.join("case.rz");
+    std::fs::write(&path, source).expect("write source");
+    let out = Command::new(bin())
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("spawn rz check");
+    (
+        path,
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code(),
+    )
+}
+
+#[test]
+fn atomic_static_let_typechecks() {
+    let (_path, stdout, stderr, code) = check_source(
+        "valid",
+        "#[atomic]\nstatic let counter = 0;\nfn main(int _d) { return 0; }\nmain(0);\n",
+    );
+    assert_eq!(
+        code,
+        Some(0),
+        "valid atomic static let should pass; stdout={stdout} stderr={stderr}"
+    );
+}
+
+#[test]
+fn atomic_on_function_is_rejected() {
+    let (path, stdout, stderr, code) = check_source(
+        "function_shape",
+        "#[atomic]\nfn counter(int x) -> int { return x; }\ncounter(0);\n",
+    );
+    assert_eq!(
+        code,
+        Some(1),
+        "atomic function shape must fail; stdout={stdout} stderr={stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert_file_line_col(&combined, &path, 2);
+    assert!(
+        combined.contains("`counter`") && combined.contains("static let"),
+        "diagnostic must name the malformed atomic declaration; got:\n{combined}"
+    );
+}
+
+#[test]
+fn atomic_attribute_arguments_are_rejected() {
+    let (path, stdout, stderr, code) = check_source(
+        "args",
+        "#[atomic(width = 64)]\nstatic let counter = 0;\nfn main(int _d) { return 0; }\nmain(0);\n",
+    );
+    assert_eq!(
+        code,
+        Some(1),
+        "atomic attributes with args must fail; stdout={stdout} stderr={stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert_file_line_col(&combined, &path, 2);
+    assert!(
+        combined.contains("#[atomic]") && combined.contains("does not accept arguments"),
+        "diagnostic must reject malformed atomic attributes; got:\n{combined}"
+    );
+}
+
+#[test]
+fn atomic_non_integer_initializer_is_rejected() {
+    let (path, stdout, stderr, code) = check_source(
+        "non_integer",
+        "#[atomic]\nstatic let flag = true;\nfn main(int _d) { return 0; }\nmain(0);\n",
+    );
+    assert_eq!(
+        code,
+        Some(1),
+        "atomic non-integer initializer must fail; stdout={stdout} stderr={stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert_file_line_col(&combined, &path, 2);
+    assert!(
+        combined.contains("`flag`") && combined.contains("integer literal"),
+        "diagnostic must reject non-integer atomic initializer; got:\n{combined}"
+    );
+}
+
+fn assert_file_line_col(output: &str, path: &std::path::Path, line: usize) {
+    let prefix = format!("{}:{}:", path.display(), line);
+    let has_line_col = output.lines().any(|line| {
+        line.strip_prefix(&prefix)
+            .and_then(|rest| rest.split_once(':'))
+            .is_some_and(|(col, _)| col.parse::<usize>().is_ok())
+    });
+    assert!(
+        has_line_col,
+        "diagnostic must include file:line:col; got:\n{output}"
+    );
+}


### PR DESCRIPTION
Closes #3392.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3392-atomic-types-check-should-validate-atomi`
Worktree: `.claude/worktrees/res-3392`

## Agent claims

(none inferred from issue)