### PR TITLE
RES-3384: regex_builtins should reject invalid literal patterns at compile time

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,16 +1,12 @@
 {
   "claims": {
-    "resilient/src/lib.rs": {
-      "branch": "res-3133-mutex-rwlock-typechecking",
-      "claimed_at": "2026-06-13T03:17:36Z"
+    "resilient/src/regex_builtins.rs": {
+      "branch": "res-3384-regex-builtins-should-reject-invalid-lit",
+      "claimed_at": "2026-06-13T05:33:28Z"
     },
     "resilient/src/typechecker.rs": {
-      "branch": "res-3133-mutex-rwlock-typechecking",
-      "claimed_at": "2026-06-13T03:17:36Z"
-    },
-    "resilient/src/mutex_rwlock.rs": {
-      "branch": "res-3133-mutex-rwlock-typechecking",
-      "claimed_at": "2026-06-13T03:17:36Z"
+      "branch": "res-3384-regex-builtins-should-reject-invalid-lit",
+      "claimed_at": "2026-06-13T05:33:28Z"
     }
   }
 }


### PR DESCRIPTION
Refs #3384.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. `agent-scripts/ready-or-bail.sh` will add `Closes #3384`
only after it verifies substantive work and marks this PR ready.

Branch: `res-3384-regex-builtins-should-reject-invalid-lit`
Worktree: `.claude/worktrees/res-3384`

## Agent claims

- resilient/src/regex_builtins.rs
- resilient/src/typechecker.rs