### PR TITLE
RES-3497: Document f32 single-precision float type

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -575,14 +575,20 @@ The current trait system does not support:
 - `int`: 64-bit signed integer. Accepts decimal (`42`), hex (`0xFF`),
   and binary (`0b1010`) literals. Underscore separators allowed in all
   three forms: `0xDEAD_BEEF`, `0b1010_0001`, `1_000_000` (RES-909).
-- `float`: 64-bit floating point. Accepts decimal-point literals
-  (`1.5`, `42.`), RES-906 scientific notation (`1e9`, `2E10`,
-  `1.5e-3`, `1.e3`), and RES-909 underscore separators in mantissa
-  and exponent body (`1_000.5e1_0`). Exponent body (`+`/`-` optional,
-  then ≥1 digit) must follow `e`/`E` — bare `1e` lexes as
+- `float`: 64-bit floating point (IEEE-754 binary64 / `f64`). Accepts
+  decimal-point literals (`1.5`, `42.`), RES-906 scientific notation
+  (`1e9`, `2E10`, `1.5e-3`, `1.e3`), and RES-909 underscore separators
+  in mantissa and exponent body (`1_000.5e1_0`). Exponent body (`+`/`-`
+  optional, then ≥1 digit) must follow `e`/`E` — bare `1e` lexes as
   `Int(1) Ident("e")`. An underscore must sit between two digits;
   `1_a` lexes as `Int(1) Ident("_a")`, never silently swallowing the
   separator.
+- `f32`: 32-bit floating point (IEEE-754 binary32). A distinct type
+  from `float` — mixing `f32` and `float` in arithmetic without an
+  explicit cast is a type error. Use on embedded targets with a
+  hardware single-precision FPU (e.g. Cortex-M4F); `float` is
+  software-emulated there and much slower. Literals: `3.14 as f32`,
+  `let x: f32 = 3.14`, or `as_f32(expr)`. Aliases: `Float32`.
 - `string`: UTF-8 text; `len(s)` returns scalar count
 - `bytes`: raw byte sequence, `b"\x00\x01abc"` literal (RES-152)
 - `bool`: `true` / `false`
@@ -642,7 +648,7 @@ let value = "Pi: " + 3.14;              // "Pi: 3.14"
 | Array index | `arr[i]` — single element |
 | Array slice | `arr[lo..hi]`, `arr[lo..=hi]`, `arr[lo..]`, `arr[..hi]`, `arr[..]` (RES-911) — returns a fresh array |
 | Compound assign | `+= -= *= /= %= &= \|= ^= <<= >>=` (RES-912) — `x OP= rhs` desugars to `x = x OP rhs` for plain identifiers |
-| Cast | `<expr> as int` / `as float` / `as string` (RES-934) — postfix sugar over `to_int`, `to_float`, `to_string` builtins; high precedence (`1 + 2 as float` is `1 + (2 as float)`) |
+| Cast | `<expr> as int` / `as float` / `as f32` / `as f64` / `as string` (RES-934, RES-2618) — postfix sugar over conversion builtins; high precedence (`1 + 2 as float` is `1 + (2 as float)`) |
 
 ## `as` cast (RES-934)
 
@@ -653,18 +659,20 @@ conversion builtin:
 let n = 3.7 as int;           // to_int(3.7)   → 3 (truncates)
 let f = 42 as float;          // to_float(42)  → 42.0
 let s = true as string;       // to_string(true) → "true"
+let narrow = 1.0 / 3.0 as f32; // as_f32 — single-precision truncate
+let wide = narrow as f64;     // as_f64 — widen back to f64
 
 let chained = 3.5 as int as float as string;   // "3"
 let sum_cast = (1 + 2) as float;               // parens to cast a sum
 ```
 
 Supported targets are `int` (also `Int` / `Int64`), `float` (also
-`Float`), and `string` (also `String`). An unsupported target name
-(`as MyStruct`) is a parse error: *"Cannot cast to `MyStruct` — `as`
-supports int / float / string"*. The runtime semantics match the
-underlying builtin, including its error policy — `to_int(NaN)`,
-`to_int(∞)`, and out-of-range floats raise runtime errors rather
-than silently saturating.
+`Float` / `f64`), `f32` (also `Float32`), `f64` (alias of `float`),
+and `string` (also `String`). An unsupported target name (`as MyStruct`)
+is a parse error. The runtime semantics match the underlying builtin,
+including its error policy — `to_int(NaN)`, `to_int(∞)`, and
+out-of-range floats raise runtime errors rather than silently
+saturating.
 
 `as` binds tightly (precedence 11, same as `.`/`?`), mirroring Rust:
 

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -264,7 +264,7 @@ FunctionType   ::= "fn" "(" [ Type { "," Type } ] ")" "->" Type
 ### Type universe
 
 ```
-T ::= int | float | string | bool | bytes | void | any
+T ::= int | float | f32 | string | bool | bytes | void | any
     | [T]                    -- dynamic array, element T
     | [T; N]                 -- fixed-length array, element T, length N
     | fn(T1,...,Tn) -> T     -- function type
@@ -281,6 +281,11 @@ Semantics:
   operation.
 - `float` is IEEE-754 binary64 (`f64`). NaN and infinities are
   representable; `to_int` rejects them.
+- `f32` is IEEE-754 binary32, distinct from `float`. The
+  interpreter stores f32 values as f64 with truncated precision.
+  `f32` and `float` do not unify — arithmetic and assignment
+  across widths require an explicit `as f32` / `as f64` cast
+  (RES-2618).
 - `string` is an owned UTF-8 sequence. `len(s)` returns the **Unicode
   scalar** count, not the byte length.
 - `bytes` is a raw byte sequence, distinct from `string`. No implicit
@@ -322,14 +327,22 @@ arithmetic and comparison operator `⊕ ∈ {+, -, *, /, %, ==, !=, <,
 Γ ⊢ e1 : float   Γ ⊢ e2 : float
 ────────────────────────────────  (T-ArithFloat)
       Γ ⊢ e1 ⊕ e2 : float
+
+Γ ⊢ e1 : f32     Γ ⊢ e2 : f32
+────────────────────────────────  (T-ArithF32)
+      Γ ⊢ e1 ⊕ e2 : f32
 ```
 
-Mixing `int` and `float` is a static error. Users bridge explicitly:
+Mixing `int` and `float` is a static error. Mixing `f32` and `float`
+is also a static error — use `as f32` or `as f64` explicitly. Users
+bridge int/float explicitly:
 
 | Signature                 | Semantics                                          |
 |:--------------------------|:---------------------------------------------------|
 | `to_float(int) -> float`  | exact widening (faithful for \|x\| < 2<sup>53</sup>) |
 | `to_int(float) -> int`    | truncate toward zero; NaN / ±∞ / out-of-range → runtime error |
+| `as_f32(int\|float) -> f32` | truncate to binary32 precision                    |
+| `as_f64(int\|f32\|float) -> float` | widen to binary64                          |
 
 Comparison and equality operators share the same same-numeric-type
 rule and produce `bool`.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -171,7 +171,8 @@ assume(x > 0, "must be positive");  // optional message shown on trap
 | Type     | Notes                                                              |
 |----------|--------------------------------------------------------------------|
 | `int`    | 64-bit signed. Decimal (`42`), hex (`0xFF`), binary (`0b1010`). Underscore separators allowed: `0xDEAD_BEEF`. |
-| `float`  | 64-bit IEEE-754                                                    |
+| `float`  | 64-bit IEEE-754 binary64 (`f64`)                                   |
+| `f32`    | 32-bit IEEE-754 binary32 — distinct from `float`; use on embedded FPU targets. Literals: `3.14 as f32`, `as_f32(x)`. |
 | `string` | UTF-8 text; `len(s)` returns scalar count                          |
 | `bytes`  | Raw byte sequence; `b"\x00\x01abc"` literal                        |
 | `bool`   | `true` / `false`                                                   |
@@ -179,8 +180,8 @@ assume(x > 0, "must be positive");  // optional message shown on trap
 ### Numeric coercion
 
 Resilient does not implicitly coerce between numeric types.
-Mixing `int` and `float` in arithmetic or comparisons is a
-type error. Use the explicit converters:
+Mixing `int` and `float`, or `f32` and `float`, in arithmetic or
+comparisons is a type error. Use the explicit converters:
 
 ```rust
 let a = 1 + 2.0;              // ERROR: Cannot apply '+' to int and float
@@ -192,6 +193,8 @@ let c = 1 + to_int(2.0);      // ok → int 3
 |---|---|
 | `to_float(int) -> float` | Exact widening (for `abs(x) < 2^53`) |
 | `to_int(float) -> int` | Truncate toward zero; `NaN` / `±∞` / out-of-range are runtime errors |
+| `as_f32(int\|float) -> f32` | Truncate to binary32; also `expr as f32` |
+| `as_f64(int\|f32\|float) -> float` | Widen to binary64; also `expr as f64` |
 
 ---
 

--- a/docs/tutorial/02-variables-and-types.md
+++ b/docs/tutorial/02-variables-and-types.md
@@ -31,12 +31,18 @@ expression on the right is evaluated eagerly; there's no lazy
 
 ## Primitive types
 
-| Type     | Literal example   |
-| -------- | ----------------- |
-| `int`    | `42`, `-3`, `0`   |
-| `float`  | `3.14`, `-0.5`    |
-| `bool`   | `true`, `false`   |
-| `string` | `"hi"`            |
+| Type     | Literal example              | Notes |
+| -------- | ---------------------------- | ----- |
+| `int`    | `42`, `-3`, `0`              | 64-bit signed |
+| `float`  | `3.14`, `-0.5`               | IEEE-754 binary64 (`f64`) |
+| `f32`    | `3.14 as f32`, `as_f32(1.5)` | IEEE-754 binary32 — use on embedded FPU targets |
+| `bool`   | `true`, `false`              | |
+| `string` | `"hi"`                       | |
+
+`float` and `f32` are **distinct types**. Mixing them in arithmetic
+without an explicit cast is a type error — the checker suggests
+`as f32` or `as f64`. On Cortex-M4F, `f32` maps to the hardware
+single-precision FPU; `float` is software-emulated and slower.
 
 You can spell the type explicitly when clarity helps:
 
@@ -54,9 +60,9 @@ main();
 
 ## Turning on static type checking
 
-By default the interpreter runs whatever parses, deferring
-type errors to runtime. The `--typecheck` (or `-t`) flag
-enables the static checker:
+By default `rz` runs the type checker in **soft mode**: mismatches
+print to stderr but the program still executes. Use `--typecheck`
+(or `-t`) for **strict mode** — any type error aborts before run:
 
 ```bash
 rz --typecheck hello.rz
@@ -91,9 +97,9 @@ Error: Type check failed
 ```
 
 The checker reports the first mismatch and refuses to run the
-program. Without `-t`, the same program would crash at runtime
-when `"oops"` hit the `println(bad)` site — same outcome,
-later signal.
+program. Without `-t`, soft mode prints the same diagnostic but
+still runs — you get the runtime failure on the crashing line
+instead of an early exit.
 
 ## Mutation and shadowing
 
@@ -117,7 +123,7 @@ point forward. (Shadowing is common in match-arm bodies.)
 
 - `let` for locals; annotations are optional and never
   required.
-- Four primitives: `int`, `float`, `bool`, `string`.
+- Primitives: `int`, `float` (f64), `f32`, `bool`, `string`.
 - `--typecheck` surfaces mismatches at compile time instead of
   on the crashing line.
 - Bindings are mutable; reassignment uses `=`.


### PR DESCRIPTION
## Summary

- Documents `f32` (IEEE-754 binary32) in the tutorial, SYNTAX.md, docs/syntax.md, and language-reference.md
- Fixes incorrect `as` cast docs that claimed only `int / float / string` were supported — `as f32` and `as f64` work in the compiler (RES-2618)
- Updates tutorial type-checking section to match current soft-mode default (RES-1088)

## Problem

`f32` shipped for embedded Cortex-M FPU targets but was absent from all user-facing docs — the worst doc gap for an embedded safety language. Developers had to read compiler source or stumble on `f32_basics.rz`.

## Test plan

- [x] Docs-only change; no compiler code touched
- [x] Verified `as f32` / `as_f32` / cross-width rules against `resilient/src/float32.rs` and typechecker tests

Closes #3497

Made with [Cursor](https://cursor.com)