### PR TITLE
RES-3159: Add derives malformed-input regression corpus

### DIFF
--- a/resilient/examples/derives_basic.expected.txt
+++ b/resilient/examples/derives_basic.expected.txt
@@ -1,0 +1,1 @@
+Point and Name created successfully

--- a/resilient/examples/derives_basic.rz
+++ b/resilient/examples/derives_basic.rz
@@ -1,0 +1,20 @@
+// RES-3159: Derives regression corpus — valid derives declarations
+// Demonstrates #[derive(...)] on structs with supported traits
+
+#[derive(Debug, Eq)]
+struct Point {
+    x: int,
+    y: int,
+}
+
+#[derive(Clone)]
+struct Name {
+    first: string,
+    last: string,
+}
+
+fn main() {
+    let p = Point { x: 10, y: 20 };
+    let n = Name { first: "Alice", last: "Smith" };
+    println("Point and Name created successfully");
+}

--- a/resilient/examples/derives_duplicate_registration.expected.txt
+++ b/resilient/examples/derives_duplicate_registration.expected.txt
@@ -1,0 +1,1 @@
+error: duplicate derive registration for `Point`

--- a/resilient/examples/derives_duplicate_registration.rz
+++ b/resilient/examples/derives_duplicate_registration.rz
@@ -1,0 +1,16 @@
+// RES-3159: Derives regression — duplicate registration
+// The same struct cannot have two #[derive(...)] declarations
+
+#[derive(Debug)]
+struct Point {
+    x: int,
+}
+
+#[derive(Clone)]
+struct Point {
+    y: int,
+}
+
+fn main() {
+    let p = Point { y: 5 };
+}

--- a/resilient/examples/derives_duplicate_traits_in_list.expected.txt
+++ b/resilient/examples/derives_duplicate_traits_in_list.expected.txt
@@ -1,0 +1,1 @@
+WithDuplicates created successfully

--- a/resilient/examples/derives_duplicate_traits_in_list.rz
+++ b/resilient/examples/derives_duplicate_traits_in_list.rz
@@ -1,0 +1,13 @@
+// RES-3159: Derives regression — duplicate traits in derive list
+// Duplicate traits within the same #[derive(...)] are allowed (deduplication)
+
+#[derive(Debug, Clone, Debug)]
+struct WithDuplicates {
+    x: int,
+    y: int,
+}
+
+fn main() {
+    let w = WithDuplicates { x: 1, y: 2 };
+    println("WithDuplicates created successfully");
+}

--- a/resilient/examples/derives_mixed_valid_invalid.expected.txt
+++ b/resilient/examples/derives_mixed_valid_invalid.expected.txt
@@ -1,0 +1,1 @@
+error: `#[derive(BadTrait)]` on `Mixed` — unknown trait. Supported: ["Debug", "Clone", "Eq", "Hash", "PartialEq", "Default", "Copy"]

--- a/resilient/examples/derives_mixed_valid_invalid.rz
+++ b/resilient/examples/derives_mixed_valid_invalid.rz
@@ -1,0 +1,11 @@
+// RES-3159: Derives regression — mixed valid and invalid traits
+// When derive list contains both valid and invalid traits, reject
+
+#[derive(Debug, BadTrait, Clone)]
+struct Mixed {
+    value: int,
+}
+
+fn main() {
+    let m = Mixed { value: 42 };
+}

--- a/resilient/examples/derives_unknown_trait.expected.txt
+++ b/resilient/examples/derives_unknown_trait.expected.txt
@@ -1,0 +1,1 @@
+error: `#[derive(InvalidTrait)]` on `Bad` — unknown trait. Supported: ["Debug", "Clone", "Eq", "Hash", "PartialEq", "Default", "Copy"]

--- a/resilient/examples/derives_unknown_trait.rz
+++ b/resilient/examples/derives_unknown_trait.rz
@@ -1,0 +1,11 @@
+// RES-3159: Derives regression — unknown trait
+// #[derive(InvalidTrait)] should be rejected
+
+#[derive(InvalidTrait)]
+struct Bad {
+    x: int,
+}
+
+fn main() {
+    let b = Bad { x: 1 };
+}


### PR DESCRIPTION
## Summary
Added comprehensive regression corpus for the derives feature validation. Includes 5 example programs demonstrating:
- Valid derives with multiple traits
- Unknown trait rejection  
- Duplicate struct registration rejection
- Mixed valid/invalid traits
- Deduplication of duplicate traits within the same derive list

## Test plan
- [x] All examples parse and compile
- [x] Error examples produce expected diagnostics
- [x] Valid examples execute successfully
- [x] No clippy warnings
- [x] Code is formatted

## Files added
- `resilient/examples/derives_basic.rz` — valid basic derives usage
- `resilient/examples/derives_unknown_trait.rz` — rejects unknown trait
- `resilient/examples/derives_duplicate_registration.rz` — rejects duplicate registration
- `resilient/examples/derives_mixed_valid_invalid.rz` — rejects mixed valid/invalid traits
- `resilient/examples/derives_duplicate_traits_in_list.rz` — deduplication example

Closes #3411

🤖 Generated with Claude Code