### PR TITLE
RES-3393: atomic_types check should validate atomic_types call-site argument contracts

### DIFF
--- a/resilient/src/atomic_types.rs
+++ b/resilient/src/atomic_types.rs
@@ -15,7 +15,7 @@
 
 use crate::Node;
 use crate::span::Span;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicI64, Ordering};
 
@@ -222,11 +222,567 @@ fn diagnostic(source_path: &str, span: Span, message: &str) -> String {
     )
 }
 
+fn span_of(node: &Node) -> Span {
+    match node {
+        Node::Identifier { span, .. }
+        | Node::IntegerLiteral { span, .. }
+        | Node::FloatLiteral { span, .. }
+        | Node::StringLiteral { span, .. }
+        | Node::StringInternLiteral { span, .. }
+        | Node::BytesLiteral { span, .. }
+        | Node::CharLiteral { span, .. }
+        | Node::BooleanLiteral { span, .. }
+        | Node::PrefixExpression { span, .. }
+        | Node::InfixExpression { span, .. }
+        | Node::CallExpression { span, .. }
+        | Node::TryExpression { span, .. }
+        | Node::OptionalChain { span, .. }
+        | Node::FunctionLiteral { span, .. }
+        | Node::Match { span, .. }
+        | Node::StructDecl { span, .. }
+        | Node::LetDestructureStruct { span, .. }
+        | Node::StructLiteral { span, .. }
+        | Node::FieldAccess { span, .. }
+        | Node::FieldAssignment { span, .. }
+        | Node::ArrayLiteral { span, .. }
+        | Node::IndexExpression { span, .. }
+        | Node::Slice { span, .. }
+        | Node::IndexAssignment { span, .. }
+        | Node::MapLiteral { span, .. }
+        | Node::SetLiteral { span, .. }
+        | Node::ImplBlock { span, .. }
+        | Node::TraitDecl { span, .. }
+        | Node::TypeAlias { span, .. }
+        | Node::RegionDecl { span, .. }
+        | Node::Actor { span, .. }
+        | Node::ActorDecl { span, .. }
+        | Node::ClusterDecl { span, .. }
+        | Node::TryCatch { span, .. }
+        | Node::Quantifier { span, .. }
+        | Node::InvariantStatement { span, .. }
+        | Node::Range { span, .. }
+        | Node::NamedArg { span, .. }
+        | Node::InterpolatedString { span, .. }
+        | Node::ModuleDecl { span, .. }
+        | Node::NewtypeDecl { span, .. }
+        | Node::NewtypeConstruct { span, .. }
+        | Node::SupervisorDecl { span, .. }
+        | Node::TupleLiteral { span, .. }
+        | Node::TupleIndex { span, .. }
+        | Node::LetTupleDestructure { span, .. }
+        | Node::UnsafeBlock { span, .. }
+        | Node::EnumDecl { span, .. }
+        | Node::RegionParam { span, .. }
+        | Node::BlanketImpl { span, .. }
+        | Node::StaticAssert { span, .. }
+        | Node::BenchBlock { span, .. }
+        | Node::Use { span, .. }
+        | Node::Extern { span, .. }
+        | Node::Function { span, .. }
+        | Node::LiveBlock { span, .. }
+        | Node::DurationLiteral { span, .. }
+        | Node::Assert { span, .. }
+        | Node::Assume { span, .. }
+        | Node::Block { span, .. }
+        | Node::LetStatement { span, .. }
+        | Node::StaticLet { span, .. }
+        | Node::Const { span, .. }
+        | Node::Assignment { span, .. }
+        | Node::ReturnStatement { span, .. }
+        | Node::Break { span, .. }
+        | Node::BreakWith { span, .. }
+        | Node::Continue { span, .. }
+        | Node::BreakLabel { span, .. }
+        | Node::ContinueLabel { span, .. }
+        | Node::DeferStatement { span, .. }
+        | Node::IfStatement { span, .. }
+        | Node::WhileStatement { span, .. }
+        | Node::ForInStatement { span, .. }
+        | Node::ExpressionStatement { span, .. } => *span,
+        Node::Program(_) => Span::default(),
+    }
+}
+
+fn arg_kind(node: &Node) -> &'static str {
+    match node {
+        Node::StringLiteral { .. }
+        | Node::StringInternLiteral { .. }
+        | Node::InterpolatedString { .. } => "string literal",
+        Node::IntegerLiteral { .. } | Node::FloatLiteral { .. } => "number literal",
+        Node::PrefixExpression {
+            operator: "+" | "-",
+            right,
+            ..
+        } if matches!(
+            right.as_ref(),
+            Node::IntegerLiteral { .. } | Node::FloatLiteral { .. }
+        ) =>
+        {
+            "number literal"
+        }
+        Node::ArrayLiteral { .. } => "list literal",
+        Node::StructLiteral { .. } => "struct literal",
+        Node::BooleanLiteral { .. } => "boolean literal",
+        Node::CharLiteral { .. } => "char literal",
+        Node::BytesLiteral { .. } => "bytes literal",
+        Node::MapLiteral { .. } => "map literal",
+        Node::SetLiteral { .. } => "set literal",
+        Node::CallExpression { .. } => "call expression",
+        _ => "expression",
+    }
+}
+
+fn atomic_call_name(function: &Node) -> Option<&'static str> {
+    match function {
+        Node::Identifier { name, .. } => match name.as_str() {
+            "atomic_load" => Some("atomic_load"),
+            "atomic_store" => Some("atomic_store"),
+            "atomic_fetch_add" => Some("atomic_fetch_add"),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn validate_atomic_target(
+    source_path: &str,
+    op: &str,
+    target: &Node,
+    atomic_names: &HashSet<String>,
+) -> Result<(), String> {
+    match target {
+        Node::Identifier { name, span } => {
+            if atomic_names.contains(name) {
+                Ok(())
+            } else {
+                Err(diagnostic(
+                    source_path,
+                    *span,
+                    &format!("{} target `{}` is not declared #[atomic]", op, name),
+                ))
+            }
+        }
+        other => Err(diagnostic(
+            source_path,
+            span_of(other),
+            &format!(
+                "{} target must be an atomic identifier, got {}",
+                op,
+                arg_kind(other)
+            ),
+        )),
+    }
+}
+
+fn validate_atomic_integer_arg(source_path: &str, op: &str, arg: &Node) -> Result<(), String> {
+    match arg {
+        Node::StringLiteral { .. }
+        | Node::StringInternLiteral { .. }
+        | Node::InterpolatedString { .. }
+        | Node::ArrayLiteral { .. }
+        | Node::StructLiteral { .. }
+        | Node::MapLiteral { .. }
+        | Node::SetLiteral { .. }
+        | Node::BooleanLiteral { .. }
+        | Node::BytesLiteral { .. }
+        | Node::CharLiteral { .. } => Err(diagnostic(
+            source_path,
+            span_of(arg),
+            &format!(
+                "{} value must be an integer expression, got {}",
+                op,
+                arg_kind(arg)
+            ),
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn validate_atomic_call(
+    source_path: &str,
+    op: &str,
+    arguments: &[Node],
+    call_span: Span,
+    atomic_names: &HashSet<String>,
+) -> Result<(), String> {
+    let expected = if op == "atomic_load" { 1 } else { 2 };
+    if arguments.len() != expected {
+        return Err(diagnostic(
+            source_path,
+            call_span,
+            &format!(
+                "{} expects {} arguments, got {}",
+                op,
+                expected,
+                arguments.len()
+            ),
+        ));
+    }
+    validate_atomic_target(source_path, op, &arguments[0], atomic_names)?;
+    if expected == 2 {
+        validate_atomic_integer_arg(source_path, op, &arguments[1])?;
+    }
+    Ok(())
+}
+
+fn check_atomic_call_sites(
+    node: &Node,
+    source_path: &str,
+    atomic_names: &HashSet<String>,
+) -> Result<(), String> {
+    match node {
+        Node::Program(stmts) => {
+            for stmt in stmts {
+                check_atomic_call_sites(&stmt.node, source_path, atomic_names)?;
+            }
+        }
+        Node::CallExpression {
+            function,
+            arguments,
+            span,
+        } => {
+            if let Some(op) = atomic_call_name(function) {
+                validate_atomic_call(source_path, op, arguments, *span, atomic_names)?;
+            }
+            check_atomic_call_sites(function, source_path, atomic_names)?;
+            for arg in arguments {
+                check_atomic_call_sites(arg, source_path, atomic_names)?;
+            }
+        }
+        Node::Block { stmts, .. } => {
+            for stmt in stmts {
+                check_atomic_call_sites(stmt, source_path, atomic_names)?;
+            }
+        }
+        Node::LetStatement { value, .. }
+        | Node::StaticLet { value, .. }
+        | Node::Const { value, .. }
+        | Node::Assignment { value, .. }
+        | Node::BreakWith { value, .. }
+        | Node::DeferStatement { expr: value, .. }
+        | Node::ExpressionStatement { expr: value, .. }
+        | Node::TryExpression { expr: value, .. }
+        | Node::InvariantStatement { expr: value, .. }
+        | Node::NamedArg { value, .. }
+        | Node::NewtypeConstruct { value, .. }
+        | Node::BenchBlock { body: value, .. }
+        | Node::UnsafeBlock { body: value, .. } => {
+            check_atomic_call_sites(value, source_path, atomic_names)?;
+        }
+        Node::ReturnStatement { value, .. } => {
+            if let Some(value) = value {
+                check_atomic_call_sites(value, source_path, atomic_names)?;
+            }
+        }
+        Node::Assert {
+            condition, message, ..
+        }
+        | Node::Assume {
+            condition, message, ..
+        } => {
+            check_atomic_call_sites(condition, source_path, atomic_names)?;
+            if let Some(message) = message {
+                check_atomic_call_sites(message, source_path, atomic_names)?;
+            }
+        }
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            check_atomic_call_sites(condition, source_path, atomic_names)?;
+            check_atomic_call_sites(consequence, source_path, atomic_names)?;
+            if let Some(alternative) = alternative {
+                check_atomic_call_sites(alternative, source_path, atomic_names)?;
+            }
+        }
+        Node::WhileStatement {
+            condition,
+            body,
+            invariants,
+            ..
+        } => {
+            check_atomic_call_sites(condition, source_path, atomic_names)?;
+            for invariant in invariants {
+                check_atomic_call_sites(invariant, source_path, atomic_names)?;
+            }
+            check_atomic_call_sites(body, source_path, atomic_names)?;
+        }
+        Node::ForInStatement {
+            iterable,
+            body,
+            invariants,
+            ..
+        } => {
+            check_atomic_call_sites(iterable, source_path, atomic_names)?;
+            for invariant in invariants {
+                check_atomic_call_sites(invariant, source_path, atomic_names)?;
+            }
+            check_atomic_call_sites(body, source_path, atomic_names)?;
+        }
+        Node::PrefixExpression { right, .. } => {
+            check_atomic_call_sites(right, source_path, atomic_names)?;
+        }
+        Node::InfixExpression { left, right, .. } => {
+            check_atomic_call_sites(left, source_path, atomic_names)?;
+            check_atomic_call_sites(right, source_path, atomic_names)?;
+        }
+        Node::OptionalChain { object, access, .. } => {
+            check_atomic_call_sites(object, source_path, atomic_names)?;
+            if let crate::ChainAccess::Method(_, arguments) = access {
+                for arg in arguments {
+                    check_atomic_call_sites(arg, source_path, atomic_names)?;
+                }
+            }
+        }
+        Node::Function {
+            defaults,
+            body,
+            requires,
+            ensures,
+            recovers_to,
+            ..
+        } => {
+            for default in defaults.iter().flatten() {
+                check_atomic_call_sites(default, source_path, atomic_names)?;
+            }
+            for expr in requires.iter().chain(ensures.iter()) {
+                check_atomic_call_sites(expr, source_path, atomic_names)?;
+            }
+            if let Some(recovers_to) = recovers_to {
+                check_atomic_call_sites(recovers_to, source_path, atomic_names)?;
+            }
+            check_atomic_call_sites(body, source_path, atomic_names)?;
+        }
+        Node::FunctionLiteral {
+            body,
+            requires,
+            ensures,
+            recovers_to,
+            ..
+        } => {
+            for expr in requires.iter().chain(ensures.iter()) {
+                check_atomic_call_sites(expr, source_path, atomic_names)?;
+            }
+            if let Some(recovers_to) = recovers_to {
+                check_atomic_call_sites(recovers_to, source_path, atomic_names)?;
+            }
+            check_atomic_call_sites(body, source_path, atomic_names)?;
+        }
+        Node::Match {
+            scrutinee, arms, ..
+        } => {
+            check_atomic_call_sites(scrutinee, source_path, atomic_names)?;
+            for (_, guard, body) in arms {
+                if let Some(guard) = guard {
+                    check_atomic_call_sites(guard, source_path, atomic_names)?;
+                }
+                check_atomic_call_sites(body, source_path, atomic_names)?;
+            }
+        }
+        Node::LetDestructureStruct { value, .. }
+        | Node::FieldAccess { target: value, .. }
+        | Node::TupleIndex { tuple: value, .. }
+        | Node::LetTupleDestructure { value, .. } => {
+            check_atomic_call_sites(value, source_path, atomic_names)?;
+        }
+        Node::StructLiteral { fields, base, .. } => {
+            if let Some(base) = base {
+                check_atomic_call_sites(base, source_path, atomic_names)?;
+            }
+            for (_, value) in fields {
+                check_atomic_call_sites(value, source_path, atomic_names)?;
+            }
+        }
+        Node::FieldAssignment { target, value, .. } => {
+            check_atomic_call_sites(target, source_path, atomic_names)?;
+            check_atomic_call_sites(value, source_path, atomic_names)?;
+        }
+        Node::ArrayLiteral { items, .. }
+        | Node::SetLiteral { items, .. }
+        | Node::TupleLiteral { items, .. } => {
+            for item in items {
+                check_atomic_call_sites(item, source_path, atomic_names)?;
+            }
+        }
+        Node::IndexExpression { target, index, .. } => {
+            check_atomic_call_sites(target, source_path, atomic_names)?;
+            check_atomic_call_sites(index, source_path, atomic_names)?;
+        }
+        Node::Slice { target, lo, hi, .. } => {
+            check_atomic_call_sites(target, source_path, atomic_names)?;
+            if let Some(lo) = lo {
+                check_atomic_call_sites(lo, source_path, atomic_names)?;
+            }
+            if let Some(hi) = hi {
+                check_atomic_call_sites(hi, source_path, atomic_names)?;
+            }
+        }
+        Node::IndexAssignment {
+            target,
+            index,
+            value,
+            ..
+        } => {
+            check_atomic_call_sites(target, source_path, atomic_names)?;
+            check_atomic_call_sites(index, source_path, atomic_names)?;
+            check_atomic_call_sites(value, source_path, atomic_names)?;
+        }
+        Node::MapLiteral { entries, .. } => {
+            for (key, value) in entries {
+                check_atomic_call_sites(key, source_path, atomic_names)?;
+                check_atomic_call_sites(value, source_path, atomic_names)?;
+            }
+        }
+        Node::ImplBlock { methods, .. } | Node::BlanketImpl { methods, .. } => {
+            for method in methods {
+                check_atomic_call_sites(method, source_path, atomic_names)?;
+            }
+        }
+        Node::Actor {
+            state_init,
+            concurrent_ensures,
+            handlers,
+            ..
+        } => {
+            check_atomic_call_sites(state_init, source_path, atomic_names)?;
+            for expr in concurrent_ensures {
+                check_atomic_call_sites(expr, source_path, atomic_names)?;
+            }
+            for handler in handlers {
+                check_atomic_call_sites(&handler.body, source_path, atomic_names)?;
+                for expr in &handler.ensures {
+                    check_atomic_call_sites(expr, source_path, atomic_names)?;
+                }
+            }
+        }
+        Node::ActorDecl {
+            state_fields,
+            always_clauses,
+            eventually_clauses,
+            receive_handlers,
+            handlers,
+            ..
+        } => {
+            for (_, _, init) in state_fields {
+                check_atomic_call_sites(init, source_path, atomic_names)?;
+            }
+            for expr in always_clauses {
+                check_atomic_call_sites(expr, source_path, atomic_names)?;
+            }
+            for clause in eventually_clauses {
+                check_atomic_call_sites(&clause.post, source_path, atomic_names)?;
+            }
+            for handler in receive_handlers {
+                check_atomic_call_sites(&handler.body, source_path, atomic_names)?;
+                for expr in handler.requires.iter().chain(handler.ensures.iter()) {
+                    check_atomic_call_sites(expr, source_path, atomic_names)?;
+                }
+            }
+            for handler in handlers {
+                check_atomic_call_sites(&handler.body, source_path, atomic_names)?;
+                for expr in &handler.ensures {
+                    check_atomic_call_sites(expr, source_path, atomic_names)?;
+                }
+            }
+        }
+        Node::ClusterDecl { invariants, .. } => {
+            for invariant in invariants {
+                check_atomic_call_sites(invariant, source_path, atomic_names)?;
+            }
+        }
+        Node::TryCatch { body, handlers, .. } => {
+            for stmt in body {
+                check_atomic_call_sites(stmt, source_path, atomic_names)?;
+            }
+            for (_, stmts) in handlers {
+                for stmt in stmts {
+                    check_atomic_call_sites(stmt, source_path, atomic_names)?;
+                }
+            }
+        }
+        Node::Quantifier { range, body, .. } => {
+            match range {
+                crate::quantifiers::QuantRange::Range { lo, hi } => {
+                    check_atomic_call_sites(lo, source_path, atomic_names)?;
+                    check_atomic_call_sites(hi, source_path, atomic_names)?;
+                }
+                crate::quantifiers::QuantRange::Iterable(expr) => {
+                    check_atomic_call_sites(expr, source_path, atomic_names)?;
+                }
+            }
+            check_atomic_call_sites(body, source_path, atomic_names)?;
+        }
+        Node::Range { lo, hi, .. } => {
+            check_atomic_call_sites(lo, source_path, atomic_names)?;
+            check_atomic_call_sites(hi, source_path, atomic_names)?;
+        }
+        Node::InterpolatedString { parts, .. } => {
+            for part in parts {
+                if let crate::string_interp::StringPart::Expr(expr) = part {
+                    check_atomic_call_sites(expr, source_path, atomic_names)?;
+                }
+            }
+        }
+        Node::ModuleDecl { body, .. } => {
+            for stmt in body {
+                check_atomic_call_sites(stmt, source_path, atomic_names)?;
+            }
+        }
+        Node::StaticAssert { condition, .. } => {
+            check_atomic_call_sites(condition, source_path, atomic_names)?;
+        }
+        Node::LiveBlock {
+            body,
+            invariants,
+            timeout,
+            ..
+        } => {
+            check_atomic_call_sites(body, source_path, atomic_names)?;
+            for invariant in invariants {
+                check_atomic_call_sites(invariant, source_path, atomic_names)?;
+            }
+            if let Some(timeout) = timeout {
+                check_atomic_call_sites(timeout, source_path, atomic_names)?;
+            }
+        }
+        Node::Extern { decls, .. } => {
+            for decl in decls {
+                for expr in &decl.requires {
+                    check_atomic_call_sites(expr, source_path, atomic_names)?;
+                }
+            }
+        }
+        Node::Identifier { .. }
+        | Node::IntegerLiteral { .. }
+        | Node::FloatLiteral { .. }
+        | Node::StringLiteral { .. }
+        | Node::StringInternLiteral { .. }
+        | Node::BytesLiteral { .. }
+        | Node::CharLiteral { .. }
+        | Node::BooleanLiteral { .. }
+        | Node::StructDecl { .. }
+        | Node::TraitDecl { .. }
+        | Node::TypeAlias { .. }
+        | Node::RegionDecl { .. }
+        | Node::NewtypeDecl { .. }
+        | Node::SupervisorDecl { .. }
+        | Node::EnumDecl { .. }
+        | Node::RegionParam { .. }
+        | Node::Use { .. }
+        | Node::DurationLiteral { .. }
+        | Node::Break { .. }
+        | Node::Continue { .. }
+        | Node::BreakLabel { .. }
+        | Node::ContinueLabel { .. } => {}
+    }
+    Ok(())
+}
+
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let attrs = collect_attrs();
-    if attrs.is_empty() {
-        return Ok(());
-    }
+    let atomic_names: HashSet<String> = attrs.iter().map(|(name, _)| name.clone()).collect();
 
     // RES-2206: move each owned `String` straight into the registry
     // via `declare_owned`. The previous `declare(&n, 0)` form borrowed
@@ -282,6 +838,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             }
         }
     }
+    check_atomic_call_sites(program, source_path, &atomic_names)?;
     Ok(())
 }
 

--- a/resilient/tests/atomic_types_callsite_smoke.rs
+++ b/resilient/tests/atomic_types_callsite_smoke.rs
@@ -1,0 +1,151 @@
+//! RES-3393: call-site shape checks for atomic_types operations.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_dir(tag: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let p = std::env::temp_dir().join(format!(
+        "res_atomic_types_callsite_{}_{}_{}",
+        tag,
+        std::process::id(),
+        n
+    ));
+    std::fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn check_source(tag: &str, source: &str) -> (PathBuf, String, String, Option<i32>) {
+    let dir = tmp_dir(tag);
+    let path = dir.join("case.rz");
+    std::fs::write(&path, source).expect("write source");
+    let out = Command::new(bin())
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("spawn rz check");
+    (
+        path,
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code(),
+    )
+}
+
+fn assert_file_line_col(output: &str, path: &Path, line: usize) {
+    let prefix = format!("{}:{}:", path.display(), line);
+    let has_line_col = output.lines().any(|line| {
+        line.strip_prefix(&prefix)
+            .and_then(|rest| rest.split_once(':'))
+            .is_some_and(|(col, _)| col.parse::<usize>().is_ok())
+    });
+    assert!(
+        has_line_col,
+        "diagnostic must include file:line:col; got:\n{output}"
+    );
+}
+
+fn assert_atomic_call_error(source: &str, expected: &str, line: usize) {
+    let (path, stdout, stderr, code) = check_source("invalid", source);
+    assert_eq!(
+        code,
+        Some(1),
+        "invalid atomic call should fail; stdout={stdout} stderr={stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert_file_line_col(&combined, &path, line);
+    assert!(
+        combined.contains(expected),
+        "diagnostic must contain `{expected}`; got:\n{combined}"
+    );
+}
+
+#[test]
+fn atomic_call_sites_accept_atomic_identifiers_and_integer_values() {
+    let (_path, stdout, stderr, code) = check_source(
+        "valid",
+        r#"
+#[atomic]
+static let counter = 0;
+fn atomic_load(any target) -> int { return 0; }
+fn atomic_store(any target, any value) -> int { return value; }
+fn atomic_fetch_add(any target, any value) -> int { return value; }
+fn main(int _d) {
+    atomic_store(counter, 1);
+    let current = atomic_load(counter);
+    return current + atomic_fetch_add(counter, 2);
+}
+main(0);
+"#,
+    );
+    assert_eq!(
+        code,
+        Some(0),
+        "valid atomic call sites should pass; stdout={stdout} stderr={stderr}"
+    );
+}
+
+#[test]
+fn atomic_load_rejects_string_number_list_and_struct_targets() {
+    let prefix = r#"
+#[atomic]
+static let counter = 0;
+struct Cell { int value }
+fn atomic_load(any target) -> int { return 0; }
+"#;
+
+    assert_atomic_call_error(
+        &format!("{prefix}fn main(int _d) {{ return atomic_load(\"counter\"); }}\nmain(0);\n"),
+        "atomic_load target must be an atomic identifier, got string literal",
+        6,
+    );
+    assert_atomic_call_error(
+        &format!("{prefix}fn main(int _d) {{ return atomic_load(1); }}\nmain(0);\n"),
+        "atomic_load target must be an atomic identifier, got number literal",
+        6,
+    );
+    assert_atomic_call_error(
+        &format!("{prefix}fn main(int _d) {{ return atomic_load([counter]); }}\nmain(0);\n"),
+        "atomic_load target must be an atomic identifier, got list literal",
+        6,
+    );
+    assert_atomic_call_error(
+        &format!(
+            "{prefix}fn main(int _d) {{ return atomic_load(new Cell {{ value: 0 }}); }}\nmain(0);\n"
+        ),
+        "atomic_load target must be an atomic identifier, got struct literal",
+        6,
+    );
+}
+
+#[test]
+fn atomic_store_and_fetch_add_validate_arity_and_integer_values() {
+    assert_atomic_call_error(
+        r#"
+#[atomic]
+static let counter = 0;
+fn atomic_store(any target) -> int { return 0; }
+fn main(int _d) { return atomic_store(counter); }
+main(0);
+"#,
+        "atomic_store expects 2 arguments, got 1",
+        5,
+    );
+    assert_atomic_call_error(
+        r#"
+#[atomic]
+static let counter = 0;
+fn atomic_fetch_add(any target, any value) -> int { return value; }
+fn main(int _d) { return atomic_fetch_add(counter, [1]); }
+main(0);
+"#,
+        "atomic_fetch_add value must be an integer expression, got list literal",
+        5,
+    );
+}


### PR DESCRIPTION
Closes #3393.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3393-atomic-types-check-should-validate-atomi`
Worktree: `.claude/worktrees/res-3393`

## Agent claims

(none inferred from issue)