### PR TITLE
RES-3449: mmio_regmap check should detect duplicate/conflicting mmio_regmap registrations

### DIFF
--- a/resilient/src/mmio_regmap.rs
+++ b/resilient/src/mmio_regmap.rs
@@ -1,8 +1,8 @@
-//! Feature 27/50 — Typed MMIO Register Maps.
+//! Feature 27/50 - Typed MMIO Register Maps.
 //!
 //! `#[mmio(base = "0x40010C14", size_bytes = "0x400")]` on a struct
 //! turns it into a typed memory-mapped peripheral. Field accesses
-//! lower to volatile reads/writes at compile-determined offsets.
+//! lower to volatile reads and writes at compile-determined offsets.
 //!
 //! Field-level metadata (bit ranges, R/W/RO permissions) lives on
 //! each field via `#[bits(0..=15), rw]`; this module focuses on the
@@ -19,6 +19,7 @@ pub struct MmioRegmap {
     pub struct_name: String,
     pub base_addr: u64,
     pub size_bytes: u64,
+    pub line: usize,
 }
 
 static REGMAPS: LazyLock<RwLock<HashMap<String, MmioRegmap>>> =
@@ -33,14 +34,18 @@ fn parse_addr(s: &str) -> Option<u64> {
     }
 }
 
+fn loc(source_path: &str, line: usize) -> String {
+    format!("{source_path}:{line}:0")
+}
+
 pub fn collect() -> Vec<MmioRegmap> {
     let attrs = crate::feature_attrs::find_kind("mmio");
-    // RES-1764: pre-size to attrs.len() — conditional push (only when
-    // both base and size parse non-zero), upper bound.
     let mut out = Vec::with_capacity(attrs.len());
+
     for (item, rec) in attrs {
         let mut base = 0;
         let mut size = 0;
+
         for chunk in rec.args.split(',') {
             let chunk = chunk.trim();
             if let Some((k, v)) = chunk.split_once('=') {
@@ -60,21 +65,28 @@ pub fn collect() -> Vec<MmioRegmap> {
                 }
             }
         }
-        out.push(MmioRegmap {
-            struct_name: item,
-            base_addr: base,
-            size_bytes: size,
-        });
+
+        if base != 0 && size != 0 {
+            out.push(MmioRegmap {
+                struct_name: item,
+                base_addr: base,
+                size_bytes: size,
+                line: rec.line,
+            });
+        }
     }
+
     out
 }
 
 pub fn install(maps: Vec<MmioRegmap>) {
-    if let Ok(mut g) = REGMAPS.write() {
-        g.clear();
-        for m in maps {
-            g.insert(m.struct_name.clone(), m);
-        }
+    let Ok(mut g) = REGMAPS.write() else {
+        return;
+    };
+
+    g.clear();
+    for m in maps {
+        g.insert(m.struct_name.clone(), m);
     }
 }
 
@@ -86,20 +98,28 @@ pub fn lookup(struct_name: &str) -> Option<MmioRegmap> {
 }
 
 pub(crate) fn check(_program: &Node, source_path: &str) -> Result<(), String> {
-    // RES-1306: gate `install` (and the overlap loop, which is
-    // already a no-op for empty maps) on the non-empty case —
-    // avoids a wasted RwLock write per compilation and removes the
-    // wipe-on-empty test race shape documented in RES-1302.
     let maps = collect();
     if maps.is_empty() {
         return Ok(());
     }
-    // RES-1491: validate (overlap check) before `install` so `maps`
-    // moves in instead of cloning. Same shape as RES-1481 (derives)
-    // / RES-1485 (recursive_types) / RES-1487 (ghost+async). The
-    // overlap check returns Err on real bug — install never runs on
-    // failure, which is the right behavior (don't pollute the
-    // registry with overlapping maps).
+
+    let mut seen: HashMap<&str, &MmioRegmap> = HashMap::new();
+    for map in &maps {
+        if let Some(prev) = seen.insert(map.struct_name.as_str(), map) {
+            let kind = if prev.base_addr == map.base_addr && prev.size_bytes == map.size_bytes {
+                "duplicate"
+            } else {
+                "conflicting"
+            };
+            let current_loc = loc(source_path, map.line);
+            let prev_loc = loc(source_path, prev.line);
+            return Err(format!(
+                "{current_loc}: error: {kind} mmio_regmap registration `{}`; first declared at {prev_loc}, second declared at {current_loc}",
+                map.struct_name,
+            ));
+        }
+    }
+
     for (i, a) in maps.iter().enumerate() {
         for b in &maps[i + 1..] {
             let a_end = a.base_addr.saturating_add(a.size_bytes);
@@ -107,12 +127,15 @@ pub(crate) fn check(_program: &Node, source_path: &str) -> Result<(), String> {
             let overlap = a.base_addr < b_end && b.base_addr < a_end;
             if overlap {
                 return Err(format!(
-                    "{}:0:0: error: MMIO regmaps `{}` and `{}` overlap in address space",
-                    source_path, a.struct_name, b.struct_name
+                    "{}: error: MMIO regmaps `{}` and `{}` overlap in address space",
+                    loc(source_path, a.line),
+                    a.struct_name,
+                    b.struct_name,
                 ));
             }
         }
     }
+
     install(maps);
     Ok(())
 }
@@ -130,12 +153,13 @@ mod tests {
             crate::feature_attrs::AttrRecord {
                 name: "mmio".into(),
                 args: r#"base = "0x40010800", size_bytes = "0x400""#.into(),
-                line: 0,
+                line: 12,
             },
         );
         let m = collect();
         assert_eq!(m[0].base_addr, 0x40010800);
         assert_eq!(m[0].size_bytes, 0x400);
+        assert_eq!(m[0].line, 12);
         crate::feature_attrs::reset();
     }
 
@@ -148,7 +172,7 @@ mod tests {
             crate::feature_attrs::AttrRecord {
                 name: "mmio".into(),
                 args: r#"base = "0x100", size_bytes = "0x100""#.into(),
-                line: 0,
+                line: 21,
             },
         );
         crate::feature_attrs::record(
@@ -156,11 +180,48 @@ mod tests {
             crate::feature_attrs::AttrRecord {
                 name: "mmio".into(),
                 args: r#"base = "0x180", size_bytes = "0x100""#.into(),
-                line: 0,
+                line: 37,
             },
         );
         let res = check(&crate::Node::Program(vec![]), "test");
         assert!(res.is_err());
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn conflicting_maps_error_reports_both_locations() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "GPIOA",
+            crate::feature_attrs::AttrRecord {
+                name: "mmio".into(),
+                args: r#"base = "0x40010800", size_bytes = "0x400""#.into(),
+                line: 12,
+            },
+        );
+        crate::feature_attrs::record(
+            "GPIOA",
+            crate::feature_attrs::AttrRecord {
+                name: "mmio".into(),
+                args: r#"base = "0x40020C00", size_bytes = "0x400""#.into(),
+                line: 34,
+            },
+        );
+        let res = check(&crate::Node::Program(vec![]), "test");
+        let msg = res.expect_err("conflicting mmio regmaps must fail");
+        assert!(
+            msg.contains("conflicting mmio_regmap registration"),
+            "unexpected diagnostic: {msg}"
+        );
+        assert!(
+            msg.contains("test:12:0"),
+            "missing first declaration: {msg}"
+        );
+        assert!(
+            msg.contains("test:34:0"),
+            "missing second declaration: {msg}"
+        );
         crate::feature_attrs::reset();
     }
 }


### PR DESCRIPTION
Closes #3449.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3449-mmio-regmap-check-should-detect-duplicat`
Worktree: `.claude/worktrees/res-3449`

## Agent claims

(none inferred from issue)