### PR TITLE
[codex] RES-3499: add Stateright actor checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -90,6 +91,12 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "async-trait"
@@ -219,6 +226,18 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "choice"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b71fc821deaf602a933ada5c845d088156d0cdf2ebf43ede390afe93466553"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "ciborium"
@@ -513,6 +532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +587,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -947,6 +986,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1078,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "id-set"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9633fadf6346456cf8531119ba4838bc6d82ac4ce84d9852126dd2aa34d49264"
 
 [[package]]
 name = "idna"
@@ -1337,6 +1388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1468,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot_core"
@@ -1701,6 +1768,7 @@ dependencies = [
  "rustyline",
  "serde_json",
  "sha2",
+ "stateright",
  "tokio",
  "tower-lsp",
  "z3",
@@ -1941,6 +2009,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stateright"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1157f21b11916f90fe1f2ac9a8d0e09a8813b28701584141060f414eedf6ba"
+dependencies = [
+ "ahash",
+ "choice",
+ "crossbeam-utils",
+ "dashmap 6.2.1",
+ "id-set",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "rand",
+ "serde",
+ "serde_json",
+ "tiny_http",
+]
+
+[[package]]
 name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2085,18 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -2082,7 +2182,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "bytes",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "httparse",
  "lsp-types",

--- a/docs/superpowers/plans/2026-06-11-stateright-bridge.md
+++ b/docs/superpowers/plans/2026-06-11-stateright-bridge.md
@@ -1,0 +1,175 @@
+# Stateright Bridge Implementation Plan
+**For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+**Goal:** Add a feature-gated `rz stateright check <file.rz>` command that model-checks a narrow Resilient actor subset with Stateright.
+**Architecture:** Reuse existing parser and actor AST, add a dedicated bridge module modeled after `tla_bridge`, and isolate all Stateright-specific translation logic inside that module. Keep the first version honest: support one integer actor state, straight-line receive handlers, and `always:` safety invariants only.
+**Tech Stack:** Rust, Cargo features, Stateright crate, existing Resilient parser/CLI/diagnostics.
+---
+
+### Task 1: Wire Cargo feature and module
+**Files:**
+- Modify: `resilient/Cargo.toml`
+- Modify: `resilient/src/lib.rs`
+
+- [ ] **Step 1: Write failing integration-oriented compile expectation**
+Document target compile surface:
+```text
+Expected: code references `stateright_bridge` from `lib.rs` and `stateright` feature from Cargo, but build/test fails until the module exists.
+```
+
+- [ ] **Step 2: Add feature-gated dependency and module declaration**
+Add:
+```toml
+stateright = ["dep:stateright"]
+```
+and
+```toml
+stateright = { version = "...", optional = true }
+```
+plus a feature-gated module declaration and CLI dispatch hook in `lib.rs`.
+
+- [ ] **Step 3: Run targeted compile/test command and verify failure moves to missing implementation**
+Run:
+```bash
+cargo test --manifest-path resilient/Cargo.toml --features stateright stateright_bridge
+```
+Expected: compile fails because bridge functions/module implementation is incomplete, not because feature wiring is absent.
+
+### Task 2: Add bridge CLI skeleton with tests first
+**Files:**
+- Create: `resilient/src/stateright_bridge.rs`
+
+- [ ] **Step 1: Write failing dispatcher tests**
+Add tests for:
+```rust
+dispatch_stateright_subcommand(&vec!["check".into(), "foo.rz".into()]).is_none()
+dispatch_stateright_subcommand(&vec!["stateright".into(), "--help".into()]) == Some(0)
+dispatch_stateright_subcommand(&vec!["stateright".into(), "check".into()]) == Some(1)
+```
+
+- [ ] **Step 2: Run targeted test and verify failure**
+Run:
+```bash
+cargo test --manifest-path resilient/Cargo.toml --features stateright stateright_bridge::tests::stateright_help_returns_zero -- --exact
+```
+Expected: FAIL because the bridge module does not yet implement the dispatcher.
+
+- [ ] **Step 3: Implement minimal CLI skeleton**
+Add help text, `dispatch_stateright_subcommand`, `run_stateright_check`, and help-detection helpers following `tla_bridge`.
+
+- [ ] **Step 4: Run targeted dispatcher tests and verify pass**
+Run:
+```bash
+cargo test --manifest-path resilient/Cargo.toml --features stateright stateright_bridge::tests -- --nocapture
+```
+Expected: PASS for CLI skeleton tests.
+
+### Task 3: Add failing model-check tests for actor subset
+**Files:**
+- Modify: `resilient/src/stateright_bridge.rs`
+
+- [ ] **Step 1: Write failing verification tests**
+Add tests using inline source strings for:
+```rust
+actor Q {
+  state: int = 0;
+  always: state <= 2;
+  receive push() requires state < 2 { self.state = self.state + 1; }
+}
+```
+Expected clean result, and:
+```rust
+actor Q {
+  state: int = 0;
+  always: state <= 2;
+  receive push() { self.state = self.state + 1; }
+}
+```
+Expected violation result.
+
+- [ ] **Step 2: Run targeted test and verify failure**
+Run:
+```bash
+cargo test --manifest-path resilient/Cargo.toml --features stateright stateright_bridge::tests::unbounded_actor_reports_violation -- --exact
+```
+Expected: FAIL because translation/model checking is not implemented yet.
+
+- [ ] **Step 3: Implement AST validation and translation**
+Implement helpers that:
+```rust
+parse actor declaration from existing AST
+enforce supported subset
+translate `requires` and `always` expressions into a small evaluator
+map each receive handler into a Stateright action
+```
+
+- [ ] **Step 4: Implement Stateright model runner**
+Build a minimal `Model` with integer state, enumerate handler actions, and assert `always:` properties through Stateright.
+
+- [ ] **Step 5: Run targeted tests and verify pass**
+Run:
+```bash
+cargo test --manifest-path resilient/Cargo.toml --features stateright stateright_bridge::tests::bounded_actor_is_clean -- --exact
+cargo test --manifest-path resilient/Cargo.toml --features stateright stateright_bridge::tests::unbounded_actor_reports_violation -- --exact
+```
+Expected: PASS.
+
+### Task 4: Add unsupported-shape coverage
+**Files:**
+- Modify: `resilient/src/stateright_bridge.rs`
+
+- [ ] **Step 1: Write failing unsupported-shape test**
+Use a handler body with control flow:
+```rust
+receive push() {
+  if state < 2 { self.state = self.state + 1; }
+}
+```
+Expected: unsupported diagnostic.
+
+- [ ] **Step 2: Run targeted test and verify failure**
+Run:
+```bash
+cargo test --manifest-path resilient/Cargo.toml --features stateright stateright_bridge::tests::control_flow_handler_is_unsupported -- --exact
+```
+Expected: FAIL before diagnostic path exists.
+
+- [ ] **Step 3: Implement unsupported-shape diagnostics**
+Return explicit Resilient-style errors with source location where available.
+
+- [ ] **Step 4: Re-run targeted test and verify pass**
+Run:
+```bash
+cargo test --manifest-path resilient/Cargo.toml --features stateright stateright_bridge::tests::control_flow_handler_is_unsupported -- --exact
+```
+Expected: PASS.
+
+### Task 5: Verify end-to-end
+**Files:**
+- Modify: `resilient/src/stateright_bridge.rs`
+- Modify: `resilient/src/lib.rs`
+- Modify: `resilient/Cargo.toml`
+
+- [ ] **Step 1: Run focused feature test suite**
+Run:
+```bash
+cargo test --manifest-path resilient/Cargo.toml --features stateright stateright_bridge::tests -- --nocapture
+```
+Expected: PASS.
+
+- [ ] **Step 2: Run broader crate tests with feature enabled**
+Run:
+```bash
+cargo test --manifest-path resilient/Cargo.toml --features stateright
+```
+Expected: PASS.
+
+- [ ] **Step 3: Manually verify CLI help**
+Run:
+```bash
+cargo run --manifest-path resilient/Cargo.toml --features stateright -- stateright --help
+```
+Expected: help text for the new subcommand.
+
+- [ ] **Step 4: Manually verify a clean and a violating inline/fixture case**
+Run commands against one bounded and one violating source file.
+Expected: one success diagnostic, one violation diagnostic.

--- a/docs/superpowers/specs/2026-06-11-stateright-bridge-design.md
+++ b/docs/superpowers/specs/2026-06-11-stateright-bridge-design.md
@@ -1,0 +1,150 @@
+# Stateright Bridge Design
+
+## Goal
+
+Add a first-class Stateright-backed verification path to Resilient via
+`rz stateright check <file.rz>` without replacing existing Z3/TLA+
+verification. The initial integration must be honest about scope and fail
+cleanly on unsupported language features.
+
+## Scope
+
+This design covers a narrow MVP:
+
+- Optional Cargo feature `stateright`
+- New CLI subcommand `rz stateright check <file.rz>`
+- Parsing and validation of Resilient actor programs
+- Translation of a small actor subset into an in-process Stateright model
+- Checking actor `always:` invariants under bounded exploration
+- Resilient-style diagnostics for:
+  - violated invariants
+  - unsupported constructs
+  - missing/invalid input
+
+This design does not cover:
+
+- General Resilient program execution in Stateright
+- `eventually:` liveness translation
+- `cluster_invariant` translation
+- Explorer UI exposure
+- Network semantics configuration
+- Replacing existing actor Z3 verification
+
+## Why This Shape
+
+Resilient already has verification-specific command seams such as the TLA+
+bridge. A Stateright bridge fits the same architecture: a separate subcommand
+with explicit feature gating and focused diagnostics. That avoids coupling an
+early integration to the full compiler pipeline.
+
+The actor subset is the only credible starting point because Stateright is a
+distributed/actor model checker, while most of Resilient is a general-purpose
+language with embedded/runtime concerns that do not map naturally to Stateright.
+
+## Supported Subset
+
+The initial translator accepts actor declarations with:
+
+- exactly one integer `state` field
+- one or more `always:` clauses
+- `receive` handlers whose bodies are straight-line updates to `self.state`
+- integer literals, `state`, handler parameters, and `+`, `-`, comparison
+  operators inside invariants and state updates
+
+The command rejects programs using unsupported shapes, including:
+
+- multiple actor declarations
+- zero actors with `always:` clauses
+- non-integer actor state
+- control flow inside handlers
+- unsupported expression forms in invariants or updates
+
+## User-Facing Behavior
+
+`rz stateright check file.rz`:
+
+- parses the file
+- locates the first actor declaration with `always:` clauses
+- validates it against the supported subset
+- runs a bounded Stateright exploration
+- prints Resilient-style diagnostics
+
+Success output:
+
+```text
+file.rz:0:0: info: Stateright model check completed — no invariant violations found.
+```
+
+Violation output:
+
+```text
+file.rz:0:0: error: Stateright found an invariant violation for actor `Q`: state <= 100
+```
+
+Unsupported subset output:
+
+```text
+file.rz:line:col: error: Stateright bridge currently supports only a single integer actor state and straight-line receive handlers.
+```
+
+## Architecture
+
+### Cargo surface
+
+Add an optional `stateright` feature in `resilient/Cargo.toml` that enables the
+new dependency and compiles the bridge module.
+
+### CLI integration
+
+Follow the `tla_bridge` pattern:
+
+- help request hook
+- subcommand dispatcher
+- dedicated help text
+- explicit exit codes
+
+### Translation layer
+
+Create `resilient/src/stateright_bridge.rs` containing:
+
+- CLI dispatch
+- subset validation
+- lightweight AST-to-model translation
+- result rendering
+
+The translator does not execute Resilient code generally. It only maps a small
+symbolic state machine into a Stateright `Model`.
+
+### Verification model
+
+The initial model treats each receive handler as a possible action from the
+current actor state. Preconditions come from `requires`; state transitions come
+from symbolic evaluation of the handler body. `always:` clauses become
+Stateright safety properties checked over reachable states.
+
+This is intentionally narrower than the runtime actor semantics, but it yields a
+real Stateright-backed invariant checker today.
+
+## Testing Strategy
+
+Add new tests only:
+
+- CLI dispatch tests for `stateright` help and error cases
+- positive unit test using `actor_queue_broken.rz`-style source that produces a
+  violation
+- positive unit test for a bounded actor that passes
+- unsupported-shape unit test
+
+## Risks
+
+- Resilient actor syntax is richer than the first translator supports. The
+  bridge must reject aggressively rather than approximate silently.
+- Stateright APIs may require small adjustments depending on crate version. The
+  integration should isolate that dependency inside the bridge module.
+
+## Success Criteria
+
+- `cargo test --manifest-path resilient/Cargo.toml --features stateright`
+  passes
+- `rz stateright check` exists behind the feature
+- one real Resilient actor example can be model-checked end-to-end

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -94,6 +94,9 @@ ffi = ["dep:libloading"]
 #   cargo test --features proptest
 #
 proptest = ["dep:proptest"]
+# RES-3010: optional Stateright bridge for actor-state model checking.
+# Default off so distributed verification dependencies stay opt-in.
+stateright = ["dep:stateright"]
 
 [dependencies]
 # RES-115: source-position types live in their own crate so
@@ -144,6 +147,7 @@ rand_core = { version = "0.6", features = ["getrandom"], optional = true }
 regex = "1"
 sha2 = "0.10"
 serde_json = "1"
+stateright = { version = "0.31.0", optional = true }
 
 # RES-510 PR 3: deps that are CLI-only and don't compile to wasm32
 # (or aren't useful there). Moved out of the unconditional

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -148,6 +148,8 @@ pub mod mcp_tool_registry;
 pub mod output_sink;
 mod peephole;
 mod span;
+#[cfg(all(not(target_arch = "wasm32"), feature = "stateright"))]
+mod stateright_bridge;
 #[cfg(not(target_arch = "wasm32"))]
 mod tla_bridge;
 // RES-400: sum-type declarations. PR 1 lands the parser scaffold for
@@ -32734,12 +32736,23 @@ pub fn run_cli() {
         tla_bridge::print_tla_check_help();
         std::process::exit(0);
     }
+    #[cfg(all(not(target_arch = "wasm32"), feature = "stateright"))]
+    if stateright_bridge::is_stateright_check_help_request(&args) {
+        stateright_bridge::print_stateright_check_help();
+        std::process::exit(0);
+    }
 
     // TLA+ bridge: `rz tla check <file.tla>` — shells out to TLC and
     // surfaces results in Resilient's diagnostic format.
     #[cfg(not(target_arch = "wasm32"))]
     if args.len() > 1
         && let Some(code) = tla_bridge::dispatch_tla_subcommand(&args[1..])
+    {
+        std::process::exit(code);
+    }
+    #[cfg(all(not(target_arch = "wasm32"), feature = "stateright"))]
+    if args.len() > 1
+        && let Some(code) = stateright_bridge::dispatch_stateright_subcommand(&args[1..])
     {
         std::process::exit(code);
     }

--- a/resilient/src/stateright_bridge.rs
+++ b/resilient/src/stateright_bridge.rs
@@ -1,0 +1,666 @@
+//! Stateright bridge — `rz stateright check <file.rz>`.
+//!
+//! The first integration targets a narrow actor-state subset and translates it
+//! into a Stateright `Model`. This makes the bridge useful today without
+//! overclaiming support for the full language or full runtime actor semantics.
+
+#![allow(clippy::collapsible_if, clippy::doc_lazy_continuation)]
+
+use crate::Node;
+use crate::span::Span;
+use stateright::{Checker, Model, Property};
+use std::fs;
+use std::path::Path;
+
+const DEFAULT_MAX_DEPTH: usize = 256;
+const DEFAULT_STATE_BOUND: i64 = 1_024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckOutcome {
+    Clean,
+    Violated,
+    Unsupported,
+    ParseError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CheckResult {
+    outcome: CheckOutcome,
+    diagnostics: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BridgeState {
+    value: i64,
+}
+
+#[derive(Debug, Clone)]
+struct BridgeHandler {
+    requires: Vec<Node>,
+    next_state: Node,
+}
+
+#[derive(Debug, Clone)]
+struct BridgeModel {
+    actor_name: String,
+    state_name: String,
+    invariants: Vec<Node>,
+    invariant_labels: Vec<String>,
+    handlers: Vec<BridgeHandler>,
+    initial_state: i64,
+    property_name: &'static str,
+    boundary_abs: i64,
+}
+
+impl Model for BridgeModel {
+    type State = BridgeState;
+    type Action = usize;
+
+    fn init_states(&self) -> Vec<Self::State> {
+        vec![BridgeState {
+            value: self.initial_state,
+        }]
+    }
+
+    fn actions(&self, _state: &Self::State, actions: &mut Vec<Self::Action>) {
+        actions.extend(0..self.handlers.len());
+    }
+
+    fn next_state(&self, last_state: &Self::State, action: Self::Action) -> Option<Self::State> {
+        let handler = self.handlers.get(action)?;
+        if !handler
+            .requires
+            .iter()
+            .all(|req| eval_bool(req, &self.state_name, last_state.value).unwrap_or(false))
+        {
+            return None;
+        }
+        let next = eval_int(&handler.next_state, &self.state_name, last_state.value).ok()?;
+        Some(BridgeState { value: next })
+    }
+
+    fn properties(&self) -> Vec<Property<Self>> {
+        vec![Property::always(self.property_name, bridge_invariants_hold)]
+    }
+
+    fn within_boundary(&self, state: &Self::State) -> bool {
+        state.value.abs() <= self.boundary_abs
+    }
+}
+
+fn bridge_invariants_hold(model: &BridgeModel, state: &BridgeState) -> bool {
+    model
+        .invariants
+        .iter()
+        .all(|inv| eval_bool(inv, &model.state_name, state.value).unwrap_or(false))
+}
+
+pub fn dispatch_stateright_subcommand(args: &[String]) -> Option<i32> {
+    let first = args.first()?;
+    if first != "stateright" {
+        return None;
+    }
+    let verb = args.get(1).map(String::as_str).unwrap_or("--help");
+    match verb {
+        "check" => Some(run_stateright_check(&args[2..])),
+        "--help" | "-h" | "help" => {
+            print_stateright_help();
+            Some(0)
+        }
+        other => {
+            eprintln!(
+                "Error: unknown `stateright` subcommand `{}`. Try `rz stateright --help`.",
+                other
+            );
+            Some(1)
+        }
+    }
+}
+
+fn run_stateright_check(args: &[String]) -> i32 {
+    if is_stateright_check_help_args(args) {
+        print_stateright_check_help();
+        return 0;
+    }
+
+    let mut input_file: Option<&str> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            f if !f.starts_with('-') => input_file = Some(f),
+            flag => {
+                eprintln!(
+                    "Error: unknown flag `{}`. Try `rz stateright check --help`.",
+                    flag
+                );
+                return 1;
+            }
+        }
+        i += 1;
+    }
+
+    let file = match input_file {
+        Some(file) => file,
+        None => {
+            eprintln!("Error: `rz stateright check` requires a .rz file path.");
+            eprintln!("Usage: rz stateright check <file.rz>");
+            return 1;
+        }
+    };
+
+    let path = Path::new(file);
+    if !path.exists() {
+        eprintln!("Error: file not found: {}", path.display());
+        return 1;
+    }
+
+    let src = match fs::read_to_string(path) {
+        Ok(src) => src,
+        Err(e) => {
+            eprintln!("Error: could not read {}: {}", path.display(), e);
+            return 1;
+        }
+    };
+
+    let result = check_source(&src, file);
+    for diag in &result.diagnostics {
+        match result.outcome {
+            CheckOutcome::Clean => println!("{diag}"),
+            _ => eprintln!("{diag}"),
+        }
+    }
+    match result.outcome {
+        CheckOutcome::Clean => 0,
+        CheckOutcome::Violated | CheckOutcome::Unsupported | CheckOutcome::ParseError => 1,
+    }
+}
+
+const STATERIGHT_HELP_TEXT: &str = r#"rz stateright — model-check a Resilient actor subset with Stateright
+
+USAGE:
+    rz stateright <SUBCOMMAND>
+
+SUBCOMMANDS:
+    check      Model-check a supported `.rz` actor program
+    help       Show this help text
+
+Run `rz stateright check --help` for details on the verifier entry point.
+"#;
+
+const STATERIGHT_CHECK_HELP_TEXT: &str = r#"rz stateright check — model-check a Resilient actor subset with Stateright
+
+USAGE:
+    rz stateright check <file.rz>
+
+SUPPORTED TODAY:
+    - exactly one actor declaration
+    - one integer actor state field
+    - `always:` safety invariants
+    - straight-line `receive` handlers
+
+EXIT CODES:
+    0 — no invariant violations found
+    1 — violation found, unsupported construct, parse error, or file error
+"#;
+
+fn print_stateright_help() {
+    print!("{STATERIGHT_HELP_TEXT}");
+}
+
+pub(crate) fn print_stateright_check_help() {
+    print!("{STATERIGHT_CHECK_HELP_TEXT}");
+}
+
+pub(crate) fn is_stateright_check_help_request(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("stateright")
+        && args.get(2).map(String::as_str) == Some("check")
+        && is_stateright_check_help_args(&args[3..])
+}
+
+fn is_stateright_check_help_args(args: &[String]) -> bool {
+    matches!(
+        args.first().map(String::as_str),
+        Some("--help" | "-h" | "help")
+    )
+}
+
+fn check_source(src: &str, filename: &str) -> CheckResult {
+    let (program, errs) = crate::parse(src);
+    if !errs.is_empty() {
+        return CheckResult {
+            outcome: CheckOutcome::ParseError,
+            diagnostics: errs
+                .into_iter()
+                .map(|err| format!("{filename}:0:0: error: {err}"))
+                .collect(),
+        };
+    }
+
+    let model = match build_model(&program, filename) {
+        Ok(model) => model,
+        Err(diag) => {
+            return CheckResult {
+                outcome: CheckOutcome::Unsupported,
+                diagnostics: vec![diag],
+            };
+        }
+    };
+
+    let checker = model
+        .clone()
+        .checker()
+        .target_max_depth(DEFAULT_MAX_DEPTH)
+        .spawn_bfs()
+        .join();
+
+    if let Some(path) = checker.discovery(model.property_name) {
+        let state = path.last_state();
+        let failed = first_failed_invariant(&model, state.value)
+            .unwrap_or_else(|| "an invariant".to_string());
+        return CheckResult {
+            outcome: CheckOutcome::Violated,
+            diagnostics: vec![format!(
+                "{filename}:0:0: error: Stateright found an invariant violation for actor `{}`: {} (state = {})",
+                model.actor_name, failed, state.value
+            )],
+        };
+    }
+
+    CheckResult {
+        outcome: CheckOutcome::Clean,
+        diagnostics: vec![format!(
+            "{filename}:0:0: info: Stateright model check completed — no invariant violations found."
+        )],
+    }
+}
+
+fn build_model(program: &Node, filename: &str) -> Result<BridgeModel, String> {
+    let Node::Program(stmts) = program else {
+        return Err(format!(
+            "{filename}:0:0: error: Stateright bridge expected a parsed program."
+        ));
+    };
+
+    let actors: Vec<&Node> = stmts
+        .iter()
+        .filter_map(|stmt| match &stmt.node {
+            Node::ActorDecl { .. } => Some(&stmt.node),
+            _ => None,
+        })
+        .collect();
+
+    if actors.len() != 1 {
+        return Err(format!(
+            "{filename}:0:0: error: Stateright bridge currently supports exactly one actor declaration."
+        ));
+    }
+
+    let Node::ActorDecl {
+        name,
+        state_fields,
+        always_clauses,
+        receive_handlers,
+        span,
+        ..
+    } = actors[0]
+    else {
+        unreachable!();
+    };
+
+    if always_clauses.is_empty() {
+        return Err(format!(
+            "{filename}:{}:{}: error: actor `{}` has no `always:` invariants for Stateright to check.",
+            span.start.line, span.start.column, name
+        ));
+    }
+
+    if state_fields.len() != 1 {
+        return Err(format!(
+            "{filename}:{}:{}: error: Stateright bridge currently supports exactly one actor state field.",
+            span.start.line, span.start.column
+        ));
+    }
+
+    let (type_name, state_name, init_expr) = &state_fields[0];
+    if type_name != "int" {
+        let s = node_span(init_expr);
+        return Err(format!(
+            "{filename}:{}:{}: error: Stateright bridge currently supports only integer actor state.",
+            s.start.line, s.start.column
+        ));
+    }
+
+    validate_expr(init_expr, state_name, true, filename)?;
+    let initial_state = eval_int(init_expr, state_name, 0).map_err(|msg| {
+        let s = node_span(init_expr);
+        format!(
+            "{filename}:{}:{}: error: {msg}",
+            s.start.line, s.start.column
+        )
+    })?;
+
+    let mut invariant_labels = Vec::with_capacity(always_clauses.len());
+    for inv in always_clauses {
+        validate_expr(inv, state_name, true, filename)?;
+        invariant_labels.push(render_expr(inv));
+    }
+
+    let mut handlers = Vec::with_capacity(receive_handlers.len());
+    for handler in receive_handlers {
+        for req in &handler.requires {
+            validate_expr(req, state_name, false, filename)?;
+        }
+        let Some(next_state) =
+            crate::verifier_actors::straight_line_post_public(&handler.body, state_name)
+        else {
+            return Err(format!(
+                "{filename}:{}:{}: error: Stateright bridge currently supports only straight-line receive handlers.",
+                handler.span.start.line, handler.span.start.column
+            ));
+        };
+        validate_expr(&next_state, state_name, false, filename)?;
+        handlers.push(BridgeHandler {
+            requires: handler.requires.clone(),
+            next_state,
+        });
+    }
+
+    Ok(BridgeModel {
+        actor_name: name.clone(),
+        state_name: state_name.clone(),
+        invariants: always_clauses.clone(),
+        invariant_labels,
+        handlers,
+        initial_state,
+        property_name: Box::leak(format!("{}_always", name).into_boxed_str()),
+        boundary_abs: DEFAULT_STATE_BOUND,
+    })
+}
+
+fn first_failed_invariant(model: &BridgeModel, state_value: i64) -> Option<String> {
+    model
+        .invariants
+        .iter()
+        .zip(&model.invariant_labels)
+        .find_map(|(inv, label)| {
+            let ok = eval_bool(inv, &model.state_name, state_value).ok()?;
+            if ok { None } else { Some(label.clone()) }
+        })
+}
+
+fn validate_expr(
+    expr: &Node,
+    state_name: &str,
+    allow_unknown_identifiers: bool,
+    filename: &str,
+) -> Result<(), String> {
+    match expr {
+        Node::IntegerLiteral { .. } | Node::BooleanLiteral { .. } => Ok(()),
+        Node::Identifier { name, span } => {
+            if name == state_name {
+                Ok(())
+            } else if allow_unknown_identifiers {
+                Ok(())
+            } else {
+                Err(format!(
+                    "{filename}:{}:{}: error: Stateright bridge does not support handler parameters or local variables in translated expressions.",
+                    span.start.line, span.start.column
+                ))
+            }
+        }
+        Node::FieldAccess {
+            target,
+            field,
+            span,
+        } => {
+            if matches!(target.as_ref(), Node::Identifier { name, .. } if name == "self")
+                && field == state_name
+            {
+                Ok(())
+            } else {
+                Err(format!(
+                    "{filename}:{}:{}: error: Stateright bridge supports only `self.{}` field access.",
+                    span.start.line, span.start.column, state_name
+                ))
+            }
+        }
+        Node::PrefixExpression {
+            operator, right, ..
+        } => match *operator {
+            "-" | "!" => validate_expr(right, state_name, allow_unknown_identifiers, filename),
+            _ => {
+                let s = node_span(expr);
+                Err(format!(
+                    "{filename}:{}:{}: error: unsupported prefix operator `{}` in Stateright bridge.",
+                    s.start.line, s.start.column, operator
+                ))
+            }
+        },
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => match *operator {
+            "+" | "-" | "*" | "/" | "<" | "<=" | ">" | ">=" | "==" | "!=" | "&&" | "||" => {
+                validate_expr(left, state_name, allow_unknown_identifiers, filename)?;
+                validate_expr(right, state_name, allow_unknown_identifiers, filename)
+            }
+            _ => {
+                let s = node_span(expr);
+                Err(format!(
+                    "{filename}:{}:{}: error: unsupported operator `{}` in Stateright bridge.",
+                    s.start.line, s.start.column, operator
+                ))
+            }
+        },
+        _ => {
+            let s = node_span(expr);
+            Err(format!(
+                "{filename}:{}:{}: error: unsupported expression shape in Stateright bridge.",
+                s.start.line, s.start.column
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EvalValue {
+    Int(i64),
+    Bool(bool),
+}
+
+fn eval_int(expr: &Node, state_name: &str, state_value: i64) -> Result<i64, String> {
+    match eval_expr(expr, state_name, state_value)? {
+        EvalValue::Int(v) => Ok(v),
+        EvalValue::Bool(_) => Err("expected integer expression in Stateright bridge".to_string()),
+    }
+}
+
+fn eval_bool(expr: &Node, state_name: &str, state_value: i64) -> Result<bool, String> {
+    match eval_expr(expr, state_name, state_value)? {
+        EvalValue::Bool(v) => Ok(v),
+        EvalValue::Int(_) => Err("expected boolean expression in Stateright bridge".to_string()),
+    }
+}
+
+fn eval_expr(expr: &Node, state_name: &str, state_value: i64) -> Result<EvalValue, String> {
+    match expr {
+        Node::IntegerLiteral { value, .. } => Ok(EvalValue::Int(*value)),
+        Node::BooleanLiteral { value, .. } => Ok(EvalValue::Bool(*value)),
+        Node::Identifier { name, .. } if name == state_name => Ok(EvalValue::Int(state_value)),
+        Node::FieldAccess { target, field, .. }
+            if matches!(target.as_ref(), Node::Identifier { name, .. } if name == "self")
+                && field == state_name =>
+        {
+            Ok(EvalValue::Int(state_value))
+        }
+        Node::PrefixExpression {
+            operator, right, ..
+        } => match (*operator, eval_expr(right, state_name, state_value)?) {
+            ("-", EvalValue::Int(v)) => Ok(EvalValue::Int(-v)),
+            ("!", EvalValue::Bool(v)) => Ok(EvalValue::Bool(!v)),
+            _ => Err("type mismatch in prefix expression".to_string()),
+        },
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => {
+            let left = eval_expr(left, state_name, state_value)?;
+            let right = eval_expr(right, state_name, state_value)?;
+            eval_infix(*operator, left, right)
+        }
+        _ => Err("unsupported expression during Stateright evaluation".to_string()),
+    }
+}
+
+fn eval_infix(operator: &str, left: EvalValue, right: EvalValue) -> Result<EvalValue, String> {
+    match (operator, left, right) {
+        ("+", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Int(a + b)),
+        ("-", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Int(a - b)),
+        ("*", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Int(a * b)),
+        ("/", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Int(a / b)),
+        ("<", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Bool(a < b)),
+        ("<=", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Bool(a <= b)),
+        (">", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Bool(a > b)),
+        (">=", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Bool(a >= b)),
+        ("==", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Bool(a == b)),
+        ("!=", EvalValue::Int(a), EvalValue::Int(b)) => Ok(EvalValue::Bool(a != b)),
+        ("==", EvalValue::Bool(a), EvalValue::Bool(b)) => Ok(EvalValue::Bool(a == b)),
+        ("!=", EvalValue::Bool(a), EvalValue::Bool(b)) => Ok(EvalValue::Bool(a != b)),
+        ("&&", EvalValue::Bool(a), EvalValue::Bool(b)) => Ok(EvalValue::Bool(a && b)),
+        ("||", EvalValue::Bool(a), EvalValue::Bool(b)) => Ok(EvalValue::Bool(a || b)),
+        _ => Err(format!("type mismatch for operator `{operator}`")),
+    }
+}
+
+fn render_expr(expr: &Node) -> String {
+    match expr {
+        Node::Identifier { name, .. } => name.clone(),
+        Node::IntegerLiteral { value, .. } => value.to_string(),
+        Node::BooleanLiteral { value, .. } => value.to_string(),
+        Node::FieldAccess { target, field, .. } => format!("{}.{}", render_expr(target), field),
+        Node::PrefixExpression {
+            operator, right, ..
+        } => {
+            format!("{operator}{}", render_expr(right))
+        }
+        Node::InfixExpression {
+            left,
+            operator,
+            right,
+            ..
+        } => format!("{} {} {}", render_expr(left), operator, render_expr(right)),
+        _ => format!("{expr:?}"),
+    }
+}
+
+fn node_span(node: &Node) -> Span {
+    match node {
+        Node::Identifier { span, .. }
+        | Node::IntegerLiteral { span, .. }
+        | Node::BooleanLiteral { span, .. }
+        | Node::PrefixExpression { span, .. }
+        | Node::InfixExpression { span, .. }
+        | Node::FieldAccess { span, .. }
+        | Node::FieldAssignment { span, .. }
+        | Node::Assignment { span, .. }
+        | Node::ExpressionStatement { span, .. }
+        | Node::Block { span, .. }
+        | Node::ActorDecl { span, .. } => *span,
+        _ => Span::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_stateright_arg_returns_none() {
+        let args: Vec<String> = vec!["check".into(), "foo.rz".into()];
+        assert!(dispatch_stateright_subcommand(&args).is_none());
+    }
+
+    #[test]
+    fn stateright_help_returns_zero() {
+        let args: Vec<String> = vec!["stateright".into(), "--help".into()];
+        assert_eq!(dispatch_stateright_subcommand(&args), Some(0));
+    }
+
+    #[test]
+    fn stateright_check_missing_file_returns_one() {
+        let args: Vec<String> = vec!["stateright".into(), "check".into()];
+        assert_eq!(dispatch_stateright_subcommand(&args), Some(1));
+    }
+
+    #[test]
+    fn stateright_check_help_request_detected() {
+        let args = vec![
+            "rz".into(),
+            "stateright".into(),
+            "check".into(),
+            "--help".into(),
+        ];
+        assert!(is_stateright_check_help_request(&args));
+    }
+
+    #[test]
+    fn bounded_actor_is_clean() {
+        let src = r#"
+actor Q {
+    state: int = 0;
+    always: state <= 2;
+    receive push() requires state < 2 { self.state = self.state + 1; }
+    receive pop() requires state > 0 { self.state = self.state - 1; }
+}
+"#;
+        let result = check_source(src, "bounded.rz");
+        assert_eq!(result.outcome, CheckOutcome::Clean);
+        assert!(
+            result.diagnostics[0].contains("no invariant violations found"),
+            "{:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn unbounded_actor_reports_violation() {
+        let src = r#"
+actor Q {
+    state: int = 0;
+    always: state <= 2;
+    receive push() { self.state = self.state + 1; }
+}
+"#;
+        let result = check_source(src, "broken.rz");
+        assert_eq!(result.outcome, CheckOutcome::Violated);
+        assert!(
+            result.diagnostics[0].contains("state <= 2"),
+            "{:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn control_flow_handler_is_unsupported() {
+        let src = r#"
+actor Q {
+    state: int = 0;
+    always: state <= 2;
+    receive push() {
+        if state < 2 { self.state = self.state + 1; }
+    }
+}
+"#;
+        let result = check_source(src, "unsupported.rz");
+        assert_eq!(result.outcome, CheckOutcome::Unsupported);
+        assert!(
+            result.diagnostics[0].contains("straight-line receive handlers"),
+            "{:?}",
+            result.diagnostics
+        );
+    }
+}


### PR DESCRIPTION
Closes #3499

## Summary
- add a feature-gated Stateright bridge and `rz stateright check <file.rz>`
- translate a narrow actor subset into a Stateright `Model` for `always:` checks
- add spec/plan docs for the bridge implementation

## Why
Resilient already has multiple verification seams, but it did not have a direct Stateright-backed path. This adds a real integration point while keeping the scope honest and rejecting unsupported shapes explicitly.

## Validation
- `cargo fmt --all`
- `cargo run --manifest-path resilient/Cargo.toml --features stateright -- stateright --help`
- `cargo run --manifest-path resilient/Cargo.toml --features stateright -- stateright check resilient/examples/actor_queue_safe.rz`
- `cargo run --manifest-path resilient/Cargo.toml --features stateright -- stateright check resilient/examples/actor_queue_broken.rz`
