### PR TITLE
RES-3472: target_profiles check should validate target_profiles declarations and reject malformed forms

### DIFF
--- a/resilient/src/target_profiles.rs
+++ b/resilient/src/target_profiles.rs
@@ -182,7 +182,7 @@ pub fn resolve_profile<'a>(
 
 // ── Typecheck pass ──────────────────────────────────────────────────────────
 
-/// Validate `[target.TRIPLE]` sections from the nearest `rz.toml`.
+/// Validate `[target.TRIPLE]` sections nearest `rz.toml`.
 ///
 /// Called from `typechecker.rs` `<EXTENSION_PASSES>`.  No-op when no
 /// manifest is found.  Errors are reported as structured diagnostics.
@@ -194,73 +194,313 @@ pub(crate) fn check(_program: &crate::Node, source_path: &str) -> Result<(), Str
         .map(|name| source_dir.join(name))
         .find(|p| p.exists());
 
-    let manifest_content = match manifest_path {
-        Some(ref p) => match std::fs::read_to_string(p) {
-            Ok(s) => s,
-            Err(_) => return Ok(()),
-        },
+    let manifest_path = match manifest_path {
+        Some(path) => path,
         None => return Ok(()),
     };
 
-    let profiles = parse_target_profiles(&manifest_content);
+    let manifest_content = match std::fs::read_to_string(&manifest_path) {
+        Ok(s) => s,
+        Err(_) => return Ok(()),
+    };
+
+    let manifest_display = manifest_path.display().to_string();
     let mut errors: Vec<String> = Vec::new();
+    let mut seen_triples: HashMap<String, usize> = HashMap::new();
+    let mut current_section: Option<SectionState> = None;
 
-    for (triple, profile) in &profiles {
-        // Validate opt_level.
-        if !profile.opt_level.is_empty() && !is_valid_opt_level(&profile.opt_level) {
-            errors.push(format!(
-                "{source_path}:0:0: error[target-profiles]: \
-                 [target.{triple}] has invalid `opt_level` `{}`; \
-                 expected one of: 0, 1, 2, 3, s",
-                profile.opt_level
-            ));
+    for (idx, raw_line) in manifest_content.lines().enumerate() {
+        let line_no = idx + 1;
+        let trimmed = raw_line.trim();
+
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
         }
 
-        // Validate stack_size parsed successfully if a value was present
-        // (parse failure means the field was ignored; detect it via raw re-scan).
-        for raw_line in manifest_content.lines() {
-            let line = raw_line.trim();
-            if line.starts_with(&format!("[target.{}]", triple)) {
-                break; // stop when we exit this section's re-scan
+        if trimmed.starts_with('[') {
+            if let Some(section) = current_section.take()
+                && !section.saw_field
+            {
+                errors.push(diagnostic(
+                    &manifest_display,
+                    section.header_line,
+                    1,
+                    &format!(
+                        "invalid [target.{}] declaration: missing required fields",
+                        section.triple
+                    ),
+                ));
             }
-        }
-        // Re-scan for this section's raw stack_size to catch non-integer values.
-        let mut in_section = false;
-        for raw_line in manifest_content.lines() {
-            let l = raw_line.trim();
-            if l == format!("[target.{}]", triple) {
-                in_section = true;
+
+            if trimmed.starts_with("[[") {
+                if trimmed.contains("[target.") {
+                    errors.push(diagnostic(
+                        &manifest_display,
+                        line_no,
+                        raw_line.find('[').map(|idx| idx + 1).unwrap_or(1),
+                        "invalid target profile declaration shape: array-of-tables syntax is not supported",
+                    ));
+                }
                 continue;
             }
-            if in_section {
-                if l.starts_with('[') {
-                    break;
+
+            let Some(header) = trimmed
+                .strip_prefix('[')
+                .and_then(|rest| rest.strip_suffix(']'))
+            else {
+                if trimmed.contains("[target") {
+                    errors.push(diagnostic(
+                        &manifest_display,
+                        line_no,
+                        raw_line.find('[').map(|idx| idx + 1).unwrap_or(1),
+                        "invalid target profile declaration shape: malformed section header",
+                    ));
                 }
-                if let Some((k, v)) = l.split_once('=') {
-                    let (k, v) = (k.trim(), v.trim());
-                    let _ = v; // suppress unused_variables until more checks are added
-                    if k == "stack_size" && v.parse::<u64>().is_err() {
-                        errors.push(format!(
-                            "{source_path}:0:0: error[target-profiles]: \
-                             [target.{triple}] `stack_size` must be a positive integer, \
-                             got `{v}`",
-                        ));
-                    }
+                continue;
+            };
+
+            let header = header.trim();
+            let header_col = raw_line.find('[').map(|idx| idx + 1).unwrap_or(1);
+
+            if header == "target" {
+                errors.push(diagnostic(
+                    &manifest_display,
+                    line_no,
+                    header_col,
+                    "invalid target profile declaration: missing required field `triple`",
+                ));
+                continue;
+            }
+
+            let Some(triple) = header.strip_prefix("target.") else {
+                current_section = None;
+                continue;
+            };
+
+            let triple = triple.trim();
+            if triple.is_empty() {
+                errors.push(diagnostic(
+                    &manifest_display,
+                    line_no,
+                    header_col,
+                    "invalid target profile declaration: missing required field `triple`",
+                ));
+                continue;
+            }
+
+            if !is_valid_target_triple(triple) {
+                errors.push(diagnostic(
+                    &manifest_display,
+                    line_no,
+                    header_col,
+                    &format!(
+                        "invalid target profile declaration shape: malformed target triple `{triple}`"
+                    ),
+                ));
+                continue;
+            }
+
+            if let Some(previous_line) = seen_triples.insert(triple.to_string(), line_no) {
+                errors.push(diagnostic(
+                    &manifest_display,
+                    line_no,
+                    header_col,
+                    &format!(
+                        "invalid target profile combination: duplicate `[target.{triple}]` declaration; previous declaration at line {previous_line}"
+                    ),
+                ));
+                current_section = None;
+                continue;
+            }
+
+            current_section = Some(SectionState::new(triple.to_string(), line_no));
+            continue;
+        }
+
+        let Some(section) = current_section.as_mut() else {
+            continue;
+        };
+
+        let Some((raw_key, raw_value)) = trimmed.split_once('=') else {
+            errors.push(diagnostic(
+                &manifest_display,
+                line_no,
+                raw_line.find(trimmed).map(|idx| idx + 1).unwrap_or(1),
+                &format!(
+                    "invalid [target.{}] declaration: malformed entry `{trimmed}`; expected `key = value`",
+                    section.triple
+                ),
+            ));
+            continue;
+        };
+
+        let key = raw_key.trim();
+        let value = raw_value.trim();
+        if key.is_empty() {
+            errors.push(diagnostic(
+                &manifest_display,
+                line_no,
+                raw_line.find(trimmed).map(|idx| idx + 1).unwrap_or(1),
+                &format!(
+                    "invalid [target.{}] declaration: malformed entry `{trimmed}`; expected a field name",
+                    section.triple
+                ),
+            ));
+            continue;
+        }
+
+        section.saw_field = true;
+        let key_col = raw_line.find(key).map(|idx| idx + 1).unwrap_or(1);
+        if let Some(previous_line) = section.seen_keys.insert(key.to_string(), line_no) {
+            errors.push(diagnostic(
+                &manifest_display,
+                line_no,
+                key_col,
+                &format!(
+                    "invalid [target.{}] combination: duplicate `{key}` field; previous declaration at line {previous_line}",
+                    section.triple
+                ),
+            ));
+            continue;
+        }
+
+        match key {
+            "features" => {
+                if let Err(message) = validate_features_value(value, &section.triple) {
+                    errors.push(diagnostic(&manifest_display, line_no, key_col, &message));
+                }
+            }
+            "opt_level" => {
+                if let Err(message) = validate_opt_level_value(value, &section.triple) {
+                    errors.push(diagnostic(&manifest_display, line_no, key_col, &message));
+                }
+            }
+            "stack_size" => {
+                if let Err(message) = validate_stack_size_value(value, &section.triple) {
+                    errors.push(diagnostic(&manifest_display, line_no, key_col, &message));
+                }
+            }
+            _ => {
+                if let Err(message) = validate_cfg_value(value, &section.triple, key) {
+                    errors.push(diagnostic(&manifest_display, line_no, key_col, &message));
                 }
             }
         }
+    }
+
+    if let Some(section) = current_section
+        && !section.saw_field
+    {
+        errors.push(diagnostic(
+            &manifest_display,
+            section.header_line,
+            1,
+            &format!(
+                "invalid [target.{}] declaration: missing required fields",
+                section.triple
+            ),
+        ));
     }
 
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(errors.join("\n"))
+        Err(errors.join(
+            "
+",
+        ))
+    }
+}
+
+fn diagnostic(source_path: &str, line: usize, column: usize, message: &str) -> String {
+    format!("{source_path}:{line}:{column}: error[target-profiles]: {message}")
+}
+
+#[derive(Default)]
+struct SectionState {
+    triple: String,
+    header_line: usize,
+    saw_field: bool,
+    seen_keys: HashMap<String, usize>,
+}
+
+impl SectionState {
+    fn new(triple: String, header_line: usize) -> Self {
+        Self {
+            triple,
+            header_line,
+            saw_field: false,
+            seen_keys: HashMap::new(),
+        }
+    }
+}
+
+fn is_valid_target_triple(triple: &str) -> bool {
+    !triple.is_empty()
+        && triple
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '+'))
+}
+
+fn validate_features_value(value: &str, triple: &str) -> Result<(), String> {
+    let Some(items) = value
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+    else {
+        return Err(format!(
+            "invalid [target.{triple}] declaration: `features` must be a string array"
+        ));
+    };
+
+    for item in items.split(',') {
+        let item = item.trim();
+        if item.is_empty() {
+            continue;
+        }
+        if extract_quoted_string(item).is_none() {
+            return Err(format!(
+                "invalid [target.{triple}] declaration: `features` entries must be double-quoted strings"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_opt_level_value(value: &str, triple: &str) -> Result<(), String> {
+    let raw = value.trim().trim_matches('"');
+    if is_valid_opt_level(raw) {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid [target.{triple}] declaration: `opt_level` `{raw}`; expected one of: 0, 1, 2, 3, s"
+        ))
+    }
+}
+
+fn validate_stack_size_value(value: &str, triple: &str) -> Result<(), String> {
+    let raw = value.trim().trim_matches('"');
+    match raw.parse::<u64>() {
+        Ok(0) | Err(_) => Err(format!(
+            "invalid [target.{triple}] declaration: `stack_size` must be a positive integer, got `{raw}`"
+        )),
+        Ok(_) => Ok(()),
+    }
+}
+
+fn validate_cfg_value(value: &str, triple: &str, key: &str) -> Result<(), String> {
+    if extract_quoted_string(value).is_some() {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid [target.{triple}] declaration: cfg field `{key}` must use a double-quoted string value"
+        ))
     }
 }
 
 // ── Small helpers ───────────────────────────────────────────────────────────
 
-/// Parse a TOML string array: `["a", "b", "c"]`.
+/// Parse TOML string array: `["a", "b", "c"]`.
 fn parse_string_array(s: &str) -> Vec<String> {
     let inner = s.trim();
     let inner = inner
@@ -443,8 +683,13 @@ mod tests {
     fn check_valid_manifest_passes() {
         let dir = std::env::temp_dir().join("__resilient_tp_valid");
         std::fs::create_dir_all(&dir).unwrap();
-        let manifest = "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\
-                        [target.arm]\nopt_level = \"s\"\nstack_size = 4096\n";
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+[target.arm]
+opt_level = "s"
+stack_size = 4096
+"#;
         std::fs::write(dir.join("rz.toml"), manifest).unwrap();
         let src = dir.join("main.rz");
         std::fs::write(&src, b"fn main() {}").unwrap();
@@ -458,8 +703,12 @@ mod tests {
     fn check_invalid_opt_level_is_error() {
         let dir = std::env::temp_dir().join("__resilient_tp_bad_opt");
         std::fs::create_dir_all(&dir).unwrap();
-        let manifest = "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\
-                        [target.arm]\nopt_level = \"fast\"\n";
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+[target.arm]
+opt_level = "fast"
+"#;
         std::fs::write(dir.join("rz.toml"), manifest).unwrap();
         let src = dir.join("main.rz");
         std::fs::write(&src, b"fn main() {}").unwrap();
@@ -473,14 +722,135 @@ mod tests {
     fn check_invalid_stack_size_is_error() {
         let dir = std::env::temp_dir().join("__resilient_tp_bad_stack");
         std::fs::create_dir_all(&dir).unwrap();
-        let manifest = "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\
-                        [target.arm]\nstack_size = notanumber\n";
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+[target.arm]
+stack_size = notanumber
+"#;
         std::fs::write(dir.join("rz.toml"), manifest).unwrap();
         let src = dir.join("main.rz");
         std::fs::write(&src, b"fn main() {}").unwrap();
         let (prog, _) = crate::parse("fn main() {}");
         let result = check(&prog, src.to_str().unwrap());
         assert!(result.is_err(), "expected error for invalid stack_size");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_malformed_target_header_shape() {
+        let dir = std::env::temp_dir().join("__resilient_tp_bad_header_shape");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target.arm.extra]
+opt_level = "s"
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected malformed target header to fail");
+        assert!(
+            err.contains("malformed target triple `arm.extra`"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_missing_target_triple() {
+        let dir = std::env::temp_dir().join("__resilient_tp_missing_triple");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target]
+opt_level = "s"
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected missing triple to fail");
+        assert!(
+            err.contains("missing required field `triple`"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_empty_target_section() {
+        let dir = std::env::temp_dir().join("__resilient_tp_empty_section");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target.arm]
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected empty target section to fail");
+        assert!(
+            err.contains("missing required fields"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_duplicate_target_sections() {
+        let dir = std::env::temp_dir().join("__resilient_tp_dup_section");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target.arm]
+opt_level = "s"
+                        [target.arm]
+stack_size = 4096
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected duplicate target section to fail");
+        assert!(
+            err.contains("duplicate `[target.arm]` declaration"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_duplicate_fields_in_target_section() {
+        let dir = std::env::temp_dir().join("__resilient_tp_dup_field");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target.arm]
+opt_level = "s"
+opt_level = "3"
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected duplicate field to fail");
+        assert!(
+            err.contains("duplicate `opt_level` field"),
+            "unexpected error: {err}"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Closes #3472.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3472-target-profiles-check-should-validate-ta`
Worktree: `.claude/worktrees/res-3472`

## Agent claims

(none inferred from issue)