### PR TITLE
RES-3465: const_eval_ext check should align compile-time errors with runtime const_eval_ext failure classes

### DIFF
--- a/resilient/src/const_eval_ext.rs
+++ b/resilient/src/const_eval_ext.rs
@@ -34,6 +34,183 @@ fn is_missing_initializer(node: &Node) -> bool {
     )
 }
 
+fn validate_const_expr(node: &Node, source_path: &str) -> Result<(), String> {
+    match node {
+        Node::Identifier { .. }
+        | Node::IntegerLiteral { .. }
+        | Node::FloatLiteral { .. }
+        | Node::StringLiteral { .. }
+        | Node::StringInternLiteral { .. }
+        | Node::BytesLiteral { .. }
+        | Node::CharLiteral { .. }
+        | Node::BooleanLiteral { .. } => Ok(()),
+        Node::ExpressionStatement { expr, .. } => validate_const_expr(expr, source_path),
+        Node::PrefixExpression { right, .. } => validate_const_expr(right, source_path),
+        Node::InfixExpression { left, right, .. } => {
+            validate_const_expr(left, source_path)?;
+            validate_const_expr(right, source_path)
+        }
+        Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            validate_const_expr(condition, source_path)?;
+            validate_const_expr(consequence, source_path)?;
+            if let Some(alt) = alternative {
+                validate_const_expr(alt, source_path)?;
+            }
+            Ok(())
+        }
+        Node::Block { stmts, span } => {
+            if stmts.len() != 1 {
+                return Err(diagnostic(
+                    source_path,
+                    *span,
+                    "invalid const expression: blocks in const initializers must contain exactly one expression",
+                ));
+            }
+
+            let inner = match &stmts[0] {
+                Node::ExpressionStatement { expr, .. } => expr.as_ref(),
+                other => other,
+            };
+            validate_const_expr(inner, source_path)
+        }
+        Node::TupleLiteral { items, .. } => items
+            .iter()
+            .try_for_each(|item| validate_const_expr(item, source_path)),
+        Node::CallExpression { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: function calls are not allowed",
+        )),
+        Node::ArrayLiteral { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: array literals are not allowed",
+        )),
+        Node::StructLiteral { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: struct literals are not allowed",
+        )),
+        Node::FieldAccess { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: field access is not allowed",
+        )),
+        Node::IndexExpression { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: index expressions are not allowed",
+        )),
+        Node::Match { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: match expressions are not allowed",
+        )),
+        Node::LetStatement { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: let statements are not allowed",
+        )),
+        Node::ReturnStatement { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: return statements are not allowed",
+        )),
+        Node::WhileStatement { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: while statements are not allowed",
+        )),
+        Node::ForInStatement { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: for-in statements are not allowed",
+        )),
+        Node::Break { span } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: break is not allowed",
+        )),
+        Node::Continue { span } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: continue is not allowed",
+        )),
+        Node::BreakWith { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: break values are not allowed",
+        )),
+        Node::BreakLabel { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: labeled break is not allowed",
+        )),
+        Node::ContinueLabel { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: labeled continue is not allowed",
+        )),
+        Node::FieldAssignment { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: field assignment is not allowed",
+        )),
+        Node::IndexAssignment { span, .. } => Err(diagnostic(
+            source_path,
+            *span,
+            "invalid const expression: index assignment is not allowed",
+        )),
+        other => Err(diagnostic(
+            source_path,
+            span_of(other),
+            "invalid const expression: this expression form is not allowed",
+        )),
+    }
+}
+
+fn span_of(node: &Node) -> Span {
+    match node {
+        Node::Identifier { span, .. }
+        | Node::IntegerLiteral { span, .. }
+        | Node::FloatLiteral { span, .. }
+        | Node::StringLiteral { span, .. }
+        | Node::StringInternLiteral { span, .. }
+        | Node::BytesLiteral { span, .. }
+        | Node::CharLiteral { span, .. }
+        | Node::BooleanLiteral { span, .. }
+        | Node::PrefixExpression { span, .. }
+        | Node::InfixExpression { span, .. }
+        | Node::CallExpression { span, .. }
+        | Node::Match { span, .. }
+        | Node::StructLiteral { span, .. }
+        | Node::FieldAccess { span, .. }
+        | Node::FieldAssignment { span, .. }
+        | Node::ArrayLiteral { span, .. }
+        | Node::IndexExpression { span, .. }
+        | Node::IndexAssignment { span, .. }
+        | Node::ExpressionStatement { span, .. }
+        | Node::IfStatement { span, .. }
+        | Node::Block { span, .. }
+        | Node::TupleLiteral { span, .. }
+        | Node::LetStatement { span, .. }
+        | Node::ReturnStatement { span, .. }
+        | Node::WhileStatement { span, .. }
+        | Node::ForInStatement { span, .. }
+        | Node::Break { span }
+        | Node::Continue { span }
+        | Node::BreakWith { span, .. }
+        | Node::BreakLabel { span, .. }
+        | Node::ContinueLabel { span, .. } => *span,
+        _ => Span::default(),
+    }
+}
+
 /// Validate const declarations before const evaluation runs.
 ///
 /// The parser can recover from malformed `const` statements by
@@ -73,6 +250,11 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
                 "invalid const declaration: missing initializer"
             };
             error = Some(diagnostic(source_path, *span, message));
+            return;
+        }
+
+        if let Err(err) = validate_const_expr(value, source_path) {
+            error = Some(err);
         }
     });
 

--- a/resilient/tests/const_eval_ext_runtime_rejections.rs
+++ b/resilient/tests/const_eval_ext_runtime_rejections.rs
@@ -1,0 +1,126 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_dir(tag: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "res3213_const_eval_ext_rejections_{}_{}_{}",
+        tag,
+        std::process::id(),
+        n
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn check_err(src: &str) -> String {
+    let dir = tmp_dir("check");
+    let path = dir.join("bad.rz");
+    std::fs::write(&path, src).expect("write source");
+
+    let output = Command::new(bin())
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("spawn rz check");
+
+    assert!(
+        !output.status.success(),
+        "expected check failure, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn const_eval_ext_rejects_function_calls() {
+    let err = check_err(
+        r#"
+fn id(int x) {
+    return x;
+}
+
+const VALUE = id(1);
+"#,
+    );
+    assert!(
+        err.contains("invalid const expression: function calls are not allowed"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn const_eval_ext_rejects_array_literals() {
+    let err = check_err(
+        r#"
+const VALUE = [1, 2];
+"#,
+    );
+    assert!(
+        err.contains("invalid const expression: array literals are not allowed"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn const_eval_ext_rejects_struct_literals() {
+    let err = check_err(
+        r#"
+struct Point { int x, int y }
+
+const VALUE = new Point { x: 1, y: 2 };
+"#,
+    );
+    assert!(
+        err.contains("invalid const expression: struct literals are not allowed"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn const_eval_ext_rejects_match_expressions() {
+    let err = check_err(
+        r#"
+const VALUE = match 1 {
+    1 => 2,
+    _ => 3,
+};
+"#,
+    );
+    assert!(
+        err.contains("invalid const expression: match expressions are not allowed"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn const_eval_ext_rejects_multi_statement_blocks() {
+    let err = check_err(
+        r#"
+const VALUE = if true {
+    1;
+    2;
+} else {
+    3;
+};
+"#,
+    );
+    assert!(
+        err.contains(
+            "invalid const expression: blocks in const initializers must contain exactly one expression"
+        ),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
Refs #3465.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3465-const-eval-ext-check-should-align-compil`
Worktree: `.claude/worktrees/res-3465`

## Agent claims

(none inferred from issue)
