### PR TITLE
RES-3386: make --emit-diagnostics-json consume eprintln-based warning passes

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -3,6 +3,42 @@
     "resilient/src/lib.rs": {
       "branch": "res-3382-check-emit-diagnostics-json-should-emit",
       "claimed_at": "2026-06-13T06:41:51Z"
+    },
+    "resilient/src/typechecker.rs": {
+      "branch": "res-3386-make-emit-diagnostics-json-consume-eprin",
+      "claimed_at": "2026-06-13T06:58:02Z"
+    },
+    "resilient/src/autopilot.rs": {
+      "branch": "res-3386-make-emit-diagnostics-json-consume-eprin",
+      "claimed_at": "2026-06-13T06:58:02Z"
+    },
+    "resilient/src/property_tests.rs": {
+      "branch": "res-3386-make-emit-diagnostics-json-consume-eprin",
+      "claimed_at": "2026-06-13T06:58:02Z"
+    },
+    "resilient/src/mutation_testing.rs": {
+      "branch": "res-3386-make-emit-diagnostics-json-consume-eprin",
+      "claimed_at": "2026-06-13T06:58:02Z"
+    },
+    "resilient/src/causal_trace.rs": {
+      "branch": "res-3386-make-emit-diagnostics-json-consume-eprin",
+      "claimed_at": "2026-06-13T06:58:02Z"
+    },
+    "resilient/src/snapshot_regression.rs": {
+      "branch": "res-3386-make-emit-diagnostics-json-consume-eprin",
+      "claimed_at": "2026-06-13T06:58:02Z"
+    },
+    "resilient/src/labeled_break.rs": {
+      "branch": "res-3386-make-emit-diagnostics-json-consume-eprin",
+      "claimed_at": "2026-06-13T06:58:02Z"
+    },
+    "resilient/src/lean_spec.rs": {
+      "branch": "res-3386-make-emit-diagnostics-json-consume-eprin",
+      "claimed_at": "2026-06-13T06:58:02Z"
+    },
+    "resilient/src/package_manager.rs": {
+      "branch": "res-3386-make-emit-diagnostics-json-consume-eprin",
+      "claimed_at": "2026-06-13T06:58:02Z"
     }
   }
 }

--- a/resilient/src/autopilot.rs
+++ b/resilient/src/autopilot.rs
@@ -112,7 +112,7 @@ pub fn format_report(report: &AutopilotReport) -> String {
     s
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let has_fn = crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::Function { .. }));
     if !has_fn {
         return Ok(());
@@ -121,24 +121,28 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     if report.entries.is_empty() {
         return Ok(());
     }
-    eprintln!(
+    let plain = format!(
         "autopilot: program-wide vibe debt {:.1}%",
         report.program_debt_pct
     );
+    crate::typechecker::emit_check_warning_plain(plain, source_path, "autopilot");
     for e in &report.entries {
         if !e.action_items.is_empty() {
-            eprintln!(
+            let plain = format!(
                 "autopilot: `{}` [{}] — {}",
                 e.function_name,
                 e.grade,
                 e.action_items.join("; ")
             );
+            crate::typechecker::emit_check_warning_plain(plain, source_path, "autopilot");
         }
         for r in &e.inferred_requires {
-            eprintln!("autopilot: `{}` suggested: requires {}", e.function_name, r);
+            let plain = format!("autopilot: `{}` suggested: requires {}", e.function_name, r);
+            crate::typechecker::emit_check_warning_plain(plain, source_path, "autopilot");
         }
         for r in &e.inferred_ensures {
-            eprintln!("autopilot: `{}` suggested: ensures {}", e.function_name, r);
+            let plain = format!("autopilot: `{}` suggested: ensures {}", e.function_name, r);
+            crate::typechecker::emit_check_warning_plain(plain, source_path, "autopilot");
         }
     }
     Ok(())

--- a/resilient/src/causal_trace.rs
+++ b/resilient/src/causal_trace.rs
@@ -78,7 +78,7 @@ pub fn format_chain(target_actor: u64) -> String {
     s
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // Fast-reject: skip programs with no actor call sites.
     let has_actor_call = crate::uniqueness_walk::any_node(program, |n| {
         if let Node::CallExpression { function, .. } = n {
@@ -92,11 +92,12 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         return Ok(());
     }
     let site_count = count_actor_sites(program);
-    eprintln!(
+    let plain = format!(
         "causal-trace: {} actor call site(s) detected — \
          circular trace buffer active ({} entries capacity)",
         site_count, TRACE_CAPACITY
     );
+    crate::typechecker::emit_check_warning_plain(plain, source_path, "causal_trace");
     Ok(())
 }
 

--- a/resilient/src/contract_inference.rs
+++ b/resilient/src/contract_inference.rs
@@ -532,11 +532,22 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         for e in &ic.ensures {
             parts.push(format!("ensures {e}"));
         }
-        eprintln!(
+        let plain = format!(
             "{source_path}:0:0: {label}: `{}` — \
              inferred suggestion: {}",
             ic.function_name,
             parts.join(", ")
+        );
+        let severity = if label.starts_with("warning") {
+            "warning"
+        } else {
+            "note"
+        };
+        crate::typechecker::emit_check_diagnostic_plain(
+            plain,
+            severity,
+            source_path,
+            "contract_infer",
         );
     }
     Ok(())

--- a/resilient/src/dead_code_lint.rs
+++ b/resilient/src/dead_code_lint.rs
@@ -30,7 +30,7 @@ use std::collections::{HashMap, HashSet};
 /// Run all dead-code lint checks on `program` and print warnings to stderr.
 pub(crate) fn check(program: &Node, source_path: &str) {
     for msg in collect_warnings(program, source_path) {
-        eprintln!("{msg}");
+        crate::typechecker::emit_check_warning_plain(msg, source_path, "dead_code");
     }
 }
 

--- a/resilient/src/labeled_break.rs
+++ b/resilient/src/labeled_break.rs
@@ -69,7 +69,7 @@ fn walk<'a>(node: &'a Node, fn_name: &'a str, depth: u32, out: &mut Vec<DeepBrea
     }
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // Fast-reject: skip programs with no loops at all.
     let has_loop = crate::uniqueness_walk::any_node(program, |n| {
         matches!(n, Node::WhileStatement { .. } | Node::ForInStatement { .. })
@@ -79,11 +79,12 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     }
     let warnings = analyze(program);
     for w in &warnings {
-        eprintln!(
+        let plain = format!(
             "warning: `{}` has a break/continue nested {} loop(s) deep — \
              consider refactoring with labeled break once the syntax is available",
             w.function, w.depth
         );
+        crate::typechecker::emit_check_warning_plain(plain, source_path, "labeled_break");
     }
     Ok(())
 }

--- a/resilient/src/lean_spec.rs
+++ b/resilient/src/lean_spec.rs
@@ -310,7 +310,7 @@ pub fn list_emittable(program: &Node) -> Vec<String> {
     out
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // Fast-reject: skip programs with no functions.
     let has_fn = crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::Function { .. }));
     if !has_fn {
@@ -320,11 +320,12 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     if emittable.is_empty() {
         return Ok(());
     }
-    eprintln!(
+    let plain = format!(
         "lean-spec: {} function(s) can be lowered to Lean 4 formal specs: [{}]",
         emittable.len(),
         emittable.join(", ")
     );
+    crate::typechecker::emit_check_warning_plain(plain, source_path, "lean_spec");
     // Emit a per-function note for functions with contracts so the
     // user knows formal theorem generation is available.
     let Node::Program(stmts) = program else {
@@ -339,12 +340,13 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         } = &s.node
         {
             if emittable.contains(name) && (!requires.is_empty() || !ensures.is_empty()) {
-                eprintln!(
+                let plain = format!(
                     "lean-spec:   `{name}` has {} requires + {} ensures clause(s) — \
                      use `rz emit-lean {name}` to generate the theorem",
                     requires.len(),
                     ensures.len()
                 );
+                crate::typechecker::emit_check_warning_plain(plain, source_path, "lean_spec");
             }
         }
     }

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -29219,6 +29219,24 @@ fn parse_diagnostics_json_values<'a>(
         .collect()
 }
 
+fn check_diagnostics_json_values(
+    diagnostics: &[typechecker::CheckDiagnostic],
+) -> Vec<serde_json::Value> {
+    diagnostics
+        .iter()
+        .map(|diag| {
+            serde_json::json!({
+                "severity": diag.severity,
+                "code": diag.code,
+                "line": diag.line,
+                "column": diag.column,
+                "message": diag.message,
+                "file": diag.file,
+            })
+        })
+        .collect()
+}
+
 /// Macro expansion helper: parse a single expression string into a `Node`.
 ///
 /// The source is wrapped in a synthetic function body so the existing
@@ -32007,7 +32025,17 @@ fn dispatch_check_subcommand(args: &[String]) -> Option<i32> {
     #[cfg(not(feature = "z3"))]
     let mut tc = tc_base;
     let path_str = path.to_string_lossy();
-    match tc.check_program_with_source(&program, path_str.as_ref()) {
+    let (check_result, check_diagnostics) = if emit_diagnostics_json {
+        typechecker::collect_check_diagnostics(|| {
+            tc.check_program_with_source(&program, path_str.as_ref())
+        })
+    } else {
+        (
+            tc.check_program_with_source(&program, path_str.as_ref()),
+            Vec::new(),
+        )
+    };
+    match check_result {
         Ok(_) => {
             // RES-390: distributed-invariant verification runs
             // AFTER successful typechecking — we only try to
@@ -32060,7 +32088,11 @@ fn dispatch_check_subcommand(args: &[String]) -> Option<i32> {
                 }
             }
             if emit_diagnostics_json {
-                println!("[]");
+                let json_diags = check_diagnostics_json_values(&check_diagnostics);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json_diags).unwrap_or_default()
+                );
             } else if !quiet {
                 println!("{}: ok", path.display());
             }
@@ -32069,14 +32101,15 @@ fn dispatch_check_subcommand(args: &[String]) -> Option<i32> {
         Err(e) => {
             if emit_diagnostics_json {
                 let (line, col, msg) = parse_error_location(&e);
-                let json_diags = serde_json::json!([{
+                let mut json_diags = check_diagnostics_json_values(&check_diagnostics);
+                json_diags.push(serde_json::json!({
                     "severity": "error",
                     "code": "typecheck",
                     "line": line,
                     "column": col,
                     "message": msg,
                     "file": path_str.as_ref(),
-                }]);
+                }));
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&json_diags).unwrap_or_default()

--- a/resilient/src/mutation_testing.rs
+++ b/resilient/src/mutation_testing.rs
@@ -429,20 +429,22 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     }
     let summary = summarize(&mutations);
     let total: usize = summary.values().map(|(c, _)| c).sum();
-    eprintln!(
+    let plain = format!(
         "mutation: {} total mutation site(s) across {} function(s)",
         total,
         summary.len()
     );
+    crate::typechecker::emit_check_warning_plain(plain, source_path, "mutation");
     let mut fns: Vec<_> = summary.iter().collect();
     fns.sort_by_key(|(n, _)| n.as_str());
     for (fn_name, (count, kinds)) in &fns {
         let mut kinds_sorted = kinds.clone();
         kinds_sorted.sort();
-        eprintln!(
+        let plain = format!(
             "mutation:   `{fn_name}`: {count} site(s) [{}]",
             kinds_sorted.join(", ")
         );
+        crate::typechecker::emit_check_warning_plain(plain, source_path, "mutation");
     }
 
     // Cross-reference with contract declarations to identify unconstrained sites.
@@ -460,17 +462,19 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     if !unconstrained.is_empty() {
         let unconstrained_total: usize = unconstrained.iter().map(|(_, n)| n).sum();
         let pct = unconstrained_total * 100 / total.max(1);
-        eprintln!(
+        let plain = format!(
             "{source_path}:0:0: warning[mutation]: \
              {unconstrained_total}/{total} mutation site(s) ({pct}%) are in \
              functions with no contracts — the Z3 verifier cannot kill them"
         );
+        crate::typechecker::emit_check_warning_plain(plain, source_path, "mutation");
         for (name, count) in &unconstrained {
-            eprintln!(
+            let plain = format!(
                 "{source_path}:0:0: warning[mutation]: \
                  `{name}`: {count} unconstrained mutation site(s) — \
                  add `requires`/`ensures` contracts"
             );
+            crate::typechecker::emit_check_warning_plain(plain, source_path, "mutation");
         }
     }
     Ok(())

--- a/resilient/src/package_manager.rs
+++ b/resilient/src/package_manager.rs
@@ -177,12 +177,13 @@ pub(crate) fn check(_program: &Node, source_path: &str) -> Result<(), String> {
 
     if errors.is_empty() {
         if !manifest.dependencies.is_empty() {
-            eprintln!(
+            let plain = format!(
                 "pkg: manifest `{}` v{} with {} dependency/ies validated",
                 manifest.name,
                 manifest.version,
                 manifest.dependencies.len()
             );
+            crate::typechecker::emit_check_warning_plain(plain, source_path, "pkg");
         }
         Ok(())
     } else {

--- a/resilient/src/recovery_checker.rs
+++ b/resilient/src/recovery_checker.rs
@@ -11,25 +11,27 @@
 use crate::Node;
 use std::collections::HashSet;
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // RES-1270 / RES-1916: the typechecker gates this call behind
     // `markers.has_live_block`, so the program is guaranteed to
     // contain at least one `LiveBlock`. The previous `any_node`
     // pre-scan was redundant — removed.
-    let mut ctx = Context::new();
+    let mut ctx = Context::new(source_path);
     ctx.collect_declarations(program);
     ctx.check_live_blocks(program);
     Ok(())
 }
 
 struct Context {
+    source_path: String,
     extern_fns: HashSet<String>,
     current_fn: Option<String>,
 }
 
 impl Context {
-    fn new() -> Self {
+    fn new(source_path: &str) -> Self {
         Context {
+            source_path: source_path.to_string(),
             extern_fns: HashSet::new(),
             current_fn: None,
         }
@@ -132,17 +134,27 @@ impl Context {
                 // `Borrow<str>`, so the clone-per-call-site was wasted.
                 if let Some(fn_name) = extract_identifier(function) {
                     if self.extern_fns.contains(fn_name) {
-                        eprintln!(
+                        let plain = format!(
                             "warning: opaque FFI call to '{}' in recovery body \
-                            cannot be modeled as TLA+ action",
+                             cannot be modeled as TLA+ action",
                             fn_name
+                        );
+                        crate::typechecker::emit_check_warning_plain(
+                            plain,
+                            &self.source_path,
+                            "recovery",
                         );
                     } else if let Some(current) = self.current_fn.as_deref()
                         && fn_name == current
                     {
-                        eprintln!(
+                        let plain = format!(
                             "warning: function '{}' recursively calls itself in recovery body",
                             current
+                        );
+                        crate::typechecker::emit_check_warning_plain(
+                            plain,
+                            &self.source_path,
+                            "recovery",
                         );
                     }
                 }
@@ -154,9 +166,14 @@ impl Context {
                 let free = crate::free_vars::free_vars(node);
                 if !free.is_empty() {
                     let captured: Vec<_> = free.iter().cloned().collect();
-                    eprintln!(
+                    let plain = format!(
                         "warning: closure in recovery body captures [{}] from outer scope",
                         captured.join(", ")
+                    );
+                    crate::typechecker::emit_check_warning_plain(
+                        plain,
+                        &self.source_path,
+                        "recovery",
                     );
                 }
             }

--- a/resilient/src/resilience_score.rs
+++ b/resilient/src/resilience_score.rs
@@ -235,13 +235,13 @@ fn count_body_statements(node: &Node) -> usize {
 ///
 /// A low resilience score is diagnostic, not a compile error — the
 /// developer may be in the middle of adding contracts. The warning
-/// surface is kept as `eprintln!` so it shows up in the build log
-/// without blocking compilation.
+/// surface is kept in the check diagnostic stream so it shows up in
+/// build logs without blocking compilation.
 pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     let scores = score_program(program);
     let f_grade: Vec<&ResilienceScore> = scores.iter().filter(|s| s.total < 40).collect();
     for s in &f_grade {
-        eprintln!(
+        let plain = format!(
             "{source_path}:0:0: warning[resilience]: \
              `{}` scores {}/100 ({}) — \
              add `requires`/`ensures` contracts to improve resilience",
@@ -249,6 +249,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             s.total,
             s.grade()
         );
+        crate::typechecker::emit_check_warning_plain(plain, source_path, "resilience");
     }
     Ok(())
 }

--- a/resilient/src/snapshot_regression.rs
+++ b/resilient/src/snapshot_regression.rs
@@ -85,7 +85,7 @@ pub fn install_snapshot_baseline(snapshots: HashMap<String, Snapshot>) {
     }
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // Fast-reject: skip programs with no function declarations.
     let has_fn = crate::uniqueness_walk::any_node(program, |n| matches!(n, Node::Function { .. }));
     if !has_fn {
@@ -102,17 +102,23 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     if let Some(baseline) = baseline {
         let changed = diff(&baseline, &current);
         if !changed.is_empty() {
-            eprintln!(
+            let plain = format!(
                 "snapshot-regression: {} function(s) have changed behavioral \
                  fingerprints: [{}]",
                 changed.len(),
                 changed.join(", ")
             );
+            crate::typechecker::emit_check_warning_plain(plain, source_path, "snapshot_regression");
             for name in &changed {
                 if let (Some(old), Some(new)) = (baseline.get(name), current.get(name)) {
-                    eprintln!(
+                    let plain = format!(
                         "snapshot-regression:   `{name}`: {} → {}",
                         old.fingerprint_digest, new.fingerprint_digest
+                    );
+                    crate::typechecker::emit_check_warning_plain(
+                        plain,
+                        source_path,
+                        "snapshot_regression",
                     );
                 }
             }

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -20,7 +20,169 @@
 
 use crate::span::{Pos, Span};
 use crate::{Node, Pattern};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckDiagnostic {
+    pub severity: String,
+    pub code: String,
+    pub file: String,
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+    pub plain: String,
+}
+
+thread_local! {
+    static CHECK_DIAGNOSTIC_COLLECTOR: RefCell<Option<Vec<CheckDiagnostic>>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn collect_check_diagnostics<T>(f: impl FnOnce() -> T) -> (T, Vec<CheckDiagnostic>) {
+    let previous = CHECK_DIAGNOSTIC_COLLECTOR.with(|slot| slot.replace(Some(Vec::new())));
+    let result = f();
+    let diagnostics =
+        CHECK_DIAGNOSTIC_COLLECTOR.with(|slot| slot.replace(previous).unwrap_or_default());
+    (result, diagnostics)
+}
+
+pub(crate) fn emit_check_warning_plain(
+    plain: impl Into<String>,
+    fallback_file: &str,
+    fallback_code: &str,
+) {
+    emit_check_diagnostic_plain(plain, "warning", fallback_file, fallback_code);
+}
+
+pub(crate) fn emit_check_diagnostic_plain(
+    plain: impl Into<String>,
+    fallback_severity: &str,
+    fallback_file: &str,
+    fallback_code: &str,
+) {
+    let plain = plain.into();
+    let diagnostic =
+        check_diagnostic_from_plain(&plain, fallback_severity, fallback_file, fallback_code);
+    let captured = CHECK_DIAGNOSTIC_COLLECTOR.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if let Some(diagnostics) = slot.as_mut() {
+            diagnostics.push(diagnostic);
+            true
+        } else {
+            false
+        }
+    });
+    if !captured {
+        eprintln!("{plain}");
+    }
+}
+
+fn check_diagnostic_from_plain(
+    plain: &str,
+    fallback_severity: &str,
+    fallback_file: &str,
+    fallback_code: &str,
+) -> CheckDiagnostic {
+    for severity in ["warning", "note", "hint"] {
+        let needle = format!(": {severity}[");
+        if let Some((loc, rest)) = plain.split_once(&needle)
+            && let Some((code, message)) = rest.split_once("]: ")
+            && let Some((file, line, column)) = parse_plain_location(loc)
+        {
+            return CheckDiagnostic {
+                severity: severity.to_string(),
+                code: code.to_string(),
+                file,
+                line,
+                column,
+                message: message.to_string(),
+                plain: plain.to_string(),
+            };
+        }
+    }
+
+    for severity in ["warning", "note", "hint"] {
+        let prefix = format!("{severity}[");
+        if let Some(rest) = plain.strip_prefix(&prefix)
+            && let Some((code, message)) = rest.split_once("]: ")
+        {
+            return fallback_diagnostic(plain, severity, fallback_file, code, message, 0, 0);
+        }
+    }
+
+    if let Some(rest) = plain.strip_prefix("warning: ") {
+        if let Some((file, line, column, message)) = parse_plain_location_message(rest) {
+            return CheckDiagnostic {
+                severity: "warning".to_string(),
+                code: fallback_code.to_string(),
+                file,
+                line,
+                column,
+                message,
+                plain: plain.to_string(),
+            };
+        }
+        return fallback_diagnostic(plain, "warning", fallback_file, fallback_code, rest, 0, 0);
+    }
+
+    if let Some(rest) = plain.strip_prefix("hint: ") {
+        return fallback_diagnostic(plain, "hint", fallback_file, fallback_code, rest, 0, 0);
+    }
+
+    fallback_diagnostic(
+        plain,
+        fallback_severity,
+        fallback_file,
+        fallback_code,
+        plain,
+        0,
+        0,
+    )
+}
+
+fn fallback_diagnostic(
+    plain: &str,
+    severity: &str,
+    fallback_file: &str,
+    code: &str,
+    message: &str,
+    line: usize,
+    column: usize,
+) -> CheckDiagnostic {
+    CheckDiagnostic {
+        severity: severity.to_string(),
+        code: code.to_string(),
+        file: fallback_file.to_string(),
+        line,
+        column,
+        message: message.to_string(),
+        plain: plain.to_string(),
+    }
+}
+
+fn parse_plain_location_message(rest: &str) -> Option<(String, usize, usize, String)> {
+    let marker = rest.find(": ")?;
+    let mut search_start = marker + 2;
+    loop {
+        let (loc, message) = rest.split_at(search_start - 2);
+        if let Some((file, line, column)) = parse_plain_location(loc) {
+            return Some((file, line, column, message[2..].to_string()));
+        }
+        let Some(next) = rest[search_start..].find(": ") else {
+            break;
+        };
+        search_start += next + 2;
+    }
+    None
+}
+
+fn parse_plain_location(loc: &str) -> Option<(String, usize, usize)> {
+    let mut parts = loc.rsplitn(3, ':');
+    let column = parts.next()?.parse().ok()?;
+    let line = parts.next()?.parse().ok()?;
+    let file = parts.next()?.to_string();
+    Some((file, line, column))
+}
 
 /// RES-189: one entry in the typechecker's post-walk inlay-hint
 /// cache. Produced for every unannotated `let` binding (i.e.
@@ -1270,10 +1432,11 @@ fn emit_partial_proof_warning(source_path: &str, clause: &Node) {
     } else {
         format!("{}:{}:{}", file, span.start.line, span.start.column)
     };
-    eprintln!(
+    let plain = format!(
         "warning[partial-proof]: Z3 returned Unknown for assertion at {} \u{2014} proof is incomplete",
         location
     );
+    emit_check_warning_plain(plain, source_path, "partial-proof");
 }
 
 /// RES-071: a single SMT-LIB2 proof certificate that the typechecker
@@ -6025,18 +6188,20 @@ impl TypeChecker {
                         }
                         crate::verifier_actors::ActorProofResult::Unknown => {
                             if self.warn_unverified {
-                                eprintln!(
+                                let plain = format!(
                                     "warning[partial-proof]: actor `{}` `always: {}` could not be proven on handler `{}` — Z3 returned Unknown",
                                     o.actor_name, o.invariant_label, o.handler_name,
                                 );
+                                emit_check_warning_plain(plain, source_path, "partial-proof");
                             }
                         }
                         crate::verifier_actors::ActorProofResult::Unsupported { reason } => {
                             if self.warn_unverified {
-                                eprintln!(
+                                let plain = format!(
                                     "warning[partial-proof]: actor `{}` `always: {}` not verified on handler `{}` — {}",
                                     o.actor_name, o.invariant_label, o.handler_name, reason,
                                 );
+                                emit_check_warning_plain(plain, source_path, "partial-proof");
                             }
                         }
                     }
@@ -7163,9 +7328,15 @@ impl TypeChecker {
                                 // continues, runtime check stays in,
                                 // audit counter bumps, user sees a hint.
                                 self.stats.verifier_timeouts += 1;
-                                eprintln!(
+                                let plain = format!(
                                     "hint: proof timed out after {}ms — runtime check retained (fn {})",
                                     self.verifier_timeout_ms, name
+                                );
+                                emit_check_diagnostic_plain(
+                                    plain,
+                                    "hint",
+                                    &self.source_path,
+                                    "proof-timeout",
                                 );
                             }
                             // RES-217: any unresolved verdict (timeout OR a
@@ -7329,9 +7500,15 @@ impl TypeChecker {
                     if verdict.is_none() && !fails.is_empty() {
                         if timed_out_flag {
                             self.stats.verifier_timeouts += 1;
-                            eprintln!(
+                            let plain = format!(
                                 "hint: proof timed out after {}ms — runtime check retained (fn {}, recovers_to)",
                                 self.verifier_timeout_ms, name
+                            );
+                            emit_check_diagnostic_plain(
+                                plain,
+                                "hint",
+                                &self.source_path,
+                                "proof-timeout",
                             );
                             if self.warn_unverified {
                                 emit_partial_proof_warning(&self.source_path, clause);
@@ -7380,7 +7557,11 @@ impl TypeChecker {
                     if let Err(bmc_msg) =
                         crate::recovers_to_bmc::check_recovers_to_bmc(name, body, requires, clause)
                     {
-                        eprintln!("warning[bmc]: {bmc_msg}");
+                        emit_check_warning_plain(
+                            format!("warning[bmc]: {bmc_msg}"),
+                            &self.source_path,
+                            "bmc",
+                        );
                     }
                 }
 
@@ -9669,7 +9850,11 @@ impl TypeChecker {
                         // that can't be typed (e.g. genuinely undefined name)
                         // should still allow the program to continue running.
                         if let Err(e) = self.check_node(expr) {
-                            eprintln!("warning: {loc}in interpolated string: {e}");
+                            emit_check_warning_plain(
+                                format!("warning: {loc}in interpolated string: {e}"),
+                                &self.source_path,
+                                "string_interp",
+                            );
                         }
                     }
                 }
@@ -10040,9 +10225,15 @@ impl TypeChecker {
                                     // RES-137: soft-failure — runtime
                                     // check stays in; audit bumps.
                                     self.stats.verifier_timeouts += 1;
-                                    eprintln!(
+                                    let plain = format!(
                                         "hint: proof timed out after {}ms — runtime check retained (call to fn {})",
                                         self.verifier_timeout_ms, callee_name
+                                    );
+                                    emit_check_diagnostic_plain(
+                                        plain,
+                                        "hint",
+                                        &self.source_path,
+                                        "proof-timeout",
                                     );
                                 }
                                 // RES-217: any unresolved verdict (timeout

--- a/resilient/src/vibe_debt.rs
+++ b/resilient/src/vibe_debt.rs
@@ -204,15 +204,16 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
         return Ok(());
     }
     for entry in report.entries.iter().filter(|e| e.is_full_vibe()) {
-        eprintln!(
+        let plain = format!(
             "{source_path}:0:0: warning[vibe_debt]: \
              `{}` has no contracts, no effect annotation, and is \
              unreferenced — fully vibe-coded",
             entry.function_name
         );
+        crate::typechecker::emit_check_warning_plain(plain, source_path, "vibe_debt");
     }
     if report.debt_percent > 75.0 {
-        eprintln!(
+        let plain = format!(
             "{source_path}:0:0: warning[vibe_debt]: \
              program-wide vibe debt is {:.1}% \
              ({} of {} function(s) have zero verification signals)",
@@ -220,6 +221,7 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
             report.fully_vibe_count,
             report.entries.len()
         );
+        crate::typechecker::emit_check_warning_plain(plain, source_path, "vibe_debt");
     }
     Ok(())
 }

--- a/resilient/tests/check_warning_json.rs
+++ b/resilient/tests/check_warning_json.rs
@@ -1,0 +1,65 @@
+//! RES-3386: warning-producing check passes use JSON diagnostics.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+fn tmp_file(tag: &str, body: &str) -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("res_3386_{}_{}_{}.rz", tag, std::process::id(), n));
+    std::fs::write(&path, body).expect("write scratch");
+    path
+}
+
+#[test]
+fn check_emit_diagnostics_json_reports_warning_passes_without_stderr() {
+    let src = tmp_file(
+        "mutation_warning",
+        "fn mutate(int x) -> int { return x + 1; }\n",
+    );
+
+    let out = Command::new(bin())
+        .args(["check", "--emit-diagnostics-json"])
+        .arg(&src)
+        .output()
+        .expect("spawn check --emit-diagnostics-json warning case");
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "expected clean check exit 0, got {:?}\nstdout: {}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("mutation:")
+            && !stderr.contains("warning[mutation]")
+            && !stderr.contains("warning[vibe_debt]")
+            && !stderr.contains("warning[resilience]"),
+        "JSON diagnostics mode must not print warning passes to stderr; stderr={stderr:?}"
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("expected valid diagnostics JSON array");
+    let arr = parsed
+        .as_array()
+        .expect("expected diagnostics JSON top level array");
+
+    assert!(
+        arr.iter().any(|diag| {
+            diag.get("severity").and_then(|v| v.as_str()) == Some("warning")
+                && diag.get("code").and_then(|v| v.as_str()) == Some("mutation")
+        }),
+        "expected a mutation warning diagnostic in JSON output, got: {stdout}"
+    );
+}


### PR DESCRIPTION
Refs #3386.

Draft PR auto-opened by `agent-scripts/dispatch-agent.sh` to claim the
ticket. `agent-scripts/ready-or-bail.sh` will add the closing issue
reference only after it verifies substantive work and marks this PR ready.

Branch: `res-3386-make-emit-diagnostics-json-consume-eprin`
Worktree: `.claude/worktrees/res-3386`

## Agent claims

- resilient/src/typechecker.rs
- resilient/src/autopilot.rs
- resilient/src/property_tests.rs
- resilient/src/mutation_testing.rs
- resilient/src/causal_trace.rs
- resilient/src/snapshot_regression.rs
- resilient/src/labeled_break.rs
- resilient/src/lean_spec.rs
- resilient/src/package_manager.rs


Closes #3386
