### PR TITLE
RES-3471: property_tests check needs malformed-input regression corpus

### DIFF
--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -652,6 +652,8 @@ mod phantom_types;
 mod power_contracts;
 mod probabilistic_contracts;
 mod property_tests;
+#[cfg(test)]
+mod property_tests_regression;
 mod recursive_types;
 mod refinement_types;
 mod resilience_score;

--- a/resilient/src/property_tests.rs
+++ b/resilient/src/property_tests.rs
@@ -497,33 +497,6 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
 mod tests {
     use super::*;
 
-    fn property_test_source(item_name: &str) -> String {
-        format!("fn {item_name}(int x) requires x > 0 ensures result > 0 {{ return x + 1; }}")
-    }
-
-    fn check_with_property_test_attr(
-        item_name: &str,
-        args: &str,
-        line: usize,
-    ) -> Result<(), String> {
-        let _g = crate::feature_attrs::lock_for_test();
-        crate::feature_attrs::reset();
-        crate::feature_attrs::record(
-            item_name,
-            crate::feature_attrs::AttrRecord {
-                name: "property_test".into(),
-                args: args.into(),
-                line,
-            },
-        );
-
-        let src = property_test_source(item_name);
-        let (prog, _) = crate::parse(&src);
-        let result = check(&prog, "<test>");
-        crate::feature_attrs::reset();
-        result
-    }
-
     #[test]
     fn parses_samples_count() {
         let _g = crate::feature_attrs::lock_for_test();
@@ -841,74 +814,5 @@ fn main() { struct_target(1); }
             "unexpected struct-kind diagnostic: {err}"
         );
         crate::feature_attrs::reset();
-    }
-
-    #[test]
-    fn check_accepts_baseline_property_test_declarations() {
-        for (item_name, args, line) in [
-            ("baseline_one", "samples = 1", 11),
-            ("baseline_compact", "samples=7", 12),
-            ("baseline_quoted", r#"samples = "42""#, 13),
-        ] {
-            let result = check_with_property_test_attr(item_name, args, line);
-            assert!(
-                result.is_ok(),
-                "expected valid declaration for {item_name}, got: {result:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn check_rejects_malformed_property_test_declarations() {
-        let cases = [
-            (
-                "missing_samples",
-                "",
-                21,
-                "<test>:21:0: error[property_test]: invalid #[property_test] declaration `missing_samples`: missing required `samples` field",
-            ),
-            (
-                "missing_equals",
-                "samples 100",
-                22,
-                "<test>:22:0: error[property_test]: invalid #[property_test] declaration `missing_equals`: malformed entry `samples 100`; expected `samples = <integer>`",
-            ),
-            (
-                "trailing_comma",
-                "samples = 100,",
-                23,
-                "<test>:23:0: error[property_test]: invalid #[property_test] declaration `trailing_comma`: malformed entry ``; expected `samples = <integer>`",
-            ),
-            (
-                "duplicate_samples",
-                "samples = 100, samples = 200",
-                24,
-                "<test>:24:0: error[property_test]: invalid #[property_test] declaration `duplicate_samples`: duplicate `samples` field",
-            ),
-            (
-                "zero_samples",
-                "samples = 0",
-                25,
-                "<test>:25:0: error[property_test]: invalid #[property_test] declaration `zero_samples`: `samples` must be greater than zero",
-            ),
-            (
-                "nonnumeric_samples",
-                "samples = nope",
-                26,
-                "<test>:26:0: error[property_test]: invalid #[property_test] declaration `nonnumeric_samples`: `samples` must be a positive integer",
-            ),
-            (
-                "unknown_field",
-                "limit = 10",
-                27,
-                "<test>:27:0: error[property_test]: invalid #[property_test] declaration `unknown_field`: unknown field `limit`",
-            ),
-        ];
-
-        for (item_name, args, line, expected) in cases {
-            let err = check_with_property_test_attr(item_name, args, line)
-                .expect_err("expected malformed property_test declaration");
-            assert_eq!(err, expected);
-        }
     }
 }

--- a/resilient/src/property_tests.rs
+++ b/resilient/src/property_tests.rs
@@ -497,6 +497,33 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
 mod tests {
     use super::*;
 
+    fn property_test_source(item_name: &str) -> String {
+        format!("fn {item_name}(int x) requires x > 0 ensures result > 0 {{ return x + 1; }}")
+    }
+
+    fn check_with_property_test_attr(
+        item_name: &str,
+        args: &str,
+        line: usize,
+    ) -> Result<(), String> {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            item_name,
+            crate::feature_attrs::AttrRecord {
+                name: "property_test".into(),
+                args: args.into(),
+                line,
+            },
+        );
+
+        let src = property_test_source(item_name);
+        let (prog, _) = crate::parse(&src);
+        let result = check(&prog, "<test>");
+        crate::feature_attrs::reset();
+        result
+    }
+
     #[test]
     fn parses_samples_count() {
         let _g = crate::feature_attrs::lock_for_test();
@@ -814,5 +841,74 @@ fn main() { struct_target(1); }
             "unexpected struct-kind diagnostic: {err}"
         );
         crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_accepts_baseline_property_test_declarations() {
+        for (item_name, args, line) in [
+            ("baseline_one", "samples = 1", 11),
+            ("baseline_compact", "samples=7", 12),
+            ("baseline_quoted", r#"samples = "42""#, 13),
+        ] {
+            let result = check_with_property_test_attr(item_name, args, line);
+            assert!(
+                result.is_ok(),
+                "expected valid declaration for {item_name}, got: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn check_rejects_malformed_property_test_declarations() {
+        let cases = [
+            (
+                "missing_samples",
+                "",
+                21,
+                "<test>:21:0: error[property_test]: invalid #[property_test] declaration `missing_samples`: missing required `samples` field",
+            ),
+            (
+                "missing_equals",
+                "samples 100",
+                22,
+                "<test>:22:0: error[property_test]: invalid #[property_test] declaration `missing_equals`: malformed entry `samples 100`; expected `samples = <integer>`",
+            ),
+            (
+                "trailing_comma",
+                "samples = 100,",
+                23,
+                "<test>:23:0: error[property_test]: invalid #[property_test] declaration `trailing_comma`: malformed entry ``; expected `samples = <integer>`",
+            ),
+            (
+                "duplicate_samples",
+                "samples = 100, samples = 200",
+                24,
+                "<test>:24:0: error[property_test]: invalid #[property_test] declaration `duplicate_samples`: duplicate `samples` field",
+            ),
+            (
+                "zero_samples",
+                "samples = 0",
+                25,
+                "<test>:25:0: error[property_test]: invalid #[property_test] declaration `zero_samples`: `samples` must be greater than zero",
+            ),
+            (
+                "nonnumeric_samples",
+                "samples = nope",
+                26,
+                "<test>:26:0: error[property_test]: invalid #[property_test] declaration `nonnumeric_samples`: `samples` must be a positive integer",
+            ),
+            (
+                "unknown_field",
+                "limit = 10",
+                27,
+                "<test>:27:0: error[property_test]: invalid #[property_test] declaration `unknown_field`: unknown field `limit`",
+            ),
+        ];
+
+        for (item_name, args, line, expected) in cases {
+            let err = check_with_property_test_attr(item_name, args, line)
+                .expect_err("expected malformed property_test declaration");
+            assert_eq!(err, expected);
+        }
     }
 }

--- a/resilient/src/property_tests_regression.rs
+++ b/resilient/src/property_tests_regression.rs
@@ -1,0 +1,100 @@
+#[cfg(test)]
+mod tests {
+    use crate::property_tests::check;
+
+    fn property_test_source(item_name: &str) -> String {
+        format!("fn {item_name}(int x) requires x > 0 ensures result > 0 {{ return x + 1; }}")
+    }
+
+    fn check_with_property_test_attr(
+        item_name: &str,
+        args: &str,
+        line: usize,
+    ) -> Result<(), String> {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            item_name,
+            crate::feature_attrs::AttrRecord {
+                name: "property_test".into(),
+                args: args.into(),
+                line,
+            },
+        );
+
+        let src = property_test_source(item_name);
+        let (prog, _) = crate::parse(&src);
+        let result = check(&prog, "<test>");
+        crate::feature_attrs::reset();
+        result
+    }
+
+    #[test]
+    fn check_accepts_baseline_property_test_declarations() {
+        for (item_name, args, line) in [
+            ("baseline_one", "samples = 1", 11),
+            ("baseline_compact", "samples=7", 12),
+            ("baseline_quoted", r#"samples = "42""#, 13),
+        ] {
+            let result = check_with_property_test_attr(item_name, args, line);
+            assert!(
+                result.is_ok(),
+                "expected valid declaration for {item_name}, got: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn check_rejects_malformed_property_test_declarations() {
+        let cases = [
+            (
+                "missing_samples",
+                "",
+                21,
+                "<test>:21:0: error[property_test]: invalid #[property_test] declaration `missing_samples`: missing required `samples` field",
+            ),
+            (
+                "missing_equals",
+                "samples 100",
+                22,
+                "<test>:22:0: error[property_test]: invalid #[property_test] declaration `missing_equals`: malformed entry `samples 100`; expected `samples = <integer>`",
+            ),
+            (
+                "trailing_comma",
+                "samples = 100,",
+                23,
+                "<test>:23:0: error[property_test]: invalid #[property_test] declaration `trailing_comma`: malformed entry ``; expected `samples = <integer>`",
+            ),
+            (
+                "duplicate_samples",
+                "samples = 100, samples = 200",
+                24,
+                "<test>:24:0: error[property_test]: invalid #[property_test] declaration `duplicate_samples`: duplicate `samples` field",
+            ),
+            (
+                "zero_samples",
+                "samples = 0",
+                25,
+                "<test>:25:0: error[property_test]: invalid #[property_test] declaration `zero_samples`: `samples` must be greater than zero",
+            ),
+            (
+                "nonnumeric_samples",
+                "samples = nope",
+                26,
+                "<test>:26:0: error[property_test]: invalid #[property_test] declaration `nonnumeric_samples`: `samples` must be a positive integer",
+            ),
+            (
+                "unknown_field",
+                "limit = 10",
+                27,
+                "<test>:27:0: error[property_test]: invalid #[property_test] declaration `unknown_field`: unknown field `limit`",
+            ),
+        ];
+
+        for (item_name, args, line, expected) in cases {
+            let err = check_with_property_test_attr(item_name, args, line)
+                .expect_err("expected malformed property_test declaration");
+            assert_eq!(err, expected);
+        }
+    }
+}


### PR DESCRIPTION
Closes #3471.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3471-property-tests-check-needs-malformed-inp`
Worktree: `.claude/worktrees/res-3471`

## Agent claims

(none inferred from issue)