### PR TITLE
RES-3826: Bump version to 0.2.3 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "resilient"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "cranelift",

--- a/resilient/Cargo.toml
+++ b/resilient/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resilient"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "A programming language designed for extreme reliability in embedded and safety-critical systems"
 authors = ["Eric Spencer"]

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "resilient-vscode",
   "displayName": "Resilient",
   "description": "Syntax highlighting, LSP diagnostics, and one-click run for Resilient (.rz) — a compiled, contract-driven language for safety-critical embedded systems.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "fromamerica",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Version bump to **0.2.3** ahead of the `v0.2.3` release, cut from the now fmt-clean `main` (RES-3824, #3825).

## Changes
- `resilient/Cargo.toml`: `0.2.2` → `0.2.3`
- `Cargo.lock`: `resilient` package entry → `0.2.3`
- `vscode-extension/package.json`: `0.2.2` → `0.2.3`

## Verification
- `cargo metadata --locked` validates the updated lockfile (release builds use `--locked`)
- `cargo fmt --all --check` clean

Once merged, `v0.2.3` is tagged on `main`, triggering `release.yml` (multi-platform `rz` binaries + GitHub release) and `vscode_extension.yml` (.vsix artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)