### PR TITLE
RES-3199: Add session_types regression corpus

### DIFF
--- a/resilient/examples/session_types_basic.expected.txt
+++ b/resilient/examples/session_types_basic.expected.txt
@@ -1,0 +1,1 @@
+Session type protocol defined

--- a/resilient/examples/session_types_basic.rz
+++ b/resilient/examples/session_types_basic.rz
@@ -1,0 +1,18 @@
+// RES-3199: session_types regression corpus — protocol session types
+
+// Define a session protocol using session type attributes
+#[session(protocol = "ClientServer")]
+trait ClientServer {
+    // Client sends request, server responds
+    send_request: fn(int) -> int,
+
+    // Server acknowledges receipt
+    acknowledge: fn(bool) -> (),
+
+    // Final response from server
+    response: fn(string) -> (),
+}
+
+fn main() {
+    println("Session type protocol defined");
+}

--- a/resilient/examples/session_types_protocol.expected.txt
+++ b/resilient/examples/session_types_protocol.expected.txt
@@ -1,0 +1,1 @@
+File transfer session protocol defined

--- a/resilient/examples/session_types_protocol.rz
+++ b/resilient/examples/session_types_protocol.rz
@@ -1,0 +1,20 @@
+// RES-3199: session_types — protocol state transitions
+
+#[session(protocol = "FileTransfer")]
+trait FileTransfer {
+    // Initiate connection
+    connect: fn(string) -> (),
+
+    // Send file metadata
+    send_metadata: fn(int) -> (),
+
+    // Transfer file content
+    send_chunk: fn(string) -> (),
+
+    // Finalize transfer
+    close: fn() -> (),
+}
+
+fn main() {
+    println("File transfer session protocol defined");
+}


### PR DESCRIPTION
Session types protocol corpus for RES-3199. Examples show protocol definitions with typed communication patterns. Closes #3446. 🤖