### PR TITLE
RES-3391: associated_constants check needs malformed-input regression corpus

### DIFF
--- a/resilient/src/associated_constants.rs
+++ b/resilient/src/associated_constants.rs
@@ -17,7 +17,7 @@
 #![allow(clippy::collapsible_if, clippy::doc_lazy_continuation, dead_code)]
 
 use crate::Node;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, RwLock};
 
 #[derive(Debug, Clone)]
@@ -45,32 +45,157 @@ pub fn collect() -> Vec<AssocConstant> {
     // attribute record (skipped when tr/name/val don't parse).
     let mut out = Vec::with_capacity(attrs.len());
     for (item, rec) in attrs {
-        let mut tr = String::new();
-        let mut name = String::new();
-        let mut val = String::new();
-        for chunk in rec.args.split(',') {
-            let chunk = chunk.trim();
-            if let Some((k, v)) = chunk.split_once('=') {
-                let k = k.trim();
-                let v = v.trim().trim_matches('"');
-                match k {
-                    "trait" => tr = v.to_string(),
-                    "name" => name = v.to_string(),
-                    "value" => val = v.to_string(),
-                    _ => {}
-                }
-            }
-        }
-        if !name.is_empty() {
-            out.push(AssocConstant {
-                type_name: item,
-                trait_name: tr,
-                const_name: name,
-                value: val,
-            });
+        if let Ok(constant) = parse_assoc_const_record(item, &rec, "assoc_const") {
+            out.push(constant);
         }
     }
     out
+}
+
+fn parse_assoc_const_record(
+    item: String,
+    rec: &crate::feature_attrs::AttrRecord,
+    source_path: &str,
+) -> Result<AssocConstant, String> {
+    if rec.args.trim().is_empty() {
+        return Err(assoc_const_diag(
+            source_path,
+            rec.line,
+            format!("#[assoc_const] on `{item}` missing required `trait` argument"),
+        ));
+    }
+
+    let mut trait_name = None;
+    let mut const_name = None;
+    let mut value = None;
+
+    for chunk in rec.args.split(',') {
+        let chunk = chunk.trim();
+        if chunk.is_empty() {
+            return Err(assoc_const_diag(
+                source_path,
+                rec.line,
+                format!("#[assoc_const] on `{item}` has empty argument"),
+            ));
+        }
+
+        let Some((raw_key, raw_value)) = chunk.split_once('=') else {
+            return Err(assoc_const_diag(
+                source_path,
+                rec.line,
+                format!("#[assoc_const] on `{item}` has malformed argument `{chunk}`"),
+            ));
+        };
+
+        let key = raw_key.trim();
+        if key.is_empty() {
+            return Err(assoc_const_diag(
+                source_path,
+                rec.line,
+                format!("#[assoc_const] on `{item}` has malformed argument `{chunk}`"),
+            ));
+        }
+
+        let parsed_value = parse_assoc_const_arg_value(&item, rec, source_path, key, raw_value)?;
+        match key {
+            "trait" => set_assoc_arg(&mut trait_name, &item, rec, source_path, key, parsed_value)?,
+            "name" => set_assoc_arg(&mut const_name, &item, rec, source_path, key, parsed_value)?,
+            "value" => set_assoc_arg(&mut value, &item, rec, source_path, key, parsed_value)?,
+            _ => {
+                return Err(assoc_const_diag(
+                    source_path,
+                    rec.line,
+                    format!("#[assoc_const] on `{item}` has unknown argument `{key}`"),
+                ));
+            }
+        }
+    }
+
+    let trait_name = trait_name.ok_or_else(|| {
+        assoc_const_diag(
+            source_path,
+            rec.line,
+            format!("#[assoc_const] on `{item}` missing required `trait` argument"),
+        )
+    })?;
+    let const_name = const_name.ok_or_else(|| {
+        assoc_const_diag(
+            source_path,
+            rec.line,
+            format!("#[assoc_const] on `{item}` missing required `name` argument"),
+        )
+    })?;
+    let value = value.ok_or_else(|| {
+        assoc_const_diag(
+            source_path,
+            rec.line,
+            format!("#[assoc_const] on `{item}` missing required `value` argument"),
+        )
+    })?;
+
+    Ok(AssocConstant {
+        type_name: item,
+        trait_name,
+        const_name,
+        value,
+    })
+}
+
+fn parse_assoc_const_arg_value(
+    item: &str,
+    rec: &crate::feature_attrs::AttrRecord,
+    source_path: &str,
+    key: &str,
+    raw_value: &str,
+) -> Result<String, String> {
+    let trimmed = raw_value.trim();
+    let Some(value) = trimmed
+        .strip_prefix('"')
+        .and_then(|without_prefix| without_prefix.strip_suffix('"'))
+    else {
+        return Err(assoc_const_diag(
+            source_path,
+            rec.line,
+            format!("#[assoc_const] on `{item}` argument `{key}` must be a quoted string"),
+        ));
+    };
+
+    if value.is_empty() {
+        return Err(assoc_const_diag(
+            source_path,
+            rec.line,
+            format!("#[assoc_const] on `{item}` argument `{key}` must not be empty"),
+        ));
+    }
+
+    Ok(value.to_string())
+}
+
+fn set_assoc_arg(
+    slot: &mut Option<String>,
+    item: &str,
+    rec: &crate::feature_attrs::AttrRecord,
+    source_path: &str,
+    key: &str,
+    value: String,
+) -> Result<(), String> {
+    if slot.is_some() {
+        return Err(assoc_const_diag(
+            source_path,
+            rec.line,
+            format!("#[assoc_const] on `{item}` has duplicate `{key}` argument"),
+        ));
+    }
+
+    *slot = Some(value);
+    Ok(())
+}
+
+fn assoc_const_diag(source_path: &str, line: usize, message: impl AsRef<str>) -> String {
+    format!(
+        "{source_path}:{line}:0: error[assoc-const]: {}",
+        message.as_ref()
+    )
 }
 
 pub fn install(items: Vec<AssocConstant>) {
@@ -104,10 +229,28 @@ pub(crate) fn check(_program: &Node, _source_path: &str) -> Result<(), String> {
     // wipe-on-empty test race documented in RES-1302 against any
     // test that calls `install` directly under
     // `feature_attrs::lock_for_test()`.
-    let items = collect();
-    if items.is_empty() {
+    let attrs = crate::feature_attrs::find_kind("assoc_const");
+    if attrs.is_empty() {
         return Ok(());
     }
+    let mut items = Vec::with_capacity(attrs.len());
+    let mut seen = HashSet::with_capacity(attrs.len());
+
+    for (item, rec) in attrs {
+        let constant = parse_assoc_const_record(item, &rec, _source_path)?;
+        if !seen.insert((constant.type_name.clone(), constant.const_name.clone())) {
+            return Err(assoc_const_diag(
+                _source_path,
+                rec.line,
+                format!(
+                    "duplicate associated constant `{}` for type `{}`",
+                    constant.const_name, constant.type_name
+                ),
+            ));
+        }
+        items.push(constant);
+    }
+
     install(items);
     Ok(())
 }
@@ -179,6 +322,220 @@ mod tests {
         let src = "fn f(int x) -> int { return x; }\n";
         let (prog, _) = crate::parse(src);
         assert!(check(&prog, "test").is_ok());
+        crate::feature_attrs::reset();
+    }
+
+    fn sample_program() -> Node {
+        let src = "fn f(int x) -> int { return x; }\n";
+        let (prog, _) = crate::parse(src);
+        prog
+    }
+
+    fn record_assoc_const(item: &str, args: &str, line: usize) {
+        crate::feature_attrs::record(
+            item,
+            crate::feature_attrs::AttrRecord {
+                name: "assoc_const".into(),
+                args: args.into(),
+                line,
+            },
+        );
+    }
+
+    struct ValidAssocConstCase<'a> {
+        name: &'a str,
+        records: &'a [AssocConstRecord<'a>],
+        expected_lookups: &'a [ExpectedAssocConstLookup<'a>],
+    }
+
+    struct AssocConstRecord<'a> {
+        item: &'a str,
+        args: &'a str,
+        line: usize,
+    }
+
+    struct ExpectedAssocConstLookup<'a> {
+        type_name: &'a str,
+        const_name: &'a str,
+        value: &'a str,
+    }
+
+    #[test]
+    fn check_rejects_malformed_assoc_const_matrix() {
+        let _g = crate::feature_attrs::lock_for_test();
+        let program = sample_program();
+        let cases = [
+            (
+                "missing trait",
+                "Temperature",
+                r#"name = "MIN", value = "-40""#,
+                3,
+                "test.rz:3:0: error[assoc-const]: #[assoc_const] on `Temperature` missing required `trait` argument",
+            ),
+            (
+                "missing name",
+                "Temperature",
+                r#"trait = "Bounded", value = "-40""#,
+                4,
+                "test.rz:4:0: error[assoc-const]: #[assoc_const] on `Temperature` missing required `name` argument",
+            ),
+            (
+                "missing value",
+                "Temperature",
+                r#"trait = "Bounded", name = "MIN""#,
+                5,
+                "test.rz:5:0: error[assoc-const]: #[assoc_const] on `Temperature` missing required `value` argument",
+            ),
+            (
+                "duplicate trait",
+                "Temperature",
+                r#"trait = "Bounded", trait = "Limits", name = "MIN", value = "-40""#,
+                6,
+                "test.rz:6:0: error[assoc-const]: #[assoc_const] on `Temperature` has duplicate `trait` argument",
+            ),
+            (
+                "unknown argument",
+                "Temperature",
+                r#"trait = "Bounded", name = "MIN", value = "-40", units = "C""#,
+                7,
+                "test.rz:7:0: error[assoc-const]: #[assoc_const] on `Temperature` has unknown argument `units`",
+            ),
+            (
+                "malformed argument",
+                "Temperature",
+                r#"trait = "Bounded", name "MIN", value = "-40""#,
+                8,
+                "test.rz:8:0: error[assoc-const]: #[assoc_const] on `Temperature` has malformed argument `name \"MIN\"`",
+            ),
+            (
+                "empty value",
+                "Temperature",
+                r#"trait = "Bounded", name = "MIN", value = """#,
+                9,
+                "test.rz:9:0: error[assoc-const]: #[assoc_const] on `Temperature` argument `value` must not be empty",
+            ),
+            (
+                "unquoted trait",
+                "Temperature",
+                r#"trait = Bounded, name = "MIN", value = "-40""#,
+                10,
+                "test.rz:10:0: error[assoc-const]: #[assoc_const] on `Temperature` argument `trait` must be a quoted string",
+            ),
+        ];
+
+        for (case, item, args, line, expected) in cases {
+            crate::feature_attrs::reset();
+            record_assoc_const(item, args, line);
+            let err = check(&program, "test.rz").expect_err(case);
+            assert_eq!(err, expected, "{case}");
+        }
+
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_rejects_duplicate_assoc_const_declaration() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        let program = sample_program();
+        record_assoc_const(
+            "Temperature",
+            r#"trait = "Bounded", name = "MIN", value = "-40""#,
+            12,
+        );
+        record_assoc_const(
+            "Temperature",
+            r#"trait = "Limits", name = "MIN", value = "-50""#,
+            13,
+        );
+
+        let err = check(&program, "test.rz").expect_err("duplicate declaration must fail");
+        assert_eq!(
+            err,
+            "test.rz:13:0: error[assoc-const]: duplicate associated constant `MIN` for type `Temperature`"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn check_accepts_valid_assoc_const_baselines() {
+        let _g = crate::feature_attrs::lock_for_test();
+        let program = sample_program();
+        let cases = [
+            ValidAssocConstCase {
+                name: "single constant",
+                records: &[AssocConstRecord {
+                    item: "Temperature",
+                    args: r#"trait = "Bounded", name = "MIN", value = "-40""#,
+                    line: 20,
+                }],
+                expected_lookups: &[ExpectedAssocConstLookup {
+                    type_name: "Temperature",
+                    const_name: "MIN",
+                    value: "-40",
+                }],
+            },
+            ValidAssocConstCase {
+                name: "reordered arguments",
+                records: &[AssocConstRecord {
+                    item: "Temperature",
+                    args: r#"value = "125", name = "MAX", trait = "Bounded""#,
+                    line: 21,
+                }],
+                expected_lookups: &[ExpectedAssocConstLookup {
+                    type_name: "Temperature",
+                    const_name: "MAX",
+                    value: "125",
+                }],
+            },
+            ValidAssocConstCase {
+                name: "distinct constants on one type",
+                records: &[
+                    AssocConstRecord {
+                        item: "Volt",
+                        args: r#"trait = "Units", name = "UNIT", value = "V""#,
+                        line: 22,
+                    },
+                    AssocConstRecord {
+                        item: "Volt",
+                        args: r#"trait = "Bounded", name = "MAX", value = "48""#,
+                        line: 23,
+                    },
+                ],
+                expected_lookups: &[
+                    ExpectedAssocConstLookup {
+                        type_name: "Volt",
+                        const_name: "UNIT",
+                        value: "V",
+                    },
+                    ExpectedAssocConstLookup {
+                        type_name: "Volt",
+                        const_name: "MAX",
+                        value: "48",
+                    },
+                ],
+            },
+        ];
+
+        for case in cases {
+            crate::feature_attrs::reset();
+            for record in case.records {
+                record_assoc_const(record.item, record.args, record.line);
+            }
+
+            check(&program, "test.rz").unwrap_or_else(|err| panic!("{}: {err}", case.name));
+            for expected in case.expected_lookups {
+                assert_eq!(
+                    lookup(expected.type_name, expected.const_name),
+                    Some(expected.value.to_string()),
+                    "{}: lookup {}::{}",
+                    case.name,
+                    expected.type_name,
+                    expected.const_name
+                );
+            }
+        }
+
         crate::feature_attrs::reset();
     }
 }


### PR DESCRIPTION
Refs #3391.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. `agent-scripts/ready-or-bail.sh` will add `Closes #3391`
only after it verifies substantive work and marks this PR ready.

Branch: `res-3391-associated-constants-check-needs-malform`
Worktree: `.claude/worktrees/res-3391`

## Agent claims

(none inferred from issue)