### PR TITLE
RES-3383: lint --emit-diagnostics-json should return parse diagnostics payload

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,3 +1,10 @@
 {
   "claims": {}
 }
+  "claims": {
+    "resilient/src/lib.rs": {
+      "branch": "res-3383-lint-emit-diagnostics-json-should-return",
+      "claimed_at": "2026-06-13T06:00:30Z"
+    }
+  }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -3419,6 +3419,7 @@ struct Parser {
     peek_line: usize,
     peek_column: usize,
     errors: Vec<String>,
+    emit_errors: bool,
     /// RES-156: fresh-name counter for array-comprehension
     /// desugaring. Each comprehension bumps this to mint a unique
     /// `_r$N` accumulator so nested / multiple comprehensions
@@ -3430,6 +3431,14 @@ struct Parser {
 
 impl Parser {
     fn new(lexer: Lexer) -> Self {
+        Self::new_with_emit_errors(lexer, true)
+    }
+
+    fn new_silent(lexer: Lexer) -> Self {
+        Self::new_with_emit_errors(lexer, false)
+    }
+
+    fn new_with_emit_errors(lexer: Lexer, emit_errors: bool) -> Self {
         let mut parser = Parser {
             lexer,
             current_token: Token::Eof,
@@ -3439,6 +3448,7 @@ impl Parser {
             peek_line: 1,
             peek_column: 1,
             errors: Vec::new(),
+            emit_errors,
             comprehension_counter: 0,
         };
 
@@ -3461,7 +3471,9 @@ impl Parser {
             return;
         }
         let full = format!("{}:{}: {}", self.current_line, self.current_column, msg);
-        eprintln!("\x1B[31mParser error: {}\x1B[0m", full);
+        if self.emit_errors {
+            eprintln!("\x1B[31mParser error: {}\x1B[0m", full);
+        }
         self.errors.push(full);
     }
 
@@ -29144,8 +29156,20 @@ fn dump_ast_json_to_stdout(src: &str) -> Result<(), Vec<String>> {
 /// parser error strings collected along the way. Used by both the
 /// driver and `imports::expand_uses`.
 fn parse(src: &str) -> (Node, Vec<String>) {
+    parse_with_emit_errors(src, true)
+}
+
+fn parse_silent(src: &str) -> (Node, Vec<String>) {
+    parse_with_emit_errors(src, false)
+}
+
+fn parse_with_emit_errors(src: &str, emit_errors: bool) -> (Node, Vec<String>) {
     let lexer = Lexer::new(src);
-    let mut parser = Parser::new(lexer);
+    let mut parser = if emit_errors {
+        Parser::new(lexer)
+    } else {
+        Parser::new_silent(lexer)
+    };
     let mut program = parser.parse_program();
     // RES-1343: `parser.errors` is already `Vec<String>`; move it
     // directly instead of the round-trip
@@ -29172,6 +29196,27 @@ fn parse(src: &str) -> (Node, Vec<String>) {
     // RES-2685: synthesize concrete ImplBlocks from BlanketImpl nodes.
     crate::blanket_impl::lower_program(&mut program);
     (program, errs)
+}
+
+fn parse_diagnostics_json_values<'a>(
+    parse_errs: impl IntoIterator<Item = &'a String>,
+    path: &Path,
+) -> Vec<serde_json::Value> {
+    let path_str = path.to_string_lossy();
+    parse_errs
+        .into_iter()
+        .map(|e| {
+            let (line, col, msg) = parse_error_location(e);
+            serde_json::json!({
+                "severity": "error",
+                "code": "parse",
+                "line": line,
+                "column": col,
+                "message": msg,
+                "file": path_str.as_ref(),
+            })
+        })
+        .collect()
 }
 
 /// Macro expansion helper: parse a single expression string into a `Node`.
@@ -31637,8 +31682,20 @@ fn dispatch_lint_subcommand(args: &[String]) -> Option<i32> {
             return Some(2);
         }
     };
-    let (program, parse_errs) = parse(&src);
+    let (program, parse_errs) = if emit_diagnostics_json {
+        parse_silent(&src)
+    } else {
+        parse(&src)
+    };
     if !parse_errs.is_empty() {
+        if emit_diagnostics_json {
+            let json_diags = parse_diagnostics_json_values(&parse_errs, &path);
+            println!(
+                "{}",
+                serde_json::to_string(&json_diags).expect("parse diagnostics JSON")
+            );
+            return Some(2);
+        }
         for e in &parse_errs {
             eprintln!("{}", e);
         }

--- a/resilient/tests/lint_parse_json.rs
+++ b/resilient/tests/lint_parse_json.rs
@@ -1,0 +1,69 @@
+//! RES-3383: parse errors in `rz lint --emit-diagnostics-json`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_file(tag: &str, body: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("res_3383_{}_{}_{}.rz", tag, std::process::id(), n));
+    std::fs::write(&path, body).expect("write scratch");
+    path
+}
+
+#[test]
+fn lint_emit_diagnostics_json_reports_parse_errors_as_json() {
+    let src = tmp_file("json_parse_error", "fn main( {\n");
+    let out = Command::new(bin())
+        .args(["lint"])
+        .arg(&src)
+        .arg("--emit-diagnostics-json")
+        .output()
+        .expect("spawn lint --emit-diagnostics-json parse error");
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected parse failure exit 2, got {:?}\nstdout: {}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("expected valid diagnostics JSON array");
+    let arr = parsed
+        .as_array()
+        .expect("expected diagnostics JSON top level array");
+    assert!(
+        !arr.is_empty(),
+        "expected at least one parse diagnostic, got: {stdout}"
+    );
+
+    for diag in arr {
+        assert_eq!(diag.get("severity").and_then(|v| v.as_str()), Some("error"));
+        assert_eq!(diag.get("code").and_then(|v| v.as_str()), Some("parse"));
+        assert!(diag.get("line").and_then(|v| v.as_u64()).is_some());
+        assert!(diag.get("column").and_then(|v| v.as_u64()).is_some());
+        assert!(diag.get("message").and_then(|v| v.as_str()).is_some());
+        assert_eq!(
+            diag.get("file").and_then(|v| v.as_str()),
+            Some(src.to_string_lossy().as_ref())
+        );
+    }
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("Parser error") && !stderr.contains("lint aborted due parse errors"),
+        "expected no human parser text in JSON mode, got stderr: {stderr}"
+    );
+
+    let _ = std::fs::remove_file(&src);
+}


### PR DESCRIPTION
Refs #3383.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. `agent-scripts/ready-or-bail.sh` will add `Closes #3383`
only after it verifies substantive work and marks this PR ready.

Branch: `res-3383-lint-emit-diagnostics-json-should-return`
Worktree: `.claude/worktrees/res-3383`

## Agent claims

- resilient/src/lib.rs


Closes #3383
