### PR TITLE
RES-3824: Fix committed rustfmt violations blocking all PR CI

### DIFF
--- a/resilient/src/const_eval_ext.rs
+++ b/resilient/src/const_eval_ext.rs
@@ -14,8 +14,8 @@
 //! This module now also validates malformed const declarations so
 //! recovery placeholders do not leak into later phases.
 
-use crate::span::Span;
 use crate::Node;
+use crate::span::Span;
 
 fn diagnostic(source_path: &str, span: Span, message: &str) -> String {
     format!(
@@ -89,9 +89,9 @@ pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::check;
+    use crate::Node;
     use crate::run_program;
     use crate::span::{Pos, Span, Spanned};
-    use crate::Node;
 
     fn run(src: &str) -> String {
         let r = run_program(src);

--- a/resilient/src/mutex_rwlock.rs
+++ b/resilient/src/mutex_rwlock.rs
@@ -283,7 +283,10 @@ println(to_string(result));
 "#;
         let r = crate::run_program(src);
         assert!(!r.ok, "mutex_lock with non-mutex should fail");
-        assert!(r.errors.iter().any(|e| e.contains("mutex")), "error should mention mutex");
+        assert!(
+            r.errors.iter().any(|e| e.contains("mutex")),
+            "error should mention mutex"
+        );
     }
 
     #[test]
@@ -294,7 +297,10 @@ let result = rwlock_write(s);
 "#;
         let r = crate::run_program(src);
         assert!(!r.ok, "rwlock_write with string should fail");
-        assert!(r.errors.iter().any(|e| e.contains("rwlock")), "error should mention rwlock");
+        assert!(
+            r.errors.iter().any(|e| e.contains("rwlock")),
+            "error should mention rwlock"
+        );
     }
 
     #[test]
@@ -305,6 +311,9 @@ let opt = mutex_try_lock(not_mutex);
 "#;
         let r = crate::run_program(src);
         assert!(!r.ok, "mutex_try_lock with non-mutex should fail");
-        assert!(r.errors.iter().any(|e| e.contains("mutex")), "error should mention mutex");
+        assert!(
+            r.errors.iter().any(|e| e.contains("mutex")),
+            "error should mention mutex"
+        );
     }
 }


### PR DESCRIPTION
## Summary
`main` carries `cargo fmt --check` violations in two files, and since `cargo fmt --check` is part of the **required** `build / test / clippy` check, every branch cut from `main` fails that check — jamming the entire open-PR merge queue.

This PR runs `cargo fmt --all` to restore a clean tree.

## Changes
- `resilient/src/const_eval_ext.rs` — rustfmt import ordering
- `resilient/src/mutex_rwlock.rs` — wrap three `assert!(...)` calls that exceeded 100 columns

Pure formatting (rustfmt output); no logic change.

## Verification
- `cargo fmt --all --check` → clean (0 diffs)
- Changes are semantics-preserving rustfmt output

Closes #3824

🤖 Generated with [Claude Code](https://claude.com/claude-code)