### PR TITLE
RES-3382: check --emit-diagnostics-json should emit parse diagnostics as pure JSON

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -1,3 +1,8 @@
 {
-  "claims": {}
+  "claims": {
+    "resilient/src/lib.rs": {
+      "branch": "res-3382-check-emit-diagnostics-json-should-emit",
+      "claimed_at": "2026-06-13T06:18:23Z"
+    }
+  }
 }


### PR DESCRIPTION
Refs #3382.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. `agent-scripts/ready-or-bail.sh` will add the closing issue
reference only after it verifies substantive work and marks this PR ready.

Branch: `res-3382-check-emit-diagnostics-json-should-emit`
Worktree: `.claude/worktrees/res-3382`

## Agent claims

- resilient/src/lib.rs