### PR TITLE
RES-3455: typestate_types check should align compile-time errors with runtime typestate_types failure classes

### DIFF
--- a/resilient/src/typestate_types.rs
+++ b/resilient/src/typestate_types.rs
@@ -20,7 +20,7 @@
 #![allow(clippy::collapsible_if, clippy::doc_lazy_continuation, dead_code)]
 
 use crate::Node;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::RwLock;
 
 #[derive(Debug, Clone)]
@@ -32,6 +32,170 @@ pub struct TypestateSpec {
 }
 
 static SPECS: RwLock<Vec<TypestateSpec>> = RwLock::new(Vec::new());
+
+fn typestate_diag(source_path: &str, line: usize, message: impl AsRef<str>) -> String {
+    format!(
+        "{source_path}:{line}:0: error[typestate]: {}",
+        message.as_ref()
+    )
+}
+
+fn validate_typestate_record(
+    source_path: &str,
+    struct_name: &str,
+    rec: &crate::feature_attrs::AttrRecord,
+) -> Result<(), String> {
+    let mut states: Option<HashSet<String>> = None;
+    let mut seen_transitions = HashSet::new();
+    let mut saw_transitions = false;
+
+    for chunk in rec.args.split(',') {
+        let chunk = chunk.trim();
+        if chunk.is_empty() {
+            continue;
+        }
+
+        let Some((k, v)) = chunk.split_once('=') else {
+            return Err(typestate_diag(
+                source_path,
+                rec.line,
+                format!("typestate `{struct_name}` expects `key = value` entries, got `{chunk}`"),
+            ));
+        };
+
+        let key = k.trim();
+        let value = v.trim().trim_matches('"');
+        match key {
+            "states" => {
+                if states.is_some() {
+                    return Err(typestate_diag(
+                        source_path,
+                        rec.line,
+                        format!("typestate `{struct_name}` declares `states` more than once"),
+                    ));
+                }
+
+                let mut parsed = HashSet::new();
+                for state in value.split_whitespace() {
+                    if !parsed.insert(state.to_string()) {
+                        return Err(typestate_diag(
+                            source_path,
+                            rec.line,
+                            format!(
+                                "typestate `{struct_name}` repeats state `{state}` in `states`"
+                            ),
+                        ));
+                    }
+                }
+
+                if parsed.is_empty() {
+                    return Err(typestate_diag(
+                        source_path,
+                        rec.line,
+                        format!("typestate `{struct_name}` must declare at least one state"),
+                    ));
+                }
+
+                states = Some(parsed);
+            }
+            "transitions" => {
+                let Some(states) = states.as_ref() else {
+                    return Err(typestate_diag(
+                        source_path,
+                        rec.line,
+                        format!(
+                            "typestate `{struct_name}` must declare `states` before `transitions`"
+                        ),
+                    ));
+                };
+
+                saw_transitions = true;
+                for transition in value.split_whitespace() {
+                    let Some((lhs, next)) = transition.split_once("->") else {
+                        return Err(typestate_diag(
+                            source_path,
+                            rec.line,
+                            format!(
+                                "typestate `{struct_name}` transition `{transition}` must use `state:method->next`"
+                            ),
+                        ));
+                    };
+
+                    let Some((state, method)) = lhs.split_once(':') else {
+                        return Err(typestate_diag(
+                            source_path,
+                            rec.line,
+                            format!(
+                                "typestate `{struct_name}` transition `{transition}` must use `state:method->next`"
+                            ),
+                        ));
+                    };
+
+                    if state.trim().is_empty() || method.trim().is_empty() || next.trim().is_empty()
+                    {
+                        return Err(typestate_diag(
+                            source_path,
+                            rec.line,
+                            format!(
+                                "typestate `{struct_name}` transition `{transition}` must name a state, method, and next state"
+                            ),
+                        ));
+                    }
+
+                    if !states.contains(state) {
+                        return Err(typestate_diag(
+                            source_path,
+                            rec.line,
+                            format!(
+                                "typestate `{struct_name}` transition `{transition}` starts from unknown state `{state}`"
+                            ),
+                        ));
+                    }
+
+                    if !states.contains(next) {
+                        return Err(typestate_diag(
+                            source_path,
+                            rec.line,
+                            format!(
+                                "typestate `{struct_name}` transition `{transition}` targets unknown state `{next}`"
+                            ),
+                        ));
+                    }
+
+                    let transition_key = (state.to_string(), method.to_string());
+                    if !seen_transitions.insert(transition_key) {
+                        return Err(typestate_diag(
+                            source_path,
+                            rec.line,
+                            format!(
+                                "typestate `{struct_name}` repeats transition `{state}:{method}`"
+                            ),
+                        ));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if states.is_none() {
+        return Err(typestate_diag(
+            source_path,
+            rec.line,
+            format!("typestate `{struct_name}` is missing a `states` declaration"),
+        ));
+    }
+
+    if !saw_transitions {
+        return Err(typestate_diag(
+            source_path,
+            rec.line,
+            format!("typestate `{struct_name}` is missing a `transitions` declaration"),
+        ));
+    }
+
+    Ok(())
+}
 
 pub fn collect() -> Vec<TypestateSpec> {
     let attrs = crate::feature_attrs::find_kind("typestate");
@@ -113,6 +277,19 @@ pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
     // RES-1306: gate `install` on the non-empty case — avoids a
     // wasted RwLock write per compilation and removes the
     // wipe-on-empty test race shape documented in RES-1302.
+    let attrs = crate::feature_attrs::find_kind("typestate");
+    let mut seen_specs = HashSet::new();
+    for (item, rec) in &attrs {
+        if !seen_specs.insert(item) {
+            return Err(typestate_diag(
+                _source_path,
+                rec.line,
+                format!("typestate `{item}` is declared more than once"),
+            ));
+        }
+        validate_typestate_record(_source_path, item, rec)?;
+    }
+
     let specs = collect();
     if specs.is_empty() {
         return Ok(());
@@ -219,5 +396,104 @@ mod tests {
         let src = "fn f(int x) -> int { return x; }\n";
         let (prog, _) = crate::parse(src);
         assert!(check(&prog, "test").is_ok());
+    }
+
+    fn assert_check_err(args: &str, expected: &str) {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "File",
+            crate::feature_attrs::AttrRecord {
+                name: "typestate".into(),
+                args: args.into(),
+                line: 0,
+            },
+        );
+        let src = "fn f(int x) -> int { return x; }\n";
+        let (prog, _) = crate::parse(src);
+        let err = check(&prog, "test").unwrap_err();
+        assert!(
+            err.contains(expected),
+            "expected `{expected}` in diagnostic, got: {err}"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn empty_states_decl_is_rejected() {
+        assert_check_err(
+            r#"states = "", transitions = "Closed:open->Open""#,
+            "must declare at least one state",
+        );
+    }
+
+    #[test]
+    fn duplicate_states_are_rejected() {
+        assert_check_err(
+            r#"states = "Closed Open Closed", transitions = "Closed:open->Open""#,
+            "repeats state `Closed`",
+        );
+    }
+
+    #[test]
+    fn missing_transitions_decl_is_rejected() {
+        assert_check_err(
+            r#"states = "Closed Open""#,
+            "missing a `transitions` declaration",
+        );
+    }
+
+    #[test]
+    fn malformed_transition_syntax_is_rejected() {
+        assert_check_err(
+            r#"states = "Closed Open", transitions = "Closed-open-Open""#,
+            "must use `state:method->next`",
+        );
+    }
+
+    #[test]
+    fn unknown_state_in_transition_is_rejected() {
+        assert_check_err(
+            r#"states = "Closed Open", transitions = "Closed:open->Open Open:close->Sealed""#,
+            "targets unknown state `Sealed`",
+        );
+    }
+
+    #[test]
+    fn duplicate_transition_is_rejected() {
+        assert_check_err(
+            r#"states = "Closed Open", transitions = "Closed:open->Open Closed:open->Closed""#,
+            "repeats transition `Closed:open`",
+        );
+    }
+
+    #[test]
+    fn duplicate_typestate_attribute_is_rejected() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "File",
+            crate::feature_attrs::AttrRecord {
+                name: "typestate".into(),
+                args: r#"states = "Closed Open", transitions = "Closed:open->Open""#.into(),
+                line: 0,
+            },
+        );
+        crate::feature_attrs::record(
+            "File",
+            crate::feature_attrs::AttrRecord {
+                name: "typestate".into(),
+                args: r#"states = "Closed Open", transitions = "Open:close->Closed""#.into(),
+                line: 1,
+            },
+        );
+        let src = "fn f(int x) -> int { return x; }\n";
+        let (prog, _) = crate::parse(src);
+        let err = check(&prog, "test").unwrap_err();
+        assert!(
+            err.contains("declared more than once"),
+            "expected duplicate-attribute diagnostic, got: {err}"
+        );
+        crate::feature_attrs::reset();
     }
 }


### PR DESCRIPTION
Closes #3455.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3455-typestate-types-check-should-align-compi`
Worktree: `.claude/worktrees/res-3455`

## Agent claims

(none inferred from issue)