### PR TITLE
RES-3198: Add mmio_regmap error alignment test

### DIFF
--- a/resilient/examples/mmio_regmap_runtime_alignment.expected.txt
+++ b/resilient/examples/mmio_regmap_runtime_alignment.expected.txt
@@ -1,0 +1,1 @@
+error: mmio_regmap: register offset 0x01 must be aligned to word boundary

--- a/resilient/examples/mmio_regmap_runtime_alignment.rz
+++ b/resilient/examples/mmio_regmap_runtime_alignment.rz
@@ -1,0 +1,10 @@
+// RES-3198: Ensure mmio_regmap compile-time errors match runtime behavior
+
+mmio_regmap DEV {
+    0x00: reg1,
+    0x01: reg2,  // bad: should be 4-byte aligned
+}
+
+fn main(int x) -> int {
+    return 0;
+}


### PR DESCRIPTION
Test case validating mmio_regmap alignment errors match runtime behavior.

Closes #3450