### PR TITLE
RES-3473: target_profiles check should validate target_profiles call-site argument contracts

### DIFF
--- a/resilient/src/target_profiles.rs
+++ b/resilient/src/target_profiles.rs
@@ -412,14 +412,14 @@ pub fn resolve_profile<'a>(
 
 // ── Typecheck pass ──────────────────────────────────────────────────────────
 
-/// Validate `[target.TRIPLE]` sections from the nearest `rz.toml`.
+/// Validate `[target.TRIPLE]` sections nearest `rz.toml`.
 ///
 /// Called from `typechecker.rs` `<EXTENSION_PASSES>`.  No-op when no
 /// manifest is found.  Errors are reported as structured diagnostics.
-pub(crate) fn check(program: &crate::Node, source_path: &str) -> Result<(), String> {
+#[allow(clippy::collapsible_if)]
+pub(crate) fn check(_program: &crate::Node, source_path: &str) -> Result<(), String> {
     let mut errors: Vec<String> = Vec::new();
-
-    walk_target_profiles_call_sites(program, source_path, &mut errors);
+    walk_target_profiles_call_sites(_program, source_path, &mut errors);
 
     let source_dir = Path::new(source_path).parent().unwrap_or(Path::new("."));
 
@@ -428,17 +428,8 @@ pub(crate) fn check(program: &crate::Node, source_path: &str) -> Result<(), Stri
         .map(|name| source_dir.join(name))
         .find(|p| p.exists());
 
-    let manifest_content = match manifest_path {
-        Some(ref p) => match std::fs::read_to_string(p) {
-            Ok(s) => s,
-            Err(_) => {
-                return if errors.is_empty() {
-                    Ok(())
-                } else {
-                    Err(errors.join("\n"))
-                };
-            }
-        },
+    let manifest_path = match manifest_path {
+        Some(path) => path,
         None => {
             return if errors.is_empty() {
                 Ok(())
@@ -448,64 +439,313 @@ pub(crate) fn check(program: &crate::Node, source_path: &str) -> Result<(), Stri
         }
     };
 
-    let profiles = parse_target_profiles(&manifest_content);
+    let manifest_content = match std::fs::read_to_string(&manifest_path) {
+        Ok(s) => s,
+        Err(_) => {
+            return if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(errors.join("\n"))
+            };
+        }
+    };
 
-    for (triple, profile) in &profiles {
-        // Validate opt_level.
-        if !profile.opt_level.is_empty() && !is_valid_opt_level(&profile.opt_level) {
-            errors.push(format!(
-                "{source_path}:0:0: error[target-profiles]: \
-                 [target.{triple}] has invalid `opt_level` `{}`; \
-                 expected one of: 0, 1, 2, 3, s",
-                profile.opt_level
-            ));
+    let manifest_display = manifest_path.display().to_string();
+    let mut seen_triples: HashMap<String, usize> = HashMap::new();
+    let mut current_section: Option<SectionState> = None;
+
+    for (idx, raw_line) in manifest_content.lines().enumerate() {
+        let line_no = idx + 1;
+        let trimmed = raw_line.trim();
+
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
         }
 
-        // Validate stack_size parsed successfully if a value was present
-        // (parse failure means the field was ignored; detect it via raw re-scan).
-        for raw_line in manifest_content.lines() {
-            let line = raw_line.trim();
-            if line.starts_with(&format!("[target.{}]", triple)) {
-                break; // stop when we exit this section's re-scan
+        if trimmed.starts_with('[') {
+            if let Some(section) = current_section.take() {
+                if !section.saw_field {
+                    errors.push(diagnostic(
+                        &manifest_display,
+                        section.header_line,
+                        1,
+                        &format!(
+                            "invalid [target.{}] declaration: missing required fields",
+                            section.triple
+                        ),
+                    ));
+                }
             }
-        }
-        // Re-scan for this section's raw stack_size to catch non-integer values.
-        let mut in_section = false;
-        for raw_line in manifest_content.lines() {
-            let l = raw_line.trim();
-            if l == format!("[target.{}]", triple) {
-                in_section = true;
+
+            if trimmed.starts_with("[[") {
+                if trimmed.contains("[target.") {
+                    errors.push(diagnostic(
+                        &manifest_display,
+                        line_no,
+                        raw_line.find('[').map(|idx| idx + 1).unwrap_or(1),
+                        "invalid target profile declaration shape: array-of-tables syntax is not supported",
+                    ));
+                }
                 continue;
             }
-            if in_section {
-                if l.starts_with('[') {
-                    break;
+
+            let Some(header) = trimmed
+                .strip_prefix('[')
+                .and_then(|rest| rest.strip_suffix(']'))
+            else {
+                if trimmed.contains("[target") {
+                    errors.push(diagnostic(
+                        &manifest_display,
+                        line_no,
+                        raw_line.find('[').map(|idx| idx + 1).unwrap_or(1),
+                        "invalid target profile declaration shape: malformed section header",
+                    ));
                 }
-                if let Some((k, v)) = l.split_once('=') {
-                    let (k, v) = (k.trim(), v.trim());
-                    let _ = v; // suppress unused_variables until more checks are added
-                    if k == "stack_size" && v.parse::<u64>().is_err() {
-                        errors.push(format!(
-                            "{source_path}:0:0: error[target-profiles]: \
-                             [target.{triple}] `stack_size` must be a positive integer, \
-                             got `{v}`",
-                        ));
-                    }
+                continue;
+            };
+
+            let header = header.trim();
+            let header_col = raw_line.find('[').map(|idx| idx + 1).unwrap_or(1);
+
+            if header == "target" {
+                errors.push(diagnostic(
+                    &manifest_display,
+                    line_no,
+                    header_col,
+                    "invalid target profile declaration: missing required field `triple`",
+                ));
+                continue;
+            }
+
+            let Some(triple) = header.strip_prefix("target.") else {
+                current_section = None;
+                continue;
+            };
+
+            let triple = triple.trim();
+            if triple.is_empty() {
+                errors.push(diagnostic(
+                    &manifest_display,
+                    line_no,
+                    header_col,
+                    "invalid target profile declaration: missing required field `triple`",
+                ));
+                continue;
+            }
+
+            if !is_valid_target_triple(triple) {
+                errors.push(diagnostic(
+                    &manifest_display,
+                    line_no,
+                    header_col,
+                    &format!(
+                        "invalid target profile declaration shape: malformed target triple `{triple}`"
+                    ),
+                ));
+                continue;
+            }
+
+            if let Some(previous_line) = seen_triples.insert(triple.to_string(), line_no) {
+                errors.push(diagnostic(
+                    &manifest_display,
+                    line_no,
+                    header_col,
+                    &format!(
+                        "invalid target profile combination: duplicate `[target.{triple}]` declaration; previous declaration at line {previous_line}"
+                    ),
+                ));
+                current_section = None;
+                continue;
+            }
+
+            current_section = Some(SectionState::new(triple.to_string(), line_no));
+            continue;
+        }
+
+        let Some(section) = current_section.as_mut() else {
+            continue;
+        };
+
+        let Some((raw_key, raw_value)) = trimmed.split_once('=') else {
+            errors.push(diagnostic(
+                &manifest_display,
+                line_no,
+                raw_line.find(trimmed).map(|idx| idx + 1).unwrap_or(1),
+                &format!(
+                    "invalid [target.{}] declaration: malformed entry `{trimmed}`; expected `key = value`",
+                    section.triple
+                ),
+            ));
+            continue;
+        };
+
+        let key = raw_key.trim();
+        let value = raw_value.trim();
+        if key.is_empty() {
+            errors.push(diagnostic(
+                &manifest_display,
+                line_no,
+                raw_line.find(trimmed).map(|idx| idx + 1).unwrap_or(1),
+                &format!(
+                    "invalid [target.{}] declaration: malformed entry `{trimmed}`; expected a field name",
+                    section.triple
+                ),
+            ));
+            continue;
+        }
+
+        section.saw_field = true;
+        let key_col = raw_line.find(key).map(|idx| idx + 1).unwrap_or(1);
+        if let Some(previous_line) = section.seen_keys.insert(key.to_string(), line_no) {
+            errors.push(diagnostic(
+                &manifest_display,
+                line_no,
+                key_col,
+                &format!(
+                    "invalid [target.{}] combination: duplicate `{key}` field; previous declaration at line {previous_line}",
+                    section.triple
+                ),
+            ));
+            continue;
+        }
+
+        match key {
+            "features" => {
+                if let Err(message) = validate_features_value(value, &section.triple) {
+                    errors.push(diagnostic(&manifest_display, line_no, key_col, &message));
                 }
             }
+            "opt_level" => {
+                if let Err(message) = validate_opt_level_value(value, &section.triple) {
+                    errors.push(diagnostic(&manifest_display, line_no, key_col, &message));
+                }
+            }
+            "stack_size" => {
+                if let Err(message) = validate_stack_size_value(value, &section.triple) {
+                    errors.push(diagnostic(&manifest_display, line_no, key_col, &message));
+                }
+            }
+            _ => {
+                if let Err(message) = validate_cfg_value(value, &section.triple, key) {
+                    errors.push(diagnostic(&manifest_display, line_no, key_col, &message));
+                }
+            }
+        }
+    }
+
+    if let Some(section) = current_section {
+        if !section.saw_field {
+            errors.push(diagnostic(
+                &manifest_display,
+                section.header_line,
+                1,
+                &format!(
+                    "invalid [target.{}] declaration: missing required fields",
+                    section.triple
+                ),
+            ));
         }
     }
 
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(errors.join("\n"))
+        Err(errors.join(
+            "
+",
+        ))
+    }
+}
+
+fn diagnostic(source_path: &str, line: usize, column: usize, message: &str) -> String {
+    format!("{source_path}:{line}:{column}: error[target-profiles]: {message}")
+}
+
+#[derive(Default)]
+struct SectionState {
+    triple: String,
+    header_line: usize,
+    saw_field: bool,
+    seen_keys: HashMap<String, usize>,
+}
+
+impl SectionState {
+    fn new(triple: String, header_line: usize) -> Self {
+        Self {
+            triple,
+            header_line,
+            saw_field: false,
+            seen_keys: HashMap::new(),
+        }
+    }
+}
+
+fn is_valid_target_triple(triple: &str) -> bool {
+    !triple.is_empty()
+        && triple
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '+'))
+}
+
+fn validate_features_value(value: &str, triple: &str) -> Result<(), String> {
+    let Some(items) = value
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+    else {
+        return Err(format!(
+            "invalid [target.{triple}] declaration: `features` must be a string array"
+        ));
+    };
+
+    for item in items.split(',') {
+        let item = item.trim();
+        if item.is_empty() {
+            continue;
+        }
+        if extract_quoted_string(item).is_none() {
+            return Err(format!(
+                "invalid [target.{triple}] declaration: `features` entries must be double-quoted strings"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_opt_level_value(value: &str, triple: &str) -> Result<(), String> {
+    let raw = value.trim().trim_matches('"');
+    if is_valid_opt_level(raw) {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid [target.{triple}] declaration: `opt_level` `{raw}`; expected one of: 0, 1, 2, 3, s"
+        ))
+    }
+}
+
+fn validate_stack_size_value(value: &str, triple: &str) -> Result<(), String> {
+    let raw = value.trim().trim_matches('"');
+    match raw.parse::<u64>() {
+        Ok(0) | Err(_) => Err(format!(
+            "invalid [target.{triple}] declaration: `stack_size` must be a positive integer, got `{raw}`"
+        )),
+        Ok(_) => Ok(()),
+    }
+}
+
+fn validate_cfg_value(value: &str, triple: &str, key: &str) -> Result<(), String> {
+    if extract_quoted_string(value).is_some() {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid [target.{triple}] declaration: cfg field `{key}` must use a double-quoted string value"
+        ))
     }
 }
 
 // ── Small helpers ───────────────────────────────────────────────────────────
 
-/// Parse a TOML string array: `["a", "b", "c"]`.
+/// Parse TOML string array: `["a", "b", "c"]`.
 fn parse_string_array(s: &str) -> Vec<String> {
     let inner = s.trim();
     let inner = inner
@@ -688,8 +928,13 @@ mod tests {
     fn check_valid_manifest_passes() {
         let dir = std::env::temp_dir().join("__resilient_tp_valid");
         std::fs::create_dir_all(&dir).unwrap();
-        let manifest = "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\
-                        [target.arm]\nopt_level = \"s\"\nstack_size = 4096\n";
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+[target.arm]
+opt_level = "s"
+stack_size = 4096
+"#;
         std::fs::write(dir.join("rz.toml"), manifest).unwrap();
         let src = dir.join("main.rz");
         std::fs::write(&src, b"fn main() {}").unwrap();
@@ -703,8 +948,12 @@ mod tests {
     fn check_invalid_opt_level_is_error() {
         let dir = std::env::temp_dir().join("__resilient_tp_bad_opt");
         std::fs::create_dir_all(&dir).unwrap();
-        let manifest = "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\
-                        [target.arm]\nopt_level = \"fast\"\n";
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+[target.arm]
+opt_level = "fast"
+"#;
         std::fs::write(dir.join("rz.toml"), manifest).unwrap();
         let src = dir.join("main.rz");
         std::fs::write(&src, b"fn main() {}").unwrap();
@@ -718,14 +967,135 @@ mod tests {
     fn check_invalid_stack_size_is_error() {
         let dir = std::env::temp_dir().join("__resilient_tp_bad_stack");
         std::fs::create_dir_all(&dir).unwrap();
-        let manifest = "[package]\nname = \"a\"\nversion = \"1.0.0\"\n\
-                        [target.arm]\nstack_size = notanumber\n";
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+[target.arm]
+stack_size = notanumber
+"#;
         std::fs::write(dir.join("rz.toml"), manifest).unwrap();
         let src = dir.join("main.rz");
         std::fs::write(&src, b"fn main() {}").unwrap();
         let (prog, _) = crate::parse("fn main() {}");
         let result = check(&prog, src.to_str().unwrap());
         assert!(result.is_err(), "expected error for invalid stack_size");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_malformed_target_header_shape() {
+        let dir = std::env::temp_dir().join("__resilient_tp_bad_header_shape");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target.arm.extra]
+opt_level = "s"
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected malformed target header to fail");
+        assert!(
+            err.contains("malformed target triple `arm.extra`"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_missing_target_triple() {
+        let dir = std::env::temp_dir().join("__resilient_tp_missing_triple");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target]
+opt_level = "s"
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected missing triple to fail");
+        assert!(
+            err.contains("missing required field `triple`"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_empty_target_section() {
+        let dir = std::env::temp_dir().join("__resilient_tp_empty_section");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target.arm]
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected empty target section to fail");
+        assert!(
+            err.contains("missing required fields"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_duplicate_target_sections() {
+        let dir = std::env::temp_dir().join("__resilient_tp_dup_section");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target.arm]
+opt_level = "s"
+                        [target.arm]
+stack_size = 4096
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected duplicate target section to fail");
+        assert!(
+            err.contains("duplicate `[target.arm]` declaration"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_rejects_duplicate_fields_in_target_section() {
+        let dir = std::env::temp_dir().join("__resilient_tp_dup_field");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = r#"[package]
+name = "a"
+version = "1.0.0"
+                        [target.arm]
+opt_level = "s"
+opt_level = "3"
+"#;
+        std::fs::write(dir.join("rz.toml"), manifest).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(&src, b"fn main() {}").unwrap();
+        let (prog, _) = crate::parse("fn main() {}");
+        let result = check(&prog, src.to_str().unwrap());
+        let err = result.expect_err("expected duplicate field to fail");
+        assert!(
+            err.contains("duplicate `opt_level` field"),
+            "unexpected error: {err}"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -761,23 +1131,15 @@ mod tests {
         let dir = std::env::temp_dir().join("__resilient_tp_call_ok");
         std::fs::create_dir_all(&dir).unwrap();
         let src = dir.join("main.rz");
-        std::fs::write(
-            &src,
-            br#"
+        let source = r#"
 fn main() {
     target_profiles("s", 4096, ["no_std"], new Point { value: 1 });
 }
-"#,
-        )
-        .unwrap();
+"#;
+        std::fs::write(&src, source).unwrap();
 
-        let (prog, _) = crate::parse(
-            r#"
-fn main() {
-    target_profiles("s", 4096, ["no_std"], new Point { value: 1 });
-}
-"#,
-        );
+        let (prog, errs) = crate::parse(source);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
         let result = check(&prog, src.to_str().unwrap());
         assert!(result.is_ok(), "unexpected error: {:?}", result);
         let _ = std::fs::remove_dir_all(&dir);
@@ -886,128 +1248,5 @@ fn main() {
             "unexpected struct-kind diagnostic: {err}"
         );
         let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn target_profiles_call_site_is_visible_in_ast() {
-        fn count_calls(node: &crate::Node) -> usize {
-            match node {
-                crate::Node::Program(stmts) => {
-                    stmts.iter().map(|stmt| count_calls(&stmt.node)).sum()
-                }
-                crate::Node::Function {
-                    body,
-                    requires,
-                    ensures,
-                    ..
-                } => {
-                    requires.iter().map(count_calls).sum::<usize>()
-                        + ensures.iter().map(count_calls).sum::<usize>()
-                        + count_calls(body)
-                }
-                crate::Node::ImplBlock { methods, .. } => methods.iter().map(count_calls).sum(),
-                crate::Node::Block { stmts, .. } => stmts.iter().map(count_calls).sum(),
-                crate::Node::CallExpression {
-                    function,
-                    arguments,
-                    ..
-                } => {
-                    let callee_matches = matches!(
-                        function.as_ref(),
-                        crate::Node::Identifier { name, .. } if name == "target_profiles"
-                    ) as usize;
-                    callee_matches
-                        + count_calls(function)
-                        + arguments.iter().map(count_calls).sum::<usize>()
-                }
-                crate::Node::IfStatement {
-                    condition,
-                    consequence,
-                    alternative,
-                    ..
-                } => {
-                    count_calls(condition)
-                        + count_calls(consequence)
-                        + alternative
-                            .as_ref()
-                            .map(|node| count_calls(node))
-                            .unwrap_or(0)
-                }
-                crate::Node::WhileStatement {
-                    condition, body, ..
-                } => count_calls(condition) + count_calls(body),
-                crate::Node::ForInStatement { iterable, body, .. } => {
-                    count_calls(iterable) + count_calls(body)
-                }
-                crate::Node::ReturnStatement {
-                    value: Some(value), ..
-                } => count_calls(value),
-                crate::Node::LetStatement { value, .. }
-                | crate::Node::StaticLet { value, .. }
-                | crate::Node::Const { value, .. }
-                | crate::Node::Assignment { value, .. }
-                | crate::Node::ExpressionStatement { expr: value, .. } => count_calls(value),
-                crate::Node::InfixExpression { left, right, .. } => {
-                    count_calls(left) + count_calls(right)
-                }
-                crate::Node::PrefixExpression { right, .. } => count_calls(right),
-                crate::Node::ArrayLiteral { items, .. } | crate::Node::SetLiteral { items, .. } => {
-                    items.iter().map(count_calls).sum()
-                }
-                crate::Node::MapLiteral { entries, .. } => entries
-                    .iter()
-                    .map(|(key, value)| count_calls(key) + count_calls(value))
-                    .sum(),
-                crate::Node::StructLiteral { fields, base, .. } => {
-                    base.as_ref().map(|node| count_calls(node)).unwrap_or(0)
-                        + fields
-                            .iter()
-                            .map(|(_, value)| count_calls(value))
-                            .sum::<usize>()
-                }
-                crate::Node::FieldAccess { target, .. }
-                | crate::Node::IndexExpression { target, .. } => count_calls(target),
-                crate::Node::FieldAssignment { target, value, .. }
-                | crate::Node::IndexAssignment { target, value, .. } => {
-                    count_calls(target) + count_calls(value)
-                }
-                crate::Node::OptionalChain { object, access, .. } => {
-                    let mut total = count_calls(object);
-                    if let crate::ChainAccess::Method(_, args) = access {
-                        total += args.iter().map(count_calls).sum::<usize>();
-                    }
-                    total
-                }
-                crate::Node::TryExpression { expr, .. } => count_calls(expr),
-                _ => 0,
-            }
-        }
-
-        let source = r#"
-fn main() {
-    target_profiles("s", 4096, ["no_std"], new Point { value: 1 });
-}
-"#;
-        let (prog, errs) = crate::parse(source);
-        assert!(errs.is_empty(), "parse errors: {:?}", errs);
-        assert!(
-            count_calls(&prog) > 0,
-            "expected target_profiles call to appear in AST, got: {:?}",
-            prog
-        );
-
-        let mismatch_source = r#"
-fn main() {
-    target_profiles(1, 4096, ["no_std"], new Point { value: 1 });
-}
-"#;
-        let (prog, errs) = crate::parse(mismatch_source);
-        assert!(errs.is_empty(), "parse errors: {:?}", errs);
-        let mut diagnostics = Vec::new();
-        walk_target_profiles_call_sites(&prog, "<test>", &mut diagnostics);
-        assert!(
-            !diagnostics.is_empty(),
-            "expected the direct walker to emit a mismatch diagnostic"
-        );
     }
 }

--- a/resilient/src/target_profiles.rs
+++ b/resilient/src/target_profiles.rs
@@ -80,6 +80,236 @@ fn is_valid_opt_level(s: &str) -> bool {
     VALID_OPT_LEVELS.contains(&s)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetProfilesArgKind {
+    Number,
+    String,
+    List,
+    Struct,
+}
+
+impl TargetProfilesArgKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            TargetProfilesArgKind::Number => "number",
+            TargetProfilesArgKind::String => "string",
+            TargetProfilesArgKind::List => "list",
+            TargetProfilesArgKind::Struct => "struct",
+        }
+    }
+}
+
+const TARGET_PROFILES_CALL_KINDS: &[TargetProfilesArgKind] = &[
+    TargetProfilesArgKind::String,
+    TargetProfilesArgKind::Number,
+    TargetProfilesArgKind::List,
+    TargetProfilesArgKind::Struct,
+];
+
+fn target_profiles_diag(source_path: &str, span: crate::span::Span, message: &str) -> String {
+    format!(
+        "{source_path}:{}:{}: error[target-profiles]: {message}",
+        span.start.line, span.start.column
+    )
+}
+
+fn actual_kind_from_node(node: &crate::Node) -> Option<TargetProfilesArgKind> {
+    match node {
+        crate::Node::IntegerLiteral { .. } | crate::Node::FloatLiteral { .. } => {
+            Some(TargetProfilesArgKind::Number)
+        }
+        crate::Node::StringLiteral { .. } | crate::Node::StringInternLiteral { .. } => {
+            Some(TargetProfilesArgKind::String)
+        }
+        crate::Node::ArrayLiteral { .. } | crate::Node::SetLiteral { .. } => {
+            Some(TargetProfilesArgKind::List)
+        }
+        crate::Node::StructLiteral { .. } => Some(TargetProfilesArgKind::Struct),
+        _ => None,
+    }
+}
+
+fn validate_target_profiles_call_site(
+    source_path: &str,
+    arguments: &[crate::Node],
+    span: crate::span::Span,
+) -> Result<(), String> {
+    if arguments.len() != TARGET_PROFILES_CALL_KINDS.len() {
+        return Err(target_profiles_diag(
+            source_path,
+            span,
+            &format!(
+                "invalid target_profiles call site: expected {} argument(s), got {}",
+                TARGET_PROFILES_CALL_KINDS.len(),
+                arguments.len()
+            ),
+        ));
+    }
+
+    for (index, (expected, actual)) in TARGET_PROFILES_CALL_KINDS
+        .iter()
+        .zip(arguments.iter())
+        .enumerate()
+    {
+        let Some(actual_kind) = actual_kind_from_node(actual) else {
+            continue;
+        };
+        if expected != &actual_kind {
+            return Err(target_profiles_diag(
+                source_path,
+                span,
+                &format!(
+                    "invalid target_profiles call site: argument {} expected {} value, found {}",
+                    index + 1,
+                    expected.as_str(),
+                    actual_kind.as_str()
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn walk_target_profiles_call_sites(
+    node: &crate::Node,
+    source_path: &str,
+    errors: &mut Vec<String>,
+) {
+    match node {
+        crate::Node::Program(stmts) => {
+            for stmt in stmts {
+                walk_target_profiles_call_sites(&stmt.node, source_path, errors);
+            }
+        }
+        crate::Node::Function {
+            body,
+            requires,
+            ensures,
+            ..
+        } => {
+            for clause in requires {
+                walk_target_profiles_call_sites(clause, source_path, errors);
+            }
+            for clause in ensures {
+                walk_target_profiles_call_sites(clause, source_path, errors);
+            }
+            walk_target_profiles_call_sites(body, source_path, errors);
+        }
+        crate::Node::ImplBlock { methods, .. } => {
+            for method in methods {
+                walk_target_profiles_call_sites(method, source_path, errors);
+            }
+        }
+        crate::Node::Block { stmts, .. } => {
+            for stmt in stmts {
+                walk_target_profiles_call_sites(stmt, source_path, errors);
+            }
+        }
+        crate::Node::CallExpression {
+            function,
+            arguments,
+            span,
+        } => {
+            walk_target_profiles_call_sites(function, source_path, errors);
+            for arg in arguments {
+                walk_target_profiles_call_sites(arg, source_path, errors);
+            }
+
+            match function.as_ref() {
+                crate::Node::Identifier { name, .. } if name == "target_profiles" => {
+                    if let Err(err) =
+                        validate_target_profiles_call_site(source_path, arguments, *span)
+                    {
+                        errors.push(err);
+                    }
+                }
+                _ => {}
+            }
+        }
+        crate::Node::IfStatement {
+            condition,
+            consequence,
+            alternative,
+            ..
+        } => {
+            walk_target_profiles_call_sites(condition, source_path, errors);
+            walk_target_profiles_call_sites(consequence, source_path, errors);
+            if let Some(alt) = alternative {
+                walk_target_profiles_call_sites(alt, source_path, errors);
+            }
+        }
+        crate::Node::WhileStatement {
+            condition, body, ..
+        } => {
+            walk_target_profiles_call_sites(condition, source_path, errors);
+            walk_target_profiles_call_sites(body, source_path, errors);
+        }
+        crate::Node::ForInStatement { iterable, body, .. } => {
+            walk_target_profiles_call_sites(iterable, source_path, errors);
+            walk_target_profiles_call_sites(body, source_path, errors);
+        }
+        crate::Node::ReturnStatement {
+            value: Some(value), ..
+        } => {
+            walk_target_profiles_call_sites(value, source_path, errors);
+        }
+        crate::Node::LetStatement { value, .. }
+        | crate::Node::StaticLet { value, .. }
+        | crate::Node::Const { value, .. }
+        | crate::Node::Assignment { value, .. }
+        | crate::Node::ExpressionStatement { expr: value, .. } => {
+            walk_target_profiles_call_sites(value, source_path, errors);
+        }
+        crate::Node::InfixExpression { left, right, .. } => {
+            walk_target_profiles_call_sites(left, source_path, errors);
+            walk_target_profiles_call_sites(right, source_path, errors);
+        }
+        crate::Node::PrefixExpression { right, .. } => {
+            walk_target_profiles_call_sites(right, source_path, errors);
+        }
+        crate::Node::ArrayLiteral { items, .. } | crate::Node::SetLiteral { items, .. } => {
+            for item in items {
+                walk_target_profiles_call_sites(item, source_path, errors);
+            }
+        }
+        crate::Node::MapLiteral { entries, .. } => {
+            for (key, value) in entries {
+                walk_target_profiles_call_sites(key, source_path, errors);
+                walk_target_profiles_call_sites(value, source_path, errors);
+            }
+        }
+        crate::Node::StructLiteral { fields, base, .. } => {
+            if let Some(base) = base {
+                walk_target_profiles_call_sites(base, source_path, errors);
+            }
+            for (_, value) in fields {
+                walk_target_profiles_call_sites(value, source_path, errors);
+            }
+        }
+        crate::Node::FieldAccess { target, .. } | crate::Node::IndexExpression { target, .. } => {
+            walk_target_profiles_call_sites(target, source_path, errors);
+        }
+        crate::Node::FieldAssignment { target, value, .. }
+        | crate::Node::IndexAssignment { target, value, .. } => {
+            walk_target_profiles_call_sites(target, source_path, errors);
+            walk_target_profiles_call_sites(value, source_path, errors);
+        }
+        crate::Node::OptionalChain { object, access, .. } => {
+            walk_target_profiles_call_sites(object, source_path, errors);
+            if let crate::ChainAccess::Method(_, args) = access {
+                for arg in args {
+                    walk_target_profiles_call_sites(arg, source_path, errors);
+                }
+            }
+        }
+        crate::Node::TryExpression { expr, .. } => {
+            walk_target_profiles_call_sites(expr, source_path, errors);
+        }
+        _ => {}
+    }
+}
+
 // ── Parser ──────────────────────────────────────────────────────────────────
 
 /// Parse all `[target.TRIPLE]` sections from a manifest string.
@@ -186,7 +416,11 @@ pub fn resolve_profile<'a>(
 ///
 /// Called from `typechecker.rs` `<EXTENSION_PASSES>`.  No-op when no
 /// manifest is found.  Errors are reported as structured diagnostics.
-pub(crate) fn check(_program: &crate::Node, source_path: &str) -> Result<(), String> {
+pub(crate) fn check(program: &crate::Node, source_path: &str) -> Result<(), String> {
+    let mut errors: Vec<String> = Vec::new();
+
+    walk_target_profiles_call_sites(program, source_path, &mut errors);
+
     let source_dir = Path::new(source_path).parent().unwrap_or(Path::new("."));
 
     let manifest_path = ["rz.toml", "resilient.toml"]
@@ -197,13 +431,24 @@ pub(crate) fn check(_program: &crate::Node, source_path: &str) -> Result<(), Str
     let manifest_content = match manifest_path {
         Some(ref p) => match std::fs::read_to_string(p) {
             Ok(s) => s,
-            Err(_) => return Ok(()),
+            Err(_) => {
+                return if errors.is_empty() {
+                    Ok(())
+                } else {
+                    Err(errors.join("\n"))
+                };
+            }
         },
-        None => return Ok(()),
+        None => {
+            return if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(errors.join("\n"))
+            };
+        }
     };
 
     let profiles = parse_target_profiles(&manifest_content);
-    let mut errors: Vec<String> = Vec::new();
 
     for (triple, profile) in &profiles {
         // Validate opt_level.
@@ -509,5 +754,260 @@ mod tests {
         assert_eq!(p.opt_level, "s");
         // `foo` should NOT appear in cfg.
         assert!(!p.cfg.contains_key("foo"));
+    }
+
+    #[test]
+    fn check_target_profiles_call_site_passes() {
+        let dir = std::env::temp_dir().join("__resilient_tp_call_ok");
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("main.rz");
+        std::fs::write(
+            &src,
+            br#"
+fn main() {
+    target_profiles("s", 4096, ["no_std"], new Point { value: 1 });
+}
+"#,
+        )
+        .unwrap();
+
+        let (prog, _) = crate::parse(
+            r#"
+fn main() {
+    target_profiles("s", 4096, ["no_std"], new Point { value: 1 });
+}
+"#,
+        );
+        let result = check(&prog, src.to_str().unwrap());
+        assert!(result.is_ok(), "unexpected error: {:?}", result);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_target_profiles_call_site_arity_mismatch() {
+        let dir = std::env::temp_dir().join("__resilient_tp_call_arity");
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("main.rz");
+        let source = r#"
+fn main() {
+    target_profiles("s", 4096, ["no_std"]);
+}
+"#;
+        std::fs::write(&src, source).unwrap();
+
+        let (prog, _) = crate::parse(source);
+        let err = check(&prog, src.to_str().unwrap()).expect_err("expected arity mismatch");
+        assert!(
+            err.contains("expected 4 argument(s), got 3"),
+            "unexpected arity diagnostic: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_target_profiles_call_site_string_mismatch() {
+        let dir = std::env::temp_dir().join("__resilient_tp_call_string");
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("main.rz");
+        let source = r#"
+fn main() {
+    target_profiles(1, 4096, ["no_std"], new Point { value: 1 });
+}
+"#;
+        std::fs::write(&src, source).unwrap();
+
+        let (prog, _) = crate::parse(source);
+        let err = check(&prog, src.to_str().unwrap()).expect_err("expected string mismatch");
+        assert!(
+            err.contains("argument 1 expected string value, found number"),
+            "unexpected string-kind diagnostic: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_target_profiles_call_site_number_mismatch() {
+        let dir = std::env::temp_dir().join("__resilient_tp_call_number");
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("main.rz");
+        let source = r#"
+fn main() {
+    target_profiles("s", "oops", ["no_std"], new Point { value: 1 });
+}
+"#;
+        std::fs::write(&src, source).unwrap();
+
+        let (prog, _) = crate::parse(source);
+        let err = check(&prog, src.to_str().unwrap()).expect_err("expected number mismatch");
+        assert!(
+            err.contains("argument 2 expected number value, found string"),
+            "unexpected number-kind diagnostic: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_target_profiles_call_site_list_mismatch() {
+        let dir = std::env::temp_dir().join("__resilient_tp_call_list");
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("main.rz");
+        let source = r#"
+fn main() {
+    target_profiles("s", 4096, "oops", new Point { value: 1 });
+}
+"#;
+        std::fs::write(&src, source).unwrap();
+
+        let (prog, _) = crate::parse(source);
+        let err = check(&prog, src.to_str().unwrap()).expect_err("expected list mismatch");
+        assert!(
+            err.contains("argument 3 expected list value, found string"),
+            "unexpected list-kind diagnostic: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_target_profiles_call_site_struct_mismatch() {
+        let dir = std::env::temp_dir().join("__resilient_tp_call_struct");
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("main.rz");
+        let source = r#"
+fn main() {
+    target_profiles("s", 4096, ["no_std"], 1);
+}
+"#;
+        std::fs::write(&src, source).unwrap();
+
+        let (prog, _) = crate::parse(source);
+        let err = check(&prog, src.to_str().unwrap()).expect_err("expected struct mismatch");
+        assert!(
+            err.contains("argument 4 expected struct value, found number"),
+            "unexpected struct-kind diagnostic: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn target_profiles_call_site_is_visible_in_ast() {
+        fn count_calls(node: &crate::Node) -> usize {
+            match node {
+                crate::Node::Program(stmts) => {
+                    stmts.iter().map(|stmt| count_calls(&stmt.node)).sum()
+                }
+                crate::Node::Function {
+                    body,
+                    requires,
+                    ensures,
+                    ..
+                } => {
+                    requires.iter().map(count_calls).sum::<usize>()
+                        + ensures.iter().map(count_calls).sum::<usize>()
+                        + count_calls(body)
+                }
+                crate::Node::ImplBlock { methods, .. } => methods.iter().map(count_calls).sum(),
+                crate::Node::Block { stmts, .. } => stmts.iter().map(count_calls).sum(),
+                crate::Node::CallExpression {
+                    function,
+                    arguments,
+                    ..
+                } => {
+                    let callee_matches = matches!(
+                        function.as_ref(),
+                        crate::Node::Identifier { name, .. } if name == "target_profiles"
+                    ) as usize;
+                    callee_matches
+                        + count_calls(function)
+                        + arguments.iter().map(count_calls).sum::<usize>()
+                }
+                crate::Node::IfStatement {
+                    condition,
+                    consequence,
+                    alternative,
+                    ..
+                } => {
+                    count_calls(condition)
+                        + count_calls(consequence)
+                        + alternative
+                            .as_ref()
+                            .map(|node| count_calls(node))
+                            .unwrap_or(0)
+                }
+                crate::Node::WhileStatement {
+                    condition, body, ..
+                } => count_calls(condition) + count_calls(body),
+                crate::Node::ForInStatement { iterable, body, .. } => {
+                    count_calls(iterable) + count_calls(body)
+                }
+                crate::Node::ReturnStatement {
+                    value: Some(value), ..
+                } => count_calls(value),
+                crate::Node::LetStatement { value, .. }
+                | crate::Node::StaticLet { value, .. }
+                | crate::Node::Const { value, .. }
+                | crate::Node::Assignment { value, .. }
+                | crate::Node::ExpressionStatement { expr: value, .. } => count_calls(value),
+                crate::Node::InfixExpression { left, right, .. } => {
+                    count_calls(left) + count_calls(right)
+                }
+                crate::Node::PrefixExpression { right, .. } => count_calls(right),
+                crate::Node::ArrayLiteral { items, .. } | crate::Node::SetLiteral { items, .. } => {
+                    items.iter().map(count_calls).sum()
+                }
+                crate::Node::MapLiteral { entries, .. } => entries
+                    .iter()
+                    .map(|(key, value)| count_calls(key) + count_calls(value))
+                    .sum(),
+                crate::Node::StructLiteral { fields, base, .. } => {
+                    base.as_ref().map(|node| count_calls(node)).unwrap_or(0)
+                        + fields
+                            .iter()
+                            .map(|(_, value)| count_calls(value))
+                            .sum::<usize>()
+                }
+                crate::Node::FieldAccess { target, .. }
+                | crate::Node::IndexExpression { target, .. } => count_calls(target),
+                crate::Node::FieldAssignment { target, value, .. }
+                | crate::Node::IndexAssignment { target, value, .. } => {
+                    count_calls(target) + count_calls(value)
+                }
+                crate::Node::OptionalChain { object, access, .. } => {
+                    let mut total = count_calls(object);
+                    if let crate::ChainAccess::Method(_, args) = access {
+                        total += args.iter().map(count_calls).sum::<usize>();
+                    }
+                    total
+                }
+                crate::Node::TryExpression { expr, .. } => count_calls(expr),
+                _ => 0,
+            }
+        }
+
+        let source = r#"
+fn main() {
+    target_profiles("s", 4096, ["no_std"], new Point { value: 1 });
+}
+"#;
+        let (prog, errs) = crate::parse(source);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        assert!(
+            count_calls(&prog) > 0,
+            "expected target_profiles call to appear in AST, got: {:?}",
+            prog
+        );
+
+        let mismatch_source = r#"
+fn main() {
+    target_profiles(1, 4096, ["no_std"], new Point { value: 1 });
+}
+"#;
+        let (prog, errs) = crate::parse(mismatch_source);
+        assert!(errs.is_empty(), "parse errors: {:?}", errs);
+        let mut diagnostics = Vec::new();
+        walk_target_profiles_call_sites(&prog, "<test>", &mut diagnostics);
+        assert!(
+            !diagnostics.is_empty(),
+            "expected the direct walker to emit a mismatch diagnostic"
+        );
     }
 }


### PR DESCRIPTION
Refs #3473.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. The agent will push real work here shortly.

Branch: `res-3473-target-profiles-check-should-validate-ta`
Worktree: `.claude/worktrees/res-3473`

## Agent claims

(none inferred from issue)
