### PR TITLE
RES-3189: http_client regression corpus

### DIFF
--- a/resilient/examples/http_client_basic.expected.txt
+++ b/resilient/examples/http_client_basic.expected.txt
@@ -1,0 +1,2 @@
+GET https://api.example.com/data
+POST https://api.example.com/create

--- a/resilient/examples/http_client_basic.rz
+++ b/resilient/examples/http_client_basic.rz
@@ -1,0 +1,11 @@
+// RES-3189: http_client regression corpus — HTTP client operations
+
+fn main() {
+    // Make HTTP GET request
+    let response = http_get("https://api.example.com/data");
+    println(response);
+
+    // Make HTTP POST request with body
+    let post_response = http_post("https://api.example.com/create", "{\"key\": \"value\"}");
+    println(post_response);
+}

--- a/resilient/examples/http_client_error_handling.expected.txt
+++ b/resilient/examples/http_client_error_handling.expected.txt
@@ -1,0 +1,1 @@
+error: http_get: invalid URL format - missing protocol (expected 'http://' or 'https://')

--- a/resilient/examples/http_client_error_handling.rz
+++ b/resilient/examples/http_client_error_handling.rz
@@ -1,0 +1,7 @@
+// RES-3189: http_client regression corpus — error handling for invalid URLs
+
+fn main() {
+    // Missing protocol in URL
+    let response = http_get("api.example.com/data");
+    println(response);
+}


### PR DESCRIPTION
Adds regression corpus examples for http_client operations.

Demonstrates:
- Valid HTTP GET requests
- Valid HTTP POST requests  
- Error handling for invalid URL formats

Examples:
- http_client_basic.rz — GET and POST requests
- http_client_error_handling.rz — invalid URL detection