### PR TITLE
RES-3828: Typecheck live block invariants

### DIFF
--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -7700,7 +7700,15 @@ impl TypeChecker {
                 Ok(effective_rt)
             }
 
-            Node::LiveBlock { body, .. } => {
+            Node::LiveBlock {
+                body, invariants, ..
+            } => {
+                for invariant in invariants {
+                    let ty = self.check_node(invariant)?;
+                    if ty != Type::Bool && ty != Type::Any {
+                        return Err(format!("live block invariant must be Bool, got {}", ty));
+                    }
+                }
                 // Live blocks preserve the type of their body
                 self.check_node(body)
             }
@@ -13858,6 +13866,34 @@ mod scope_and_reachability_tests {
             }",
         )
         .expect("live { return X } should count as a terminating body");
+    }
+
+    #[test]
+    fn res3828_live_block_bool_invariant_passes() {
+        check(
+            "fn safe(int fuel) -> int { \
+                live invariant fuel >= 0 { \
+                    return fuel; \
+                } \
+            }",
+        )
+        .expect("boolean live invariant should typecheck");
+    }
+
+    #[test]
+    fn res3828_live_block_non_bool_invariant_is_rejected() {
+        let err = check(
+            "fn unsafe_live(int fuel) -> int { \
+                live invariant 1 { \
+                    return fuel; \
+                } \
+            }",
+        )
+        .expect_err("non-bool live invariant should be rejected");
+        assert!(
+            err.contains("live block invariant must be Bool"),
+            "expected live invariant Bool diagnostic, got: {err}"
+        );
     }
 
     // --- RES-1113: unreachable code after return -----------------------------


### PR DESCRIPTION
## What
Typecheck `live invariant` clauses as boolean predicates before accepting a live block.

## Why
Live blocks are Resilient's supervised recovery boundary. The parser already records `live invariant <expr>` clauses, but the typechecker only checked the block body, allowing malformed non-boolean recovery predicates to slip through until runtime behavior.

## Changes
- Check every `Node::LiveBlock` invariant in the typechecker.
- Reject invariant expressions whose type is not `Bool`, while preserving the existing `Any` fallback used by parser recovery and incomplete inference paths.
- Add regression tests for a valid boolean live invariant and invalid `invariant 1`.

## Test changes
- Added `res3828_live_block_bool_invariant_passes` to cover the valid predicate path.
- Added `res3828_live_block_non_bool_invariant_is_rejected` to prove non-boolean live invariants are rejected statically.

## Validation
- `cargo fmt --all --manifest-path resilient/Cargo.toml --check`
- `cargo fmt --all --manifest-path resilient-runtime/Cargo.toml --check`
- `CARGO_TARGET_DIR=/tmp/resilient-pr-3828-target cargo test --manifest-path resilient/Cargo.toml res3828_live_block --lib`
- `CARGO_TARGET_DIR=/tmp/resilient-pr-3828-target cargo test --manifest-path resilient/Cargo.toml`
- `CARGO_TARGET_DIR=/tmp/resilient-pr-3828-target cargo test --manifest-path resilient-runtime/Cargo.toml`
- `CARGO_TARGET_DIR=/tmp/resilient-pr-3828-target cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/resilient-pr-3828-target cargo clippy --manifest-path resilient-runtime/Cargo.toml --all-targets -- -D warnings`

Closes #3828
