### PR TITLE
RES-3482: harden agent PR vetting workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,12 @@ reviewers can read the diff for the what._
 
 ## Linked issue
 
-Closes #<issue-number>
+Refs #<issue-number>
+
+<!-- Agent PRs must not use `Closes #N` while draft. `ready-or-bail.sh`
+adds `Closes #N` only after substantive guardrails pass and `agent-vetted`
+is applied. Human-maintained PRs may use `Closes #N` only when intentionally
+closing the issue. -->
 
 
 ## Acceptance criteria
@@ -41,6 +46,8 @@ $ cargo test --manifest-path resilient/Cargo.toml
 - [ ] `cargo clippy --all-targets -- -D warnings` clean
 - [ ] `cargo build --manifest-path resilient/Cargo.toml` succeeds with any
       feature flags this PR touches
+- [ ] PR contains substantive source, test, documentation, or tooling changes
+      beyond claim metadata
 
 ## Stability impact
 
@@ -50,7 +57,8 @@ Delete this section if it is purely internal / not surface-visible. -->
 
 - [ ] STABILITY.md CHANGELOG updated (if user-visible syntax or builtin
       changed)
-- [ ] GitHub Issue closed via `Closes #N` in the PR body
+- [ ] Agent PRs: `ready-or-bail.sh` passed, `agent-vetted` is applied, and
+      only then `Closes #N` is present
 
 ## Notes for reviewers
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,7 +61,9 @@ PRs that fail any CI test will not be merged.
 - Commits: `RES-NNN: short description` (≤72 chars).
 - All CI checks must be green: build, test, clippy, fmt, embedded
   cross-compile, size gate, perf gate.
-- Link the GitHub issue (`Closes #N`) in the PR body.
-- Close the GitHub Issue via `Closes #N` in the PR body.
+- Link the GitHub issue with `Refs #N` while the PR is draft.
+- Do not add `Closes #N` until the PR contains substantive work and the
+  guardrailed ready path has vetted it.
+- Do not ready, merge, or ask to merge empty or claim-only PRs.
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full checklist.

--- a/.github/workflows/agent-auto-merge.yml
+++ b/.github/workflows/agent-auto-merge.yml
@@ -5,11 +5,12 @@ name: agent-auto-merge
 # Preconditions — all must hold before a PR is eligible:
 #   1. PR is not a draft.
 #   2. PR has the `integration-synced` label (applied by sync-integration.sh).
-#   3. Every required check has conclusion == SUCCESS.
+#   3. PR has the `agent-vetted` label (applied by ready-or-bail.sh).
+#   4. Every required check has conclusion == SUCCESS.
 #      The diff-shape guardrail's "overlap" sub-check is allowed to be
 #      FAILURE here because the admin merge handles append-only conflicts;
 #      the shape-rules portion still must pass.
-#   4. PR base is `main`.
+#   5. PR base is `main`.
 #
 # The merge itself uses `gh pr merge --squash --auto` with GitHub's
 # auto-merge feature. That ensures a final freshness re-check happens
@@ -67,11 +68,13 @@ jobs:
             is_draft=$(echo "$info" | jq -r '.isDraft')
             base=$(echo "$info" | jq -r '.baseRefName')
             synced=$(echo "$info" | jq -r '[.labels[].name] | index("integration-synced") // empty')
+            vetted=$(echo "$info" | jq -r '[.labels[].name] | index("agent-vetted") // empty')
 
             if [[ "$state" != "OPEN" ]]; then echo "  state=$state — skip"; continue; fi
             if [[ "$is_draft" == "true" ]]; then echo "  draft — skip"; continue; fi
             if [[ "$base" != "main" ]]; then echo "  base=$base (not main) — skip"; continue; fi
             if [[ -z "$synced" ]]; then echo "  not integration-synced — skip"; continue; fi
+            if [[ -z "$vetted" ]]; then echo "  not agent-vetted — skip"; continue; fi
 
             # Exclude checks that aren't in branch protection's
             # required-status-checks list. Two known non-blocking checks

--- a/.github/workflows/release-file-claims.yml
+++ b/.github/workflows/release-file-claims.yml
@@ -26,7 +26,7 @@ jobs:
           BRANCH="${{ github.event.pull_request.head.ref }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
           MERGED="${{ github.event.pull_request.merged }}"
-          bash agent-scripts/release-claims.sh "$BRANCH"
+          bash agent-scripts/release-claims.sh "$BRANCH" "$PR_NUMBER"
 
           if [ "$MERGED" != "true" ]; then
             gh pr comment "$PR_NUMBER" --body "This PR was closed without merge. The branch claims were released and the ticket returned to the queue." >/dev/null || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,12 @@ Full setup, feature flags, and cross-compile instructions are in
 
 1. Browse [open issues](https://github.com/EricSpencer00/Resilient/issues?q=is%3Aissue+is%3Aopen).
 2. Comment to claim, then create a branch `res-NNN-short-title`.
-3. Open a draft PR early with `Closes #N` in the body.
+3. Open a draft PR early with `Refs #N` in the body.
 4. Use `agent-scripts/ready-or-bail.sh --pr N` to leave draft state.
-   Do not call `gh pr ready` directly for agent PRs.
-5. On merge, the issue closes automatically.
+   Do not call `gh pr ready` directly for agent PRs. The script verifies
+   substantive work, syncs integration, applies `agent-vetted`, and adds
+   `Closes #N`.
+5. On vetted merge, the issue closes automatically.
 6. If the active requester has write access and explicitly asks for an autonomous issue/PR cycle, treat that as approval to continue through the normal guardrailed merge workflow without a second confirmation.
 
 Commit format: `RES-NNN: short description` (≤72 chars).
@@ -145,3 +147,4 @@ local gate is green.
 - Leave half-implemented features with `TODO` markers — scope them to a
   follow-up ticket instead.
 - Force-push or amend commits that have been reviewed.
+- Ready, merge, or ask to merge empty or claim-only PRs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,8 +104,8 @@ the merge.** Your job is to make CI green.
    ```bash
    agent-scripts/claim-files.sh res-NNN-short-title resilient/src/lib.rs resilient/src/typechecker.rs resilient/src/lexer_logos.rs
    ```
-5. **Open a draft PR early** with `Closes #N` in the body — this signals
-   the ticket is taken.
+5. **Open a draft PR early** with `Refs #N` in the body — this signals the
+   ticket is taken without closing the issue before vetting.
 6. **Build, test, lint locally.** Match every CI gate (see "CI gates"
    below) before pushing. A red CI run wastes minutes you could spend
    shipping.
@@ -115,22 +115,24 @@ the merge.** Your job is to make CI green.
    ```bash
    agent-scripts/ready-or-bail.sh --pr N
    ```
-   This runs the local guardrail, syncs your branch onto
-   `agents/integration`, marks the PR ready, and applies the
-   `integration-synced` label that releases the auto-merge gate.
+   This runs the local guardrail, rejects empty or claim-only PRs, syncs your
+   branch onto `agents/integration`, marks the PR ready, applies
+   `integration-synced` and `agent-vetted`, and adds `Closes #N`.
    Do not call `gh pr ready` directly — the guardrail owns the
    draft-to-ready transition.
-9. **Walk away.** Once the PR is ready + integration-synced, the
+9. **Walk away.** Once the PR is ready + integration-synced + agent-vetted, the
    `agent-auto-merge` workflow watches CI. As soon as every required
    check is `SUCCESS`, GitHub squashes and merges the PR
-   (`gh pr merge --squash --auto --delete-branch`). The issue closes
-   automatically; file claims release on merge.
+   (`gh pr merge --squash --auto --delete-branch`). The issue closes only
+   after that vetted merge; file claims release on merge.
 
 If you spot CI fail-then-pass flakiness, open a follow-up ticket — do
 not retry blindly.
 
 Commit format: `RES-NNN: short description` (≤72 chars on the first line).
-Include a `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` trailer.
+Do not add a `Co-Authored-By` trailer unless the actual executor identity is
+explicitly configured and accurate. Never hardcode Claude, Codex, or another
+agent as coauthor.
 
 ---
 
@@ -433,14 +435,15 @@ workflow file.
 - **Action**: workflow runs `gh pr merge $PR --squash --auto --delete-branch`.
   GitHub's server-side auto-merge then waits for any in-flight checks
   to settle and lands the squash merge.
-- **Issue closure**: GitHub closes the issue when the squash commit
-  containing `Closes #N` lands on `main`.
+- **Issue closure**: `ready-or-bail.sh` adds `Closes #N` only after
+  substantive guardrails pass; the issue closes when that vetted squash commit
+  lands on `main`.
 - **File-claim release**: `.github/workflows/release-file-claims.yml`
   fires on the merge commit and clears the agent's claim entries.
 
-If your PR is ready + green but not merging, the most likely cause is
-a missing `integration-synced` label. Re-run `ready-or-bail.sh` to
-re-apply it.
+If your PR is ready + green but not merging, the most likely cause is a
+missing `integration-synced` or `agent-vetted` label. Re-run
+`ready-or-bail.sh` to re-apply the gate labels.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,10 @@ Welcome! Resilient is an open project for safety-critical embedded systems. Cont
 3. Create a branch named `res-NNN-short-title` (e.g., `res-376-contributing-guide`)
    - `NNN` is the issue number
    - Use lowercase with hyphens for multi-word titles
-4. Open a **draft PR** immediately with `Closes #NNN` in the description
+4. Open a **draft PR** immediately with `Refs #NNN` in the description
    - The draft PR is the canonical claim signal
-   - Convert to ready-for-review with `agent-scripts/ready-or-bail.sh --pr <number>` when you're done
+   - `agent-scripts/ready-or-bail.sh --pr <number>` adds `Closes #NNN`
+     only after it verifies substantive work and applies `agent-vetted`
 
 ---
 
@@ -67,16 +68,12 @@ RES-NNN: short description (≤72 characters)
 
 Optional longer explanation if the commit warrants it.
 Wrap at ~72 characters.
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 ### Examples
 
 ```
 RES-376: CONTRIBUTING.md documentation
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 ```
@@ -84,15 +81,15 @@ RES-150: fix clippy warning in type checker
 
 The pattern matching on Token could be simplified by using
 unreachable_patterns. Applied the suggestion.
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 ### Notes
 
 - The issue number `NNN` is **required**
 - First line must be ≤72 characters (git standard)
-- Include the `Co-Authored-By` trailer for all commits
+- Do not add a `Co-Authored-By` trailer unless the actual executor identity
+  is explicitly configured and accurate. Never hardcode Claude, Codex, or
+  another agent as coauthor.
 - **Push immediately** after each commit — don't accumulate local commits
 
 ---
@@ -345,19 +342,19 @@ Resilient tracks active work in GitHub Issues and pull requests. The
 `agent-ready` issue template is the live queue.
 
 - **OPEN**: Ticket is available; nobody is actively working on it
-- **CLAIMED**: An agent has opened a draft PR with `Closes #NNN`
-- **DONE**: PR is merged; the issue closes automatically when you add
-  `Closes #NNN` in the PR body
+- **CLAIMED**: An agent has opened a draft PR with `Refs #NNN`
+- **DONE**: A vetted PR is merged; the issue closes automatically after
+  `ready-or-bail.sh` has added `Closes #NNN`
 
 ### Workflow
 
 1. **Pick** an `agent-ready` issue.
 2. **Create a branch** named `res-NNN-short-title`.
-3. **Open a draft PR** immediately with `Closes #NNN` in the body.
+3. **Open a draft PR** immediately with `Refs #NNN` in the body.
 4. **Push after every commit** — don't accumulate local commits.
-5. **Mark ready for review** with `agent-scripts/ready-or-bail.sh --pr <number>` once the implementation and CI are green.
+5. **Mark ready for review** with `agent-scripts/ready-or-bail.sh --pr <number>` once the implementation and CI are green. The script rejects empty or claim-only PRs, applies `agent-vetted`, and adds `Closes #NNN` only after guardrails pass.
 6. **Monitor for feedback** via the PR comment subscription.
-7. Merge is automatic once CI is green and the PR has been synced; the issue closes.
+7. Merge is automatic once CI is green and the PR is synced and vetted; the issue closes only after that vetted merge.
 
 ### Legacy Local Ledger
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -9,5 +9,6 @@ GitHub Issues:
 
 Each issue has concrete, verifiable acceptance criteria. Claim one by
 commenting on it, create a branch named `res-NNN-short-title`, open a draft PR
-with `Closes #N` in the body, and land the work. Commit with
-`RES-NNN: one-line summary`.
+with `Refs #N` in the body, and land the work through
+`agent-scripts/ready-or-bail.sh`. That guardrail adds `Closes #N` only after
+substantive work is vetted. Commit with `RES-NNN: one-line summary`.

--- a/agent-scripts/README.md
+++ b/agent-scripts/README.md
@@ -16,7 +16,7 @@ file-claims + extension-point system introduced in PR #230.
 | `refresh-open-prs.sh` | Rebase every open non-draft PR branch against `main` after `main` advances |
 | `agent-status.sh` | One-screen or JSON view of worktrees, open PRs, queue health, claims, and the next ticket |
 | **`verify-scope.sh`** | Guardrail: diff-shape + fmt + clippy + test + overlap, writes JSON report |
-| **`ready-or-bail.sh`** | Runs `verify-scope.sh`; marks PR ready on green, posts failure comment on red |
+| **`ready-or-bail.sh`** | Runs `verify-scope.sh`; marks PR ready, labels `agent-vetted`, and adds `Closes #N` only on green |
 | **`orchestrator.sh`** | The grand loop: pick → dispatch → sub-agent → ready-or-bail |
 | **`ralph-loop.sh`** | The reusable open-ended improvement loop, preloaded with the Ralph prompt |
 
@@ -98,7 +98,7 @@ own pipeline) with `--skip tests --skip clippy --skip fmt`.
 `pick-ticket.sh` excludes an issue if:
 
 - It isn't labeled `agent-ready`, or it's closed.
-- An open PR references it — either `Closes #N` in the body, a matching
+- An open PR references it — either `Refs #N` or `Closes #N` in the body, a matching
   `RES-NNN` in the title/body/branch, or a `res-NNN-*` branch name.
 - It's assigned to a human (non-bot). The Copilot and Claude bot
   accounts are treated as non-human and don't block the pick.
@@ -114,9 +114,12 @@ own pipeline) with `--skip tests --skip clippy --skip fmt`.
 
 - Always branches off `origin/main`, not off any in-flight branch.
 - Creates the worktree at `.claude/worktrees/res-<N>/`.
-- Opens a draft PR with `Closes #<N>` so `pick-ticket.sh` sees it as
-  claimed on the next run. An empty claim commit lets `gh pr create`
-  compute a diff.
+- Opens a draft PR with `Refs #<N>` so `pick-ticket.sh` sees it as claimed
+  without closing the issue. An empty claim commit lets `gh pr create`
+  compute a diff, but that metadata alone must never be readied or merged.
+- `ready-or-bail.sh` is the only agent path that may add `Closes #<N>`; it
+  does so after substantive guardrails pass and the PR receives
+  `agent-vetted`.
 - Does **not** run the agent itself. The caller (a human, another
   script, or a spawned Claude agent) does the actual work inside the
   worktree.

--- a/agent-scripts/agent-profile.sh
+++ b/agent-scripts/agent-profile.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Shared defaults for autonomous agent loops.
+#
+# Keep this agent-neutral. Callers may export any value before launching:
+#   AGENT_CMD="claude -p --permission-mode acceptEdits"
+#   AGENT_CMD="codex exec"
+#   AGENT_COAUTHOR_NAME="..."
+#   AGENT_COAUTHOR_EMAIL="..."
+
+REPO_ROOT="${REPO_ROOT:-${PRIMARY_ROOT:-$(git rev-parse --show-toplevel)}}"
+
+: "${AGENT_DISPLAY_NAME:=Resilient Agent}"
+: "${AGENT_GITHUB_USER:=}"
+: "${AGENT_CMD:=${RESILIENT_IMPROVEMENT_AGENT_CMD:-codex exec}}"
+: "${AGENT_COAUTHOR_NAME:=}"
+: "${AGENT_COAUTHOR_EMAIL:=}"
+: "${AGENT_LOOP_PROMPT_FILE:=$REPO_ROOT/.board/prompts/ralph-loop.md}"
+: "${AGENT_BOT_LOGINS:=Copilot,Claude,claude,copilot-swe-agent,anthropic-code-agent,codex}"
+
+export AGENT_DISPLAY_NAME
+export AGENT_GITHUB_USER
+export AGENT_CMD
+export AGENT_COAUTHOR_NAME
+export AGENT_COAUTHOR_EMAIL
+export AGENT_LOOP_PROMPT_FILE
+export AGENT_BOT_LOGINS

--- a/agent-scripts/agent-status.sh
+++ b/agent-scripts/agent-status.sh
@@ -5,7 +5,7 @@
 #   - active worktrees in .claude/worktrees/
 #   - open PRs (by author kind: human / copilot / claude)
 #   - queue-health counts for ready-ish, stale, and unclaimed PRs
-#   - unclaimed open PRs (no `Closes #N` in body)
+#   - unclaimed open PRs (no `Refs #N`, `Closes #N`, or RES-NNN marker)
 #   - stale PRs (>72h without an update)
 #   - stale claims whose branch no longer has an open PR
 #
@@ -68,8 +68,8 @@ import re
 
 prs = json.loads(os.environ.get("PRS_JSON") or "[]")
 claims = json.loads(os.environ.get("CLAIMS_JSON") or '{"claims":{}}').get("claims", {})
-now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
-ref_re = re.compile(r"(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
+now = dt.datetime.now(dt.timezone.utc)
+ref_re = re.compile(r"(?:refs|closes|fixes|resolves)\s+#(\d+)|\bRES-(\d+)\b", re.IGNORECASE)
 
 main_prs = [pr for pr in prs if pr.get("baseRefName") == "main"]
 draft_prs = [pr for pr in prs if pr.get("isDraft")]
@@ -85,7 +85,8 @@ for pr in prs:
         age_h = 0
     if age_h >= 72:
         stale_prs.append({"number": pr["number"], "title": pr.get("title") or "", "age_h": age_h})
-    if not ref_re.findall(pr.get("body") or ""):
+    haystack = " ".join([pr.get("title") or "", pr.get("body") or "", pr.get("headRefName") or ""])
+    if not ref_re.findall(haystack):
         unclaimed_prs.append(pr["number"])
 
 open_heads = {pr.get("headRefName") for pr in prs if pr.get("headRefName")}
@@ -148,8 +149,8 @@ if not prs:
     print("  (none)")
     sys.exit(0)
 
-now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
-ref_re = re.compile(r"(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
+now = dt.datetime.now(dt.timezone.utc)
+ref_re = re.compile(r"(?:refs|closes|fixes|resolves)\s+#(\d+)|\bRES-(\d+)\b", re.IGNORECASE)
 
 for pr in sorted(prs, key=lambda p: p["updatedAt"]):
     login = pr["author"].get("login") or "?"
@@ -157,8 +158,12 @@ for pr in sorted(prs, key=lambda p: p["updatedAt"]):
     age_h = int((now - dt.datetime.fromisoformat(pr["updatedAt"].replace("Z", "+00:00"))).total_seconds() // 3600)
     stale = " [STALE]" if age_h >= 72 else ""
     draft = " [draft]" if pr["isDraft"] else ""
-    closes = ref_re.findall(pr.get("body") or "")
-    claim = f" closes #{','.join(closes)}" if closes else " [UNCLAIMED]"
+    refs = []
+    for match in ref_re.findall(" ".join([pr.get("title") or "", pr.get("body") or ""])):
+        issue = match[0] or match[1]
+        if issue and issue not in refs:
+            refs.append(issue)
+    claim = f" refs #{','.join(refs)}" if refs else " [UNCLAIMED]"
     base = "" if pr.get("baseRefName") == "main" else f" [base:{pr.get('baseRefName') or '?'}]"
     print(f"  #{pr['number']:>4} [{kind:<7}] {age_h:>3}h{draft}{stale}{claim}{base}  {pr['title'][:70]}")
 PYEOF

--- a/agent-scripts/dispatch-agent.sh
+++ b/agent-scripts/dispatch-agent.sh
@@ -7,8 +7,8 @@
 #      new branch `res-<N>-<short-slug>` based on origin/main.
 #   3. Extracts expected file ownership from the issue form and refuses
 #      overlapping dispatches before the agent starts editing.
-#   4. Opens a draft PR against origin/main with `Closes #<N>` so the
-#      ticket is visibly claimed.
+#   4. Opens a draft PR against origin/main with `Refs #<N>` so the ticket is
+#      visibly claimed without closing the issue before vetting.
 #   5. Prints the worktree path + branch + PR URL.
 #
 # Usage:
@@ -173,10 +173,11 @@ fi
 PR_URL="$(cd "$WORKTREE" && gh pr create --draft --base main --head "$BRANCH" \
   --title "RES-${ISSUE}: ${TITLE#RES-*: }" \
   --body "$(cat <<EOF
-Closes #${ISSUE}.
+Refs #${ISSUE}.
 
 Draft PR auto-opened by \`agent-scripts/dispatch-agent.sh\` to claim the
-ticket. The agent will push real work here shortly.
+ticket. \`agent-scripts/ready-or-bail.sh\` will add \`Closes #${ISSUE}\`
+only after it verifies substantive work and marks this PR ready.
 
 Branch: \`${BRANCH}\`
 Worktree: \`${WORKTREE#${PRIMARY_ROOT}/}\`

--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,3 @@
 {
-  "claims": {
-    "resilient/src/typechecker.rs": {
-      "branch": "res-2810-register-missing-builtins",
-      "claimed_at": "2026-05-31T14:03:04Z"
-    }
-  }
+  "claims": {}
 }

--- a/agent-scripts/orchestrator.sh
+++ b/agent-scripts/orchestrator.sh
@@ -31,11 +31,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+if [ -f "$SCRIPT_DIR/agent-profile.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/agent-profile.sh"
+fi
+
 N=1
 UNBOUNDED=0
 PARALLEL=1
 DRY_RUN=0
-AGENT_CMD="${AGENT_CMD:-claude -p --permission-mode acceptEdits}"
+AGENT_CMD="${AGENT_CMD:?set AGENT_CMD or RESILIENT_IMPROVEMENT_AGENT_CMD}"
 LOOP_PROMPT_FILE="${AGENT_LOOP_PROMPT_FILE:-}"
 
 while [[ $# -gt 0 ]]; do
@@ -80,6 +85,12 @@ run_one() {
   gh issue view "$issue" --json title,body -q '.title + "\n\n" + .body' > "$body_file"
 
   local prompt_file="/tmp/agent-prompt-${issue}.md"
+  local coauthor_instruction
+  if [ -n "${AGENT_COAUTHOR_NAME:-}" ] && [ -n "${AGENT_COAUTHOR_EMAIL:-}" ]; then
+    coauthor_instruction="If and only if that is accurate for the executor that performed the work, include this trailer on implementation commits: Co-Authored-By: ${AGENT_COAUTHOR_NAME} <${AGENT_COAUTHOR_EMAIL}>."
+  else
+    coauthor_instruction="Do not add a Co-Authored-By trailer unless this run explicitly configured the executor identity. Never hardcode Claude, Codex, or any other agent as coauthor."
+  fi
   {
     if [ -n "$LOOP_PROMPT_FILE" ] && [ -f "$LOOP_PROMPT_FILE" ]; then
       cat "$LOOP_PROMPT_FILE"
@@ -88,7 +99,7 @@ run_one() {
     cat <<EOF
 You are working on Resilient. A worktree is prepared at:
   ${worktree}
-Branch is pushed and tracks origin. Draft PR is #${pr} with 'Closes #${issue}'.
+Branch is pushed and tracks origin. Draft PR is #${pr} with 'Refs #${issue}'.
 The single existing commit is an empty claim commit — don't amend it, add new commits on top.
 
 Your ticket (from GitHub):
@@ -106,7 +117,7 @@ Rules (enforced post-hoc by agent-scripts/verify-scope.sh, which decides whether
 Work in this order:
   1. cd ${worktree}
   2. Read CLAUDE.md, explore the relevant source files.
-  3. Implement. Commit in logical chunks with 'RES-${issue}: ...' subject lines and a Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com> trailer.
+  3. Implement a substantive improvement. Commit in logical chunks with 'RES-${issue}: ...' subject lines. ${coauthor_instruction}
   4. Push (the branch already tracks).
   5. Run agent-scripts/ready-or-bail.sh --pr ${pr}. If it fails, read the comment it posts, fix the issues, push again, re-run. Do NOT run 'gh pr ready' manually — let the guardrail decide.
 

--- a/agent-scripts/pick-ticket.sh
+++ b/agent-scripts/pick-ticket.sh
@@ -4,7 +4,7 @@
 # Filters:
 #   - label `agent-ready`
 #   - state open
-#   - no open PR whose body or branch references `#<number>`
+#   - no open PR whose title, body, or branch references `#<number>`
 #   - not assigned (or only the agent bots)
 #
 # Ordering:

--- a/agent-scripts/ready-or-bail.sh
+++ b/agent-scripts/ready-or-bail.sh
@@ -79,10 +79,28 @@ PYEOF
           --summary "$BODY" >/dev/null || true
         exit 1
       fi
-    fi
+  fi
 
-    gh pr ready "$PR" 2>&1 | tail -2
-    if [ "$PRE_SYNC_HEAD" != "$POST_SYNC_HEAD" ]; then
+  gh pr ready "$PR" 2>&1 | tail -2
+  gh label create "agent-vetted" \
+    --color "0E8A16" \
+    --description "ready-or-bail passed substantive local guardrails and integration sync" \
+    >/dev/null 2>&1 || true
+  gh pr edit "$PR" --add-label "agent-vetted" >/dev/null
+
+  BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/resilient-pr-body.XXXXXX")"
+  gh pr view "$PR" --json body -q '.body // ""' > "$BODY_FILE"
+  ISSUE="$(sed -nE 's/.*([Rr]efs|[Cc]loses) #([0-9]+).*/\2/p' "$BODY_FILE" | head -1 || true)"
+  if [ -n "$ISSUE" ] && ! grep -qiE "(^|[^A-Za-z])Closes #${ISSUE}([^0-9]|$)" "$BODY_FILE"; then
+    {
+      cat "$BODY_FILE"
+      printf '\n\nCloses #%s\n' "$ISSUE"
+    } > "${BODY_FILE}.next"
+    gh pr edit "$PR" --body-file "${BODY_FILE}.next" >/dev/null
+  fi
+  rm -f "$BODY_FILE" "${BODY_FILE}.next"
+
+  if [ "$PRE_SYNC_HEAD" != "$POST_SYNC_HEAD" ]; then
       READY_BODY="Guardrail passed ✓ — fmt, clippy, tests, diff-shape, overlap. Synced against \`agents/integration\` and rechecked on the refreshed branch. Auto-merge will fire once remaining checks complete."
     else
       READY_BODY="Guardrail passed ✓ — fmt, clippy, tests, diff-shape, overlap. Synced against \`agents/integration\`. Auto-merge will fire once remaining checks complete."

--- a/agent-scripts/release-claims.sh
+++ b/agent-scripts/release-claims.sh
@@ -55,6 +55,19 @@ fi
 
 echo "Resolved merged PR #${PR_NUMBER} for branch ${BRANCH}."
 
+PR_STATE="$(gh pr view "$PR_NUMBER" --json state -q .state 2>/dev/null || echo "UNKNOWN")"
+PR_MERGED_AT="$(gh pr view "$PR_NUMBER" --json mergedAt -q '.mergedAt // ""' 2>/dev/null || true)"
+if [ "$PR_STATE" != "MERGED" ] && [ -z "$PR_MERGED_AT" ]; then
+  echo "PR #${PR_NUMBER} is ${PR_STATE}; claims released but linked-issue closure skipped."
+  exit 0
+fi
+
+if ! gh pr view "$PR_NUMBER" --json labels -q '.labels[].name' | grep -Fxq "agent-vetted"; then
+  echo "PR #${PR_NUMBER} is not agent-vetted; claims released but linked-issue closure skipped."
+  gh pr comment "$PR_NUMBER" --body "Linked issue closure skipped because this merged PR was not marked \`agent-vetted\` by \`agent-scripts/ready-or-bail.sh\`." >/dev/null || true
+  exit 0
+fi
+
 CLOSING_ISSUES="$(python3 - "$PR_NUMBER" "$REPO_SLUG" <<'PYEOF'
 import json
 import os

--- a/agent-scripts/verify-scope.sh
+++ b/agent-scripts/verify-scope.sh
@@ -76,7 +76,20 @@ for entry in "${MAPFILE_DIFF[@]}"; do
   esac
 done
 
-# Rule 1a: existing tests can't be weakened.
+# Rule 1a: agent PRs must contain real work. The initial claim commit and
+# file-claims registry changes are orchestration metadata, not an improvement.
+SUBSTANTIVE_FILES=()
+for f in "${MODIFIED_FILES[@]}" "${ADDED_FILES[@]}" "${DELETED_FILES[@]}"; do
+  case "$f" in
+    ""|agent-scripts/file-claims.json) ;;
+    *) SUBSTANTIVE_FILES+=("$f") ;;
+  esac
+done
+if (( ${#SUBSTANTIVE_FILES[@]} == 0 )); then
+  fail "no substantive changes beyond claim metadata — do not ready or merge empty/claim-only PRs"
+fi
+
+# Rule 1b: existing tests can't be weakened.
 #
 # We allow modifications to test files (mechanical renames across the
 # suite are common — e.g. when a public API or env var name changes),
@@ -201,8 +214,8 @@ if bad:
 PYEOF
 fi
 
-# Rule 1f: claim commit stays at the bottom (if present) — the orchestrator
-# needs the empty claim commit so the PR's "Closes #N" is preserved.
+# Rule 1f: claim commit stays at the bottom (if present). It is only claim
+# metadata; ready-or-bail adds "Closes #N" after substantive guardrails pass.
 FIRST_COMMIT_MSG=$(git log --format=%s "${BASE}..${HEAD}" --reverse 2>/dev/null | head -1)
 if [[ "$FIRST_COMMIT_MSG" =~ ^res-[0-9]+:\ claim\ ticket ]]; then
   pass "claim commit preserved at base of branch"

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -29,13 +29,13 @@ safely re-converges.
 | Stage | Mechanism | Output |
 |---|---|---|
 | Pick | `pick-ticket.sh` | `<issue-number>\t<title>` from the highest-priority eligible issue |
-| Dispatch | `dispatch-agent.sh --issue N` | Worktree at `.claude/worktrees/res-N/`, draft PR with `Closes #N` |
+| Dispatch | `dispatch-agent.sh --issue N` | Worktree at `.claude/worktrees/res-N/`, draft PR with `Refs #N` |
 | Implement | (agent free-form) | Follow feature-isolation pattern in CLAUDE.md |
-| Verify | `ready-or-bail.sh --pr P` | Runs `verify-scope.sh` + `sync-integration.sh`; reruns `verify-scope.sh` if sync moved HEAD; marks PR ready on green |
+| Verify | `ready-or-bail.sh --pr P` | Runs `verify-scope.sh` + `sync-integration.sh`; reruns `verify-scope.sh` if sync moved HEAD; rejects empty or claim-only PRs; marks PR ready, applies `agent-vetted`, and adds `Closes #N` on green |
 | Sync | `sync-integration.sh` (called by ready-or-bail) | Rebases branch onto `origin/main`, fast-forwards `agents/integration`, stamps PR with `integration-synced` label |
-| Auto-merge | `agent-auto-merge.yml` (CI) | Enables `gh pr merge --auto` when every check is green AND PR is labeled `integration-synced` |
+| Auto-merge | `agent-auto-merge.yml` (CI) | Enables `gh pr merge --auto` when every check is green AND PR is labeled `integration-synced` and `agent-vetted` |
 | Follow-main | `integration-follow-main.yml` (CI) | Fast-forwards `agents/integration` to `main` after every merge, refreshes every open non-draft PR branch against `main`, and runs a periodic safety sweep |
-| Release | `release-file-claims.yml` (CI) | `agent-scripts/file-claims.json` cleared for the branch on PR close; linked issues are explicitly closed or flagged if the close fails; stale claims are swept and closed PRs re-enter the queue |
+| Release | `release-file-claims.yml` (CI) | `agent-scripts/file-claims.json` cleared for the branch on PR close; linked issues close only for merged `agent-vetted` PRs; stale claims are swept so closed PRs don't re-enter the queue |
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -81,10 +81,11 @@ Each issue carries a unique `RES-NNN` identifier, a clear goal,
 priority, roadmap goal, and concrete acceptance criteria.
 
 - **Claiming a ticket**: create a branch named `res-NNN-short-title`
-  and open a draft PR with `Closes #N` in the body. Commenting on the
+  and open a draft PR with `Refs #N` in the body. Commenting on the
   issue is optional.
-- **Landing a ticket**: open a PR with `Closes #N` in the body; the
-  commit message should reference the ticket ID
+- **Landing a ticket**: for agent PRs, run `agent-scripts/ready-or-bail.sh`
+  so substantive guardrails pass before `Closes #N` is added. The commit
+  message should reference the ticket ID
   (e.g. `RES-042: add float division`).
 - **Opening a ticket**: file a GitHub issue using the Agent-Ready
   Ticket template with a clear goal and acceptance criteria.


### PR DESCRIPTION
Hardens the agent orchestration workflow so future autonomous PRs cannot bypass substantive vetting.

Changes:
- Draft claim PRs use `Refs #N`; `ready-or-bail.sh` adds closing refs only after guardrails pass.
- `agent-vetted` is created/applied by `ready-or-bail.sh`; auto-merge now requires both `integration-synced` and `agent-vetted`.
- Removes hardcoded Claude coauthor instructions; coauthor trailers require explicit executor identity config.
- Rejects empty/no-diff/claim-only PRs even when CI passes.
- Cleans stale file-claim state and documents the new workflow contract.

Validation:
- `bash -n` on touched scripts
- YAML parse for touched workflows
- `git diff --check origin/main..HEAD`
- `agent-scripts/agent-status.sh --json`
- `agent-scripts/pick-ticket.sh --json`

No issue-closing keyword here; this PR deploys the workflow contract itself.