### PR TITLE
RES-3780: Require contracts for @ai_generated functions

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -8,9 +8,21 @@
       "branch": "res-3231-format-builtin-call-site-validation",
       "claimed_at": "2026-06-13T15:00:45Z"
     },
-    "resilient/src/typestate_types.rs": {
-      "branch": "res-3200-typestate-validation",
-      "claimed_at": "2026-06-15T02:09:15Z"
+    "resilient/src/ai_generated.rs": {
+      "branch": "RES-3780",
+      "claimed_at": "2026-06-25T01:26:58Z"
+    },
+    "resilient/src/lib.rs": {
+      "branch": "RES-3780",
+      "claimed_at": "2026-06-25T01:26:58Z"
+    },
+    "docs/language-reference.md": {
+      "branch": "RES-3780",
+      "claimed_at": "2026-06-25T01:26:58Z"
+    },
+    "docs/LANGUAGE.md": {
+      "branch": "RES-3780",
+      "claimed_at": "2026-06-25T01:26:58Z"
     }
   }
 }

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -93,7 +93,7 @@ This table will be populated in follow-up PRs with all Resilient language featur
 
 | Feature | Tier | Backends | Notes |
 |---------|------|----------|-------|
-| (To be populated) | — | — | — |
+| `@ai_generated` function attribute | Experimental | Typechecker | Requires at least one `requires` or `ensures` clause on the annotated function. |
 
 ---
 

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -211,7 +211,7 @@ Other          ?  _
 
 The composite token `#{` opens a set literal; the closing brace is an
 ordinary `}`. The attribute prefix `@` introduces function
-annotations (currently only `@pure`).
+annotations such as `@pure` and `@ai_generated`.
 
 ### Operator precedence and associativity
 
@@ -599,6 +599,11 @@ Contract         ::= "requires" Expression
                    | "invariant" Expression
 ImplDecl         ::= "impl" Identifier "{" { FnDecl } "}"
 ```
+
+`@ai_generated` marks a function whose body came from an AI tool. The
+function must declare at least one `requires` or `ensures` clause; a
+missing contract is a static type-check error. The marker does not call
+an external model and does not infer a contract for the user.
 
 ### `let` semantics
 

--- a/resilient/src/ai_generated.rs
+++ b/resilient/src/ai_generated.rs
@@ -1,0 +1,117 @@
+//! `@ai_generated` validation.
+//!
+//! AI-generated functions are allowed only when they carry explicit
+//! `requires` or `ensures` clauses. The verifier can then reason about
+//! the stated contract without making any network call or trusting an
+//! external model.
+
+use std::collections::HashMap;
+
+use crate::Node;
+
+fn diagnostic(source_path: &str, line: usize, fn_name: &str, message: &str) -> String {
+    format!(
+        "{source_path}:{line}:0: error[ai_generated]: invalid @ai_generated declaration `{fn_name}`: {message}"
+    )
+}
+
+pub(crate) fn check(program: &Node, source_path: &str) -> Result<(), String> {
+    let attrs = crate::feature_attrs::find_kind("ai_generated");
+    if attrs.is_empty() {
+        return Ok(());
+    }
+
+    let mut contract_counts = HashMap::new();
+    if let Node::Program(stmts) = program {
+        for stmt in stmts {
+            if let Node::Function {
+                name,
+                requires,
+                ensures,
+                ..
+            } = &stmt.node
+            {
+                contract_counts.insert(name.clone(), requires.len() + ensures.len());
+            }
+        }
+    }
+
+    for (fn_name, rec) in attrs {
+        let Some(contract_count) = contract_counts.get(&fn_name) else {
+            continue;
+        };
+        if *contract_count == 0 {
+            return Err(diagnostic(
+                source_path,
+                rec.line,
+                &fn_name,
+                "function must declare at least one `requires` or `ensures` clause",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_at_ai_generated_attribute() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        let src = "@ai_generated\nfn made_by_model(int x) requires x >= 0 { return x + 1; }";
+        let (_prog, errs) = crate::parse(src);
+        assert!(errs.is_empty(), "parse errors: {errs:?}");
+        let attrs = crate::feature_attrs::find_kind("ai_generated");
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].0, "made_by_model");
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn rejects_ai_generated_function_without_contracts() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        crate::feature_attrs::record(
+            "made_by_model",
+            crate::feature_attrs::AttrRecord {
+                name: "ai_generated".into(),
+                args: "".into(),
+                line: 1,
+            },
+        );
+        let src = "fn made_by_model(int x) -> int { return x + 1; }";
+        let (prog, errs) = crate::parse(src);
+        assert!(errs.is_empty(), "parse errors: {errs:?}");
+
+        let err = check(&prog, "<test>").expect_err("missing contracts must be rejected");
+        assert_eq!(
+            err,
+            "<test>:1:0: error[ai_generated]: invalid @ai_generated declaration `made_by_model`: function must declare at least one `requires` or `ensures` clause"
+        );
+        crate::feature_attrs::reset();
+    }
+
+    #[test]
+    fn typechecker_rejects_at_ai_generated_without_contracts() {
+        let _g = crate::feature_attrs::lock_for_test();
+        crate::feature_attrs::reset();
+        let src = "@ai_generated\nfn made_by_model(int x) -> int { return x + 1; }";
+        let (prog, errs) = crate::parse(src);
+        assert!(errs.is_empty(), "parse errors: {errs:?}");
+
+        let mut tc = crate::typechecker::TypeChecker::new();
+        let err = tc
+            .check_program_with_source(&prog, "<test>")
+            .expect_err("typecheck must reject @ai_generated without contracts");
+        assert!(
+            err.contains("error[ai_generated]")
+                && err
+                    .contains("function must declare at least one `requires` or `ensures` clause"),
+            "expected ai_generated missing-contract diagnostic, got: {err}"
+        );
+        crate::feature_attrs::reset();
+    }
+}

--- a/resilient/src/lib.rs
+++ b/resilient/src/lib.rs
@@ -589,6 +589,7 @@ mod capabilities;
 // 50-feature missing-language-features pass — shared attribute registry
 // and 50 new feature modules. See feature_attrs.rs for the registry,
 // and the per-feature module docs for what each does.
+mod ai_generated;
 mod ai_threat_model;
 mod anti_regression;
 mod associated_constants;
@@ -4100,6 +4101,7 @@ impl Parser {
     /// cascade into unrelated parse errors just because of a typo.
     fn parse_attributed_item(&mut self) -> Node {
         debug_assert_eq!(self.current_token, Token::At);
+        let attr_line = self.current_line;
         self.next_token(); // skip '@'
 
         let attr_name = match &self.current_token {
@@ -4129,9 +4131,10 @@ impl Parser {
             // purity checker (via `pure: bool`) and the RES-389
             // effect-annotation checker (via `EffectSet::pure()`).
             "pure" => (true, EffectSet::pure()),
+            "ai_generated" => (false, EffectSet::io()),
             other => {
                 self.record_error(format!(
-                    "Unknown attribute `@{}`. Known: @pure, @repr(C)",
+                    "Unknown attribute `@{}`. Known: @pure, @repr(C), @ai_generated",
                     other
                 ));
                 // Fall through — treat as if no attribute was
@@ -4157,7 +4160,20 @@ impl Parser {
             });
         }
 
-        self.parse_function_with_pure_and_effects(pure_flag, effects)
+        let node = self.parse_function_with_pure_and_effects(pure_flag, effects);
+        if attr_name == "ai_generated"
+            && let Node::Function { name, .. } = &node
+        {
+            crate::feature_attrs::record(
+                name,
+                crate::feature_attrs::AttrRecord {
+                    name: "ai_generated".to_string(),
+                    args: String::new(),
+                    line: attr_line,
+                },
+            );
+        }
+        node
     }
 
     /// RES-317: parse `@repr(C)` immediately followed by a `struct`

--- a/resilient/src/typechecker.rs
+++ b/resilient/src/typechecker.rs
@@ -6573,6 +6573,7 @@ impl TypeChecker {
                     crate::vibe_debt::check(program, source_path)?;
                     crate::contract_inference::check(program, source_path)?;
                 }
+                crate::ai_generated::check(program, source_path)?;
                 // RES-2436 gate: behavioral_fingerprint only processes
                 // `Node::Function` nodes (fingerprint_program iterates
                 // top-level Functions). Programs with no functions have


### PR DESCRIPTION
## What
Adds `@ai_generated` as a parsed function attribute and makes the typechecker reject annotated functions that do not declare at least one `requires` or `ensures` clause.

## Why
Issue #3780 asks for an offline correctness guard for AI-generated code. This first compiler slice makes the marker enforceable without external LLM calls: AI-originated functions must carry explicit contracts the local verifier/typechecker can reason about.

## Changes
- Add `resilient/src/ai_generated.rs` with validation for recorded `@ai_generated` functions.
- Teach the parser to accept `@ai_generated fn ...` and record it in the shared feature-attribute registry.
- Invoke the validation from the extension pass block in `typechecker.rs`.
- Document the attribute in `docs/language-reference.md` and classify it in `docs/LANGUAGE.md`.
- Update file-claim metadata via `agent-scripts/claim-files.sh`.

## Validation
- `cargo fmt --all --manifest-path resilient/Cargo.toml --check`
- `cargo test --manifest-path resilient/Cargo.toml --lib ai_generated`
- `cargo test --manifest-path resilient/Cargo.toml`
- `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path resilient-runtime/Cargo.toml`

Note: the first full runtime-suite run hit `gpio::tests::input_read_isolates_pins_within_port`; the same test passed when rerun directly, and the full runtime suite passed on rerun.

Closes #3780