### PR TITLE
RES-3134: Route warning-producing check passes to structured diagnostics in JSON mode

### DIFF
--- a/resilient/src/assume_false_checker.rs
+++ b/resilient/src/assume_false_checker.rs
@@ -46,9 +46,14 @@ impl<'a> AssumeChecker<'a> {
                 // Warn about statements after assume(false)
                 if i + 1 < statements.len() {
                     let next_stmt = &statements[i + 1];
-                    eprintln!(
-                        "{}:{}  warning: dead-code region following assume(false)",
-                        self.source_path, next_stmt.span.start
+                    let msg = format!(
+                        "{}:{}:{}: warning[assume-false]: dead-code region following assume(false)",
+                        self.source_path, next_stmt.span.start.line, next_stmt.span.start.column
+                    );
+                    crate::typechecker::emit_check_warning_plain(
+                        &msg,
+                        self.source_path,
+                        "assume-false",
                     );
                 }
             }
@@ -63,9 +68,14 @@ impl<'a> AssumeChecker<'a> {
             if self.is_assume_false(stmt) {
                 // Warn about statements after assume(false)
                 if i + 1 < stmts.len() {
-                    eprintln!(
-                        "{}:  warning: dead-code region following assume(false)",
+                    let msg = format!(
+                        "{}:0:0: warning[assume-false]: dead-code region following assume(false)",
                         self.source_path
+                    );
+                    crate::typechecker::emit_check_warning_plain(
+                        &msg,
+                        self.source_path,
+                        "assume-false",
                     );
                 }
             }

--- a/resilient/src/coverage_warnings.rs
+++ b/resilient/src/coverage_warnings.rs
@@ -166,7 +166,7 @@ fn is_catch_all_arm(p: &crate::Pattern, guard: &Option<Node>) -> bool {
     matches!(p, crate::Pattern::Wildcard | crate::Pattern::Identifier(_))
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // RES-1284 / RES-1916: the typechecker gates this call behind
     // `markers.call_idents.contains("Err")`, so the program is
     // guaranteed to contain at least one `Err(…)` call. The three
@@ -175,7 +175,11 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
     // the OR logic meant the fast-reject could never trigger.
     let warnings = analyze(program);
     for w in &warnings {
-        eprintln!("warning: coverage in `{}`: {}", w.function, w.message);
+        let msg = format!(
+            "warning[coverage]: coverage in `{}`: {}",
+            w.function, w.message
+        );
+        crate::typechecker::emit_check_warning_plain(&msg, source_path, "coverage");
     }
     Ok(())
 }

--- a/resilient/src/deadlock_freedom.rs
+++ b/resilient/src/deadlock_freedom.rs
@@ -145,7 +145,7 @@ pub fn detect_cycles<'a>(graph: &'a ActorGraph) -> Vec<Vec<&'a str>> {
     cycles
 }
 
-pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
     // RES-1291 / RES-1916: the typechecker gates this call behind
     // `markers.has_actor_decl`, so the program is guaranteed to
     // contain at least one `ActorDecl`. The previous `any_node`
@@ -157,13 +157,17 @@ pub(crate) fn check(program: &Node, _source_path: &str) -> Result<(), String> {
         // record that the actor network was proven cycle-free at this
         // compilation.
         let actor_count = g.edges.len();
-        eprintln!("deadlock-free: actor network ({actor_count} actor(s)) verified cycle-free");
+        let msg = format!(
+            "note[deadlock-free]: actor network ({actor_count} actor(s)) verified cycle-free"
+        );
+        crate::typechecker::emit_check_diagnostic_plain(&msg, "note", source_path, "deadlock-free");
     } else {
         for c in &cycles {
-            eprintln!(
-                "warning: potential deadlock cycle in actor graph: {}",
+            let msg = format!(
+                "warning[deadlock-cycle]: potential deadlock cycle in actor graph: {}",
                 c.join(" -> ")
             );
+            crate::typechecker::emit_check_warning_plain(&msg, source_path, "deadlock-cycle");
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary

Convert eprintln!-based warning output in compile-time check passes to use the typechecker's structured diagnostic collection system. When `--emit-diagnostics-json` is active, warnings are now captured and emitted as JSON instead of bypassing the diagnostic collector.

## Changes

- **coverage_warnings.rs**: Route coverage warnings via `emit_check_warning_plain`
- **assume_false_checker.rs**: Route assume-false warnings via `emit_check_warning_plain`
- **deadlock_freedom.rs**: Route deadlock detection notes and warnings via `emit_check_diagnostic_plain`

## Test Plan

- [x] All lib tests pass (5786 tests)
- [x] No clippy warnings
- [x] Code formats cleanly
- [x] Warnings are now captured in JSON mode instead of printed to stderr

Fixes #3386

https://claude.ai/code/session_014Tv7qMRWB9qNTGZ2qjsk3p


---
_Generated by [Claude Code](https://claude.ai/code/session_014Tv7qMRWB9qNTGZ2qjsk3p)_