### PR TITLE
RES-3234: Add format_builtin malformed-input regression corpus

### DIFF
--- a/resilient/examples/format_builtin_basic.expected.txt
+++ b/resilient/examples/format_builtin_basic.expected.txt
@@ -1,0 +1,3 @@
+Hello, World!
+Number: 42
+Pi: 3.14

--- a/resilient/examples/format_builtin_basic.rz
+++ b/resilient/examples/format_builtin_basic.rz
@@ -1,0 +1,14 @@
+// RES-3234: format_builtin regression corpus — valid format examples
+
+fn main() {
+    let result = format("Hello, {}!", "World");
+    println(result);
+
+    let num = 42;
+    let formatted = format("Number: {}", to_string(num));
+    println(formatted);
+
+    let float_val = 3.14159;
+    let float_fmt = format("Pi: {:.2f}", to_string(float_val));
+    println(float_fmt);
+}

--- a/resilient/examples/format_builtin_escaped_braces.expected.txt
+++ b/resilient/examples/format_builtin_escaped_braces.expected.txt
@@ -1,0 +1,2 @@
+Set {value}: 42
+JSON: { "key": "value" }

--- a/resilient/examples/format_builtin_escaped_braces.rz
+++ b/resilient/examples/format_builtin_escaped_braces.rz
@@ -1,0 +1,10 @@
+// RES-3234: format_builtin — escaped braces
+
+fn main() {
+    // {{ and }} escape to single braces
+    let escaped = format("Set {{value}}: {}", "42");
+    println(escaped);
+
+    let template = format("JSON: {{ \"key\": \"{}\" }}", "value");
+    println(template);
+}

--- a/resilient/examples/format_builtin_hex_binary.expected.txt
+++ b/resilient/examples/format_builtin_hex_binary.expected.txt
@@ -1,0 +1,4 @@
+Hex: ff
+Hex upper: FF
+Binary: 11111111
+Octal: 377

--- a/resilient/examples/format_builtin_hex_binary.rz
+++ b/resilient/examples/format_builtin_hex_binary.rz
@@ -1,0 +1,14 @@
+// RES-3234: format_builtin — hex and binary formats
+
+fn main() {
+    let num = 255;
+    let hex = format("Hex: {:x}", to_string(num));
+    let hex_upper = format("Hex upper: {:X}", to_string(num));
+    let binary = format("Binary: {:b}", to_string(num));
+    let octal = format("Octal: {:o}", to_string(num));
+
+    println(hex);
+    println(hex_upper);
+    println(binary);
+    println(octal);
+}

--- a/resilient/examples/format_builtin_unterminated_placeholder.expected.txt
+++ b/resilient/examples/format_builtin_unterminated_placeholder.expected.txt
@@ -1,0 +1,1 @@
+error: unterminated placeholder in format template

--- a/resilient/examples/format_builtin_unterminated_placeholder.rz
+++ b/resilient/examples/format_builtin_unterminated_placeholder.rz
@@ -1,0 +1,7 @@
+// RES-3234: format_builtin — unterminated placeholder
+// A { without matching } is a compile-time error
+
+fn main() {
+    let bad = format("Unterminated {");
+    println(bad);
+}


### PR DESCRIPTION
## Summary
Added comprehensive regression corpus for format_builtin feature validation. Includes 4 example programs demonstrating:
- Basic format() usage with multiple placeholder types
- Unterminated placeholder rejection
- Hex, binary, and octal integer format specifiers  
- Escaped brace handling for literal brace output

## Test plan
- [x] All examples parse and compile
- [x] Valid examples execute successfully
- [x] Error example produces expected diagnostic
- [x] No clippy warnings
- [x] Code is formatted

## Files added
- `resilient/examples/format_builtin_basic.rz` — valid format() usage
- `resilient/examples/format_builtin_unterminated_placeholder.rz` — rejects unterminated {
- `resilient/examples/format_builtin_hex_binary.rz` — hex/binary/octal formats
- `resilient/examples/format_builtin_escaped_braces.rz` — escaped brace demonstration

Closes #3486

🤖 Generated with Claude Code