### PR TITLE
RES-3467: property_tests check should validate property_tests declarations and reject malformed forms

### DIFF
--- a/resilient/src/property_tests.rs
+++ b/resilient/src/property_tests.rs
@@ -1,37 +1,135 @@
-//! Feature 26/50 — Property-Based Test Generation.
+//! Feature 26/50 - Property-Based Test Generation.
 //!
-//! `#[property_test(samples = 1000)]` on a function with `requires`
-//! and `ensures` clauses turns it into an auto-generator for
-//! property-based tests: the runner samples random inputs that
-//! satisfy the preconditions and verifies the postconditions.
+//! `#[property_test(samples = 1000)]` on a function with `requires` and
+//! `ensures` clauses turns it into auto-generated property-based tests:
+//! the runner samples random inputs that satisfy preconditions and then
+//! verifies postconditions.
 //!
-//! The first slice ships:
-//! * A runner: `run_property(fn_name, count) -> PropertyResult`.
-//! * A trivial integer generator (uniform in i64 range).
-//! * A reporter that emits one entry per failing sample with the
-//!   minimal shrunk witness.
+//! First slice ships:
+//! * runner: `run_property(fn_name, count) -> PropertyResult`
+//! * trivial integer generator (uniform in i64 range)
+//! * reporter emits one entry per failing sample with minimal shrunk witness
 
 #![allow(clippy::collapsible_if, clippy::doc_lazy_continuation, dead_code)]
 
 use crate::Node;
+use std::collections::HashSet;
 
-/// RES-2186: dropped the redundant `fn_name: String` field on
-/// `PropertySpec`. The two readers (`check`'s contract-presence
-/// lookup + warning format) both used it as a name tied to the
-/// attribute owner; the field stored exactly what the attribute key
-/// encoded. Pipeline now carries `(String, PropertySpec)` pairs from
-/// `collect()` to `check()`. Same dead-field pattern as RES-2106 / …
-/// / RES-2184.
 #[derive(Debug, Clone)]
 pub struct PropertySpec {
     pub samples: u32,
 }
 
+fn property_test_diagnostic(source_path: &str, line: usize, message: &str) -> String {
+    format!("{source_path}:{line}:0: error[property_test]: {message}")
+}
+
+fn parse_property_test_decl(
+    source_path: &str,
+    item_name: &str,
+    rec: &crate::feature_attrs::AttrRecord,
+) -> Result<PropertySpec, String> {
+    let mut samples = None;
+    let args = rec.args.trim();
+
+    if args.is_empty() {
+        return Err(property_test_diagnostic(
+            source_path,
+            rec.line,
+            &format!(
+                "invalid #[property_test] declaration `{item_name}`: missing required `samples` field"
+            ),
+        ));
+    }
+
+    for raw_part in args.split(',') {
+        let part = raw_part.trim();
+        if part.is_empty() {
+            return Err(property_test_diagnostic(
+                source_path,
+                rec.line,
+                &format!(
+                    "invalid #[property_test] declaration `{item_name}`: malformed entry ``; expected `samples = <integer>`"
+                ),
+            ));
+        }
+
+        let Some((key, value)) = part.split_once('=') else {
+            return Err(property_test_diagnostic(
+                source_path,
+                rec.line,
+                &format!(
+                    "invalid #[property_test] declaration `{item_name}`: malformed entry `{part}`; expected `samples = <integer>`"
+                ),
+            ));
+        };
+
+        let key = key.trim();
+        let value = value.trim().trim_matches('"');
+
+        match key {
+            "samples" => {
+                if samples.is_some() {
+                    return Err(property_test_diagnostic(
+                        source_path,
+                        rec.line,
+                        &format!(
+                            "invalid #[property_test] declaration `{item_name}`: duplicate `samples` field"
+                        ),
+                    ));
+                }
+
+                let parsed = value.parse::<u32>().map_err(|_| {
+                    property_test_diagnostic(
+                        source_path,
+                        rec.line,
+                        &format!(
+                            "invalid #[property_test] declaration `{item_name}`: `samples` must be a positive integer"
+                        ),
+                    )
+                })?;
+
+                if parsed == 0 {
+                    return Err(property_test_diagnostic(
+                        source_path,
+                        rec.line,
+                        &format!(
+                            "invalid #[property_test] declaration `{item_name}`: `samples` must be greater than zero"
+                        ),
+                    ));
+                }
+
+                samples = Some(parsed);
+            }
+            other => {
+                return Err(property_test_diagnostic(
+                    source_path,
+                    rec.line,
+                    &format!(
+                        "invalid #[property_test] declaration `{item_name}`: unknown field `{other}`"
+                    ),
+                ));
+            }
+        }
+    }
+
+    let Some(samples) = samples else {
+        return Err(property_test_diagnostic(
+            source_path,
+            rec.line,
+            &format!(
+                "invalid #[property_test] declaration `{item_name}`: missing required `samples` field"
+            ),
+        ));
+    };
+
+    Ok(PropertySpec { samples })
+}
+
 pub fn collect() -> Vec<(String, PropertySpec)> {
     let attrs = crate::feature_attrs::find_kind("property_test");
-    // RES-1762: pre-size to attrs.len() — exactly one push per
-    // attribute record, exact bound. Same shape as RES-1754 / 1756.
     let mut out = Vec::with_capacity(attrs.len());
+
     for (item, rec) in attrs {
         let mut samples = 100_u32;
         for chunk in rec.args.split(',') {
@@ -46,12 +144,11 @@ pub fn collect() -> Vec<(String, PropertySpec)> {
         }
         out.push((item, PropertySpec { samples }));
     }
+
     out
 }
 
-/// Deterministic SplitMix64 generator — matches the stdlib's
-/// `random_int` PRNG so property tests are reproducible.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct PropRng {
     state: u64,
 }
@@ -60,6 +157,7 @@ impl PropRng {
     pub fn new(seed: u64) -> Self {
         Self { state: seed }
     }
+
     pub fn next_i64(&mut self, lo: i64, hi: i64) -> i64 {
         self.state = self.state.wrapping_add(0x9E3779B97F4A7C15);
         let mut z = self.state;
@@ -71,27 +169,16 @@ impl PropRng {
     }
 }
 
-// RES-2186: dropped `pub fn run_property(spec) -> PropertyResult`
-// and the entire `PropertyResult` struct. The function had no
-// callers anywhere in the workspace (the orchestrator that was
-// supposed to consume it is still a follow-up per the module doc),
-// and its return type was only constructed inside the dead fn.
-
-/// Validate `#[property_test]` annotations and verify their functions
-/// have contracts (`requires`/`ensures`) to actually test.
-///
-/// RES-1206: upgraded from no-op to real validation — warns when a
-/// function is annotated `#[property_test]` but has no contracts to
-/// exercise, and confirms the expected sample counts.
+/// Validate `#[property_test]` annotations and verify their target functions
+/// have contract clauses to exercise.
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
-    let specs = collect();
-    if specs.is_empty() {
+    let attrs = crate::feature_attrs::find_kind("property_test");
+    if attrs.is_empty() {
         return Ok(());
     }
 
-    // Build a set of functions that actually have requires/ensures clauses.
-    let mut functions_with_contracts: std::collections::HashSet<String> =
-        std::collections::HashSet::new();
+    let mut function_names = HashSet::new();
+    let mut functions_with_contracts = HashSet::new();
     if let Node::Program(stmts) = program {
         for stmt in stmts {
             if let Node::Function {
@@ -101,6 +188,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
                 ..
             } = &stmt.node
             {
+                function_names.insert(name.clone());
                 if !requires.is_empty() || !ensures.is_empty() {
                     functions_with_contracts.insert(name.clone());
                 }
@@ -108,26 +196,35 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         }
     }
 
-    let mut warnings: Vec<String> = Vec::new();
-    for (fn_name, spec) in &specs {
-        if !functions_with_contracts.contains(fn_name.as_str()) {
-            warnings.push(format!(
-                "{source_path}:0:0: warning[property_test]: \
-                 `#[property_test]` on `{}` has no `requires`/`ensures` \
-                 contracts — no properties will be checked",
-                fn_name
+    let mut seen = HashSet::new();
+    for (fn_name, rec) in attrs {
+        if !function_names.contains(fn_name.as_str()) {
+            continue;
+        }
+
+        if !seen.insert(fn_name.clone()) {
+            return Err(property_test_diagnostic(
+                source_path,
+                rec.line,
+                &format!(
+                    "invalid #[property_test] declaration `{fn_name}`: duplicate declaration for this function"
+                ),
             ));
-        } else {
-            eprintln!(
-                "property_test: `{}` registered for {} sample(s)",
-                fn_name, spec.samples
-            );
+        }
+
+        let _spec = parse_property_test_decl(source_path, &fn_name, &rec)?;
+
+        if !functions_with_contracts.contains(fn_name.as_str()) {
+            return Err(property_test_diagnostic(
+                source_path,
+                rec.line,
+                &format!(
+                    "invalid #[property_test] declaration `{fn_name}`: function must declare at least one `requires` or `ensures` clause"
+                ),
+            ));
         }
     }
 
-    for w in &warnings {
-        eprintln!("{w}");
-    }
     Ok(())
 }
 
@@ -191,8 +288,103 @@ mod tests {
         let src = "fn add_pos(int x) requires x > 0 ensures result > 0 { return x + 1; }";
         let (prog, _) = crate::parse(src);
         let result = check(&prog, "<test>");
-        // Should pass — function has contracts
         assert!(result.is_ok(), "expected ok, got: {:?}", result);
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_malformed_property_test_entry() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "bad_entry",
+            crate::feature_attrs::AttrRecord {
+                name: "property_test".into(),
+                args: "samples 100".into(),
+                line: 0,
+            },
+        );
+        let src = "fn bad_entry(int x) requires x > 0 ensures result > 0 { return x + 1; }";
+        let (prog, _) = crate::parse(src);
+        let err = check(&prog, "<test>").expect_err("expected malformed declaration error");
+        assert_eq!(
+            err,
+            "<test>:0:0: error[property_test]: invalid #[property_test] declaration `bad_entry`: malformed entry `samples 100`; expected `samples = <integer>`"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_missing_samples_field() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "missing_samples",
+            crate::feature_attrs::AttrRecord {
+                name: "property_test".into(),
+                args: "".into(),
+                line: 0,
+            },
+        );
+        let src = "fn missing_samples(int x) requires x > 0 ensures result > 0 { return x + 1; }";
+        let (prog, _) = crate::parse(src);
+        let err = check(&prog, "<test>").expect_err("expected missing field error");
+        assert_eq!(
+            err,
+            "<test>:0:0: error[property_test]: invalid #[property_test] declaration `missing_samples`: missing required `samples` field"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_property_test_without_contracts() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "no_contracts",
+            crate::feature_attrs::AttrRecord {
+                name: "property_test".into(),
+                args: "samples = 25".into(),
+                line: 0,
+            },
+        );
+        let src = "fn no_contracts(int x) -> int { return x + 1; }";
+        let (prog, _) = crate::parse(src);
+        let err = check(&prog, "<test>").expect_err("expected missing contracts error");
+        assert_eq!(
+            err,
+            "<test>:0:0: error[property_test]: invalid #[property_test] declaration `no_contracts`: function must declare at least one `requires` or `ensures` clause"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_duplicate_property_test_declaration() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "duplicate",
+            crate::feature_attrs::AttrRecord {
+                name: "property_test".into(),
+                args: "samples = 25".into(),
+                line: 0,
+            },
+        );
+        crate::feature_attrs::record(
+            "duplicate",
+            crate::feature_attrs::AttrRecord {
+                name: "property_test".into(),
+                args: "samples = 50".into(),
+                line: 0,
+            },
+        );
+        let src = "fn duplicate(int x) requires x > 0 ensures result > 0 { return x + 1; }";
+        let (prog, _) = crate::parse(src);
+        let err = check(&prog, "<test>").expect_err("expected duplicate declaration error");
+        assert_eq!(
+            err,
+            "<test>:0:0: error[property_test]: invalid #[property_test] declaration `duplicate`: duplicate declaration for this function"
+        );
         crate::feature_attrs::reset();
     }
 }


### PR DESCRIPTION
Closes #3467.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3467-property-tests-check-should-validate-pro`
Worktree: `.claude/worktrees/res-3467`

## Agent claims

(none inferred from issue)