### PR TITLE
RES-3154: Add regression corpus tests for hw_state_machine validation

### DIFF
--- a/resilient/src/derives.rs
+++ b/resilient/src/derives.rs
@@ -277,4 +277,58 @@ mod tests {
         assert!(derives_trait("MyIter", "Iterator"));
         crate::feature_attrs::reset();
     }
+
+    // ── Malformed-input regression corpus (RES-3159) ──────────────
+    #[test]
+    fn corpus_single_derive() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "Point",
+            crate::feature_attrs::AttrRecord {
+                name: "derive".into(),
+                args: "Clone".into(),
+                line: 0,
+            },
+        );
+        assert!(check(&Node::Program(vec![]), "test").is_ok());
+        assert!(derives_trait("Point", "Clone"));
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn corpus_multiple_derives() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "Vec3",
+            crate::feature_attrs::AttrRecord {
+                name: "derive".into(),
+                args: "Clone, Copy, Default".into(),
+                line: 0,
+            },
+        );
+        assert!(check(&Node::Program(vec![]), "test").is_ok());
+        assert!(derives_trait("Vec3", "Clone"));
+        assert!(derives_trait("Vec3", "Copy"));
+        assert!(derives_trait("Vec3", "Default"));
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn corpus_duplicate_traits_accepted() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "Dup",
+            crate::feature_attrs::AttrRecord {
+                name: "derive".into(),
+                args: "Clone, Clone, Clone".into(),
+                line: 0,
+            },
+        );
+        assert!(check(&Node::Program(vec![]), "test").is_ok());
+        assert!(derives_trait("Dup", "Clone"));
+        crate::feature_attrs::reset();
+    }
 }

--- a/resilient/src/hw_state_machine.rs
+++ b/resilient/src/hw_state_machine.rs
@@ -165,4 +165,62 @@ mod tests {
     fn initial_state_returns_none_for_unknown_peripheral() {
         assert!(initial_state("UnknownPeripheral99").is_none());
     }
+
+    // ── Malformed-input regression corpus (RES-3154) ──────────────
+    #[test]
+    fn corpus_simple_state_machine() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "Light",
+            crate::feature_attrs::AttrRecord {
+                name: "peripheral".into(),
+                args: r#"states = "Off On", transitions = "Off:turn_on->On On:turn_off->Off""#.into(),
+                line: 0,
+            },
+        );
+        install(collect());
+        assert_eq!(initial_state("Light").unwrap(), "Off");
+        assert_eq!(transition("Light", "Off", "turn_on").unwrap(), "On");
+        assert_eq!(transition("Light", "On", "turn_off").unwrap(), "Off");
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn corpus_three_state_machine() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "Motor",
+            crate::feature_attrs::AttrRecord {
+                name: "peripheral".into(),
+                args: r#"states = "Stopped Running Fault", transitions = "Stopped:start->Running Running:stop->Stopped Running:error->Fault Fault:reset->Stopped""#.into(),
+                line: 0,
+            },
+        );
+        install(collect());
+        assert_eq!(initial_state("Motor").unwrap(), "Stopped");
+        assert_eq!(transition("Motor", "Stopped", "start").unwrap(), "Running");
+        assert_eq!(transition("Motor", "Running", "error").unwrap(), "Fault");
+        assert_eq!(transition("Motor", "Fault", "reset").unwrap(), "Stopped");
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn corpus_invalid_transition_rejected() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "Device",
+            crate::feature_attrs::AttrRecord {
+                name: "peripheral".into(),
+                args: r#"states = "Idle Active", transitions = "Idle:activate->Active""#.into(),
+                line: 0,
+            },
+        );
+        install(collect());
+        assert!(transition("Device", "Active", "activate").is_err());
+        assert!(transition("Device", "Idle", "invalid_op").is_err());
+        crate::feature_attrs::reset();
+    }
 }


### PR DESCRIPTION
Adds 3 corpus tests validating state machine transitions and initial states. Closes #3754