### PR TITLE
RES-3781: Seed quantized matmul kernel example

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -23,6 +23,18 @@
     "docs/LANGUAGE.md": {
       "branch": "RES-3780",
       "claimed_at": "2026-06-25T01:26:58Z"
+    },
+    "resilient/examples/llm_quantized_matmul.rz": {
+      "branch": "RES-3781",
+      "claimed_at": "2026-06-25T01:54:28Z"
+    },
+    "resilient/examples/llm_quantized_matmul.expected.txt": {
+      "branch": "RES-3781",
+      "claimed_at": "2026-06-25T01:54:28Z"
+    },
+    "resilient/tests/llm_quantized_ops_smoke.rs": {
+      "branch": "RES-3781",
+      "claimed_at": "2026-06-25T01:54:28Z"
     }
   }
 }

--- a/resilient/examples/llm_quantized_matmul.expected.txt
+++ b/resilient/examples/llm_quantized_matmul.expected.txt
@@ -1,0 +1,2 @@
+[42, -1, -22, -9]
+Program executed successfully

--- a/resilient/examples/llm_quantized_matmul.rz
+++ b/resilient/examples/llm_quantized_matmul.rz
@@ -1,0 +1,39 @@
+fn q8_dot3(array lhs, array rhs, int row, int col, int rhs_cols) -> int
+    requires len(lhs) == 6
+    requires len(rhs) == 6
+    requires row >= 0
+    requires row < 2
+    requires col >= 0
+    requires col < rhs_cols
+    requires rhs_cols == 2
+{
+    let acc = 0;
+    let k = 0;
+    while k < 3 {
+        let a = lhs[row * 3 + k];
+        let b = rhs[k * rhs_cols + col];
+        acc = acc + a * b;
+        k = k + 1;
+    }
+    return acc;
+}
+
+fn q8_matmul_2x2(array activations, array weights) -> array
+    requires len(activations) == 6
+    requires len(weights) == 6
+{
+    return [
+        q8_dot3(activations, weights, 0, 0, 2),
+        q8_dot3(activations, weights, 0, 1, 2),
+        q8_dot3(activations, weights, 1, 0, 2),
+        q8_dot3(activations, weights, 1, 1, 2),
+    ];
+}
+
+fn main() {
+    let activations = [3, -2, 5, 1, 0, -4];
+    let weights = [2, -1, -3, 4, 6, 2];
+    println(q8_matmul_2x2(activations, weights));
+}
+
+main();

--- a/resilient/tests/llm_quantized_ops_smoke.rs
+++ b/resilient/tests/llm_quantized_ops_smoke.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rz")
+}
+
+#[test]
+fn llm_quantized_matmul_example_runs_cpu_fallback_kernel() {
+    let output = Command::new(bin())
+        .arg("examples/llm_quantized_matmul.rz")
+        .output()
+        .expect("failed to run llm quantized matmul example");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "example should exit cleanly; stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("[42, -1, -22, -9]"),
+        "expected flattened 2x2 q8 matmul output, got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add a runnable q8-style matrix multiply example using flat row-major integer arrays.
- Add a golden output sidecar and focused smoke coverage for the example.
- Establish a small CPU-fallback kernel shape that can grow toward the larger llama.cpp-in-Resilient goal.

Refs #3781

## Validation
- `cargo fmt --all --manifest-path resilient/Cargo.toml --check`
- `cargo test --manifest-path resilient/Cargo.toml --test llm_quantized_ops_smoke`
- `cargo test --manifest-path resilient/Cargo.toml --test examples_golden golden_outputs_match -- --exact`
- `cargo test --manifest-path resilient/Cargo.toml`
- `cargo clippy --manifest-path resilient/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path resilient-runtime/Cargo.toml`

## Notes
- This is intentionally a first vertical slice, not the full llama.cpp port. It leaves #3781 open for the larger model-loading, quantization, SIMD, and benchmark work.