### PR TITLE
RES-3385: validate mutex/rwlock builtin arguments in typechecker

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,16 +1,16 @@
 {
   "claims": {
-    "resilient/src/param_destructuring.rs": {
-      "branch": "res-3490-param-destructuring-align",
-      "claimed_at": "2026-06-12T19:41:50Z"
+    "resilient/src/mutex_rwlock.rs": {
+      "branch": "res-3385-validate-mutex-rwlock-builtin-arguments",
+      "claimed_at": "2026-06-12T20:11:02Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-3490-param-destructuring-align",
-      "claimed_at": "2026-06-12T19:41:50Z"
+      "branch": "res-3385-validate-mutex-rwlock-builtin-arguments",
+      "claimed_at": "2026-06-12T20:11:02Z"
     },
     "resilient/src/lib.rs": {
-      "branch": "res-3490-param-destructuring-align",
-      "claimed_at": "2026-06-12T19:41:50Z"
+      "branch": "res-3385-validate-mutex-rwlock-builtin-arguments",
+      "claimed_at": "2026-06-12T20:11:02Z"
     }
   }
 }


### PR DESCRIPTION
Refs #3385.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. `agent-scripts/ready-or-bail.sh` will add `Closes #3385`
only after it verifies substantive work and marks this PR ready.

Branch: `res-3385-validate-mutex-rwlock-builtin-arguments`
Worktree: `.claude/worktrees/res-3385`

## Agent claims

- resilient/src/mutex_rwlock.rs
- resilient/src/typechecker.rs
- resilient/src/lib.rs