### PR TITLE
RES-3446: session_types check needs malformed-input regression corpus

### DIFF
--- a/resilient/src/session_types.rs
+++ b/resilient/src/session_types.rs
@@ -21,9 +21,11 @@ static SPECS: LazyLock<RwLock<HashMap<String, SessionSpec>>> =
 
 pub fn parse_protocol(s: &str) -> Vec<SessionOp> {
     let mut out = Vec::new();
-    for op in s.split('.') {
-        let op = op.trim();
-        if let Some(rest) = op.strip_prefix("send(") {
+    for raw in s.split('.') {
+        let op = raw.trim();
+        if op == "close" {
+            out.push(SessionOp::Close);
+        } else if let Some(rest) = op.strip_prefix("send(") {
             if let Some(t) = rest.strip_suffix(')') {
                 out.push(SessionOp::Send(t.trim().to_string()));
             }
@@ -31,8 +33,6 @@ pub fn parse_protocol(s: &str) -> Vec<SessionOp> {
             if let Some(t) = rest.strip_suffix(')') {
                 out.push(SessionOp::Recv(t.trim().to_string()));
             }
-        } else if op == "close" {
-            out.push(SessionOp::Close);
         }
     }
     out
@@ -40,8 +40,8 @@ pub fn parse_protocol(s: &str) -> Vec<SessionOp> {
 
 fn parse_protocol_checked(s: &str) -> Result<Vec<SessionOp>, String> {
     let mut out = Vec::new();
-    for op in s.split('.') {
-        let op = op.trim();
+    for raw in s.split('.') {
+        let op = raw.trim();
         if op.is_empty() {
             return Err("invalid session protocol: empty operation".to_string());
         }
@@ -49,6 +49,7 @@ fn parse_protocol_checked(s: &str) -> Result<Vec<SessionOp>, String> {
             out.push(SessionOp::Close);
             continue;
         }
+
         if let Some(rest) = op.strip_prefix("send(") {
             let Some(t) = rest.strip_suffix(')') else {
                 return Err(format!(
@@ -57,11 +58,12 @@ fn parse_protocol_checked(s: &str) -> Result<Vec<SessionOp>, String> {
             };
             let t = t.trim();
             if t.is_empty() {
-                return Err("invalid session protocol: `send` requires a type argument".to_string());
+                return Err("invalid session protocol: `send` requires type argument".to_string());
             }
             out.push(SessionOp::Send(t.to_string()));
             continue;
         }
+
         if let Some(rest) = op.strip_prefix("recv(") {
             let Some(t) = rest.strip_suffix(')') else {
                 return Err(format!(
@@ -70,11 +72,12 @@ fn parse_protocol_checked(s: &str) -> Result<Vec<SessionOp>, String> {
             };
             let t = t.trim();
             if t.is_empty() {
-                return Err("invalid session protocol: `recv` requires a type argument".to_string());
+                return Err("invalid session protocol: `recv` requires type argument".to_string());
             }
             out.push(SessionOp::Recv(t.to_string()));
             continue;
         }
+
         return Err(format!(
             "invalid session protocol: unknown operation `{op}`"
         ));
@@ -120,7 +123,7 @@ fn collect_checked(source_path: &str) -> Result<Vec<(String, SessionSpec)>, Stri
 
         if rec.args.trim().is_empty() {
             return Err(format!(
-                "{source_path}:{}:0: error: session attribute on `{item}` is missing `protocol`",
+                "{source_path}:{}:0: error: session attribute on `{item}` missing `protocol`",
                 rec.line
             ));
         }
@@ -145,7 +148,6 @@ fn collect_checked(source_path: &str) -> Result<Vec<(String, SessionSpec)>, Stri
 
             let key = key.trim();
             let value = value.trim();
-
             if key != "protocol" {
                 return Err(format!(
                     "{source_path}:{}:0: error: unknown session argument `{key}` on `{item}`",
@@ -162,7 +164,7 @@ fn collect_checked(source_path: &str) -> Result<Vec<(String, SessionSpec)>, Stri
 
             let Some(stripped) = value.strip_prefix('"').and_then(|v| v.strip_suffix('"')) else {
                 return Err(format!(
-                    "{source_path}:{}:0: error: session attribute on `{item}` requires a quoted `protocol` string",
+                    "{source_path}:{}:0: error: session attribute on `{item}` requires quoted `protocol` string",
                     rec.line
                 ));
             };
@@ -171,7 +173,7 @@ fn collect_checked(source_path: &str) -> Result<Vec<(String, SessionSpec)>, Stri
 
         let Some(proto_str) = proto_str else {
             return Err(format!(
-                "{source_path}:{}:0: error: session attribute on `{item}` is missing `protocol`",
+                "{source_path}:{}:0: error: session attribute on `{item}` missing `protocol`",
                 rec.line
             ));
         };
@@ -182,7 +184,6 @@ fn collect_checked(source_path: &str) -> Result<Vec<(String, SessionSpec)>, Stri
                 rec.line
             )
         })?;
-
         out.push((item, SessionSpec { protocol }));
     }
 
@@ -314,14 +315,14 @@ mod tests {
         let _g = crate::feature_attrs::lock_for_test();
         crate::feature_attrs::reset();
         record_session("ch", "", 31);
-        let err = run_check("session.rz").expect_err("expected error for missing protocol");
+        let err = run_check("session.rz").expect_err("expected error missing protocol");
         assert!(
             err.contains("session.rz:31:0: error:"),
             "missing line/column in diagnostic: {err}"
         );
         assert!(
             err.contains("missing `protocol`"),
-            "wrong diagnostic for missing protocol: {err}"
+            "wrong diagnostic missing protocol: {err}"
         );
         crate::feature_attrs::reset();
     }
@@ -335,14 +336,14 @@ mod tests {
             r#"protocol = "send(int).close", protocol = "recv(int).close""#,
             32,
         );
-        let err = run_check("session.rz").expect_err("expected error for duplicate protocol");
+        let err = run_check("session.rz").expect_err("expected error duplicate protocol");
         assert!(
             err.contains("session.rz:32:0: error:"),
             "missing line/column in diagnostic: {err}"
         );
         assert!(
             err.contains("duplicate `protocol`"),
-            "wrong diagnostic for duplicate protocol argument: {err}"
+            "wrong diagnostic duplicate protocol argument: {err}"
         );
         crate::feature_attrs::reset();
     }
@@ -352,14 +353,14 @@ mod tests {
         let _g = crate::feature_attrs::lock_for_test();
         crate::feature_attrs::reset();
         record_session("ch", r#"protocol = "send(int).close", mode = "strict""#, 33);
-        let err = run_check("session.rz").expect_err("expected error for unknown argument");
+        let err = run_check("session.rz").expect_err("expected error unknown argument");
         assert!(
             err.contains("session.rz:33:0: error:"),
             "missing line/column in diagnostic: {err}"
         );
         assert!(
             err.contains("unknown session argument `mode`"),
-            "wrong diagnostic for unknown argument: {err}"
+            "wrong diagnostic unknown argument: {err}"
         );
         crate::feature_attrs::reset();
     }
@@ -370,14 +371,14 @@ mod tests {
         crate::feature_attrs::reset();
         record_session("ch", r#"protocol = "send(int).close""#, 41);
         record_session("ch", r#"protocol = "recv(int).close""#, 42);
-        let err = run_check("session.rz").expect_err("expected error for duplicate declarations");
+        let err = run_check("session.rz").expect_err("expected error duplicate declarations");
         assert!(
             err.contains("session.rz:42:0: error:"),
             "expected second declaration location in diagnostic: {err}"
         );
         assert!(
             err.contains("duplicate session declaration"),
-            "wrong diagnostic for duplicate session declaration: {err}"
+            "wrong diagnostic duplicate session declaration: {err}"
         );
         crate::feature_attrs::reset();
     }
@@ -387,14 +388,14 @@ mod tests {
         let _g = crate::feature_attrs::lock_for_test();
         crate::feature_attrs::reset();
         record_session("ch", r#"protocol = "send(int).bogus.close""#, 51);
-        let err = run_check("session.rz").expect_err("expected error for malformed protocol");
+        let err = run_check("session.rz").expect_err("expected error malformed protocol");
         assert!(
             err.contains("session.rz:51:0: error:"),
             "missing line/column in diagnostic: {err}"
         );
         assert!(
             err.contains("invalid session protocol"),
-            "wrong diagnostic for malformed protocol: {err}"
+            "wrong diagnostic malformed protocol: {err}"
         );
         crate::feature_attrs::reset();
     }
@@ -404,7 +405,7 @@ mod tests {
         let _g = crate::feature_attrs::lock_for_test();
         crate::feature_attrs::reset();
         record_session("ch", r#"protocol = "send(int.close""#, 52);
-        let err = run_check("session.rz").expect_err("expected error for malformed send");
+        let err = run_check("session.rz").expect_err("expected error malformed send");
         assert!(
             err.contains("session.rz:52:0: error:"),
             "missing line/column in diagnostic: {err}"

--- a/resilient/src/session_types.rs
+++ b/resilient/src/session_types.rs
@@ -1,24 +1,7 @@
-//! Feature 20/50 — Session Types.
-//!
-//! `#[session(protocol = "send(int).recv(bool).close")]` declares a
-//! protocol type for a channel: a sequence of operations that must
-//! be performed in order. Calls that violate the sequence are
-//! rejected at compile time.
-//!
-//! Protocol grammar (string-encoded for now): operations separated
-//! by `.`. Each operation is one of:
-//! * `send(T)` — caller sends a value of type T
-//! * `recv(T)` — caller receives a value of type T
-//! * `close` — terminates the protocol
-//!
-//! This module records the protocol definitions and exposes a
-//! `next_op(channel, operation)` API the runtime / typechecker
-//! consults to validate a call.
-
 #![allow(clippy::collapsible_if, clippy::doc_lazy_continuation, dead_code)]
 
 use crate::Node;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, RwLock};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,12 +11,6 @@ pub enum SessionOp {
     Close,
 }
 
-/// RES-2198: dropped the redundant `channel_name: String` field. The
-/// only reader was `install`'s key clone (`g.insert(s.channel_name.clone(), s)`),
-/// which used it strictly as the HashMap key the spec was stored
-/// under. The field stored exactly what the registry key encoded.
-/// Pipeline now carries `(String, SessionSpec)` tuples from `collect()`
-/// to `install()`. Same dead-field pattern as RES-2106 / … / RES-2196.
 #[derive(Debug, Clone)]
 pub struct SessionSpec {
     pub protocol: Vec<SessionOp>,
@@ -43,31 +20,70 @@ static SPECS: LazyLock<RwLock<HashMap<String, SessionSpec>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 pub fn parse_protocol(s: &str) -> Vec<SessionOp> {
-    // RES-1764: pre-size to (dot-count + 1) — that's the exact number
-    // of segments `split('.')` yields. At most one push per segment;
-    // sometimes fewer when a segment fails to match any prefix.
-    let mut out = Vec::with_capacity(s.matches('.').count() + 1);
-    for raw in s.split('.') {
-        let op = raw.trim();
-        if op == "close" {
-            out.push(SessionOp::Close);
-        } else if let Some(rest) = op.strip_prefix("send(") {
+    let mut out = Vec::new();
+    for op in s.split('.') {
+        let op = op.trim();
+        if let Some(rest) = op.strip_prefix("send(") {
             if let Some(t) = rest.strip_suffix(')') {
-                out.push(SessionOp::Send(t.to_string()));
+                out.push(SessionOp::Send(t.trim().to_string()));
             }
         } else if let Some(rest) = op.strip_prefix("recv(") {
             if let Some(t) = rest.strip_suffix(')') {
-                out.push(SessionOp::Recv(t.to_string()));
+                out.push(SessionOp::Recv(t.trim().to_string()));
             }
+        } else if op == "close" {
+            out.push(SessionOp::Close);
         }
     }
     out
 }
 
+fn parse_protocol_checked(s: &str) -> Result<Vec<SessionOp>, String> {
+    let mut out = Vec::new();
+    for op in s.split('.') {
+        let op = op.trim();
+        if op.is_empty() {
+            return Err("invalid session protocol: empty operation".to_string());
+        }
+        if op == "close" {
+            out.push(SessionOp::Close);
+            continue;
+        }
+        if let Some(rest) = op.strip_prefix("send(") {
+            let Some(t) = rest.strip_suffix(')') else {
+                return Err(format!(
+                    "invalid session protocol: malformed operation `{op}`"
+                ));
+            };
+            let t = t.trim();
+            if t.is_empty() {
+                return Err("invalid session protocol: `send` requires a type argument".to_string());
+            }
+            out.push(SessionOp::Send(t.to_string()));
+            continue;
+        }
+        if let Some(rest) = op.strip_prefix("recv(") {
+            let Some(t) = rest.strip_suffix(')') else {
+                return Err(format!(
+                    "invalid session protocol: malformed operation `{op}`"
+                ));
+            };
+            let t = t.trim();
+            if t.is_empty() {
+                return Err("invalid session protocol: `recv` requires a type argument".to_string());
+            }
+            out.push(SessionOp::Recv(t.to_string()));
+            continue;
+        }
+        return Err(format!(
+            "invalid session protocol: unknown operation `{op}`"
+        ));
+    }
+    Ok(out)
+}
+
 pub fn collect() -> Vec<(String, SessionSpec)> {
     let attrs = crate::feature_attrs::find_kind("session");
-    // RES-1764: pre-size to attrs.len() — exactly one push per
-    // attribute record.
     let mut out = Vec::with_capacity(attrs.len());
     for (item, rec) in attrs {
         let mut proto_str = String::new();
@@ -89,45 +105,119 @@ pub fn collect() -> Vec<(String, SessionSpec)> {
     out
 }
 
+fn collect_checked(source_path: &str) -> Result<Vec<(String, SessionSpec)>, String> {
+    let attrs = crate::feature_attrs::find_kind("session");
+    let mut out = Vec::with_capacity(attrs.len());
+    let mut seen_items = HashSet::with_capacity(attrs.len());
+
+    for (item, rec) in attrs {
+        if !seen_items.insert(item.clone()) {
+            return Err(format!(
+                "{source_path}:{}:0: error: duplicate session declaration `{item}`",
+                rec.line
+            ));
+        }
+
+        if rec.args.trim().is_empty() {
+            return Err(format!(
+                "{source_path}:{}:0: error: session attribute on `{item}` is missing `protocol`",
+                rec.line
+            ));
+        }
+
+        let mut proto_str: Option<String> = None;
+
+        for chunk in rec.args.split(',') {
+            let chunk = chunk.trim();
+            if chunk.is_empty() {
+                return Err(format!(
+                    "{source_path}:{}:0: error: malformed session attribute on `{item}`: empty argument",
+                    rec.line
+                ));
+            }
+
+            let Some((key, value)) = chunk.split_once('=') else {
+                return Err(format!(
+                    "{source_path}:{}:0: error: malformed session attribute on `{item}`: expected `key = value`",
+                    rec.line
+                ));
+            };
+
+            let key = key.trim();
+            let value = value.trim();
+
+            if key != "protocol" {
+                return Err(format!(
+                    "{source_path}:{}:0: error: unknown session argument `{key}` on `{item}`",
+                    rec.line
+                ));
+            }
+
+            if proto_str.is_some() {
+                return Err(format!(
+                    "{source_path}:{}:0: error: duplicate `protocol` argument on `{item}`",
+                    rec.line
+                ));
+            }
+
+            let Some(stripped) = value.strip_prefix('"').and_then(|v| v.strip_suffix('"')) else {
+                return Err(format!(
+                    "{source_path}:{}:0: error: session attribute on `{item}` requires a quoted `protocol` string",
+                    rec.line
+                ));
+            };
+            proto_str = Some(stripped.to_string());
+        }
+
+        let Some(proto_str) = proto_str else {
+            return Err(format!(
+                "{source_path}:{}:0: error: session attribute on `{item}` is missing `protocol`",
+                rec.line
+            ));
+        };
+
+        let protocol = parse_protocol_checked(&proto_str).map_err(|msg| {
+            format!(
+                "{source_path}:{}:0: error: session attribute on `{item}`: {msg}",
+                rec.line
+            )
+        })?;
+
+        out.push((item, SessionSpec { protocol }));
+    }
+
+    Ok(out)
+}
+
 pub fn install(specs: Vec<(String, SessionSpec)>) {
     if let Ok(mut g) = SPECS.write() {
         g.clear();
-        // RES-2198: move (channel_name, spec) pairs straight from
-        // `collect()` into the map. The previous shape per-spec cloned
-        // `s.channel_name` to produce the key, since the field and
-        // the key encoded the same string.
         g.extend(specs);
     }
 }
 
 pub fn validate_step(channel: &str, step: usize, op: &SessionOp) -> Result<(), String> {
-    // RES-1552: hold the read guard so we don't clone the whole
-    // `HashMap<String, SessionSpec>` (each spec owns a `Vec<SessionOp>`)
-    // just to look up one channel by name. Same lock-then-borrow
-    // shape as RES-1544 / RES-1547 / RES-1549.
     let g = SPECS
         .read()
-        .map_err(|_| format!("no session protocol for `{channel}`"))?;
+        .map_err(|_| format!("no session protocol `{channel}`"))?;
     let spec = g
         .get(channel)
-        .ok_or_else(|| format!("no session protocol for `{channel}`"))?;
-    let expected = spec.protocol.get(step).ok_or_else(|| {
-        format!("session protocol for `{channel}` already terminated at step {step}")
-    })?;
+        .ok_or_else(|| format!("no session protocol `{channel}`"))?;
+    let expected = spec
+        .protocol
+        .get(step)
+        .ok_or_else(|| format!("session protocol `{channel}` already terminated step {step}"))?;
     if expected != op {
         return Err(format!(
-            "session violation on `{}`: expected {:?} at step {}, got {:?}",
+            "session violation on `{}`: expected {:?} step {}, got {:?}",
             channel, expected, step, op
         ));
     }
     Ok(())
 }
 
-pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
-    // RES-1306: gate `install` on the non-empty case — avoids a
-    // wasted RwLock write per compilation and removes the
-    // wipe-on-empty test race shape documented in RES-1302.
-    let specs = collect();
+pub(crate) fn check(_program: &Node, source_path: &str) -> Result<(), String> {
+    let specs = collect_checked(source_path)?;
     if specs.is_empty() {
         return Ok(());
     }
@@ -138,6 +228,28 @@ pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parse;
+
+    fn record_session(item: &str, args: &str, line: usize) {
+        crate::feature_attrs::record(
+            item,
+            crate::feature_attrs::AttrRecord {
+                name: "session".into(),
+                args: args.into(),
+                line,
+            },
+        );
+    }
+
+    fn dummy_program() -> Node {
+        let (prog, errs) = parse("");
+        assert!(errs.is_empty(), "unexpected parse errors: {errs:?}");
+        prog
+    }
+
+    fn run_check(source_path: &str) -> Result<(), String> {
+        check(&dummy_program(), source_path)
+    }
 
     #[test]
     fn parses_simple_protocol() {
@@ -163,6 +275,144 @@ mod tests {
         install(collect());
         assert!(validate_step("ch", 0, &SessionOp::Send("int".into())).is_ok());
         assert!(validate_step("ch", 0, &SessionOp::Close).is_err());
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_accepts_empty_session_registry() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        assert!(run_check("session.rz").is_ok());
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_accepts_single_valid_session_protocol() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        record_session("ch", r#"protocol = "send(int).close""#, 11);
+        assert!(run_check("session.rz").is_ok());
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_accepts_multiple_valid_session_protocols() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        record_session("client", r#"protocol = "send(int).recv(bool).close""#, 21);
+        record_session("server", r#"protocol = "recv(int).close""#, 22);
+        let result = run_check("session.rz");
+        assert!(
+            result.is_ok(),
+            "expected valid session declarations: {result:?}"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_missing_protocol_argument() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        record_session("ch", "", 31);
+        let err = run_check("session.rz").expect_err("expected error for missing protocol");
+        assert!(
+            err.contains("session.rz:31:0: error:"),
+            "missing line/column in diagnostic: {err}"
+        );
+        assert!(
+            err.contains("missing `protocol`"),
+            "wrong diagnostic for missing protocol: {err}"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_duplicate_protocol_arguments() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        record_session(
+            "ch",
+            r#"protocol = "send(int).close", protocol = "recv(int).close""#,
+            32,
+        );
+        let err = run_check("session.rz").expect_err("expected error for duplicate protocol");
+        assert!(
+            err.contains("session.rz:32:0: error:"),
+            "missing line/column in diagnostic: {err}"
+        );
+        assert!(
+            err.contains("duplicate `protocol`"),
+            "wrong diagnostic for duplicate protocol argument: {err}"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_unknown_session_argument() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        record_session("ch", r#"protocol = "send(int).close", mode = "strict""#, 33);
+        let err = run_check("session.rz").expect_err("expected error for unknown argument");
+        assert!(
+            err.contains("session.rz:33:0: error:"),
+            "missing line/column in diagnostic: {err}"
+        );
+        assert!(
+            err.contains("unknown session argument `mode`"),
+            "wrong diagnostic for unknown argument: {err}"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_duplicate_session_declarations() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        record_session("ch", r#"protocol = "send(int).close""#, 41);
+        record_session("ch", r#"protocol = "recv(int).close""#, 42);
+        let err = run_check("session.rz").expect_err("expected error for duplicate declarations");
+        assert!(
+            err.contains("session.rz:42:0: error:"),
+            "expected second declaration location in diagnostic: {err}"
+        );
+        assert!(
+            err.contains("duplicate session declaration"),
+            "wrong diagnostic for duplicate session declaration: {err}"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_malformed_protocol_step() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        record_session("ch", r#"protocol = "send(int).bogus.close""#, 51);
+        let err = run_check("session.rz").expect_err("expected error for malformed protocol");
+        assert!(
+            err.contains("session.rz:51:0: error:"),
+            "missing line/column in diagnostic: {err}"
+        );
+        assert!(
+            err.contains("invalid session protocol"),
+            "wrong diagnostic for malformed protocol: {err}"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_malformed_send_form() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        record_session("ch", r#"protocol = "send(int.close""#, 52);
+        let err = run_check("session.rz").expect_err("expected error for malformed send");
+        assert!(
+            err.contains("session.rz:52:0: error:"),
+            "missing line/column in diagnostic: {err}"
+        );
+        assert!(
+            err.contains("invalid session protocol"),
+            "wrong diagnostic for malformed send: {err}"
+        );
         crate::feature_attrs::reset();
     }
 }


### PR DESCRIPTION
Closes #3446.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3446-session-types-check-needs-malformed-inpu`
Worktree: `.claude/worktrees/res-3446`

## Agent claims

(none inferred from issue)