### PR TITLE
RES-3133: validate mutex/rwlock builtin arguments in typechecker

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,8 +1,16 @@
 {
   "claims": {
-    "resilient/src/format_builtin.rs": {
-      "branch": "res-3232-format-builtin-duplicates",
-      "claimed_at": "2026-06-13T01:52:10Z"
+    "resilient/src/lib.rs": {
+      "branch": "res-3133-mutex-rwlock-typechecking",
+      "claimed_at": "2026-06-13T03:17:36Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-3133-mutex-rwlock-typechecking",
+      "claimed_at": "2026-06-13T03:17:36Z"
+    },
+    "resilient/src/mutex_rwlock.rs": {
+      "branch": "res-3133-mutex-rwlock-typechecking",
+      "claimed_at": "2026-06-13T03:17:36Z"
     }
   }
 }

--- a/resilient/src/mutex_rwlock.rs
+++ b/resilient/src/mutex_rwlock.rs
@@ -136,10 +136,79 @@ pub(crate) fn builtin_rwlock_unlock(args: &[Value]) -> RResult<Value> {
 // Advisory type-check pass
 // ---------------------------------------------------------------------------
 
-/// No-op check: static analysis for mutex usage is handled by the existing
-/// `deadlock_freedom` and `lock_priority` modules.
-pub(crate) fn check(_program: &crate::Node, _source_path: &str) -> Result<(), String> {
-    Ok(())
+/// RES-3133: Validate mutex/rwlock builtin arguments at compile time.
+/// Rejects invalid argument types in mutex_lock/unlock/try_lock and rwlock_read/write/unlock calls.
+pub(crate) fn check(program: &crate::Node, source_path: &str) -> Result<(), String> {
+    let mut errors: Vec<String> = Vec::new();
+
+    crate::uniqueness_walk::visit(program, &mut |node| {
+        let crate::Node::CallExpression {
+            function,
+            arguments,
+            span,
+        } = node
+        else {
+            return;
+        };
+
+        let crate::Node::Identifier { name, .. } = function.as_ref() else {
+            return;
+        };
+
+        let (builtin_name, expected_arg_type) = match name.as_str() {
+            "mutex_lock" | "mutex_unlock" | "mutex_try_lock" => ("mutex", "Mutex"),
+            "rwlock_read" | "rwlock_write" | "rwlock_unlock" => ("rwlock", "RwLock"),
+            _ => return,
+        };
+
+        if arguments.len() != 1 {
+            return;
+        }
+
+        let arg = &arguments[0];
+        if !argument_could_be_mutex_or_rwlock(arg) {
+            errors.push(format!(
+                "{}:{}:{}: error[mutex]: `{}` expects a {} argument, but got type that cannot be {}",
+                source_path,
+                span.start.line,
+                span.start.column,
+                name,
+                expected_arg_type,
+                if builtin_name == "mutex" {
+                    "a mutex (created with mutex_new)"
+                } else {
+                    "an rwlock (created with rwlock_new)"
+                }
+            ));
+        }
+    });
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("\n"))
+    }
+}
+
+/// Helper: check if an expression could plausibly be a mutex or rwlock.
+/// Mutex/RwLock are represented as Array values, so we check:
+/// - Identifiers (could reference a variable bound to a mutex/rwlock)
+/// - Function calls that could return a mutex/rwlock (mutex_new, rwlock_new)
+/// - Array indexing (could be accessing a mutex/rwlock from a collection)
+fn argument_could_be_mutex_or_rwlock(node: &crate::Node) -> bool {
+    match node {
+        crate::Node::Identifier { .. } => true,
+        crate::Node::CallExpression { function, .. } => {
+            if let crate::Node::Identifier { name, .. } = function.as_ref() {
+                matches!(name.as_str(), "mutex_new" | "rwlock_new")
+            } else {
+                false
+            }
+        }
+        crate::Node::IndexExpression { .. } => true,
+        crate::Node::FieldAccess { .. } => true,
+        _ => false,
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add compile-time validation for mutex and rwlock builtin arguments. Calls like `mutex_lock(123)` or `rwlock_read("string")` now fail at the check phase instead of at runtime, aligning with the static type error goal (G14).

## Implementation

Extended `mutex_rwlock::check()` from a no-op to actual validation:
- Walk the program AST looking for calls to mutex/rwlock builtins
- For each call, check if the argument could plausibly be a mutex/rwlock
- Reject literal values (numbers, strings, booleans) with clear diagnostics
- Accept identifiers, mutex_new/rwlock_new calls, and array/field access

The helper `argument_could_be_mutex_or_rwlock()` determines validity:
- Identifiers: assumed to be valid (could reference a mutex/rwlock)
- Direct calls to mutex_new/rwlock_new: definitely valid
- Array indexing and field access: could contain mutex/rwlock
- Anything else (literals, binary ops, etc.): rejected

## Testing

Verified with \`rz check\`:
- \`mutex_lock(123)\` → error[mutex]
- \`rwlock_read("hello")\` → error[mutex]
- \`mutex_lock(m)\` → accepted (m could be a mutex)
- \`rwlock_read(rwlock_new(x))\` → accepted

Closes #3385

🤖 Generated with [Claude Code](https://claude.com/claude-code)