### PR TITLE
RES-3783: Guard VS Code extension release sync

### DIFF
--- a/agent-scripts/file-claims.json
+++ b/agent-scripts/file-claims.json
@@ -23,6 +23,18 @@
     "docs/LANGUAGE.md": {
       "branch": "RES-3780",
       "claimed_at": "2026-06-25T01:26:58Z"
+    },
+    "docs/VSCODE_EXTENSION_RELEASE.md": {
+      "branch": "RES-3783",
+      "claimed_at": "2026-06-25T02:32:37Z"
+    },
+    "resilient/tests/vscode_release_sync_smoke.rs": {
+      "branch": "RES-3783",
+      "claimed_at": "2026-06-25T02:32:37Z"
+    },
+    "vscode-extension/package.json": {
+      "branch": "RES-3783",
+      "claimed_at": "2026-06-25T02:32:37Z"
     }
   }
 }

--- a/docs/VSCODE_EXTENSION_RELEASE.md
+++ b/docs/VSCODE_EXTENSION_RELEASE.md
@@ -1,0 +1,29 @@
+# VS Code Extension Release Sync
+
+The VS Code extension version is intended to track the compiler crate version
+in `resilient/Cargo.toml`.
+
+Tracked release state:
+
+- `resilient/Cargo.toml` is the compiler release source of truth.
+- `vscode-extension/package.json` must use the same version.
+- `.github/workflows/vscode_extension.yml` publishes the extension on `v*`
+  release tags with the `VSCE_PAT` GitHub Actions secret.
+- `.github/workflows/vsce-token-check.yml` verifies the PAT before release day.
+- `npm run vscode:publish` is the manual fallback from `vscode-extension/`.
+
+## Marketplace History
+
+The Marketplace can contain older accidental versions that are numerically
+higher than the compiler version. Publishing `0.2.x` after `1.5.x` does not
+make `0.2.x` outrank `1.5.x` under semver ordering.
+
+If the Marketplace still presents `1.5.x` as latest after a synced `0.2.x`
+publish, fix it from the publisher account by either:
+
+1. unpublishing the accidental `1.5.x` versions, or
+2. choosing an explicit forward-only extension version policy and documenting
+   that the extension no longer mirrors the compiler crate version.
+
+Do not roll `package.json` backward below the compiler version; that preserves
+the mismatch instead of fixing Marketplace history.

--- a/resilient/tests/vscode_release_sync_smoke.rs
+++ b/resilient/tests/vscode_release_sync_smoke.rs
@@ -1,0 +1,65 @@
+use serde_json::Value;
+
+fn json_file(path: &str) -> Value {
+    serde_json::from_str(&std::fs::read_to_string(repo_path(path)).expect("read json file"))
+        .expect("parse json file")
+}
+
+fn repo_path(path: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repo root")
+        .join(path)
+}
+
+fn cargo_version() -> String {
+    let cargo =
+        std::fs::read_to_string(repo_path("resilient/Cargo.toml")).expect("read Cargo.toml");
+    cargo
+        .lines()
+        .find_map(|line| line.strip_prefix("version = "))
+        .and_then(|raw| raw.trim().trim_matches('"').split_whitespace().next())
+        .expect("resilient/Cargo.toml version")
+        .to_string()
+}
+
+#[test]
+fn vscode_extension_version_matches_compiler_release() {
+    let compiler = cargo_version();
+    let package = json_file("vscode-extension/package.json");
+
+    assert_eq!(package["version"], compiler);
+}
+
+#[test]
+fn vscode_extension_publish_path_is_tag_and_pat_driven() {
+    let package = json_file("vscode-extension/package.json");
+    assert_eq!(package["publisher"], "fromamerica");
+    assert_eq!(package["name"], "resilient-vscode");
+    assert_eq!(
+        package["scripts"]["vscode:publish"], "vsce publish",
+        "package.json should keep the documented manual publish fallback"
+    );
+
+    let workflow = std::fs::read_to_string(repo_path(".github/workflows/vscode_extension.yml"))
+        .expect("read workflow");
+    assert!(
+        workflow.contains("tags:\n      - \"v*\""),
+        "vscode_extension.yml should publish from release tags"
+    );
+    assert!(
+        workflow.contains("npx --yes @vscode/vsce publish --pat \"$VSCE_PAT\""),
+        "workflow should publish with vsce and the PAT secret"
+    );
+    assert!(
+        workflow.contains("VSCE_PAT: ${{ secrets.VSCE_PAT }}"),
+        "workflow should read VSCE_PAT from GitHub Actions secrets"
+    );
+
+    let token_check = std::fs::read_to_string(repo_path(".github/workflows/vsce-token-check.yml"))
+        .expect("read workflow");
+    assert!(
+        token_check.contains("verify-pat \"$PUBLISHER\" --pat \"$VSCE_PAT\""),
+        "token check workflow should verify publisher access before release day"
+    );
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -112,7 +112,8 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "package": "vsce package --out resilient-vscode.vsix"
+    "package": "vsce package --out resilient-vscode.vsix",
+    "vscode:publish": "vsce publish"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"


### PR DESCRIPTION
## Summary
- Add a release-sync smoke test that pins the compiler/package version match and verifies the tag + `VSCE_PAT` publish path is wired.
- Add the documented `npm run vscode:publish` manual fallback script.
- Document the remaining Marketplace-history issue: `0.2.3` is published, but older accidental `1.5.x` versions are numerically higher and may still appear as latest until handled from the publisher account.

Refs #3783

## Marketplace verification
`npx --yes @vscode/vsce show fromamerica.resilient-vscode --json` shows:
- `0.2.3` exists and was last updated `2026-06-23T16:18:22.020Z`.
- `1.5.3` also exists and is higher semver, so a synced `0.2.x` publish cannot outrank it as latest.

## Validation
- `cargo fmt --all --manifest-path resilient/Cargo.toml --check`
- `cargo test --manifest-path resilient/Cargo.toml --test vscode_release_sync_smoke`
- `cargo clippy --manifest-path resilient/Cargo.toml --test vscode_release_sync_smoke -- -D warnings`
- `npm install --no-audit --no-fund --package-lock=false`
- `npm run compile`
- `npx --yes @vscode/vsce package --out /tmp/resilient-vscode-3783.vsix`

## Notes
- This PR does not unpublish Marketplace versions; that requires publisher-account authority and should be done deliberately for the accidental `1.5.x` history, or the project should choose a forward-only extension version policy.