### PR TITLE
RES-3188: Add regex_builtins regression corpus

### DIFF
--- a/resilient/examples/regex_basic.expected.txt
+++ b/resilient/examples/regex_basic.expected.txt
@@ -1,0 +1,3 @@
+true
+10
+The quick brown active dog

--- a/resilient/examples/regex_basic.rz
+++ b/resilient/examples/regex_basic.rz
@@ -1,0 +1,17 @@
+// RES-3188: regex_builtins regression corpus — regular expression operations
+
+fn main() {
+    let text = "The quick brown fox jumps over the lazy dog";
+
+    // Test if pattern matches
+    let has_fox = regex_match("fox", text);
+    println(to_string(has_fox));
+
+    // Find pattern in text
+    let pos = regex_find("brown", text);
+    println(to_string(pos));
+
+    // Replace pattern in text
+    let replaced = regex_replace("lazy", "active", text);
+    println(replaced);
+}

--- a/resilient/examples/regex_patterns.expected.txt
+++ b/resilient/examples/regex_patterns.expected.txt
@@ -1,0 +1,4 @@
+true
+true
+true
+[1, 2, 3]

--- a/resilient/examples/regex_patterns.rz
+++ b/resilient/examples/regex_patterns.rz
@@ -1,0 +1,19 @@
+// RES-3188: regex_builtins — pattern classes and special features
+
+fn main() {
+    // Match digits
+    let has_digits = regex_match("\\d+", "There are 42 items");
+    println(to_string(has_digits));
+
+    // Match word boundary
+    let has_word = regex_match("\\bword\\b", "This is a word in text");
+    println(to_string(has_word));
+
+    // Case-insensitive matching
+    let case_match = regex_match_ignore_case("HELLO", "hello world");
+    println(to_string(case_match));
+
+    // Extract all matches
+    let all_matches = regex_find_all("\\d", "1a2b3c");
+    println(to_string(all_matches));
+}


### PR DESCRIPTION
Added regex operations corpus examples for RES-3188. Examples cover regex_match, regex_find, regex_replace, pattern classes, and case-insensitive matching. Closes #3441. 🤖