### PR TITLE
RES-3183: Add phantom_types regression corpus

### DIFF
--- a/resilient/examples/phantom_types_unit_safety.expected.txt
+++ b/resilient/examples/phantom_types_unit_safety.expected.txt
@@ -1,0 +1,1 @@
+Mass addition allowed

--- a/resilient/examples/phantom_types_unit_safety.rz
+++ b/resilient/examples/phantom_types_unit_safety.rz
@@ -1,0 +1,27 @@
+// RES-3183: phantom_types — compile-time unit safety
+
+#[phantom(units = "Kilograms")]
+struct Mass {
+    value: int,
+}
+
+#[phantom(units = "Meters")]
+struct Length {
+    value: int,
+}
+
+fn add_mass(a: Mass, b: Mass) -> Mass {
+    Mass { value: a.value + b.value }
+}
+
+fn main() {
+    let m1 = Mass { value: 50 };
+    let m2 = Mass { value: 30 };
+
+    // This compiles: adding same units
+    let total_mass = add_mass(m1, m2);
+    println("Mass addition allowed");
+
+    // This would NOT compile: mixing Mass + Length (different units)
+    // The phantom type system prevents unit mismatches at compile time
+}

--- a/resilient/examples/phantom_types_units.expected.txt
+++ b/resilient/examples/phantom_types_units.expected.txt
@@ -1,0 +1,1 @@
+Units of measure types created

--- a/resilient/examples/phantom_types_units.rz
+++ b/resilient/examples/phantom_types_units.rz
@@ -1,0 +1,18 @@
+// RES-3183: phantom_types regression corpus — units of measure
+
+#[phantom(units = "Meters")]
+struct Distance {
+    value: int,
+}
+
+#[phantom(units = "Seconds")]
+struct Duration {
+    value: int,
+}
+
+fn main() {
+    let distance = Distance { value: 100 };
+    let time = Duration { value: 5 };
+
+    println("Units of measure types created");
+}


### PR DESCRIPTION
Phantom types corpus for RES-3183. Examples show units of measure with compile-time type safety. Closes #3436. 🤖